### PR TITLE
fix: use relative URLs for emagram and flight viewer API calls

### DIFF
--- a/apps/frontend/src/components/complex/EmagramWidget.tsx
+++ b/apps/frontend/src/components/complex/EmagramWidget.tsx
@@ -315,8 +315,6 @@ export default function EmagramWidget({
             const screenshots = JSON.parse(emagram.screenshot_paths);
             const sourceKeys = Object.keys(screenshots);
             if (sourceKeys.length > 0) {
-              // Use window.location to get the current host, backend is on same host:8001
-              const API_BASE = `${window.location.protocol}//${window.location.hostname}:8001`;
               return (
                 <div className="mt-3 pt-3 border-t border-gray-100">
                   <div className="text-xs text-gray-600 font-semibold mb-2">
@@ -329,7 +327,7 @@ export default function EmagramWidget({
                         .split(' ')
                         .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
                         .join(' ');
-                      const screenshotUrl = `${API_BASE}/api/emagram/screenshot/${emagram.id}/${source}`;
+                      const screenshotUrl = `/api/emagram/screenshot/${emagram.id}/${source}`;
                       return (
                         <a
                           key={source}

--- a/apps/frontend/src/components/complex/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/complex/FlightViewer3D.tsx
@@ -31,13 +31,6 @@ interface FlightViewer3DProps {
   flightTitle?: string;
 }
 
-// API base URL - use environment variable or derive from current location
-const API_BASE_URL =
-  import.meta.env.VITE_API_URL ||
-  (typeof window !== 'undefined'
-    ? `${window.location.protocol}//${window.location.hostname}:8001`
-    : 'http://localhost:8001');
-
 /**
  * AccordionSection - Collapsible section component for control panel
  */
@@ -1219,7 +1212,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           ) {
                             // Download video
                             window.open(
-                              `${API_BASE_URL}/api/exports/${flight.video_export_job_id}/download`,
+                              `/api/exports/${flight.video_export_job_id}/download`,
                               '_blank'
                             );
                           } else if (
@@ -1229,7 +1222,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                             // Generate video
                             try {
                               const response = await fetch(
-                                `${API_BASE_URL}/api/flights/${flightId}/generate-video`,
+                                `/api/flights/${flightId}/generate-video`,
                                 {
                                   method: 'POST',
                                 }
@@ -1304,7 +1297,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
                               try {
                                 const response = await fetch(
-                                  `${API_BASE_URL}/api/exports/${flight.video_export_job_id}/cancel`,
+                                  `/api/exports/${flight.video_export_job_id}/cancel`,
                                   {
                                     method: 'DELETE',
                                   }
@@ -1351,7 +1344,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
                             try {
                               const response = await fetch(
-                                `${API_BASE_URL}/api/flights/${flightId}/generate-video`,
+                                `/api/flights/${flightId}/generate-video`,
                                 {
                                   method: 'POST',
                                 }

--- a/apps/frontend/src/hooks/useEmagramAnalysis.ts
+++ b/apps/frontend/src/hooks/useEmagramAnalysis.ts
@@ -5,12 +5,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { EmagramAnalysis, EmagramListItem } from '../types/emagram';
 
-const API_BASE =
-  import.meta.env.VITE_API_URL ||
-  (typeof window !== 'undefined'
-    ? `${window.location.protocol}//${window.location.hostname}:8001`
-    : 'http://localhost:8001');
-
 const emagramKeys = {
   all: ['emagram'] as const,
   latest: (siteId: string, dayIndex: number) =>
@@ -32,12 +26,13 @@ export function useLatestEmagram(
     queryFn: async (): Promise<EmagramAnalysis | null> => {
       if (!siteId) return null;
 
-      const url = new URL(`${API_BASE}/api/emagram/latest`);
-      url.searchParams.set('site_id', siteId);
-      url.searchParams.set('day_index', dayIndex.toString());
-      url.searchParams.set('auto_analyze', 'true');
+      const params = new URLSearchParams({
+        site_id: siteId,
+        day_index: dayIndex.toString(),
+        auto_analyze: 'true',
+      });
 
-      const response = await fetch(url.toString());
+      const response = await fetch(`/api/emagram/latest?${params}`);
 
       if (!response.ok) {
         throw new Error(
@@ -70,13 +65,14 @@ export function useEmagramHistory(
         return [];
       }
 
-      const url = new URL(`${API_BASE}/api/emagram/history`);
-      url.searchParams.set('user_lat', userLat.toString());
-      url.searchParams.set('user_lon', userLon.toString());
-      url.searchParams.set('days', days.toString());
-      url.searchParams.set('max_distance_km', maxDistanceKm.toString());
+      const params = new URLSearchParams({
+        user_lat: userLat.toString(),
+        user_lon: userLon.toString(),
+        days: days.toString(),
+        max_distance_km: maxDistanceKm.toString(),
+      });
 
-      const response = await fetch(url.toString());
+      const response = await fetch(`/api/emagram/history?${params}`);
 
       if (!response.ok) {
         throw new Error(
@@ -104,7 +100,7 @@ export function useTriggerEmagram() {
       user_longitude?: number;
       force_refresh?: boolean;
     }): Promise<EmagramAnalysis> => {
-      const response = await fetch(`${API_BASE}/api/emagram/analyze`, {
+      const response = await fetch('/api/emagram/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),


### PR DESCRIPTION
## Summary
- Replace hardcoded `hostname:8001` absolute URLs with relative `/api/...` paths in emagram hooks, EmagramWidget, and FlightViewer3D
- Fixes emagram and flight video export not loading when accessing the app from outside the local network (behind reverse proxy)
- Aligns these components with the rest of the app which already uses relative URLs via `ky`

## Test plan
- [ ] Verify emagram loads correctly in dev mode (`pnpm dev`)
- [ ] Verify emagram loads correctly behind the reverse proxy (external access)
- [ ] Verify emagram screenshots links work
- [ ] Verify flight video export/download works behind reverse proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced API communication stability by updating URL path handling across multiple frontend components to use standardized relative paths. This replaces environment-dependent endpoint construction with a more reliable and flexible approach that ensures consistent performance regardless of deployment configuration, server location, or browser environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->