### PR TITLE
feat: scheduled Strava token refresh + Infrastructure page

### DIFF
--- a/apps/backend/app_settings.py
+++ b/apps/backend/app_settings.py
@@ -83,11 +83,15 @@ def set_setting(db: Session, key: str, value: str) -> None:
     logger.info(f"Setting updated: {key} = {value}")
 
 
+# Keys that must never be exposed via the public settings API
+_SENSITIVE_KEYS = {"strava_refresh_token"}
+
+
 def get_all_settings(db: Session) -> dict[str, str]:
-    """Read all settings as a dict."""
+    """Read all settings as a dict (sensitive keys excluded)."""
     if not _cache_loaded:
         reload_cache(db)
-    return dict(_settings_cache)
+    return {k: v for k, v in _settings_cache.items() if k not in _SENSITIVE_KEYS}
 
 
 def invalidate_cache() -> None:

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -20,7 +20,7 @@ import models  # noqa: F401 - imported for side effects (model registration)
 from database import Base, SessionLocal, engine
 from models import Site  # Needed for database initialization
 from routes import public_router, router
-from scheduler import start_scheduler, stop_scheduler
+from scheduler import scheduler, start_scheduler, stop_scheduler
 from webhooks import router as webhooks_router
 
 # Configure logging
@@ -556,6 +556,20 @@ async def lifespan(app: FastAPI):
 
         emagram_scheduler = setup_emagram_scheduler(app)
         start_emagram(emagram_scheduler)
+
+        # Strava token refresh every 4 hours
+        from apscheduler.triggers.interval import IntervalTrigger
+
+        from strava import refresh_access_token
+
+        scheduler.add_job(
+            refresh_access_token,
+            trigger=IntervalTrigger(hours=4),
+            id="strava_token_refresh",
+            name="Strava token refresh every 4h",
+            replace_existing=True,
+        )
+        logger.info("🔑 Strava token refresh scheduled (every 4h)")
 
         # Initial cache warmup (non-blocking)
         logger.info("🔥 Triggering initial cache warmup...")

--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -262,6 +262,18 @@ class WeatherSourceConfig(Base):
         return "active"  # All good
 
 
+class StravaTokenLog(Base):
+    """Log of Strava token refresh attempts"""
+
+    __tablename__ = "strava_token_logs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    timestamp = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+    success = Column(Boolean, nullable=False)
+    message = Column(String, nullable=True)
+    expires_at = Column(DateTime, nullable=True)
+
+
 class EmagramFeedback(Base):
     """Pilot feedback on emagram analysis accuracy"""
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4767,6 +4767,48 @@ async def debug_gemini_api():
 
 
 # ============================================================================
+# STRAVA TOKEN MANAGEMENT
+# ============================================================================
+
+
+@router.get("/admin/strava/token-status")
+def strava_token_status():
+    """Get current Strava token status."""
+    from strava import get_token_status
+
+    return get_token_status()
+
+
+@router.post("/admin/strava/refresh-token")
+async def strava_refresh_token():
+    """Force a manual Strava token refresh."""
+    from strava import get_token_status, refresh_access_token
+
+    token = await refresh_access_token()
+    status = get_token_status()
+    status["refreshed"] = token is not None
+    return status
+
+
+@router.get("/admin/strava/token-logs")
+def strava_token_logs(limit: int = 20, db: Session = Depends(get_db)):
+    """Get recent Strava token refresh logs."""
+    from models import StravaTokenLog
+
+    logs = db.query(StravaTokenLog).order_by(StravaTokenLog.timestamp.desc()).limit(limit).all()
+    return [
+        {
+            "id": log.id,
+            "timestamp": log.timestamp.isoformat(),
+            "success": log.success,
+            "message": log.message,
+            "expires_at": log.expires_at.isoformat() if log.expires_at else None,
+        }
+        for log in logs
+    ]
+
+
+# ============================================================================
 # APP SETTINGS
 # ============================================================================
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4781,17 +4781,22 @@ def strava_token_status():
 
 @router.post("/admin/strava/refresh-token")
 async def strava_refresh_token():
-    """Force a manual Strava token refresh."""
+    """Force a manual Strava token refresh (bypasses the 'still valid' check)."""
     from strava import get_token_status, refresh_access_token
 
-    token = await refresh_access_token()
+    token = await refresh_access_token(force=True)
+    if token is None:
+        raise HTTPException(status_code=502, detail="Strava token refresh failed")
     status = get_token_status()
-    status["refreshed"] = token is not None
+    status["refreshed"] = True
     return status
 
 
 @router.get("/admin/strava/token-logs")
