### PR TITLE
fix(strava): make end date inclusive when importing activities

### DIFF
--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -372,7 +372,7 @@ async def get_activities_by_period(
     try:
         # Convertir dates en timestamps Unix
         from_dt = datetime.strptime(date_from, "%Y-%m-%d")
-        to_dt = datetime.strptime(date_to, "%Y-%m-%d")
+        to_dt = datetime.strptime(date_to, "%Y-%m-%d") + timedelta(days=1)
 
         after_timestamp = int(from_dt.timestamp())
         before_timestamp = int(to_dt.timestamp())

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -23,6 +23,7 @@ import pytest
 from strava import (
     download_gpx,
     get_access_token,
+    get_activities_by_period,
     get_activity_details,
     parse_gpx,
     refresh_access_token,
@@ -513,3 +514,51 @@ def test_streams_to_gpx_mismatched_arrays():
     assert gpx_content is not None
     assert "<trkpt" in gpx_content
     # Should handle mismatched lengths gracefully
+
+
+# ============================================================================
+# GET ACTIVITIES BY PERIOD TESTS
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_activities_by_period_end_date_is_inclusive():
+    """Test that date_to is inclusive: before timestamp should be midnight of the next day"""
+
+    mock_activity = {
+        "id": 999,
+        "name": "Evening Flight",
+        "type": "Workout",
+        "start_date_local": "2026-03-15T18:00:00Z",
+    }
+
+    captured_params = {}
+
+    async def mock_get(url, **kwargs):
+        if not captured_params:
+            captured_params.update(kwargs.get("params", {}))
+            return MagicMock(
+                status_code=200,
+                json=MagicMock(return_value=[mock_activity]),
+                raise_for_status=MagicMock(),
+            )
+        return MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=[]),
+            raise_for_status=MagicMock(),
+        )
+
+    with (
+        patch("strava.get_access_token", new=AsyncMock(return_value="test_token")),
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(side_effect=mock_get)
+
+        await get_activities_by_period("2026-03-01", "2026-03-15")
+
+    # "before" should be 2026-03-16 00:00:00, not 2026-03-15 00:00:00
+    expected_before = int(datetime(2026, 3, 16).timestamp())
+    expected_after = int(datetime(2026, 3, 1).timestamp())
+
+    assert captured_params["after"] == expected_after
+    assert captured_params["before"] == expected_before


### PR DESCRIPTION
## Summary
- Le paramètre `before` de l'API Strava est exclusif : en parsant `date_to` comme minuit, les activités du dernier jour étaient exclues
- Ajout de `+ timedelta(days=1)` pour inclure la totalité de la journée de fin
- Ajout d'un test unitaire vérifiant que le timestamp `before` correspond bien à minuit du jour suivant

## Test plan
- [x] Test unitaire `test_get_activities_by_period_end_date_is_inclusive` ajouté et passant
- [x] Les 27 tests Strava existants passent toujours

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed date range handling for Strava activity queries—end dates are now treated as inclusive when fetching activities for a specified period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->