### PR TITLE
feat(strava): add manual/automatic mode to token refresh logs

### DIFF
--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -272,6 +272,7 @@ class StravaTokenLog(Base):
     success = Column(Boolean, nullable=False)
     message = Column(String, nullable=True)
     expires_at = Column(DateTime, nullable=True)
+    refresh_mode = Column(String(32), nullable=True)
 
 
 class EmagramFeedback(Base):

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4942,6 +4942,7 @@ def strava_token_logs(
             "success": log.success,
             "message": log.message,
             "expires_at": log.expires_at.isoformat() + "Z" if log.expires_at else None,
+            "refresh_mode": log.refresh_mode,
         }
         for log in logs
     ]

--- a/apps/backend/sql_migrations/009_add_strava_token_refresh_mode.sql
+++ b/apps/backend/sql_migrations/009_add_strava_token_refresh_mode.sql
@@ -1,0 +1,2 @@
+-- Add refresh mode tracking for Strava token logs
+ALTER TABLE strava_token_logs ADD COLUMN refresh_mode TEXT;

--- a/apps/backend/sql_migrations/009_add_strava_token_refresh_mode.sql
+++ b/apps/backend/sql_migrations/009_add_strava_token_refresh_mode.sql
@@ -1,2 +1,4 @@
 -- Add refresh mode tracking for Strava token logs
-ALTER TABLE strava_token_logs ADD COLUMN refresh_mode TEXT;
+ALTER TABLE strava_token_logs
+ADD COLUMN refresh_mode TEXT
+CHECK (refresh_mode IN ('manual', 'automatic') OR refresh_mode IS NULL);

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -64,7 +64,12 @@ def _persist_refresh_token(token: str) -> None:
     logger.info("Refresh token persisted to DB")
 
 
-def _log_token_refresh(success: bool, message: str, expires_at: datetime | None = None) -> None:
+def _log_token_refresh(
+    success: bool,
+    message: str,
+    expires_at: datetime | None = None,
+    refresh_mode: str | None = None,
+) -> None:
     """Insert a StravaTokenLog entry."""
     try:
         from database import get_db_context
@@ -75,6 +80,7 @@ def _log_token_refresh(success: bool, message: str, expires_at: datetime | None 
                 success=success,
                 message=message,
                 expires_at=expires_at,
+                refresh_mode=refresh_mode,
             )
             db.add(log)
             db.commit()
@@ -98,6 +104,8 @@ async def refresh_access_token(force: bool = False) -> str | None:
     global _access_token, _token_expires_at, _refresh_token
 
     async with _refresh_lock:
+        refresh_mode = "manual" if force else "automatic"
+
         # Check if token is still valid (with 5 min buffer) — skip when forced
         if not force and _access_token and _token_expires_at:
             if datetime.now() < _token_expires_at - timedelta(minutes=5):
@@ -110,13 +118,13 @@ async def refresh_access_token(force: bool = False) -> str | None:
         if not current_refresh_token:
             msg = "No refresh token available (not in memory, DB, or env)"
             logger.error(msg)
-            _log_token_refresh(False, msg)
+            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
             return None
 
         if not STRAVA_CLIENT_ID or not STRAVA_CLIENT_SECRET:
             msg = f"Missing Strava credentials: CLIENT_ID={STRAVA_CLIENT_ID}, CLIENT_SECRET={'***' if STRAVA_CLIENT_SECRET else None}"
             logger.error(msg)
-            _log_token_refresh(False, msg)
+            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
             return None
 
         try:
@@ -151,14 +159,14 @@ async def refresh_access_token(force: bool = False) -> str | None:
 
             msg = f"Access token refreshed (expires at {new_token_expires_at})"
             logger.info(f"✅ {msg}")
-            _log_token_refresh(True, msg, new_token_expires_at)
+            _log_token_refresh(True, msg, new_token_expires_at, refresh_mode=refresh_mode)
 
             return _access_token
 
         except httpx.HTTPStatusError as e:
             msg = f"Strava API error (HTTP {e.response.status_code}): {e.response.text}"
             logger.error(msg)
-            _log_token_refresh(False, msg)
+            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
             return None
         except Exception as e:
             msg = f"Failed to refresh token: {type(e).__name__}: {e}"
