### PR TITLE
fix: add missing design-system lib to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 # Copier fichiers de configuration Nx et pnpm
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml nx.json tsconfig.base.json ./
 
-# Copier libs/shared-types (dépendance du frontend)
+# Copier libs (dépendances du frontend)
 COPY libs/shared-types ./libs/shared-types
+COPY libs/design-system ./libs/design-system
 
 # Copier frontend
 COPY apps/frontend ./apps/frontend


### PR DESCRIPTION
## Summary
- The frontend imports `@dashboard-parapente/design-system` (in `App.tsx` and `FlightHistory.tsx`) but only `libs/shared-types` was copied into the Docker build stage
- This caused `nx build frontend --configuration=production` to fail with exit code 1 during Portainer deployment
- Added `COPY libs/design-system ./libs/design-system` to the Dockerfile

## Test plan
- [ ] Deploy on Portainer and verify the build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)