-def strava_token_logs(limit: int = 20, db: Session = Depends(get_db)):
+def strava_token_logs(
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
     """Get recent Strava token refresh logs."""
     from models import StravaTokenLog
 
@@ -4799,10 +4804,10 @@ def strava_token_logs(limit: int = 20, db: Session = Depends(get_db)):
     return [
         {
             "id": log.id,
-            "timestamp": log.timestamp.isoformat(),
+            "timestamp": log.timestamp.isoformat() + "Z",
             "success": log.success,
             "message": log.message,
-            "expires_at": log.expires_at.isoformat() if log.expires_at else None,
+            "expires_at": log.expires_at.isoformat() + "Z" if log.expires_at else None,
         }
         for log in logs
     ]

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -140,7 +140,12 @@ async def refresh_access_token(force: bool = False) -> str | None:
         _token_expires_at = datetime.fromtimestamp(data["expires_at"])
 
         # Persist the new refresh token to DB
-        _persist_refresh_token(_refresh_token)
+        try:
+            _persist_refresh_token(_refresh_token)
+        except Exception as e:
+            # If persistence fails in an environment without migrations applied yet
+            # (for example during unit tests), keep the in-memory token working.
+            logger.warning(f"Could not persist refresh token: {e}")
 
         msg = f"Access token refreshed (expires at {_token_expires_at})"
         logger.info(f"✅ {msg}")

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -32,10 +32,59 @@ _token_expires_at = None
 _refresh_token = None
 
 
+def _get_persisted_refresh_token() -> str | None:
+    """Read the refresh token from DB (app_settings), fallback to env."""
+    try:
+        from app_settings import get_setting
+        from database import get_db_context
+
+        with get_db_context() as db:
+            persisted = get_setting("strava_refresh_token", db=db)
+            if persisted:
+                logger.info("Using persisted refresh token from DB")
+                return persisted
+    except Exception as e:
+        logger.warning(f"Could not read persisted refresh token: {e}")
+    return STRAVA_REFRESH_TOKEN
+
+
+def _persist_refresh_token(token: str) -> None:
+    """Save the new refresh token to DB so it survives restarts."""
+    try:
+        from app_settings import set_setting
+        from database import get_db_context
+
+        with get_db_context() as db:
+            set_setting(db, "strava_refresh_token", token)
+        logger.info("Refresh token persisted to DB")
+    except Exception as e:
+        logger.warning(f"Could not persist refresh token: {e}")
+
+
+def _log_token_refresh(success: bool, message: str, expires_at: datetime | None = None) -> None:
+    """Insert a StravaTokenLog entry."""
+    try:
+        from database import get_db_context
+        from models import StravaTokenLog
+
+        with get_db_context() as db:
+            log = StravaTokenLog(
+                success=success,
+                message=message,
+                expires_at=expires_at,
+            )
+            db.add(log)
+            db.commit()
+    except Exception as e:
+        logger.warning(f"Could not log token refresh: {e}")
+
+
 async def refresh_access_token() -> str | None:
     """
-    Refresh Strava access token
-    Based on logic from /home/capic/.openclaw/scripts/refresh-strava-token-daytime.js
+    Refresh Strava access token.
+
+    Token priority: in-memory → DB (app_settings) → env (.env).
+    After refresh, persists new refresh_token to DB and logs the attempt.
 
     Returns:
         New access token or None on error
@@ -48,21 +97,24 @@ async def refresh_access_token() -> str | None:
             logger.info("Access token still valid")
             return _access_token
 
-    # Refresh token
-    if not STRAVA_REFRESH_TOKEN:
-        logger.error("STRAVA_REFRESH_TOKEN not set in environment")
+    # Resolve the refresh token: in-memory → DB → env
+    current_refresh_token = _refresh_token or _get_persisted_refresh_token()
+
+    if not current_refresh_token:
+        msg = "No refresh token available (not in memory, DB, or env)"
+        logger.error(msg)
+        _log_token_refresh(False, msg)
         return None
 
     if not STRAVA_CLIENT_ID or not STRAVA_CLIENT_SECRET:
-        logger.error(
-            f"Missing Strava credentials: CLIENT_ID={STRAVA_CLIENT_ID}, CLIENT_SECRET={'***' if STRAVA_CLIENT_SECRET else None}"
-        )
+        msg = f"Missing Strava credentials: CLIENT_ID={STRAVA_CLIENT_ID}, CLIENT_SECRET={'***' if STRAVA_CLIENT_SECRET else None}"
+        logger.error(msg)
+        _log_token_refresh(False, msg)
         return None
 
     try:
         logger.info("Refreshing Strava access token...")
         logger.debug(f"Using CLIENT_ID: {STRAVA_CLIENT_ID}")
-        logger.debug(f"Using REFRESH_TOKEN: {STRAVA_REFRESH_TOKEN[:10]}...")
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
@@ -71,7 +123,7 @@ async def refresh_access_token() -> str | None:
                     "client_id": STRAVA_CLIENT_ID,
                     "client_secret": STRAVA_CLIENT_SECRET,
                     "grant_type": "refresh_token",
-                    "refresh_token": _refresh_token or STRAVA_REFRESH_TOKEN,
+                    "refresh_token": current_refresh_token,
                 },
             )
 
@@ -83,19 +135,38 @@ async def refresh_access_token() -> str | None:
         _refresh_token = data["refresh_token"]
         _token_expires_at = datetime.fromtimestamp(data["expires_at"])
 
-        logger.info(f"✅ Access token refreshed (expires at {_token_expires_at})")
+        # Persist the new refresh token to DB
+        _persist_refresh_token(_refresh_token)
+
+        msg = f"Access token refreshed (expires at {_token_expires_at})"
+        logger.info(f"✅ {msg}")
+        _log_token_refresh(True, msg, _token_expires_at)
 
         return _access_token
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"Strava API error (HTTP {e.response.status_code}): {e.response.text}")
+        msg = f"Strava API error (HTTP {e.response.status_code}): {e.response.text}"
+        logger.error(msg)
+        _log_token_refresh(False, msg)
         return None
     except Exception as e:
-        logger.error(f"Failed to refresh token: {type(e).__name__}: {e}")
+        msg = f"Failed to refresh token: {type(e).__name__}: {e}"
+        logger.error(msg)
         import traceback
 
         logger.error(traceback.format_exc())
+        _log_token_refresh(False, msg)
         return None
+
+
+def get_token_status() -> dict:
+    """Return the current Strava token status for the UI."""
+    now = datetime.now()
+    valid = bool(_access_token and _token_expires_at and now < _token_expires_at)
+    return {
+        "valid": valid,
+        "expires_at": _token_expires_at.isoformat() if _token_expires_at else None,
+    }
 
 
 async def get_access_token() -> str | None:

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -49,16 +49,17 @@ def _get_persisted_refresh_token() -> str | None:
 
 
 def _persist_refresh_token(token: str) -> None:
-    """Save the new refresh token to DB so it survives restarts."""
-    try:
-        from app_settings import set_setting
-        from database import get_db_context
+    """Save the new refresh token to DB so it survives restarts.
 
-        with get_db_context() as db:
-            set_setting(db, "strava_refresh_token", token)
-        logger.info("Refresh token persisted to DB")
-    except Exception as e:
-        logger.warning(f"Could not persist refresh token: {e}")
+    Raises on failure — a lost refresh token means permanent auth failure
+    after restart since Strava rotates tokens on each exchange.
+    """
+    from app_settings import set_setting
+    from database import get_db_context
+
+    with get_db_context() as db:
+        set_setting(db, "strava_refresh_token", token)
+    logger.info("Refresh token persisted to DB")
 
 
 def _log_token_refresh(success: bool, message: str, expires_at: datetime | None = None) -> None:
@@ -79,20 +80,23 @@ def _log_token_refresh(success: bool, message: str, expires_at: datetime | None 
         logger.warning(f"Could not log token refresh: {e}")
 
 
-async def refresh_access_token() -> str | None:
+async def refresh_access_token(force: bool = False) -> str | None:
     """
     Refresh Strava access token.
 
     Token priority: in-memory → DB (app_settings) → env (.env).
     After refresh, persists new refresh_token to DB and logs the attempt.
 
+    Args:
+        force: If True, skip the "still valid" check and always refresh.
+
     Returns:
         New access token or None on error
     """
     global _access_token, _token_expires_at, _refresh_token
 
-    # Check if token is still valid (with 5 min buffer)
-    if _access_token and _token_expires_at:
+    # Check if token is still valid (with 5 min buffer) — skip when forced
+    if not force and _access_token and _token_expires_at:
         if datetime.now() < _token_expires_at - timedelta(minutes=5):
             logger.info("Access token still valid")
             return _access_token

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -71,6 +71,44 @@ async def test_refresh_access_token_success():
 
 
 @pytest.mark.asyncio
+async def test_refresh_access_token_ignores_persist_failure(caplog):
+    """Test token refresh still works if token persistence fails"""
+
+    mock_response = {
+        "access_token": "fallback_access_token",
+        "refresh_token": "fallback_refresh_token",
+        "expires_at": int((datetime.now() + timedelta(hours=6)).timestamp()),
+    }
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava.STRAVA_REFRESH_TOKEN", "test_refresh_token"),
+        patch("strava._persist_refresh_token") as mock_persist,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_persist.side_effect = RuntimeError("no such table: app_settings")
+
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=MagicMock(status_code=200, json=MagicMock(return_value=mock_response))
+        )
+
+        import strava
+
+        strava._access_token = None
+        strava._token_expires_at = None
+
+        with caplog.at_level("WARNING"):
+            token = await refresh_access_token()
+
+        assert token == "fallback_access_token"
+        assert strava._access_token == "fallback_access_token"
+        assert strava._refresh_token == "fallback_refresh_token"
+        assert mock_persist.call_count == 1
+        assert any("Could not persist refresh token" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_refresh_access_token_uses_cached():
     """Test that cached token is used when still valid"""
 

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -44,8 +44,8 @@ export default function Header() {
             <Link to="/settings" className={linkClass}>
               {t('header.settings')}
             </Link>
-            <Link to="/cache" className={linkClass}>
-              {t('header.cache')}
+            <Link to="/infrastructure" className={linkClass}>
+              {t('header.infrastructure')}
             </Link>
             <a
               href="http://portainer.local:9000"

--- a/apps/frontend/src/hooks/admin/useStravaToken.ts
+++ b/apps/frontend/src/hooks/admin/useStravaToken.ts
@@ -1,0 +1,72 @@
+/**
+ * React Query hooks for Strava token management endpoints
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+import { api } from '../../lib/api';
+
+// --- Zod schemas ---
+
+const TokenStatusSchema = z.object({
+  valid: z.boolean(),
+  expires_at: z.string().nullable(),
+});
+
+const TokenRefreshResponseSchema = TokenStatusSchema.extend({
+  refreshed: z.boolean(),
+});
+
+const TokenLogSchema = z.object({
+  id: z.number(),
+  timestamp: z.string(),
+  success: z.boolean(),
+  message: z.string().nullable(),
+  expires_at: z.string().nullable(),
+});
+
+// --- Inferred types ---
+
+export type TokenLog = z.infer<typeof TokenLogSchema>;
+
+// --- Hooks ---
+
+export const useStravaTokenStatus = () => {
+  return useQuery({
+    queryKey: ['admin-strava-token-status'],
+    queryFn: async () => {
+      const data = await api.get('admin/strava/token-status').json();
+      return TokenStatusSchema.parse(data);
+    },
+    refetchInterval: 60_000,
+  });
+};
+
+export const useStravaTokenLogs = (limit = 20) => {
+  return useQuery({
+    queryKey: ['admin-strava-token-logs', limit],
+    queryFn: async () => {
+      const data = await api
+        .get('admin/strava/token-logs', { searchParams: { limit } })
+        .json();
+      return z.array(TokenLogSchema).parse(data);
+    },
+  });
+};
+
+export const useStravaRefreshToken = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const data = await api.post('admin/strava/refresh-token').json();
+      return TokenRefreshResponseSchema.parse(data);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['admin-strava-token-status'],
+      });
+      queryClient.invalidateQueries({ queryKey: ['admin-strava-token-logs'] });
+    },
+  });
+};

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -537,7 +537,11 @@
       "refreshSuccess": "Token refreshed successfully",
       "refreshError": "Token refresh failed",
       "logs": "Refresh history",
-      "noLogs": "No history"
+      "noLogs": "No history",
+      "date": "Date",
+      "message": "Message",
+      "ok": "OK",
+      "fail": "Fail"
     }
   }
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -6,7 +6,7 @@
     "analytics": "Analytics",
     "sites": "Sites",
     "settings": "Settings",
-    "cache": "Cache",
+    "infrastructure": "Infrastructure",
     "weather": "Weather",
     "login": "Login",
     "logout": "Logout"
@@ -518,5 +518,23 @@
     "keyDetail": "Key Detail",
     "cachedAt": "Cached At",
     "truncatedWarning": "Display limited to the first 500 keys. The cache contains more entries."
+  },
+  "infrastructure": {
+    "title": "Infrastructure",
+    "strava": {
+      "title": "Strava Token",
+      "status": "Status",
+      "valid": "Valid",
+      "expired": "Expired",
+      "unknown": "Unknown",
+      "expiresAt": "Expires at",
+      "lastRefresh": "Last refresh",
+      "refresh": "Refresh token",
+      "refreshing": "Refreshing...",
+      "refreshSuccess": "Token refreshed successfully",
+      "refreshError": "Token refresh failed",
+      "logs": "Refresh history",
+      "noLogs": "No history"
+    }
   }
 }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -537,7 +537,11 @@
       "refreshSuccess": "Token rafraîchi avec succès",
       "refreshError": "Échec du rafraîchissement",
       "logs": "Historique des refresh",
-      "noLogs": "Aucun historique"
+      "noLogs": "Aucun historique",
+      "date": "Date",
+      "message": "Message",
+      "ok": "OK",
+      "fail": "Echec"
     }
   }
 }

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -6,7 +6,7 @@
     "analytics": "Analyses",
     "sites": "Sites",
     "settings": "Paramètres",
-    "cache": "Cache",
+    "infrastructure": "Infrastructure",
     "weather": "Météo",
     "login": "Connexion",
     "logout": "Déconnexion"
@@ -518,5 +518,23 @@
     "keyDetail": "Détail de la clé",
     "cachedAt": "Mis en cache le",
     "truncatedWarning": "Affichage limité aux 500 premières clés. Le cache contient plus d'entrées."
+  },
+  "infrastructure": {
+    "title": "Infrastructure",
+    "strava": {
+      "title": "Token Strava",
+      "status": "Statut",
+      "valid": "Valide",
+      "expired": "Expiré",
+      "unknown": "Inconnu",
+      "expiresAt": "Expire le",
+      "lastRefresh": "Dernier refresh",
+      "refresh": "Rafraîchir le token",
+      "refreshing": "Rafraîchissement...",
+      "refreshSuccess": "Token rafraîchi avec succès",
+      "refreshError": "Échec du rafraîchissement",
+      "logs": "Historique des refresh",
+      "noLogs": "Aucun historique"
+    }
   }
 }

--- a/apps/frontend/src/pages/CacheViewer.chromatic.stories.tsx
+++ b/apps/frontend/src/pages/CacheViewer.chromatic.stories.tsx
@@ -4,7 +4,7 @@ import { Default } from './CacheViewer.stories.tsx';
 import { defaultHandlers } from './CacheViewer.stories.handlers';
 
 const meta = preview.meta({
-  title: 'Pages/CacheViewer/Chromatic',
+  title: 'Pages/Infrastructure/Chromatic',
   parameters: {
     layout: 'padded',
     chromatic: {
@@ -15,7 +15,7 @@ const meta = preview.meta({
   tags: ['!autodocs'],
 });
 
-export const CacheViewerChromatic = meta.story({
+export const InfrastructureChromatic = meta.story({
   render: () => (
     <div className="flex flex-col gap-2">
       <FigureWrapper title={Default.composed.name}>

--- a/apps/frontend/src/pages/CacheViewer.stories.handlers.ts
+++ b/apps/frontend/src/pages/CacheViewer.stories.handlers.ts
@@ -86,26 +86,33 @@ const initialEntries: CacheEntry[] = [
 
 export const cacheDb: CacheEntry[] = [...initialEntries];
 
-// --- Strava token mock data ---
+// --- Strava token mock state ---
+
+let stravaTokenState = {
+  valid: true,
+  expires_at: '2026-01-15T16:00:00Z',
+};
+
+let nextLogId = 4;
 
 const stravaTokenLogs: TokenLog[] = [
   {
     id: 3,
-    timestamp: '2026-01-15T10:00:00',
+    timestamp: '2026-01-15T10:00:00Z',
     success: true,
     message: 'Access token refreshed (expires at 2026-01-15 16:00:00)',
-    expires_at: '2026-01-15T16:00:00',
+    expires_at: '2026-01-15T16:00:00Z',
   },
   {
     id: 2,
-    timestamp: '2026-01-15T06:00:00',
+    timestamp: '2026-01-15T06:00:00Z',
     success: true,
     message: 'Access token refreshed (expires at 2026-01-15 12:00:00)',
-    expires_at: '2026-01-15T12:00:00',
+    expires_at: '2026-01-15T12:00:00Z',
   },
   {
     id: 1,
-    timestamp: '2026-01-15T02:00:00',
+    timestamp: '2026-01-15T02:00:00Z',
     success: false,
     message:
       'Strava API error (HTTP 401): {"message":"Bad Request","errors":[]}',
@@ -113,9 +120,16 @@ const stravaTokenLogs: TokenLog[] = [
   },
 ];
 
+const initialStravaLogs = [...stravaTokenLogs];
+
 export const resetCacheDb = () => {
   cacheDb.length = 0;
   cacheDb.push(...initialEntries);
+  // Reset Strava state
+  stravaTokenState = { valid: true, expires_at: '2026-01-15T16:00:00Z' };
+  stravaTokenLogs.length = 0;
+  stravaTokenLogs.push(...initialStravaLogs);
+  nextLogId = 4;
 };
 
 // --- Helper: build overview response from cacheDb ---
@@ -155,43 +169,57 @@ function buildOverview() {
 
 const stravaHandlers = [
   http.get('*/api/admin/strava/token-status', () =>
-    HttpResponse.json({
-      valid: true,
-      expires_at: '2026-01-15T16:00:00',
-    })
+    HttpResponse.json(stravaTokenState)
   ),
 
   http.get('*/api/admin/strava/token-logs', () =>
     HttpResponse.json(stravaTokenLogs)
   ),
 
-  http.post('*/api/admin/strava/refresh-token', () =>
-    HttpResponse.json({
+  http.post('*/api/admin/strava/refresh-token', () => {
+    const newExpiry = '2026-01-15T22:00:00Z';
+    stravaTokenState = { valid: true, expires_at: newExpiry };
+    stravaTokenLogs.unshift({
+      id: nextLogId++,
+      timestamp: new Date().toISOString(),
+      success: true,
+      message: `Access token refreshed (expires at ${newExpiry})`,
+      expires_at: newExpiry,
+    });
+    return HttpResponse.json({
       valid: true,
-      expires_at: '2026-01-15T22:00:00',
+      expires_at: newExpiry,
       refreshed: true,
-    })
-  ),
+    });
+  }),
 ];
 
 export const stravaExpiredHandlers = [
   http.get('*/api/admin/strava/token-status', () =>
     HttpResponse.json({
       valid: false,
-      expires_at: '2026-01-14T10:00:00',
+      expires_at: '2026-01-14T10:00:00Z',
     })
   ),
 
   http.get('*/api/admin/strava/token-logs', () =>
-    HttpResponse.json([stravaTokenLogs[2]])
+    HttpResponse.json([
+      {
+        id: 1,
+        timestamp: '2026-01-15T02:00:00Z',
+        success: false,
+        message:
+          'Strava API error (HTTP 401): {"message":"Bad Request","errors":[]}',
+        expires_at: null,
+      },
+    ])
   ),
 
   http.post('*/api/admin/strava/refresh-token', () =>
-    HttpResponse.json({
-      valid: false,
-      expires_at: null,
-      refreshed: false,
-    })
+    HttpResponse.json(
+      { detail: 'Strava token refresh failed' },
+      { status: 502 }
+    )
   ),
 ];
 

--- a/apps/frontend/src/pages/CacheViewer.stories.handlers.ts
+++ b/apps/frontend/src/pages/CacheViewer.stories.handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import type { CacheKeyDetail } from '../hooks/admin/useCache';
+import type { TokenLog } from '../hooks/admin/useStravaToken';
 
 // --- In-memory cache database ---
 
@@ -85,6 +86,33 @@ const initialEntries: CacheEntry[] = [
 
 export const cacheDb: CacheEntry[] = [...initialEntries];
 
+// --- Strava token mock data ---
+
+const stravaTokenLogs: TokenLog[] = [
+  {
+    id: 3,
+    timestamp: '2026-01-15T10:00:00',
+    success: true,
+    message: 'Access token refreshed (expires at 2026-01-15 16:00:00)',
+    expires_at: '2026-01-15T16:00:00',
+  },
+  {
+    id: 2,
+    timestamp: '2026-01-15T06:00:00',
+    success: true,
+    message: 'Access token refreshed (expires at 2026-01-15 12:00:00)',
+    expires_at: '2026-01-15T12:00:00',
+  },
+  {
+    id: 1,
+    timestamp: '2026-01-15T02:00:00',
+    success: false,
+    message:
+      'Strava API error (HTTP 401): {"message":"Bad Request","errors":[]}',
+    expires_at: null,
+  },
+];
+
 export const resetCacheDb = () => {
   cacheDb.length = 0;
   cacheDb.push(...initialEntries);
@@ -123,7 +151,53 @@ function buildOverview() {
 
 // --- MSW handlers reading/modifying cacheDb ---
 
-export const defaultHandlers = [
+// --- Strava handlers ---
+
+const stravaHandlers = [
+  http.get('*/api/admin/strava/token-status', () =>
+    HttpResponse.json({
+      valid: true,
+      expires_at: '2026-01-15T16:00:00',
+    })
+  ),
+
+  http.get('*/api/admin/strava/token-logs', () =>
+    HttpResponse.json(stravaTokenLogs)
+  ),
+
+  http.post('*/api/admin/strava/refresh-token', () =>
+    HttpResponse.json({
+      valid: true,
+      expires_at: '2026-01-15T22:00:00',
+      refreshed: true,
+    })
+  ),
+];
+
+export const stravaExpiredHandlers = [
+  http.get('*/api/admin/strava/token-status', () =>
+    HttpResponse.json({
+      valid: false,
+      expires_at: '2026-01-14T10:00:00',
+    })
+  ),
+
+  http.get('*/api/admin/strava/token-logs', () =>
+    HttpResponse.json([stravaTokenLogs[2]])
+  ),
+
+  http.post('*/api/admin/strava/refresh-token', () =>
+    HttpResponse.json({
+      valid: false,
+      expires_at: null,
+      refreshed: false,
+    })
+  ),
+];
+
+// --- Combined handlers ---
+
+export const cacheHandlers = [
   http.get('*/api/admin/cache', () => HttpResponse.json(buildOverview())),
 
   http.get('*/api/admin/cache/:key', ({ request }) => {
@@ -181,3 +255,5 @@ export const defaultHandlers = [
     return HttpResponse.json({ success: true, keys_deleted: 0 });
   }),
 ];
+
+export const defaultHandlers = [...stravaHandlers, ...cacheHandlers];

--- a/apps/frontend/src/pages/CacheViewer.stories.tsx
+++ b/apps/frontend/src/pages/CacheViewer.stories.tsx
@@ -1,7 +1,9 @@
 import preview from '../../.storybook/preview';
-import CacheViewer from './CacheViewer';
+import InfrastructurePage from './InfrastructurePage';
 import {
   defaultHandlers,
+  stravaExpiredHandlers,
+  cacheHandlers,
   resetCacheDb,
   cacheDb,
 } from './CacheViewer.stories.handlers';
@@ -9,8 +11,8 @@ import {
 // --- Stories ---
 
 const meta = preview.meta({
-  title: 'Pages/CacheViewer',
-  component: CacheViewer,
+  title: 'Pages/Infrastructure',
+  component: InfrastructurePage,
   parameters: {
     layout: 'padded',
     msw: { handlers: defaultHandlers },
@@ -23,161 +25,13 @@ export const Default = meta.story({
   beforeEach: resetCacheDb,
 });
 
-/*
-Default.test('displays cache groups and key counts', async ({ canvas }) => {
-  await expect(await canvas.findByText('weather:forecast')).toBeInTheDocument();
-  await expect(await canvas.findByText('best_spot')).toBeInTheDocument();
-  await expect(await canvas.findByText('emagram:sounding')).toBeInTheDocument();
+export const TokenExpired = meta.story({
+  name: 'Token Expired',
+  beforeEach: resetCacheDb,
+  parameters: {
+    msw: { handlers: [...stravaExpiredHandlers, ...cacheHandlers] },
+  },
 });
-
-Default.test('can filter keys', async ({ canvas, userEvent }) => {
-  const input = await canvas.findByPlaceholderText(
-    i18n.t('cache.searchPlaceholder')
-  );
-  await userEvent.type(input, 'best_spot');
-
-  await expect(await canvas.findByText('best_spot')).toBeInTheDocument();
-  const forecastElements = canvas.queryAllByText('weather:forecast');
-  await expect(forecastElements).toHaveLength(0);
-});
-
-Default.test('can open key detail modal', async ({ canvas, userEvent }) => {
-  // Expand best_spot group
-  await userEvent.click(await canvas.findByText('best_spot'));
-
-  // Click view on first key
-  const viewButtons = await canvas.findAllByText(i18n.t('cache.view'));
-  await userEvent.click(viewButtons[0]);
-
-  // Modal should show key detail
-  const modal = await screen.findByRole('dialog');
-  await expect(
-    within(modal).getByText(i18n.t('cache.keyDetail'))
-  ).toBeInTheDocument();
-  await expect(
-    await within(modal).findByText('best_spot:day_0')
-  ).toBeInTheDocument();
-});
-
-Default.test('can delete a single key', async ({ canvas, userEvent }) => {
-  // Expand best_spot group
-  await userEvent.click(await canvas.findByText('best_spot'));
-
-  // Click delete on first key
-  const deleteButtons = await canvas.findAllByRole('button', {
-    name: i18n.t('cache.deleteKey'),
-  });
-  await userEvent.click(deleteButtons[0]);
-
-  // Confirm in alertdialog
-  const dialog = within(await screen.findByRole('alertdialog'));
-  await userEvent.click(
-    dialog.getByRole('button', { name: i18n.t('common.confirm') })
-  );
-
-  // best_spot group should now show 1 key
-  await expect(await canvas.findByText('best_spot')).toBeInTheDocument();
-});
-
-Default.test('can clear a group', async ({ canvas, userEvent }) => {
-  // Click "clear group" on weather:forecast (3 keys)
-  const clearButtons = await canvas.findAllByRole('button', {
-    name: i18n.t('cache.clearPattern'),
-  });
-  // weather:forecast is first alphabetically (before best_spot? no — best_spot < emagram < weather)
-  // Groups sorted: best_spot, emagram:sounding, weather:forecast → index 2
-  await userEvent.click(clearButtons[2]);
-
-  // Confirm in alertdialog
-  const dialog = within(await screen.findByRole('alertdialog'));
-  await userEvent.click(
-    dialog.getByRole('button', { name: i18n.t('common.confirm') })
-  );
-
-  // weather:forecast group should be gone, others remain
-  await expect(await canvas.findByText('best_spot')).toBeInTheDocument();
-  await expect(await canvas.findByText('emagram:sounding')).toBeInTheDocument();
-  await waitFor(() => {
-    expect(canvas.queryByText('weather:forecast')).toBeNull();
-  });
-});
-
-Default.test('can clear all cache', async ({ canvas, userEvent }) => {
-  await userEvent.click(
-    await canvas.findByRole('button', { name: i18n.t('cache.clearAll') })
-  );
-
-  // Confirm in alertdialog
-  const dialog = within(await screen.findByRole('alertdialog'));
-  await userEvent.click(
-    dialog.getByRole('button', { name: i18n.t('common.confirm') })
-  );
-
-  // Should show empty state
-  await expect(
-    await canvas.findByText(i18n.t('cache.noKeys'))
-  ).toBeInTheDocument();
-});
-
-Default.test('can refresh manually', async ({ canvas, userEvent }) => {
-  // Verify initial state
-  await expect(await canvas.findByText('weather:forecast')).toBeInTheDocument();
-
-  // Mutate cacheDb externally (simulate server-side change)
-  cacheDb.push({
-    key: 'weather:forecast:newkey',
-    ttl: 3600,
-    size: 1024,
-    value: JSON.stringify({
-      temperature: 25,
-      cached_at: '2026-01-15T12:00:00+00:00',
-    }),
-  });
-
-  // Click refresh
-  await userEvent.click(
-    await canvas.findByRole('button', { name: i18n.t('cache.refresh') })
-  );
-
-  // Expand weather:forecast to see the new key
-  await userEvent.click(await canvas.findByText('weather:forecast'));
-  await expect(
-    await canvas.findByText('weather:forecast:newkey')
-  ).toBeInTheDocument();
-});
-*/
-
-/*
-Default.test('auto-refresh updates data', async ({ canvas, userEvent }) => {
-  // Verify initial total keys
-  await expect(await canvas.findByText('6')).toBeInTheDocument();
-
-  // Enable auto-refresh
-  await userEvent.click(
-    await canvas.findByRole('checkbox', { name: i18n.t('cache.autoRefresh') })
-  );
-
-  // Mutate cacheDb externally (simulate server-side change)
-  cacheDb.push({
-    key: 'best_spot:day_3',
-    ttl: 1800,
-    size: 256,
-    value: JSON.stringify({
-      site: 'new',
-      cached_at: '2026-01-15T12:00:00+00:00',
-    }),
-  });
-
-  // Wait for auto-refresh to pick up the change (interval is 5s)
-  // Total keys should go from 6 to 7
-  await waitFor(
-    async () => {
-      await expect(await canvas.findByText('7')).toBeInTheDocument();
-    },
-    { timeout: 10000 }
-  );
-});
-*/
 
 export const Empty = meta.story({
   name: 'Empty Cache',

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -15,6 +15,13 @@ import {
   useDeleteCacheKey,
 } from '../hooks/admin/useCache';
 import type { CacheKeyInfo } from '../hooks/admin/useCache';
+import {
+  useStravaTokenStatus,
+  useStravaTokenLogs,
+  useStravaRefreshToken,
+} from '../hooks/admin/useStravaToken';
+
+// --- Helpers ---
 
 interface PendingConfirm {
   message: string;
@@ -37,7 +44,157 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-export default function CacheViewer() {
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+// =============================================================================
+// STRAVA TOKEN SECTION
+// =============================================================================
+
+function StravaTokenSection() {
+  const { t } = useTranslation();
+  const { data: status, isLoading: statusLoading } = useStravaTokenStatus();
+  const { data: logs, isLoading: logsLoading } = useStravaTokenLogs();
+  const refreshMutation = useStravaRefreshToken();
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+        {t('infrastructure.strava.title')}
+      </h3>
+
+      {/* Status card */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-wrap items-center gap-6">
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {t('infrastructure.strava.status')}:
+          </span>
+          {statusLoading ? (
+            <span className="text-sm text-gray-400">...</span>
+          ) : (
+            <span
+              className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                status?.valid
+                  ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300'
+                  : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300'
+              }`}
+            >
+              {status?.valid
+                ? t('infrastructure.strava.valid')
+                : t('infrastructure.strava.expired')}
+            </span>
+          )}
+        </div>
+
+        {status?.expires_at && (
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-gray-500 dark:text-gray-400">
+              {t('infrastructure.strava.expiresAt')}:
+            </span>
+            <span className="text-gray-800 dark:text-gray-200">
+              {formatDate(status.expires_at)}
+            </span>
+          </div>
+        )}
+
+        <Button
+          onPress={() => refreshMutation.mutate()}
+          isDisabled={refreshMutation.isPending}
+          className="ml-auto px-3 py-1.5 rounded-md bg-orange-500 text-white text-sm hover:bg-orange-600 transition-colors disabled:opacity-50 cursor-pointer"
+        >
+          {refreshMutation.isPending
+            ? t('infrastructure.strava.refreshing')
+            : t('infrastructure.strava.refresh')}
+        </Button>
+      </div>
+
+      {/* Refresh success/error feedback */}
+      {refreshMutation.isSuccess && (
+        <div className="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 rounded-xl p-3 text-sm text-green-800 dark:text-green-200">
+          {t('infrastructure.strava.refreshSuccess')}
+        </div>
+      )}
+      {refreshMutation.isError && (
+        <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700 rounded-xl p-3 text-sm text-red-800 dark:text-red-200">
+          {t('infrastructure.strava.refreshError')}
+        </div>
+      )}
+
+      {/* Logs table */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {t('infrastructure.strava.logs')}
+          </h4>
+        </div>
+        {logsLoading ? (
+          <div className="p-4 text-sm text-gray-400">...</div>
+        ) : !logs || logs.length === 0 ? (
+          <div className="p-4 text-sm text-gray-500 dark:text-gray-400 text-center">
+            {t('infrastructure.strava.noLogs')}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 dark:bg-gray-900/50 text-left">
+                  <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
+                    Date
+                  </th>
+                  <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
+                    {t('infrastructure.strava.status')}
+                  </th>
+                  <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
+                    Message
+                  </th>
+                  <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
+                    {t('infrastructure.strava.expiresAt')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log) => (
+                  <tr
+                    key={log.id}
+                    className="border-t border-gray-100 dark:border-gray-700/50"
+                  >
+                    <td className="px-4 py-2 text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                      {formatDate(log.timestamp)}
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                          log.success
+                            ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300'
+                            : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300'
+                        }`}
+                      >
+                        {log.success ? 'OK' : 'FAIL'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400 text-xs max-w-md truncate">
+                      {log.message}
+                    </td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                      {log.expires_at ? formatDate(log.expires_at) : '—'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// CACHE SECTION (former CacheViewer)
+// =============================================================================
+
+function CacheSection() {
   const { t } = useTranslation();
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [searchFilter, setSearchFilter] = useState('');
@@ -105,10 +262,10 @@ export default function CacheViewer() {
   };
 
   return (
-    <div className="py-4 space-y-4">
-      <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
         {t('cache.title')}
-      </h2>
+      </h3>
 
       {/* Stats bar */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -325,6 +482,29 @@ export default function CacheViewer() {
     </div>
   );
 }
+
+// =============================================================================
+// MAIN PAGE
+// =============================================================================
+
+export default function InfrastructurePage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="py-4 space-y-8">
+      <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
+        {t('infrastructure.title')}
+      </h2>
+
+      <StravaTokenSection />
+      <CacheSection />
+    </div>
+  );
+}
+
+// =============================================================================
+// CACHE GROUP TABLE (unchanged)
+// =============================================================================
 
 const columnHelper = createColumnHelper<CacheKeyInfo>();
 

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -55,9 +55,35 @@ function formatDate(iso: string): string {
 
 function StravaTokenSection() {
   const { t } = useTranslation();
-  const { data: status, isLoading: statusLoading } = useStravaTokenStatus();
+  const {
+    data: status,
+    isLoading: statusLoading,
+    isError: statusError,
+  } = useStravaTokenStatus();
   const { data: logs, isLoading: logsLoading } = useStravaTokenLogs();
   const refreshMutation = useStravaRefreshToken();
+
+  const statusBadge = (() => {
+    if (statusLoading) return null;
+    if (statusError || !status) {
+      return {
+        className:
+          'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+        label: t('infrastructure.strava.unknown'),
+      };
+    }
+    return status.valid
+      ? {
+          className:
+            'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300',
+          label: t('infrastructure.strava.valid'),
+        }
+      : {
+          className:
+            'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300',
+          label: t('infrastructure.strava.expired'),
+        };
+  })();
 
   return (
     <div className="space-y-4">
@@ -73,19 +99,13 @@ function StravaTokenSection() {
           </span>
           {statusLoading ? (
             <span className="text-sm text-gray-400">...</span>
-          ) : (
+          ) : statusBadge ? (
             <span
-              className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                status?.valid
-                  ? 'bg-green-100 dark:bg-green-900 text-green-700 dark:text-green-300'
-                  : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300'
-              }`}
+              className={`px-2 py-0.5 rounded-full text-xs font-medium ${statusBadge.className}`}
             >
-              {status?.valid
-                ? t('infrastructure.strava.valid')
-                : t('infrastructure.strava.expired')}
+              {statusBadge.label}
             </span>
-          )}
+          ) : null}
         </div>
 
         {status?.expires_at && (
@@ -141,13 +161,13 @@ function StravaTokenSection() {
               <thead>
                 <tr className="bg-gray-50 dark:bg-gray-900/50 text-left">
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
-                    Date
+                    {t('infrastructure.strava.date')}
                   </th>
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
                     {t('infrastructure.strava.status')}
                   </th>
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
-                    Message
+                    {t('infrastructure.strava.message')}
                   </th>
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
                     {t('infrastructure.strava.expiresAt')}
@@ -171,7 +191,9 @@ function StravaTokenSection() {
                             : 'bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300'
                         }`}
                       >
-                        {log.success ? 'OK' : 'FAIL'}
+                        {log.success
+                          ? t('infrastructure.strava.ok')
+                          : t('infrastructure.strava.fail')}
                       </span>
                     </td>
                     <td className="px-4 py-2 text-gray-600 dark:text-gray-400 text-xs max-w-md truncate">

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -16,7 +16,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as FlightsRouteImport } from './routes/flights'
 import { Route as ExportViewerRouteImport } from './routes/export-viewer'
-import { Route as CacheRouteImport } from './routes/cache'
+import { Route as InfrastructureRouteImport } from './routes/infrastructure'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ViewerFlightIdRouteImport } from './routes/viewer.$flightId'
@@ -56,11 +56,11 @@ const ExportViewerRoute = ExportViewerRouteImport.update({
   path: '/export-viewer',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/export-viewer.lazy').then((d) => d.Route))
-const CacheRoute = CacheRouteImport.update({
-  id: '/cache',
-  path: '/cache',
+const InfrastructureRoute = InfrastructureRouteImport.update({
+  id: '/infrastructure',
+  path: '/infrastructure',
   getParentRoute: () => rootRouteImport,
-} as any).lazy(() => import('./routes/cache.lazy').then((d) => d.Route))
+} as any).lazy(() => import('./routes/infrastructure.lazy').then((d) => d.Route))
 const AnalyticsRoute = AnalyticsRouteImport.update({
   id: '/analytics',
   path: '/analytics',
@@ -82,7 +82,7 @@ const ViewerFlightIdRoute = ViewerFlightIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/cache': typeof CacheRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
   '/login': typeof LoginRoute
@@ -95,7 +95,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/cache': typeof CacheRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
   '/login': typeof LoginRoute
@@ -109,7 +109,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/cache': typeof CacheRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
   '/login': typeof LoginRoute
@@ -124,7 +124,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/analytics'
-    | '/cache'
+    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
     | '/login'
@@ -137,7 +137,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/analytics'
-    | '/cache'
+    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
     | '/login'
@@ -150,7 +150,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/analytics'
-    | '/cache'
+    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
     | '/login'
@@ -164,7 +164,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AnalyticsRoute: typeof AnalyticsRoute
-  CacheRoute: typeof CacheRoute
+  InfrastructureRoute: typeof InfrastructureRoute
   ExportViewerRoute: typeof ExportViewerRoute
   FlightsRoute: typeof FlightsRoute
   LoginRoute: typeof LoginRoute
@@ -226,11 +226,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ExportViewerRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/cache': {
-      id: '/cache'
-      path: '/cache'
-      fullPath: '/cache'
-      preLoaderRoute: typeof CacheRouteImport
+    '/infrastructure': {
+      id: '/infrastructure'
+      path: '/infrastructure'
+      fullPath: '/infrastructure'
+      preLoaderRoute: typeof InfrastructureRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/analytics': {
@@ -260,7 +260,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRoute,
-  CacheRoute: CacheRoute,
+  InfrastructureRoute: InfrastructureRoute,
   ExportViewerRoute: ExportViewerRoute,
   FlightsRoute: FlightsRoute,
   LoginRoute: LoginRoute,

--- a/apps/frontend/src/routes/cache.lazy.tsx
+++ b/apps/frontend/src/routes/cache.lazy.tsx
@@ -1,6 +1,0 @@
-import { createLazyFileRoute } from '@tanstack/react-router';
-import CacheViewer from '../pages/CacheViewer';
-
-export const Route = createLazyFileRoute('/cache')({
-  component: CacheViewer,
-});

--- a/apps/frontend/src/routes/infrastructure.lazy.tsx
+++ b/apps/frontend/src/routes/infrastructure.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import InfrastructurePage from '../pages/InfrastructurePage';
+
+export const Route = createLazyFileRoute('/infrastructure')({
+  component: InfrastructurePage,
+});

--- a/apps/frontend/src/routes/infrastructure.tsx
+++ b/apps/frontend/src/routes/infrastructure.tsx
@@ -3,7 +3,7 @@ import { queryClient } from '../lib/queryClient';
 import { cacheOverviewQueryOptions } from '../hooks/admin/useCache';
 import { requireAuth } from '../lib/authGuard';
 
-export const Route = createFileRoute('/cache')({
+export const Route = createFileRoute('/infrastructure')({
   beforeLoad: requireAuth,
   loader: async () => {
     await queryClient.ensureQueryData(cacheOverviewQueryOptions());


### PR DESCRIPTION
## Summary
- Add APScheduler job (every 4h) to proactively refresh the Strava access token, replacing the external cron that no longer exists
- Persist the refresh_token in DB (`app_settings` table) so it survives server restarts (Strava rotates refresh tokens on each use)
- Log all refresh attempts (success/failure) in a new `strava_token_logs` table
- Rename `/cache` route to `/infrastructure` and add a Strava token management section (status badge, expiration, manual refresh button, refresh history) above the existing Redis cache viewer
- Add 3 new API endpoints: `GET /admin/strava/token-status`, `POST /admin/strava/refresh-token`, `GET /admin/strava/token-logs`
- Add Storybook stories with MSW handlers for the new Strava section (Default + Token Expired variants)

## Test plan
- [ ] Backend starts and logs `Strava token refresh scheduled (every 4h)`
- [ ] Navigate to `/infrastructure` — both Strava and Cache sections render
- [ ] Click "Refresh token" — status updates, log entry appears
- [ ] Restart backend — refresh_token is recovered from DB, not `.env`
- [ ] `pytest apps/backend/tests/` — 422 tests pass
- [ ] `pnpm type-check` — no TypeScript errors
- [ ] Storybook renders `Pages/Infrastructure` stories correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic Strava token refresh job (every 4 hours) with persisted refresh history.
  * Infrastructure admin UI: view token status/expiry, trigger manual refresh, and browse refresh logs.

* **Changes**
  * Renamed "Cache" to "Infrastructure" across navigation, routes, pages, and translations.
  * Frontend hooks and validation added for Strava admin flows.
  * Sensitive settings (refresh token) excluded from settings output.

* **Tests / Stories**
  * Storybook updated with Infrastructure stories and Strava mock handlers; new unit test for refresh persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->