@@ -166,7 +174,7 @@ async def refresh_access_token(force: bool = False) -> str | None:
             import traceback
 
             logger.error(traceback.format_exc())
-            _log_token_refresh(False, msg)
+            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
             return None
 
 

--- a/apps/backend/tests/test_admin.py
+++ b/apps/backend/tests/test_admin.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import pytest
 
-from models import EmagramAnalysis
+from models import EmagramAnalysis, StravaTokenLog
 
 
 class TestAdminEndpoints:
@@ -88,6 +88,27 @@ class TestAdminEndpoints:
         finally:
             # Restore original value
             config.GOOGLE_API_KEY = original_key
+
+    def test_strava_token_logs_include_refresh_mode(self, client, db_session):
+        """Token logs endpoint includes refresh mode for each entry."""
+
+        log = StravaTokenLog(
+            success=True,
+            message="Access token refreshed",
+            timestamp=datetime.utcnow(),
+            refresh_mode="manual",
+        )
+        db_session.add(log)
+        db_session.commit()
+
+        response = client.get("/api/admin/strava/token-logs")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["refresh_mode"] == "manual"
+        assert "timestamp" in data[0]
 
     @pytest.mark.integration
     def test_debug_gemini_with_api_key(self, client):

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -51,6 +51,7 @@ async def test_refresh_access_token_success():
         patch("strava.STRAVA_REFRESH_TOKEN", "test_refresh_token"),
         patch("strava._get_persisted_refresh_token", return_value="test_refresh_token"),
         patch("strava._persist_refresh_token") as mock_persist,
+        patch("strava._log_token_refresh") as mock_log,
         patch("strava.httpx.AsyncClient") as mock_client,
     ):
 
@@ -71,6 +72,44 @@ async def test_refresh_access_token_success():
         assert strava._refresh_token == "new_refresh_token_456"
         assert strava._token_expires_at is not None
         mock_persist.assert_called_once_with("new_refresh_token_456")
+        assert mock_log.call_count == 1
+        assert mock_log.call_args.kwargs.get("refresh_mode") == "automatic"
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_manual_mode_logged():
+    """Manual refresh uses refresh_mode='manual' in token logs."""
+
+    mock_response = {
+        "access_token": "manual_access_token",
+        "refresh_token": "manual_refresh_token",
+        "expires_at": int((datetime.now() + timedelta(hours=6)).timestamp()),
+    }
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava.STRAVA_REFRESH_TOKEN", "test_refresh_token"),
+        patch("strava._get_persisted_refresh_token", return_value="test_refresh_token"),
+        patch("strava._persist_refresh_token"),
+        patch("strava._log_token_refresh") as mock_log,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+            return_value=MagicMock(status_code=200, json=MagicMock(return_value=mock_response))
+        )
+
+        import strava
+
+        strava._access_token = None
+        strava._token_expires_at = None
+        strava._refresh_token = None
+
+        token = await refresh_access_token(force=True)
+
+        assert token == "manual_access_token"
+        assert mock_log.call_count == 1
+        assert mock_log.call_args.kwargs.get("refresh_mode") == "manual"
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/hooks/admin/useStravaToken.ts
+++ b/apps/frontend/src/hooks/admin/useStravaToken.ts
@@ -23,6 +23,7 @@ const TokenLogSchema = z.object({
   success: z.boolean(),
   message: z.string().nullable(),
   expires_at: z.string().nullable(),
+  refresh_mode: z.enum(['manual', 'automatic']).nullable().optional(),
 });
 
 // --- Inferred types ---

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -546,6 +546,10 @@
       "logs": "Refresh history",
       "noLogs": "No history",
       "date": "Date",
+      "mode": "Mode",
+      "manual": "Manual",
+      "automatic": "Automatic",
+      "modeUnknown": "Unknown",
       "message": "Message",
       "ok": "OK",
       "fail": "Fail"

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -546,6 +546,10 @@
       "logs": "Historique des refresh",
       "noLogs": "Aucun historique",
       "date": "Date",
