### PR TITLE
fix: move mobile drawer to the left

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -51,7 +51,7 @@ body {
 /* Mobile drawer slide-in animation */
 @keyframes slide-in {
   from {
-    transform: translateX(100%);
+    transform: translateX(-100%);
   }
   to {
     transform: translateX(0);

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -125,7 +125,7 @@ export default function Header() {
             className="fixed inset-0 z-50 bg-black/40"
             isDismissable
           >
-            <Modal className="fixed top-0 right-0 h-full w-64 bg-white dark:bg-gray-800 shadow-xl outline-none animate-[slide-in_0.2s_ease-out]">
+            <Modal className="fixed top-0 left-0 h-full w-64 bg-white dark:bg-gray-800 shadow-xl outline-none animate-[slide-in_0.2s_ease-out]">
               <Dialog className="h-full flex flex-col outline-none">
                 {({ close }) => (
                   <>


### PR DESCRIPTION
## Summary
- Move the mobile drawer to the left side of the screen.
- Flip the slide-in animation so it enters from the left.

## Verification
- Commit hooks ran successfully during `git commit`.