### PR TITLE
feat: tooltip ouverture au clic avec curseur help

### DIFF
--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -565,8 +565,17 @@ export default function HourlyForecast({
         setActiveTooltip(null);
       }
     };
+    const handleViewportChange = () => {
+      setActiveTooltip(null);
+    };
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('scroll', handleViewportChange, true);
+    window.addEventListener('resize', handleViewportChange);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('scroll', handleViewportChange, true);
+      window.removeEventListener('resize', handleViewportChange);
+    };
   }, [activeTooltip]);
 
   // Detect mobile on mount and window resize


### PR DESCRIPTION
## Summary
- Remplace le hover par un clic pour ouvrir les tooltips des prévisions horaires
- Fermeture au clic en dehors de la tooltip (click outside)
- Curseur `help` (?) sur les cellules pour indiquer qu'on peut obtenir des infos en cliquant

## Test plan
- [ ] Cliquer sur une cellule → la tooltip s'ouvre
- [ ] Cliquer en dehors de la tooltip → elle se ferme
- [ ] Cliquer sur un lien dans la tooltip → le lien fonctionne
- [ ] Vérifier le curseur `?` au survol des cellules
- [ ] Vérifier sur mobile que le comportement est identique

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now reliably close when clicking outside, on scroll, or when resizing the window.

* **UI/UX**
  * Tooltip interaction unified to use click across devices for consistent behavior.
  * Trigger cursors updated to a help indicator for clearer affordance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->