### PR TITLE
Refactor best-spot display in dashboard and weather page

### DIFF
--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery, useQueries } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import StatsPanel from '../components/dashboard/StatsPanel';
-import DaySelector from '../components/dashboard/DaySelector';
 import AllSitesConditions from '../components/dashboard/AllSitesConditions';
 import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
@@ -17,8 +15,7 @@ export default function Dashboard() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { data: sites } = useSuspenseQuery(sitesQueryOptions());
-  const [selectedDayIndex, setSelectedDayIndex] = useState(0);
-  const { data: bestSpot } = useBestSpotAPI(selectedDayIndex);
+  const { data: bestSpot } = useBestSpotAPI(0);
 
   // Fetch current weather for all sites (day 0), auto-refresh every hour
   const weatherQueries = useQueries({
@@ -69,18 +66,13 @@ export default function Dashboard() {
         {/* 1. Stats Panel */}
         <StatsPanel />
 
-        {/* 2. Day Selector + Best Spot */}
-        <DaySelector
-          selectedDayIndex={selectedDayIndex}
-          onSelectDay={setSelectedDayIndex}
-        />
-
+        {/* 2. Best Spot (Today) */}
         <BestSpotSuggestion
           bestSpot={bestSpot ?? null}
           onSelectSite={(siteId) =>
             void navigate({ to: '/weather', search: { siteId } })
           }
-          selectedDayIndex={selectedDayIndex}
+          selectedDayIndex={0}
         />
 
         {/* 3. Current Conditions - All Sites (auto-refresh hourly) */}

--- a/apps/frontend/src/pages/WeatherPage.chromatic.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.chromatic.stories.tsx
@@ -1,0 +1,30 @@
+import { FigureWrapper } from '../../.storybook/FigureWrapper.tsx';
+import preview from '../../.storybook/preview.tsx';
+import { Default, Loading, WeatherError } from './WeatherPage.stories.tsx';
+
+const meta = preview.meta({
+  title: 'Pages/WeatherPage/Chromatic',
+  parameters: {
+    layout: 'padded',
+    chromatic: {
+      disableSnapshot: false,
+    },
+  },
+  tags: ['!autodocs'],
+});
+
+export const WeatherPageChromatic = meta.story({
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <FigureWrapper title={Default.composed.name}>
+        <Default.Component />
+      </FigureWrapper>
+      <FigureWrapper title={Loading.composed.name}>
+        <Loading.Component />
+      </FigureWrapper>
+      <FigureWrapper title={WeatherError.composed.name}>
+        <WeatherError.Component />
+      </FigureWrapper>
+    </div>
+  ),
+});

--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -377,6 +377,13 @@ const mockBestSpotByDay: Record<number, typeof mockBestSpot> = {
 
 const defaultHandlers = [
   http.get('*/api/spots', () => HttpResponse.json(mockSites)),
+  http.get('*/api/spots/best', ({ request }) => {
+    const dayIndex = Number(
+      new URL(request.url).searchParams.get('day_index') || '0'
+    );
+
+    return HttpResponse.json(mockBestSpotByDay[dayIndex] ?? mockBestSpot);
+  }),
   http.get('*/api/spots/:id', ({ params }) => {
     const site = mockSites.sites.find((s) => s.id === params.id);
     return site
@@ -389,13 +396,6 @@ const defaultHandlers = [
   http.get('*/api/weather/site-chalais', () =>
     HttpResponse.json(mockWeatherChalais)
   ),
-  http.get('*/api/spots/best', ({ request }) => {
-    const dayIndex = Number(
-      new URL(request.url).searchParams.get('day_index') || '0'
-    );
-
-    return HttpResponse.json(mockBestSpotByDay[dayIndex] ?? mockBestSpot);
-  }),
   http.get('*/api/weather/:spotId/daily-summary', () =>
     HttpResponse.json(mockDailySummary)
   ),

--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -340,6 +340,41 @@ const mockLandingWeather = [
   },
 ];
 
+const mockBestSpot = {
+  site: {
+    id: 'site-arguel',
+    name: 'Arguel',
+    rating: 4,
+    orientation: 'SW',
+  },
+  paraIndex: 78,
+  windDirection: 'SW',
+  windSpeed: 12,
+  windFavorability: 'good',
+  score: 82,
+  verdict: 'BON',
+  reason: 'Bonnes conditions pour le vol.',
+  flyableSlot: '10h-17h',
+  thermalCeiling: 1850,
+  cached_at: '2025-06-15T08:30:00Z',
+};
+
+const mockBestSpotByDay: Record<number, typeof mockBestSpot> = {
+  0: mockBestSpot,
+  1: {
+    ...mockBestSpot,
+    score: 74,
+    paraIndex: 74,
+    reason: 'Prévisions stables demain.',
+  },
+  2: {
+    ...mockBestSpot,
+    score: 60,
+    paraIndex: 60,
+    reason: 'Conditions moyennes.',
+  },
+};
+
 const defaultHandlers = [
   http.get('*/api/spots', () => HttpResponse.json(mockSites)),
   http.get('*/api/spots/:id', ({ params }) => {
@@ -354,6 +389,13 @@ const defaultHandlers = [
   http.get('*/api/weather/site-chalais', () =>
     HttpResponse.json(mockWeatherChalais)
   ),
+  http.get('*/api/spots/best', ({ request }) => {
+    const dayIndex = Number(
+      new URL(request.url).searchParams.get('day_index') || '0'
+    );
+
+    return HttpResponse.json(mockBestSpotByDay[dayIndex] ?? mockBestSpot);
+  }),
   http.get('*/api/weather/:spotId/daily-summary', () =>
     HttpResponse.json(mockDailySummary)
   ),
@@ -391,9 +433,19 @@ export const Default = meta.story({
 
 Default.test(
   'renders weather page with site selector and conditions',
-  async ({ canvas }) => {
+  async ({ canvas, userEvent }) => {
     await canvas.findByText('Arguel');
     await expect(canvas.getByText('Chalais')).toBeInTheDocument();
+    await canvas.findByText(
+      /Meilleur spot pour aujourd'hui|Best spot for today/
+    );
+
+    const tomorrowButton = await canvas.findByRole('button', {
+      name: /\b85\b/,
+    });
+    await userEvent.click(tomorrowButton);
+
+    await canvas.findByText(/Meilleur spot pour demain|Best spot for tomorrow/);
   }
 );
 
@@ -413,6 +465,7 @@ WithSelectedSite.test(
   async ({ canvas }) => {
     await canvas.findByText('Chalais');
     await expect(canvas.getByText('Arguel')).toBeInTheDocument();
+    await canvas.findByText(/Best spot for|Meilleur spot pour/);
   }
 );
 
@@ -454,6 +507,7 @@ export const WeatherError = meta.story({
     router: weatherRouteConfig,
     msw: {
       handlers: [
+        http.get('*/api/spots/best', () => HttpResponse.json(mockBestSpot)),
         http.get('*/api/spots', () => HttpResponse.json(mockSites)),
         http.get('*/api/spots/:id', ({ params }) => {
           const site = mockSites.sites.find((s) => s.id === params.id);
@@ -488,6 +542,7 @@ WeatherError.test(
   async ({ canvas }) => {
     await canvas.findByText('Arguel');
     await expect(canvas.getByText('Chalais')).toBeInTheDocument();
+    await canvas.findByText(/Best spot for|Meilleur spot pour/);
   }
 );
 

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -8,9 +8,11 @@ import Forecast7Day from '../components/weather/Forecast7Day';
 import HourlyForecast from '../components/weather/HourlyForecast';
 import EmagramWidget from '../components/dashboard/EmagramWidget';
 import WeatherMultiLanding from '../components/weather/WeatherMultiLanding';
+import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import { useAuthStore } from '../stores/authStore';
 import { useNavigate } from '@tanstack/react-router';
+import { useBestSpotAPI } from '../hooks/weather/useBestSpotAPI';
 
 export default function WeatherPage() {
   const { t } = useTranslation();
@@ -19,6 +21,7 @@ export default function WeatherPage() {
   const search = useSearch({ from: '/weather' });
   const routeSiteId = search ? search.siteId : '';
   const [selectedDayIndex, setSelectedDayIndex] = useState(0);
+  const { data: bestSpot } = useBestSpotAPI(selectedDayIndex);
   const selectedSiteId =
     sites.find((site) => site.id === routeSiteId)?.id ?? sites[0]?.id ?? '';
 
@@ -61,6 +64,15 @@ export default function WeatherPage() {
             void navigate({ to: '/weather', search: { siteId } })
           }
           weatherData={weatherDataMap}
+        />
+
+        {/* Best Spot for selected day */}
+        <BestSpotSuggestion
+          bestSpot={bestSpot ?? null}
+          onSelectSite={(siteId) =>
+            void navigate({ to: '/weather', search: { siteId } })
+          }
+          selectedDayIndex={selectedDayIndex}
         />
 
         {/* Current Conditions */}


### PR DESCRIPTION
## Summary
- Remove day selection from dashboard best-spot and show today's best spot only.
- Add best-spot recommendation to Weather page tied to selected forecast day.
- Add weather page interaction test that switches day in 7-day forecast and verifies best-spot title updates.
- Add WeatherPage chromatic wrapper story to keep Storybook/Chromatic pairing consistent.

## Validation
- pnpm nx lint frontend
- pnpm exec vitest run --config vitest.config.ts --project storybook src/pages/Dashboard.stories.tsx src/pages/WeatherPage.stories.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WeatherPage now shows a day-specific "Best Spot" suggestion and lets you navigate to a chosen site.
  * Dashboard displays a "Best Spot" suggestion fixed to today.

* **Tests**
  * Added visual/regression story for WeatherPage.
  * Updated story tests and mocks to verify Best Spot rendering across states (default, tomorrow, error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->