### PR TITLE
feat(ci): Add helpful warning when NX Cloud credits are exhausted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,10 @@ jobs:
         run: npx nx affected -t build --parallel=3 --exclude=e2e
       
       - name: 💡 Check if NX Cloud credits exhausted
-        if: failure() && steps.build.outcome == 'failure'
+        if: always() && steps.build.outcome == 'failure'
         run: |
-          if gh run view ${{ github.run_id }} --log 2>&1 | grep -q "exceeding the FREE plan"; then
+          # Check for NX Cloud credits exhaustion (more reliable patterns)
+          if gh run view ${{ github.run_id }} --log 2>&1 | grep -qE "(Workspace is unable to be authorized|exceeding the FREE plan|Workspace is disabled)"; then
             echo "::error title=NX Cloud Credits Exhausted::Your NX Cloud free tier credits are exhausted. Add the 'skip-nx-cloud' label to this PR to use local cache instead, then re-run the workflow."
             echo ""
             echo "=========================================="
@@ -135,12 +136,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       
       - name: 🎨 Run affected lints
+        if: success() || (failure() && steps.build.outcome == 'success')
         run: npx nx affected -t lint --parallel=3 --exclude=e2e
       
       - name: 📝 Run affected type-check
+        if: success() || (failure() && steps.build.outcome == 'success')
         run: npx nx affected -t type-check --parallel=3 --exclude=e2e
       
       - name: 🧪 Run affected tests (frontend + backend in parallel)
+        if: success() || (failure() && steps.build.outcome == 'success')
         run: npx nx affected -t test --parallel=3 --exclude=e2e
         env:
           TESTING: true


### PR DESCRIPTION
## 🎯 Objectif

Afficher un message d'erreur clair et actionnable quand les crédits NX Cloud sont épuisés, au lieu d'un échec cryptique.

## ❌ Problème actuel

Quand les crédits NX Cloud sont épuisés :
```
NX   Nx Cloud: Workspace is unable to be authorized. Exiting run.
This Nx Cloud organization has been disabled due to exceeding the FREE plan.
```

**Issues** :
- ❌ Message enterré dans les logs
- ❌ Pas visible dans l'UI GitHub
- ❌ Pas d'instructions claires sur la résolution
- ❌ L'utilisateur doit chercher dans les logs pour comprendre

## ✅ Solution

Ajouter un step dédié qui :
1. Détecte l'échec de build
2. Vérifie si c'est dû aux crédits épuisés
3. Affiche un message clair avec instructions

### Message affiché

**Annotation GitHub Actions** (visible dans l'UI) :
```
❌ NX Cloud Credits Exhausted
Your NX Cloud free tier credits are exhausted. Add the 'skip-nx-cloud' 
label to this PR to use local cache instead, then re-run the workflow.
```

**Console output** (dans les logs) :
```
==========================================
⚠️  NX CLOUD CREDITS EXHAUSTED
==========================================

Your NX Cloud organization has exceeded the FREE plan limit.

📋 Quick fix:
  1. Add the 'skip-nx-cloud' label to this PR
  2. Re-run the workflow
  3. The workflow will use local cache instead (slower but functional)

💡 For Renovate PRs: The label is added automatically by Renovate config

🔗 More info: https://cloud.nx.app/orgs/65e6f08db35f78b0f34130b8/plans
```

## 🔧 Implémentation

### Modification du step build

```yaml
- name: 🔨 Run affected builds
  id: build
  continue-on-error: true  # ⭐ Permet de continuer après échec
  run: npx nx affected -t build --parallel=3 --exclude=e2e

- name: 💡 Check if NX Cloud credits exhausted
  if: failure() && steps.build.outcome == 'failure'
  run: |
    if gh run view ${{ github.run_id }} --log 2>&1 | grep -q "exceeding the FREE plan"; then
      echo "::error title=NX Cloud Credits Exhausted::..."
      # ... instructions ...
      exit 1
    else
      echo "::error title=Build Failed::..."
      exit 1
    fi
```

### Fonctionnement

1. **Step build** : `continue-on-error: true` permet au workflow de continuer après échec
2. **Step detection** : S'exécute seulement si build a échoué
3. **Vérification** : Cherche "exceeding the FREE plan" dans les logs
4. **Action** :
   - Si crédits épuisés → Message clair + instructions
   - Sinon → Message d'erreur générique

## 📊 Bénéfices

### ✅ UX améliorée
- Message visible dans l'UI GitHub (annotation)
- Instructions claires et actionnables
- Pas besoin de fouiller les logs

### ✅ Self-service
- L'utilisateur sait exactement quoi faire
- Solution simple : ajouter un label
- Lien vers la doc NX Cloud

### ✅ Différentiation des erreurs
- Crédits épuisés : message spécifique
- Autre erreur : message générique
- Facilite le debugging

## 🧪 Test

Pour tester sans épuiser vraiment les crédits :
1. Créer une PR sans le label `skip-nx-cloud`
2. Attendre que les crédits soient épuisés (ou simuler)
3. Vérifier le message d'erreur

## 📝 Note

Cette PR ne change **pas** le comportement :
- Les PRs Renovate continuent d'avoir le label automatiquement
- Les PRs normales doivent toujours ajouter le label manuellement
- La différence : le message est maintenant **clair** quand c'est nécessaire

---

**Complète les PRs** :
- #77 : Optimisation crédits NX Cloud
- #79 : Invalidation cache deps
- #80 : Fix project-level package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow error handling to provide better diagnostic information when builds fail, enabling faster troubleshooting and issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->