+      "mode": "Mode",
+      "manual": "Manuel",
+      "automatic": "Automatique",
+      "modeUnknown": "Inconnu",
       "message": "Message",
       "ok": "OK",
       "fail": "Echec"

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -158,6 +158,7 @@ const buildStravaTokenLogs = (base = STRAVA_MOCK_BASE_MS): TokenLog[] => [
     success: true,
     message: `Access token refreshed (expires at ${getExpiresAt(-1, base)})`,
     expires_at: getExpiresAt(-1, base),
+    refresh_mode: 'automatic',
   },
   {
     id: 2,
@@ -165,6 +166,7 @@ const buildStravaTokenLogs = (base = STRAVA_MOCK_BASE_MS): TokenLog[] => [
     success: true,
     message: `Access token refreshed (expires at ${getExpiresAt(-5, base)})`,
     expires_at: getExpiresAt(-5, base),
+    refresh_mode: 'automatic',
   },
   {
     id: 1,
@@ -173,6 +175,7 @@ const buildStravaTokenLogs = (base = STRAVA_MOCK_BASE_MS): TokenLog[] => [
     message:
       'Strava API error (HTTP 401): {"message":"Bad Request","errors":[]}',
     expires_at: null,
+    refresh_mode: 'manual',
   },
 ];
 
@@ -186,6 +189,7 @@ const buildStravaExpiredTokenLogs = (
     message:
       'Strava API error (HTTP 401): {"message":"Bad Request","errors":[]}',
     expires_at: null,
+    refresh_mode: 'manual',
   },
 ];
 
@@ -201,6 +205,7 @@ const refreshStravaToken = () => {
     success: true,
     message: `Access token refreshed (expires at ${newExpiry})`,
     expires_at: newExpiry,
+    refresh_mode: 'manual',
   };
 
   nextLogId += 1;

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -51,6 +51,19 @@ function formatDate(iso: string): string {
   return new Date(normalizedIso).toLocaleString();
 }
 
+function getRefreshModeLabel(
+  refreshMode: 'manual' | 'automatic' | null | undefined,
+  t: (key: string, options?: Record<string, unknown>) => string
+): string {
+  if (refreshMode === 'manual') {
+    return t('infrastructure.strava.manual');
+  }
+  if (refreshMode === 'automatic') {
+    return t('infrastructure.strava.automatic');
+  }
+  return t('infrastructure.strava.modeUnknown');
+}
+
 export function getResolvedLabel(
   resolved: CacheKeyInfo['resolved'],
   t: (key: string, options?: Record<string, unknown>) => string
@@ -224,6 +237,9 @@ function StravaTokenSection() {
                     {t('infrastructure.strava.status')}
                   </th>
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
+                    {t('infrastructure.strava.mode')}
+                  </th>
+                  <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
                     {t('infrastructure.strava.message')}
                   </th>
                   <th className="px-4 py-2 font-medium text-gray-500 dark:text-gray-400">
@@ -252,6 +268,9 @@ function StravaTokenSection() {
                           ? t('infrastructure.strava.ok')
                           : t('infrastructure.strava.fail')}
                       </span>
+                    </td>
+                    <td className="px-4 py-2 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                      {getRefreshModeLabel(log.refresh_mode, t)}
                     </td>
                     <td className="px-4 py-2 text-gray-600 dark:text-gray-400 text-xs max-w-md truncate">
                       {log.message}


### PR DESCRIPTION
## Summary
- add `refresh_mode` to Strava token refresh logs in backend model and SQL migration, and persist `manual` vs `automatic` when logging refresh attempts
- expose `refresh_mode` in `/api/admin/strava/token-logs` and update frontend schema + Infrastructure UI table with localized mode labels and unknown fallback
- update MSW/story handlers and backend tests to cover the new field and mode behavior

## Validation
- `apps/backend/.venv/bin/pytest apps/backend/tests/unit/test_strava.py apps/backend/tests/test_admin.py`
- `pnpm --dir apps/frontend test InfrastructurePage.test.ts`
- `pnpm --dir apps/frontend type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added refresh mode tracking to Strava token logs and display of whether a refresh was manual or automatic in the Infrastructure page and admin token logs.

* **Localization**
  * Added English and French translations for the new refresh mode labels (manual, automatic, unknown).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->