### PR TITLE
fix(api): use correct flight_date key in flight records response

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -2016,7 +2016,7 @@ def get_flight_records(db: Session = Depends(get_db)):
             "value": getattr(flight, value_key),
             "flight_id": flight.id,
             "flight_name": flight.name or flight.title,
-            "date": flight.flight_date.isoformat() if flight.flight_date else None,
+            "flight_date": flight.flight_date.isoformat() if flight.flight_date else None,
             "site_name": flight.site.name if flight.site else None,
             "site_id": flight.site_id,
         }


### PR DESCRIPTION
## Summary
- The `/flights/records` endpoint returned `"date"` instead of `"flight_date"` in its response, causing Zod validation errors on the frontend ("Records Personnels" section)
- Renamed the key to `"flight_date"` to match the `FlightRecordSchema`

## Test plan
- [x] Backend tests pass (27/27)
- [ ] Verify "Records Personnels" section loads without error in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `/flights/records` API endpoint to use a more descriptive field name for flight date data in response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->