### PR TITLE
fix(renovate): replace invalid $comment option with description

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "$comment": "Add 'skip-nx-cloud' label to all PRs to conserve NX Cloud credits. Remove the label from a PR to enable NX Cloud for that specific update.",
+  "description": "Add 'skip-nx-cloud' label to all PRs to conserve NX Cloud credits. Remove the label from a PR to enable NX Cloud for that specific update.",
   "labels": ["skip-nx-cloud"]
 }


### PR DESCRIPTION
Renovate rejects unknown configuration options and $comment is not a valid Renovate property. This caused Renovate to stop creating PRs and open issue #83.

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to use a new field format while preserving existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->