### PR TITLE
fix: require E2E Tests check in Mergify before merging

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,10 +19,12 @@ queue_rules:
       {{ body }}
     queue_conditions:
       - check-success=main
+      - check-success=E2E Tests
       - base=main
       - "#approved-reviews-by>=0"
     merge_conditions:
       - check-success=main
+      - check-success=E2E Tests
       - base=main
       - "#approved-reviews-by>=0"
 
@@ -34,6 +36,7 @@ pull_request_rules:
       - base=main
       - label=automerge
       - check-success=main
+      - check-success=E2E Tests
       - "#changes-requested-reviews-by=0"
     actions:
       queue:
@@ -48,6 +51,7 @@ pull_request_rules:
       - base=main
       - author=renovate[bot]
       - check-success=main
+      - check-success=E2E Tests
       - "title~=^(fix|chore)\\(deps\\):.*\\[SECURITY\\]"
     actions:
       queue:
@@ -68,6 +72,7 @@ pull_request_rules:
       - base=main
       - author=renovate[bot]
       - check-success=main
+      - check-success=E2E Tests
       - "title~=^fix\\(deps\\):"
       - "-title~=major"
     actions:
@@ -89,6 +94,7 @@ pull_request_rules:
       - base=main
       - author=renovate[bot]
       - check-success=main
+      - check-success=E2E Tests
       - "title~=^chore\\(deps\\):"
       - "-title~=major"
     actions:
@@ -140,6 +146,7 @@ pull_request_rules:
     conditions:
       - base=main
       - check-success=main
+      - check-success=E2E Tests
       - "#changes-requested-reviews-by=0"
       - "-draft"
       - "-conflict"
@@ -152,7 +159,9 @@ pull_request_rules:
   - name: Retirer ready-to-merge si conditions non remplies
     conditions:
       - base=main
-      - check-failure=main
+      - or:
+        - check-failure=main
+        - check-failure=E2E Tests
     actions:
       label:
         remove:
@@ -222,6 +231,13 @@ merge_protections:
       - base=main
     success_conditions:
       - check-success=main
+
+  - name: Verification des tests E2E
+    description: Les tests E2E doivent passer
+    if:
+      - base=main
+    success_conditions:
+      - check-success=E2E Tests
 
   - name: Branche a jour avec main
     description: La branche doit etre a jour avec main


### PR DESCRIPTION
## Summary
- PRs could be merged even when E2E tests were failing because Mergify only checked the `main` CI job
- Added `check-success=E2E Tests` to all queue conditions, merge conditions, pull request rules, and merge protections
- Updated the `ready-to-merge` label removal rule to also trigger on E2E test failures

## Test plan
- [ ] Verify Mergify config is valid (Mergify will validate on PR)
- [ ] Confirm a PR with failing E2E tests is no longer auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation by adding E2E tests as a required verification gate alongside existing checks. This ensures stricter quality standards and more rigorous testing before code merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->