### PR TITLE
fix(nx): Invalidate cache when dependencies change

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -21,6 +21,16 @@
     ],
     "sharedGlobals": [
       "{workspaceRoot}/.env"
+    ],
+    "packageFiles": [
+      "{projectRoot}/package.json",
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/package-lock.json"
+    ],
+    "pythonDependencies": [
+      "{projectRoot}/requirements.txt",
+      "{projectRoot}/pyproject.toml",
+      "{projectRoot}/setup.py"
     ]
   },
   "targetDefaults": {
@@ -31,7 +41,8 @@
       ],
       "inputs": [
         "production",
-        "^production"
+        "^production",
+        "packageFiles"
       ]
     },
     "test": {
@@ -39,20 +50,25 @@
       "inputs": [
         "default",
         "^production",
-        "{workspaceRoot}/.env"
+        "{workspaceRoot}/.env",
+        "packageFiles",
+        "pythonDependencies"
       ]
     },
     "lint": {
       "cache": true,
       "inputs": [
-        "default"
+        "default",
+        "packageFiles",
+        "pythonDependencies"
       ]
     },
     "type-check": {
       "cache": true,
       "inputs": [
         "production",
-        "^production"
+        "^production",
+        "packageFiles"
       ]
     },
     "serve": {


### PR DESCRIPTION
## 🎯 Objectif

Garantir que le cache NX est invalidé quand les dépendances changent (via Renovate ou autre), pour s'assurer que les tests et builds s'exécutent réellement avec les nouvelles versions.

## ❌ Problème identifié

**Situation actuelle** :
- Quand Renovate met à jour une dépendance (ex: React 18.2 → 18.3)
- `package.json` et `package-lock.json` changent
- Mais le cache NX n'inclut pas ces fichiers dans les inputs
- → NX restaure le cache des tests avec l'ancienne version
- → Les tests ne s'exécutent pas vraiment, ils sont lus depuis le cache
- → Les breaking changes de la nouvelle version ne sont pas détectés ❌

**Exemple concret** :
```
1. Renovate update React 18.2 → 18.3
2. package-lock.json change
3. NX calcule hash des inputs: src/**/* → identique
4. NX trouve un cache valide (ancienne version)
5. Tests "réussissent" (depuis cache)
6. Mais React 18.3 n'a jamais été testé ! 💥
```

## ✅ Solution implémentée

### Modifications de `nx.json`

#### 1. Ajout de 2 nouveaux `namedInputs`

```json
"namedInputs": {
  // ... existing ...
  
  "packageFiles": [
    "{projectRoot}/package.json",
    "{workspaceRoot}/package.json",
    "{workspaceRoot}/package-lock.json"
  ],
  
  "pythonDependencies": [
    "{projectRoot}/requirements.txt",
    "{projectRoot}/pyproject.toml",
    "{projectRoot}/setup.py"
  ]
}
```

#### 2. Inclusion dans les `targetDefaults`

**Build** :
```json
"inputs": [
  "production",
  "^production",
  "packageFiles"  // ⭐ NOUVEAU
]
```

**Test** :
```json
"inputs": [
  "default",
  "^production",
  "{workspaceRoot}/.env",
  "packageFiles",        // ⭐ NOUVEAU (JS/TS)
  "pythonDependencies"   // ⭐ NOUVEAU (Python)
]
```

**Lint** :
```json
"inputs": [
  "default",
  "packageFiles",        // ⭐ NOUVEAU
  "pythonDependencies"   // ⭐ NOUVEAU
]
```

**Type-check** :
```json
"inputs": [
  "production",
  "^production",
  "packageFiles"  // ⭐ NOUVEAU
]
```

## 🔄 Nouveau comportement

### Scénario 1 : Renovate update React
```
1. Renovate change package.json + package-lock.json
2. NX calcule hash des inputs pour "test" frontend:
   - default: hash des src/**/* ✓
   - ^production: hash de shared-types ✓
   - packageFiles: hash de package.json + package-lock.json ✅ CHANGÉ
3. Hash différent → Cache invalide
4. Tests VRAIMENT exécutés avec React 18.3 ✅
5. Breaking changes détectés si présents ✅
```

### Scénario 2 : Renovate update pytest (backend)
```
1. Renovate change requirements.txt
2. NX calcule hash pour "test" backend:
   - pythonDependencies: hash de requirements.txt ✅ CHANGÉ
3. Hash différent → Cache invalide
4. Tests backend ré-exécutés avec nouvelle version pytest ✅
```

### Scénario 3 : Modification code (pas de deps)
```
1. Modification de src/App.tsx
2. NX calcule hash:
   - default: CHANGÉ (App.tsx modifié)
   - packageFiles: IDENTIQUE
3. Cache invalide pour le code changé
4. Cache hit pour les parties non modifiées ✅
```

## 📊 Bénéfices

### ✅ **Sécurité maximale**
- Garantit que les tests s'exécutent avec les nouvelles dépendances
- Détecte automatiquement les breaking changes
- Pas de faux positifs

### ✅ **Solution native NX**
- Utilise les mécanismes intégrés de NX (`namedInputs`)
- Pas de hacks dans la CI
- Maintenable et documenté officiellement

### ✅ **Granularité fine**
- NX invalide **uniquement** ce qui doit l'être
- Frontend deps changent → Backend cache préservé
- Code change (pas deps) → Cache partiel utilisé

### ✅ **Universel**
- Fonctionne pour **TOUTES** les PRs (pas juste Renovate)
- Un dev change manuellement package.json → même comportement
- Cohérent et prévisible

### ✅ **Compatible avec PR #77**
Fonctionne parfaitement avec la stratégie `skip-nx-cloud` label :
- Renovate PRs : skip NX Cloud (économie crédits) + cache local invalidé correctement
- PRs normales : NX Cloud activé + cache invalidé quand nécessaire

## ⚖️ Impact sur la performance

### Avant (problématique)
- ❌ Renovate update deps → cache hit → tests PAS exécutés
- ⚡ Très rapide (~30s) mais **dangereux**

### Après (correct)
- ✅ Renovate update deps → cache miss → tests EXÉCUTÉS
- ⏱️ Plus lent (~2-3 min) mais **sûr et correct**
- ✅ Autres cas (code changes) : performance identique

## 🧪 Tests à effectuer

### Test 1 : Vérifier invalidation sur update deps
1. Merger cette PR
2. Attendre une PR Renovate
3. Vérifier dans les logs CI que les tests s'exécutent vraiment (pas de cache hit)

### Test 2 : Vérifier cache partiel fonctionne
1. Modifier un fichier source (pas package.json)
2. Vérifier que NX utilise le cache pour les parties non modifiées

### Test 3 : Test local
```bash
# Baseline
npx nx test frontend

# Modifier package.json (ajouter un commentaire par exemple)
npx nx test frontend
# → Devrait ré-exécuter les tests (cache invalidé)
```

## 📁 Fichiers modifiés

- `nx.json` (+20 lignes, -4 lignes)
  - Ajout de `packageFiles` et `pythonDependencies` dans `namedInputs`
  - Inclusion dans les `inputs` de build, test, lint, type-check

## 🔗 Relation avec les autres PRs

Cette PR est **complémentaire** à la PR #77 :
- **PR #77** : Économise les crédits NX Cloud (label `skip-nx-cloud` pour Renovate)
- **Cette PR** : Garantit que le cache (local ou distant) est invalidé correctement

Ensemble, elles forment une solution complète :
1. Économie de crédits NX Cloud sur Renovate ✅
2. Cache local comme fallback ✅
3. Cache invalidé quand nécessaire ✅
4. Tests toujours exécutés avec bonnes versions ✅

---

**Note** : Cette PR contient uniquement la configuration NX, aucun code applicatif n'est modifié.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cache invalidation for build, type-check, test, and lint tasks to monitor dependency files, ensuring more accurate cache invalidation when package or dependency configurations change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->