### PR TITLE
feat(ui): add shared responsive button primitive

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-#set -e
+set -e
 
 # Ensure node/pnpm are in PATH (nvm/fnm)
 export NVM_DIR="$HOME/.nvm"

--- a/apps/frontend/src/components/analytics/FilterBar.tsx
+++ b/apps/frontend/src/components/analytics/FilterBar.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useFiltersStore } from '../../stores/filtersStore';
-import { DatePicker, Select } from '@dashboard-parapente/design-system';
+import { DatePicker, Select, Button } from '@dashboard-parapente/design-system';
 import type { Site } from '@dashboard-parapente/shared-types';
 
 interface FilterBarProps {
@@ -32,12 +32,14 @@ export function FilterBar({ sites }: FilterBarProps) {
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
             {t('filters.title')}
           </h3>
-          <button
+          <Button
             onClick={resetFilters}
+            tone="ghost"
+            size="sm"
             className="text-sm text-sky-600 hover:text-sky-700 font-medium"
           >
             {t('filters.reset')}
-          </button>
+          </Button>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
   ModalOverlay,
 } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import { useAuthStore } from '../../stores/authStore';
 
 const linkClass =
@@ -84,12 +85,14 @@ export default function Header() {
       <nav className="hidden sm:flex gap-2 flex-wrap items-center">
         {navLinks(linkClass)}
         {isAuthenticated ? (
-          <button
+          <Button
             onClick={handleLogout}
+            size="sm"
+            tone="secondary"
             className="px-3 py-1.5 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs font-medium transition-all hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900 dark:hover:text-red-300"
           >
             {t('header.logout', 'Logout')}
-          </button>
+          </Button>
         ) : (
           <Link
             to="/login"
@@ -158,15 +161,17 @@ export default function Header() {
                     </nav>
                     <div className="p-4 border-t border-gray-200 dark:border-gray-700">
                       {isAuthenticated ? (
-                        <button
+                        <Button
                           onClick={() => {
                             close();
                             handleLogout();
                           }}
+                          size="sm"
+                          tone="secondary"
                           className="w-full py-3 px-4 min-h-11 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-sm font-medium transition-all hover:bg-red-100 hover:text-red-600 dark:hover:bg-red-900 dark:hover:text-red-300"
                         >
                           {t('header.logout', 'Logout')}
-                        </button>
+                        </Button>
                       ) : (
                         <Link
                           to="/login"

--- a/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
+++ b/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
 import { WindIndicator } from '../common/WindIndicator';
 import CacheTimestamp from '../common/CacheTimestamp';
+import { Button } from '@dashboard-parapente/design-system';
 import type { WeatherData } from '../../types';
 import type { Site } from '@dashboard-parapente/shared-types';
 
@@ -49,7 +50,7 @@ function SiteConditionCard({
   };
 
   return (
-    <button
+    <Button
       onClick={handleClick}
       className="w-full text-left bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border border-gray-200 dark:border-gray-700 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-lg transition-all cursor-pointer"
     >
@@ -133,7 +134,7 @@ function SiteConditionCard({
           </div>
         </>
       )}
-    </button>
+    </Button>
   );
 }
 

--- a/apps/frontend/src/components/dashboard/DaySelector.tsx
+++ b/apps/frontend/src/components/dashboard/DaySelector.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { addDays } from 'date-fns';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface DaySelectorProps {
   selectedDayIndex: number;
@@ -28,7 +29,7 @@ export default function DaySelector({
       {Array.from({ length: 7 }, (_, i) => {
         const isSelected = i === selectedDayIndex;
         return (
-          <button
+          <Button
             key={i}
             type="button"
             onClick={() => onSelectDay(i)}
@@ -40,7 +41,7 @@ export default function DaySelector({
             }`}
           >
             {getDayLabel(i)}
-          </button>
+          </Button>
         );
       })}
     </div>

--- a/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
+++ b/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
@@ -10,6 +10,7 @@
 import { useState, useRef, useEffect } from 'react';
 import type { Site } from '../../types';
 import { WindIndicatorCompact } from '../common/WindIndicator';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface MultiOrientationSelectorProps {
   sites: Site[]; // All variants of this site (different orientations)
@@ -86,7 +87,7 @@ export function MultiOrientationSelector({
   return (
     <div ref={dropdownRef} className={`relative ${className}`}>
       {/* Main button */}
-      <button
+      <Button
         onClick={() => setIsOpen(!isOpen)}
         className={`w-full h-full p-3 sm:p-2.5 rounded-lg font-medium transition-all ${
           selectedSite
@@ -115,7 +116,7 @@ export function MultiOrientationSelector({
             />
           </svg>
         </div>
-      </button>
+      </Button>
 
       {/* Dropdown menu */}
       {isOpen && (
@@ -131,7 +132,7 @@ export function MultiOrientationSelector({
               const shortName = extractShortName(site.name, displayName);
 
               return (
-                <button
+                <Button
                   key={site.id}
                   onClick={() => handleSelect(site.id)}
                   className={`w-full flex items-center justify-between px-3 py-2 rounded-md transition-colors ${
@@ -162,7 +163,7 @@ export function MultiOrientationSelector({
                       windSpeed={weather.windSpeed}
                     />
                   )}
-                </button>
+                </Button>
               );
             })}
           </div>

--- a/apps/frontend/src/components/dashboard/SiteSelector.tsx
+++ b/apps/frontend/src/components/dashboard/SiteSelector.tsx
@@ -5,6 +5,7 @@ import { MultiOrientationSelector } from './MultiOrientationSelector';
 import { useQueryClient } from '@tanstack/react-query';
 import { createWeatherQueryFn } from '../../hooks/weather/useWeather';
 import type { Site } from '../../types';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface SiteSelectorProps {
   selectedSiteId: string;
@@ -111,7 +112,7 @@ export default function SiteSelector({
             const isActive = selectedSiteId === site.id;
 
             return (
-              <button
+              <Button
                 key={site.id}
                 className={`
                   flex-1 min-w-[120px] sm:min-w-[100px] 
@@ -138,7 +139,7 @@ export default function SiteSelector({
                 >
                   {site.elevation_m || '?'}m
                 </span>
-              </button>
+              </Button>
             );
           }
 

--- a/apps/frontend/src/components/flights/CreateFlightModal.tsx
+++ b/apps/frontend/src/components/flights/CreateFlightModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Modal } from '@dashboard-parapente/design-system';
+import { Modal, Button } from '@dashboard-parapente/design-system';
 import { useCreateFlightFromGPX } from '../../hooks/flights/useFlights';
 import { useToast } from '../../hooks/useToast';
 
@@ -46,7 +46,8 @@ export function CreateFlightModal({
     createFlight(formData, {
       onSuccess: (result) => {
         toast.success(
-          t('flights.createdSuccess') + ` ${result.flight.name || t('flights.unnamed')}`
+          t('flights.createdSuccess') +
+            ` ${result.flight.name || t('flights.unnamed')}`
         );
         onCreateComplete();
         setSelectedFile(null);
@@ -175,14 +176,14 @@ export function CreateFlightModal({
 
         {/* Boutons */}
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
             onClick={handleClose}
             className="px-4 py-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
             disabled={isPending}
           >
             {t('common.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleUpload}
             disabled={isPending || !selectedFile}
             className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
@@ -195,7 +196,7 @@ export function CreateFlightModal({
             ) : (
               `📤 ${t('flights.createButton')}`
             )}
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/apps/frontend/src/components/flights/CreateSiteModal.tsx
+++ b/apps/frontend/src/components/flights/CreateSiteModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Label, Input, TextField, Button } from 'react-aria-components';
+import { Label, Input, TextField } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import { Modal } from '@dashboard-parapente/design-system';
 import { useCreateSite, useGeocode } from '../../hooks/sites/useSites';
 import { useFlightGPX } from '../../hooks/flights/useFlightGPX';
@@ -120,7 +121,7 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
     <Modal isOpen={isOpen} onClose={onClose} title={t('createSite.title')}>
       <div className="space-y-4">
         {/* Mode selector */}
-        <div className="flex gap-2">
+        <div className="flex flex-col sm:flex-row gap-2">
           {flightId && gpxData?.coordinates && (
             <Button
               onPress={() => {
@@ -128,7 +129,9 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
                 setError(null);
               }}
               className={`px-4 py-2 rounded ${
-                mode === 'auto' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
+                mode === 'auto'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
               }`}
             >
               {t('createSite.autoDetect')}
@@ -140,7 +143,9 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
               setError(null);
             }}
             className={`px-4 py-2 rounded ${
-              mode === 'search' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
+              mode === 'search'
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
             }`}
           >
             {t('createSite.search')}
@@ -151,7 +156,9 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
               setError(null);
             }}
             className={`px-4 py-2 rounded ${
-              mode === 'manual' ? 'bg-blue-500 text-white' : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
+              mode === 'manual'
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-200 dark:bg-gray-600 dark:text-gray-200'
             }`}
           >
             {t('createSite.manualEntry')}
@@ -190,7 +197,7 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
               <Label className="block text-sm font-medium">
                 Nom de la ville
               </Label>
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row gap-2">
                 <Input
                   type="text"
                   value={searchQuery}
@@ -211,7 +218,9 @@ export const CreateSiteModal: React.FC<CreateSiteModalProps> = ({
 
             {searchResult && (
               <div className="mt-3 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded">
-                <p className="text-sm font-medium text-green-800 dark:text-green-200">✓ Trouvé !</p>
+                <p className="text-sm font-medium text-green-800 dark:text-green-200">
+                  ✓ Trouvé !
+                </p>
                 <p className="text-sm text-gray-600 dark:text-gray-300">
                   {searchResult.display_name}
                 </p>

--- a/apps/frontend/src/components/flights/ExportVideoModal.tsx
+++ b/apps/frontend/src/components/flights/ExportVideoModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface VideoExportConfig {
   quality: '720p' | '1080p' | '4K';
@@ -36,14 +37,18 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-md w-full mx-4">
         {/* Header */}
-        <h2 className="text-2xl font-bold mb-4 dark:text-white">🎥 Export Vidéo</h2>
+        <h2 className="text-2xl font-bold mb-4 dark:text-white">
+          🎥 Export Vidéo
+        </h2>
 
         {/* Quality Selection */}
         <div className="mb-4">
-          <label className="block text-sm font-medium mb-2 dark:text-gray-200">Qualité</label>
+          <label className="block text-sm font-medium mb-2 dark:text-gray-200">
+            Qualité
+          </label>
           <div className="grid grid-cols-3 gap-2">
             {(['720p', '1080p', '4K'] as const).map((q) => (
-              <button
+              <Button
                 key={q}
                 onClick={() => setQuality(q)}
                 className={`px-3 py-2 rounded border ${
@@ -53,7 +58,7 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
                 }`}
               >
                 {q}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -65,7 +70,7 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
           </label>
           <div className="grid grid-cols-2 gap-2">
             {([30, 60] as const).map((f) => (
-              <button
+              <Button
                 key={f}
                 onClick={() => setFps(f)}
                 className={`px-3 py-2 rounded border ${
@@ -75,7 +80,7 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
                 }`}
               >
                 {f} FPS
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -90,7 +95,7 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
           </label>
           <div className="grid grid-cols-4 gap-2">
             {([1, 2, 4, 8] as const).map((s) => (
-              <button
+              <Button
                 key={s}
                 onClick={() => setSpeed(s)}
                 className={`px-3 py-2 rounded border ${
@@ -100,7 +105,7 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
                 }`}
               >
                 {s}x
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -138,18 +143,18 @@ export const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
 
         {/* Actions */}
         <div className="flex gap-2">
-          <button
+          <Button
             onClick={onCancel}
             className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-300 dark:hover:bg-gray-500"
           >
             Annuler
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleExport}
             className="flex-1 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
           >
             🎥 Exporter
-          </button>
+          </Button>
         </div>
 
         {/* Help Text */}

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -103,7 +103,7 @@ export function FlightDetails({
         ) : (
           <>
             {/* Header */}
-            <div className="flex justify-between items-start mb-4">
+            <div className="flex flex-col sm:flex-row justify-between items-start gap-2 mb-4">
               <h2 className="text-lg font-bold text-gray-900 dark:text-white">
                 {flight.title ?? t('flights.untitledFlight')}
               </h2>

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, lazy, Suspense, ChangeEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { TextField, TextArea, Button } from 'react-aria-components';
+import { TextField, TextArea } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import {
   useUpdateFlight,
   useUploadGPXToFlight,
@@ -106,7 +107,7 @@ export function FlightDetails({
               <h2 className="text-lg font-bold text-gray-900 dark:text-white">
                 {flight.title ?? t('flights.untitledFlight')}
               </h2>
-              <div className="flex gap-2 ml-4">
+              <div className="flex flex-col sm:flex-row gap-2 ml-0 sm:ml-4 w-full sm:w-auto">
                 <Button
                   className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-sky-600 text-white rounded-md hover:bg-sky-700 transition-all"
                   onPress={() => setEditingMode(true)}
@@ -256,7 +257,7 @@ export function FlightDetails({
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-600 resize-none dark:bg-gray-700 dark:text-gray-100"
                     />
                   </TextField>
-                  <div className="flex gap-2">
+                  <div className="flex flex-col sm:flex-row gap-2">
                     <Button
                       className="px-4 py-2 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 transition-all disabled:opacity-50"
                       onPress={handleSaveNotes}

--- a/apps/frontend/src/components/flights/FlightEditForm.tsx
+++ b/apps/frontend/src/components/flights/FlightEditForm.tsx
@@ -8,9 +8,8 @@ import {
   Label,
   Input,
   TextArea,
-  Button,
 } from 'react-aria-components';
-import { Select } from '@dashboard-parapente/design-system';
+import { Select, Button } from '@dashboard-parapente/design-system';
 import type { Key } from 'react-aria-components';
 import type { Flight, FlightFormData, Site } from '../../types';
 
@@ -157,7 +156,7 @@ export function FlightEditForm({
           </form.Field>
         </div>
 
-        <div className="flex gap-2 sm:ml-4 justify-end">
+        <div className="flex flex-col sm:flex-row gap-2 sm:ml-4 justify-end">
           <form.Subscribe selector={(state) => state.isSubmitting}>
             {(isSubmitting) => (
               <Button
@@ -230,7 +229,7 @@ export function FlightEditForm({
           <span className={s.label()}>{t('flights.siteLabel')}</span>
           <form.Field name="site_id">
             {(field) => (
-              <div className="flex gap-2 mt-1">
+              <div className="flex flex-col sm:flex-row gap-2 mt-1">
                 <div className="flex-1">
                   <Select
                     label=""

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -26,8 +26,9 @@ import {
 import { api } from '../../lib/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
+import { Button } from '@dashboard-parapente/design-system';
 
-import {GPXData} from "@dashboard-parapente/shared-types";
+import { GPXData } from '@dashboard-parapente/shared-types';
 
 declare global {
   interface Window {
@@ -61,10 +62,9 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
 
   return (
     <div className="border-b border-gray-200 dark:border-gray-700 last:border-0">
-      <button
+      <Button
         onClick={() => setIsOpen(!isOpen)}
         className="w-full flex items-center justify-between py-2 px-1 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded"
-        type="button"
       >
         <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
           {emoji && <span className="mr-1.5">{emoji}</span>}
@@ -76,7 +76,7 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
         >
           ▶
         </span>
-      </button>
+      </Button>
       {isOpen && <div className="pb-3 pt-1 space-y-3">{children}</div>}
     </div>
   );
@@ -1028,7 +1028,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         <div className="absolute inset-0 flex items-center justify-center bg-blue-50 dark:bg-blue-900/20 z-20">
           <div className="text-center p-8">
             <p className="text-lg dark:text-white">⏳ Chargement du vol...</p>
-            <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">Flight ID: {flightId}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
+              Flight ID: {flightId}
+            </p>
           </div>
         </div>
       );
@@ -1044,7 +1046,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
             <p className="text-sm text-yellow-700 dark:text-yellow-300">
               Les données GPS ne sont pas disponibles pour ce vol.
             </p>
-            <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">Error: {String(error)}</p>
+            <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
+              Error: {String(error)}
+            </p>
           </div>
         </div>
       );
@@ -1054,7 +1058,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       return (
         <div className="absolute inset-0 flex items-center justify-center bg-red-50 dark:bg-red-900/20 z-20">
           <div className="text-center p-8">
-            <p className="text-lg dark:text-white">❌ Aucune donnée GPS disponible</p>
+            <p className="text-lg dark:text-white">
+              ❌ Aucune donnée GPS disponible
+            </p>
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
               GPX Data: {JSON.stringify(gpxData)}
             </p>
@@ -1098,13 +1104,13 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       {/* Bouton plein écran */}
       {gpxData?.coordinates && (
-        <button
+        <Button
           onClick={toggleFullscreen}
           className="absolute top-4 right-4 z-10 px-3 py-2 bg-gray-800 text-white rounded-lg shadow-lg hover:bg-gray-700"
           title={isFullscreen ? 'Quitter le plein écran' : 'Plein écran'}
         >
           {isFullscreen ? '🗗 Quitter' : '⛶ Plein écran'}
-        </button>
+        </Button>
       )}
 
       {/* Controls - only show when data is loaded */}
@@ -1118,7 +1124,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
             {!isPanelCollapsed && (
               <h3 className="text-lg font-bold">🪂 {flightTitle}</h3>
             )}
-            <button
+            <Button
               onClick={() => setIsPanelCollapsed(!isPanelCollapsed)}
               className="px-2 py-1 bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300 dark:hover:bg-gray-600 text-sm dark:text-gray-200"
               title={
@@ -1126,7 +1132,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
               }
             >
               {isPanelCollapsed ? '▶' : '◀'}
-            </button>
+            </Button>
           </div>
 
           {!isPanelCollapsed && (
@@ -1149,18 +1155,18 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                 {/* ========== SECTION 1: LECTURE ========== */}
                 <AccordionSection title="Lecture" emoji="🎮" defaultOpen={true}>
                   <div className="flex gap-2">
-                    <button
+                    <Button
                       onClick={togglePlayPause}
                       className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400"
                     >
                       {isPlaying ? '⏸ Pause' : '▶ Play'}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={reset}
                       className="px-3 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 disabled:bg-gray-400"
                     >
                       ⏮ Reset
-                    </button>
+                    </Button>
                   </div>
 
                   {/* Progress Slider */}
@@ -1215,7 +1221,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                   >
                     <>
                       {/* Download/Generate Button */}
-                      <button
+                      <Button
                         onClick={async () => {
                           if (
                             flight.video_export_status === 'completed' &&
@@ -1242,7 +1248,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                               if (!response.ok) {
                                 const error = await response.json();
                                 toast.error(
-                                  error.detail || 'Impossible de lancer la génération'
+                                  error.detail ||
+                                    'Impossible de lancer la génération'
                                 );
                                 return;
                               }
@@ -1291,12 +1298,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         {flight.video_export_status === 'failed' &&
                           '🔄 Relancer la génération'}
                         {!flight.video_export_status && '🎥 Générer la vidéo'}
-                      </button>
+                      </Button>
 
                       {/* Cancel Button (only when processing) */}
                       {flight.video_export_status === 'processing' &&
                         flight.video_export_job_id && (
-                          <button
+                          <Button
                             onClick={async () => {
                               if (
                                 !confirm(
@@ -1317,7 +1324,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                                 if (!response.ok) {
                                   const error = await response.json();
                                   toast.error(
-                                    error.detail || "Impossible d'annuler la génération"
+                                    error.detail ||
+                                      "Impossible d'annuler la génération"
                                   );
                                   return;
                                 }
@@ -1338,12 +1346,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                             title="Annuler la génération vidéo en cours"
                           >
                             🛑 Annuler la génération
-                          </button>
+                          </Button>
                         )}
 
                       {/* Regenerate Button (only when video exists) */}
                       {flight.video_export_status === 'completed' && (
-                        <button
+                        <Button
                           onClick={async () => {
                             if (
                               !confirm(
@@ -1364,7 +1372,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                               if (!response.ok) {
                                 const error = await response.json();
                                 toast.error(
-                                  error.detail || 'Impossible de lancer la régénération'
+                                  error.detail ||
+                                    'Impossible de lancer la régénération'
                                 );
                                 return;
                               }
@@ -1385,7 +1394,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           title="Régénérer la vidéo (remplace l'ancienne)"
                         >
                           🔄 Régénérer la vidéo
-                        </button>
+                        </Button>
                       )}
                     </>
                   </AccordionSection>
@@ -1485,13 +1494,13 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                       </div>
 
                       {/* Apply Button */}
-                      <button
+                      <Button
                         onClick={applyCameraSettings}
                         disabled={isUpdatingCamera}
                         className="w-full px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         {isUpdatingCamera ? '⏳ Mise à jour...' : '✓ Appliquer'}
-                      </button>
+                      </Button>
 
                       <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
                         💡 Ces réglages seront sauvegardés pour le site &quot;
@@ -1513,14 +1522,14 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                       <label className="block text-sm font-medium">
                         Élévation: {elevationOffset.toFixed(1)}m
                       </label>
-                      <button
+                      <Button
                         onClick={calculateAutoElevationOffset}
                         disabled={isCalculatingOffset}
                         className="text-xs px-2 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-400"
                         title="Calculer automatiquement l'offset par rapport au terrain"
                       >
                         {isCalculatingOffset ? '⏳' : '🔄'} Auto
-                      </button>
+                      </Button>
                     </div>
                     <input
                       type="range"

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -28,7 +28,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
 import { Button } from '@dashboard-parapente/design-system';
 
-import { GPXData } from '@dashboard-parapente/shared-types';
+import type { GPXData } from '@dashboard-parapente/shared-types';
 
 declare global {
   interface Window {

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Row, RowSelectionState, OnChangeFn } from '@tanstack/react-table';
 import type { Selection } from 'react-aria-components';
-import { DataList } from '@dashboard-parapente/design-system';
+import { DataList, Button } from '@dashboard-parapente/design-system';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
 import type { Flight } from '../../types';
 
@@ -81,7 +81,9 @@ export function FlightsTable({
         >
           {/* Bouton supprimer au survol */}
           {!selectionMode && (
-            <button
+            <Button
+              size="icon"
+              tone="danger"
               className="absolute top-2 right-2 w-10 h-10 sm:w-7 sm:h-7 flex items-center justify-center rounded-full bg-red-100 text-red-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-red-200 hover:text-red-700 transition-all"
               onClick={(e) => {
                 e.stopPropagation();
@@ -104,7 +106,7 @@ export function FlightsTable({
                   d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
                 />
               </svg>
-            </button>
+            </Button>
           )}
           <div className="flex justify-between items-start mb-2">
             <h3 className="font-semibold text-sm text-gray-900 dark:text-white truncate flex-1">

--- a/apps/frontend/src/components/flights/StravaSyncModal.tsx
+++ b/apps/frontend/src/components/flights/StravaSyncModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Modal, DatePicker } from '@dashboard-parapente/design-system';
+import { Modal, DatePicker, Button } from '@dashboard-parapente/design-system';
 import { useStravaSyncMutation } from '../../hooks/flights/useFlights';
 import { useToast } from '../../hooks/useToast';
 
@@ -55,7 +55,9 @@ export function StravaSyncModal({
       size="md"
     >
       <div className="space-y-4">
-        <p className="text-sm text-gray-600 dark:text-gray-300">{t('strava.description')}</p>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          {t('strava.description')}
+        </p>
 
         <div className="grid grid-cols-2 gap-4">
           <DatePicker
@@ -96,14 +98,14 @@ export function StravaSyncModal({
 
         {/* Boutons */}
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
             onClick={onClose}
             className="px-4 py-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
             disabled={isPending}
           >
             {t('common.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleSync}
             disabled={isPending || !dateFrom || !dateTo}
             className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
@@ -116,7 +118,7 @@ export function StravaSyncModal({
             ) : (
               `🔄 ${t('strava.sync')}`
             )}
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/apps/frontend/src/components/settings/WeatherSourceCard.tsx
+++ b/apps/frontend/src/components/settings/WeatherSourceCard.tsx
@@ -5,14 +5,8 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Button,
-  Switch,
-  TextField,
-  Input,
-  Text,
-  Link,
-} from 'react-aria-components';
+import { Switch, TextField, Input, Text, Link } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import type { WeatherSource } from '../../types/weatherSources';
 import {
   useUpdateWeatherSource,
@@ -57,10 +51,12 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
     };
 
     const statusClasses = {
-      active: 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-200',
+      active:
+        'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-200',
       error: 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-200',
       disabled: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300',
-      unknown: 'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200',
+      unknown:
+        'bg-yellow-100 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200',
     };
 
     return (
@@ -217,7 +213,9 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
   return (
     <article
       className={`bg-white dark:bg-gray-800 rounded-lg shadow-md p-5 border-2 transition-all ${
-        source.is_enabled ? 'border-sky-200 dark:border-sky-700' : 'border-gray-200 dark:border-gray-700'
+        source.is_enabled
+          ? 'border-sky-200 dark:border-sky-700'
+          : 'border-gray-200 dark:border-gray-700'
       }`}
       aria-label={`Configuration de la source météo ${source.display_name}`}
     >
@@ -251,7 +249,10 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
             </h3>
             {getStatusBadge()}
           </div>
-          <Text slot="description" className="text-sm text-gray-600 dark:text-gray-300">
+          <Text
+            slot="description"
+            className="text-sm text-gray-600 dark:text-gray-300"
+          >
             {source.description}
           </Text>
         </div>
@@ -302,7 +303,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
           </div>
 
           {isEditingApiKey ? (
-            <div className="flex gap-2">
+            <div className="flex flex-col sm:flex-row gap-2">
               <TextField
                 value={apiKeyValue}
                 onChange={setApiKeyValue}
@@ -479,7 +480,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
 
       {/* Actions */}
       <div
-        className="flex gap-2"
+        className="flex flex-col sm:flex-row gap-2"
         role="group"
         aria-label="Actions sur la source météo"
       >

--- a/apps/frontend/src/components/sites/EditSiteModal.tsx
+++ b/apps/frontend/src/components/sites/EditSiteModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { TextField, Label, Input, Button } from 'react-aria-components';
+import { TextField, Label, Input } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import type {
   Site,
   SiteUpdate,
@@ -444,7 +445,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
           )}
 
         {/* Actions */}
-        <div className="flex gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+        <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-gray-200 dark:border-gray-700">
           <Button
             type="button"
             onPress={onClose}

--- a/apps/frontend/src/components/sites/LandingAssociationsManager.tsx
+++ b/apps/frontend/src/components/sites/LandingAssociationsManager.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSites } from '../../hooks/sites/useSites';
+import { Button } from '@dashboard-parapente/design-system';
 import {
   useLandingAssociations,
   useAddLandingAssociation,
@@ -94,7 +95,8 @@ export default function LandingAssociationsManager({
               className="flex items-center justify-between bg-gray-50 dark:bg-gray-700 rounded px-2 py-1.5 text-sm"
             >
               <div className="flex items-center gap-2 min-w-0">
-                <button
+                <Button
+                  size="icon"
                   type="button"
                   onClick={() => handleSetPrimary(assoc.id)}
                   className={`w-4 h-4 rounded-full border-2 flex-shrink-0 ${
@@ -118,14 +120,16 @@ export default function LandingAssociationsManager({
                   </span>
                 </div>
               </div>
-              <button
+              <Button
+                size="icon"
                 type="button"
                 onClick={() => handleRemove(assoc.id)}
+                tone="ghost"
                 className="text-red-400 hover:text-red-600 flex-shrink-0 ml-2"
                 title="Supprimer"
               >
                 &times;
-              </button>
+              </Button>
             </li>
           ))}
         </ul>
@@ -133,14 +137,15 @@ export default function LandingAssociationsManager({
 
       {/* Add new association */}
       {!showAddDropdown ? (
-        <button
+        <Button
           type="button"
           onClick={() => setShowAddDropdown(true)}
+          tone="ghost"
           className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
           disabled={availableLandings.length === 0}
         >
           + {t('landings.addLanding')}
-        </button>
+        </Button>
       ) : (
         <div className="space-y-2 bg-gray-50 dark:bg-gray-700 rounded p-2">
           <select
@@ -164,25 +169,27 @@ export default function LandingAssociationsManager({
             className="w-full text-sm border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 rounded px-2 py-1"
           />
           <div className="flex gap-2">
-            <button
+            <Button
               type="button"
               onClick={handleAdd}
+              tone="ghost"
               disabled={!selectedLandingId || addMutation.isPending}
               className="text-xs bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 disabled:opacity-50"
             >
               {addMutation.isPending ? t('landings.adding') : t('common.add')}
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={() => {
                 setShowAddDropdown(false);
                 setSelectedLandingId('');
                 setNewNotes('');
               }}
+              tone="ghost"
               className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
             >
               {t('common.cancel')}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/apps/frontend/src/components/sites/SiteCard.tsx
+++ b/apps/frontend/src/components/sites/SiteCard.tsx
@@ -143,8 +143,9 @@ export const SiteCard: React.FC<SiteCardProps> = ({
           onClick={() => onDelete(site)}
           className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700"
           title={t('sites.deleteSite')}
+          aria-label={t('sites.deleteSite')}
         >
-          🗑️
+          <span aria-hidden="true">🗑️</span>
         </Button>
       </div>
     </div>

--- a/apps/frontend/src/components/sites/SiteCard.tsx
+++ b/apps/frontend/src/components/sites/SiteCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Site } from '@dashboard-parapente/shared-types';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface SiteCardProps {
   site: Site;
@@ -123,28 +124,28 @@ export const SiteCard: React.FC<SiteCardProps> = ({
       </div>
 
       {/* Actions */}
-      <div className="flex gap-2 pt-3 border-t dark:border-gray-700">
-        <button
+      <div className="flex flex-col sm:flex-row gap-2 pt-3 border-t dark:border-gray-700">
+        <Button
           onClick={() => onEdit(site)}
           className="flex-1 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
           title={t('sites.editSite')}
         >
           ✏️ {t('common.edit')}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => onViewFlights(site)}
           className="flex-1 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-gray-600 text-white rounded hover:bg-gray-700"
           title={t('sites.viewFlights')}
         >
           📋 {t('header.flights')}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => onDelete(site)}
           className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700"
           title={t('sites.deleteSite')}
         >
           🗑️
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -13,6 +13,7 @@ import { fr } from 'date-fns/locale';
 import CacheTimestamp from '../common/CacheTimestamp';
 import { enUS } from 'date-fns/locale';
 import { WindIndicator } from '../common/WindIndicator';
+import { Button } from '@dashboard-parapente/design-system';
 import type { BestSpotResult } from '@dashboard-parapente/shared-types';
 
 interface BestSpotSuggestionProps {
@@ -148,7 +149,10 @@ export function BestSpotSuggestion({
     verdict,
     windFavorability,
   } = bestSpot;
-  const adjustedScore = Math.min(100, Math.max(0, score != null ? Math.round(score) : paraIndex));
+  const adjustedScore = Math.min(
+    100,
+    Math.max(0, score != null ? Math.round(score) : paraIndex)
+  );
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
 
@@ -310,13 +314,13 @@ export function BestSpotSuggestion({
         </p>
 
         {/* Footer: button + cache */}
-        <div className="flex items-center justify-between">
-          <button
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <Button
             onClick={() => onSelectSite(site.id)}
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors"
           >
             {t('weather.viewForecast')}
-          </button>
+          </Button>
           <CacheTimestamp cachedAt={bestSpot.cached_at} />
         </div>
       </div>
@@ -343,7 +347,7 @@ export function BestSpotSuggestionCompact({
   const scoreColor = getScoreColor(adjustedScore);
 
   return (
-    <button
+    <Button
       onClick={() => onSelectSite(site.id)}
       className={`w-full text-left p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors overflow-hidden ${className}`}
     >
@@ -374,6 +378,6 @@ export function BestSpotSuggestionCompact({
           {adjustedScore}
         </span>
       </div>
-    </button>
+    </Button>
   );
 }

--- a/apps/frontend/src/components/weather/Forecast7Day.tsx
+++ b/apps/frontend/src/components/weather/Forecast7Day.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../hooks/weather/useWeather';
 import { useQueryClient } from '@tanstack/react-query';
 import CacheTimestamp from '../common/CacheTimestamp';
+import { Button } from '@dashboard-parapente/design-system';
 
 interface Forecast7DayProps {
   spotId: string;
@@ -116,7 +117,7 @@ export default function Forecast7Day({
           const isSelected = index === selectedDayIndex;
 
           return (
-            <button
+            <Button
               key={index}
               onClick={() => onSelectDay?.(index)}
               onMouseEnter={() => handleMouseEnter(index)}
@@ -151,7 +152,7 @@ export default function Forecast7Day({
               <div className="text-xs text-gray-500 dark:text-gray-400 text-center truncate">
                 {day.verdict}
               </div>
-            </button>
+            </Button>
           );
         })}
       </div>

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -246,6 +246,7 @@ const ParaIndexTooltip = ({
           onClick={onClose}
           tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+          aria-label="Fermer l'infobulle"
         >
           ✕
         </Button>
@@ -340,6 +341,7 @@ const VerdictTooltip = ({
           onClick={onClose}
           tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+          aria-label="Fermer le verdict"
         >
           ✕
         </Button>
@@ -421,6 +423,7 @@ const SourceDataTooltip = ({
           onClick={onClose}
           tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
+          aria-label="Fermer les données source"
         >
           ✕
         </Button>

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -11,6 +11,7 @@ import {
   Flame,
   CircleCheck,
 } from 'lucide-react';
+import { Button } from '@dashboard-parapente/design-system';
 import { useWeather } from '../../hooks/weather/useWeather';
 import type { HourlyForecastItem } from '../../types';
 import CacheTimestamp from '../common/CacheTimestamp';
@@ -241,12 +242,13 @@ const ParaIndexTooltip = ({
       }
     >
       {onClose && (
-        <button
+        <Button
           onClick={onClose}
+          tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
         >
           ✕
-        </button>
+        </Button>
       )}
       <div className="font-bold mb-3 text-sky-700 dark:text-sky-400 flex items-center gap-2">
         📊 Para-Index - {hour}
@@ -334,12 +336,13 @@ const VerdictTooltip = ({
       }
     >
       {onClose && (
-        <button
+        <Button
           onClick={onClose}
+          tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
         >
           ✕
-        </button>
+        </Button>
       )}
       <div className="font-bold mb-3 text-emerald-700 dark:text-emerald-400 flex items-center gap-2">
         ✓ Verdict - {hour}
@@ -414,12 +417,13 @@ const SourceDataTooltip = ({
       }
     >
       {onClose && (
-        <button
+        <Button
           onClick={onClose}
+          tone="ghost"
           className="absolute top-2 right-2 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
         >
           ✕
-        </button>
+        </Button>
       )}
       <div className="font-bold mb-3 text-gray-800 dark:text-gray-100 flex items-center gap-2">
         {label} - {hour}

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from '@tanstack/react-router';
 import StatsPanel from '../components/dashboard/StatsPanel';
 import AllSitesConditions from '../components/dashboard/AllSitesConditions';
 import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
+import { Button } from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import { useBestSpotAPI } from '../hooks/weather/useBestSpotAPI';
 import { createWeatherQueryFn } from '../hooks/weather/useWeather';
@@ -49,12 +50,12 @@ export default function Dashboard() {
               'Ajoutez votre premier site de vol pour commencer.'
             )}
           </p>
-          <button
+          <Button
             onClick={() => void navigate({ to: '/sites' })}
             className="px-6 py-3 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition-all"
           >
             {t('dashboard.addSite', 'Ajouter un site')}
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -10,7 +10,11 @@ import { CreateSiteModal } from '../components/flights/CreateSiteModal';
 import { FlightsTable } from '../components/flights/FlightsTable';
 import { FlightDetails } from '../components/flights/FlightDetails';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
-import { ToastContainer, Modal } from '@dashboard-parapente/design-system';
+import {
+  ToastContainer,
+  Modal,
+  Button,
+} from '@dashboard-parapente/design-system';
 import { useToast, useToastStore } from '../hooks/useToast';
 import { HTTPError } from 'ky';
 import { api } from '../lib/api';
@@ -148,7 +152,7 @@ export default function FlightHistory() {
       <ToastContainer toasts={toasts} onClose={removeToast} />
 
       <div className="mb-4 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        <div className="flex justify-between items-center mb-3">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-3">
           <div>
             <h1 className="text-xl font-bold text-gray-900 dark:text-white">
               {t('flights.history')}
@@ -164,26 +168,26 @@ export default function FlightHistory() {
             </div>
           </div>
 
-          <div className="flex gap-2">
+          <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
             {!selectionMode && (
-              <button
+              <Button
                 onClick={() => setShowCreateFlightModal(true)}
                 className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-all flex items-center gap-2"
               >
                 {t('flights.createFlight')}
-              </button>
+              </Button>
             )}
 
             {!selectionMode && (
-              <button
+              <Button
                 onClick={() => setShowStravaSyncModal(true)}
                 className="px-4 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition-all flex items-center gap-2"
               >
                 {t('flights.syncStrava')}
-              </button>
+              </Button>
             )}
 
-            <button
+            <Button
               onClick={handleToggleSelectionMode}
               className={`px-4 py-2 rounded-lg transition-all flex items-center gap-2 ${
                 selectionMode
@@ -192,31 +196,31 @@ export default function FlightHistory() {
               }`}
             >
               {selectionMode ? t('flights.cancel') : t('flights.select')}
-            </button>
+            </Button>
           </div>
         </div>
 
         {selectionMode && (
-          <div className="flex gap-2 pt-3 border-t border-gray-200 dark:border-gray-700">
-            <button
+          <div className="flex flex-col sm:flex-row gap-2 pt-3 border-t border-gray-200 dark:border-gray-700">
+            <Button
               onClick={handleSelectAll}
               className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
             >
               {t('flights.selectAll')}
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={handleDeselectAll}
               className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
             >
               {t('flights.deselectAll')}
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() => setShowMultiDeleteConfirm(true)}
               disabled={selectedCount === 0}
-              className="ml-auto px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all disabled:bg-gray-300 disabled:cursor-not-allowed"
+              className="ml-0 sm:ml-auto px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all disabled:bg-gray-300 disabled:cursor-not-allowed"
             >
               {t('flights.deleteCount', { count: selectedCount })}
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -296,19 +300,19 @@ export default function FlightHistory() {
           . {t('flights.confirmDeleteSingleSuffix')}
         </p>
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
             onClick={() => setFlightToDelete(null)}
             className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
           >
             {t('common.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleDeleteFlight}
             disabled={isDeleting}
             className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all disabled:opacity-50"
           >
             {isDeleting ? t('flights.deleting') : t('flights.deleteButton')}
-          </button>
+          </Button>
         </div>
       </Modal>
 
@@ -324,13 +328,13 @@ export default function FlightHistory() {
           {t('flights.confirmDeleteMulti', { count: selectedCount })}
         </p>
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
             onClick={() => setShowMultiDeleteConfirm(false)}
             className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
           >
             {t('common.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={handleDeleteFlight}
             disabled={isDeleting}
             className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all disabled:opacity-50"
@@ -338,7 +342,7 @@ export default function FlightHistory() {
             {isDeleting
               ? t('flights.deleting')
               : t('flights.deleteButtonCount', { count: selectedCount })}
-          </button>
+          </Button>
         </div>
       </Modal>
     </div>

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useTranslation } from 'react-i18next';
-import { Button, Checkbox, Input, TextField } from 'react-aria-components';
+import { Checkbox, Input, TextField } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -391,7 +392,7 @@ function CacheSection() {
       )}
 
       {/* Controls */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-wrap items-center gap-3">
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-col sm:flex-row sm:flex-wrap items-stretch sm:items-center gap-3">
         <Checkbox
           isSelected={autoRefresh}
           onChange={setAutoRefresh}
@@ -671,7 +672,7 @@ function GroupSection({
         id: 'actions',
         header: t('cache.actions'),
         cell: (info) => (
-          <div className="flex gap-2">
+          <div className="flex flex-col sm:flex-row gap-2">
             <Button
               onPress={() => onViewKey(info.row.original.key)}
               className="min-h-11 px-3 py-2 sm:min-h-0 sm:px-2 sm:py-1 rounded text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 hover:bg-sky-200 dark:hover:bg-sky-800 transition-colors cursor-pointer"
@@ -715,7 +716,7 @@ function GroupSection({
           }
         }}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 min-w-0">
           <span
             className={`text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
           >

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from '@tanstack/react-router';
 import { useForm } from '@tanstack/react-form';
 import { useTranslation } from 'react-i18next';
-import { TextField, Label, Input, Button, Form } from 'react-aria-components';
+import { TextField, Label, Input, Form } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import { useAuthStore } from '../stores/authStore';
 
 export default function Login() {

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import {
   useWeatherSources,
@@ -113,7 +114,7 @@ function SitesTab({
                   </p>
                 )}
               </div>
-              <button
+              <Button
                 onClick={() => toggleFavorite(site.id)}
                 className={`ml-4 px-4 py-2 rounded-lg font-medium transition-all ${
                   settings.favoriteSites.includes(site.id)
@@ -124,7 +125,7 @@ function SitesTab({
                 {settings.favoriteSites.includes(site.id)
                   ? '⭐ ' + t('settings.favorites.favorite')
                   : '☆ ' + t('settings.favorites.add')}
-              </button>
+              </Button>
             </div>
           ))}
         </div>
@@ -330,7 +331,7 @@ function PerformanceSection() {
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
             {t('settings.performance.freshnessHelp')}
           </p>
-          <div className="flex gap-3">
+          <div className="flex flex-col sm:flex-row gap-3">
             {(
               [
                 {
@@ -341,7 +342,7 @@ function PerformanceSection() {
                 { value: 'economy', label: t('settings.performance.economy') },
               ] as const
             ).map((opt) => (
-              <button
+              <Button
                 key={opt.value}
                 onClick={() => setFreshnessLevel(opt.value as FreshnessLevel)}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
@@ -351,7 +352,7 @@ function PerformanceSection() {
                 }`}
               >
                 {opt.label}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -383,7 +384,7 @@ function PerformanceSection() {
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
             {t('settings.performance.httpTimeoutHelp')}
           </p>
-          <div className="flex gap-3">
+          <div className="flex flex-col sm:flex-row gap-3">
             {(
               [
                 {
@@ -405,7 +406,7 @@ function PerformanceSection() {
                 },
               ] as const
             ).map((opt) => (
-              <button
+              <Button
                 key={opt.value}
                 onClick={() => setHttpTimeout(opt.value as HttpTimeout)}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
@@ -415,7 +416,7 @@ function PerformanceSection() {
                 }`}
               >
                 {opt.label}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -434,7 +435,7 @@ function PerformanceSection() {
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
             {t('settings.performance.backendCacheHelp')}
           </p>
-          <div className="flex gap-3">
+          <div className="flex flex-col sm:flex-row gap-3">
             {(
               [
                 {
@@ -460,7 +461,7 @@ function PerformanceSection() {
                 },
               ] as const
             ).map((opt) => (
-              <button
+              <Button
                 key={opt.value}
                 onClick={() =>
                   handleBackendSetting('cache_ttl_default', opt.value)
@@ -473,7 +474,7 @@ function PerformanceSection() {
                 } disabled:opacity-50`}
               >
                 {opt.label}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -486,7 +487,7 @@ function PerformanceSection() {
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
             {t('settings.performance.schedulerIntervalHelp')}
           </p>
-          <div className="flex gap-3">
+          <div className="flex flex-col sm:flex-row gap-3">
             {(
               [
                 {
@@ -508,7 +509,7 @@ function PerformanceSection() {
                 },
               ] as const
             ).map((opt) => (
-              <button
+              <Button
                 key={opt.value}
                 onClick={() =>
                   handleBackendSetting('scheduler_interval_minutes', opt.value)
@@ -521,7 +522,7 @@ function PerformanceSection() {
                 } disabled:opacity-50`}
               >
                 {opt.label}
-              </button>
+              </Button>
             ))}
           </div>
         </div>
@@ -678,8 +679,8 @@ export default function Settings() {
       </div>
 
       {/* Tabs Navigation */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md mb-4 p-2 flex gap-2">
-        <button
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md mb-4 p-2 grid grid-cols-2 gap-2 sm:flex">
+        <Button
           onClick={() => setActiveTab('general')}
           className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
             activeTab === 'general'
@@ -688,8 +689,8 @@ export default function Settings() {
           }`}
         >
           🎛️ {t('settings.tabs.general')}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => setActiveTab('sites')}
           className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
             activeTab === 'sites'
@@ -698,8 +699,8 @@ export default function Settings() {
           }`}
         >
           📍 {t('settings.tabs.favoriteSites')}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => setActiveTab('weather')}
           className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
             activeTab === 'weather'
@@ -708,8 +709,8 @@ export default function Settings() {
           }`}
         >
           🌦️ {t('settings.tabs.weatherSources')}
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => setActiveTab('data')}
           className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
             activeTab === 'data'
@@ -718,7 +719,7 @@ export default function Settings() {
           }`}
         >
           💾 {t('settings.tabs.data')}
-        </button>
+        </Button>
       </div>
 
       {/* Content */}
@@ -736,8 +737,8 @@ export default function Settings() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('settings.units.distance')}
                   </label>
-                  <div className="flex gap-4">
-                    <button
+                  <div className="flex flex-wrap gap-2 sm:gap-4">
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -751,8 +752,8 @@ export default function Settings() {
                       }`}
                     >
                       {t('settings.units.kilometers')}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -766,7 +767,7 @@ export default function Settings() {
                       }`}
                     >
                       {t('settings.units.miles')}
-                    </button>
+                    </Button>
                   </div>
                 </div>
 
@@ -774,8 +775,8 @@ export default function Settings() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('settings.units.altitude')}
                   </label>
-                  <div className="flex gap-4">
-                    <button
+                  <div className="flex flex-wrap gap-2 sm:gap-4">
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -789,8 +790,8 @@ export default function Settings() {
                       }`}
                     >
                       {t('settings.units.meters')}
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -804,7 +805,7 @@ export default function Settings() {
                       }`}
                     >
                       {t('settings.units.feet')}
-                    </button>
+                    </Button>
                   </div>
                 </div>
 
@@ -812,8 +813,8 @@ export default function Settings() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('settings.units.speed')}
                   </label>
-                  <div className="flex gap-4">
-                    <button
+                  <div className="flex flex-wrap gap-2 sm:gap-4">
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -827,8 +828,8 @@ export default function Settings() {
                       }`}
                     >
                       km/h
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() =>
                         setSettings((prev) => ({
                           ...prev,
@@ -842,7 +843,7 @@ export default function Settings() {
                       }`}
                     >
                       mph
-                    </button>
+                    </Button>
                   </div>
                 </div>
               </div>
@@ -858,8 +859,8 @@ export default function Settings() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('settings.languageTheme.language')}
                   </label>
-                  <div className="flex gap-4">
-                    <button
+                  <div className="flex flex-wrap gap-2 sm:gap-4">
+                    <Button
                       onClick={() => {
                         setSettings((prev) => ({ ...prev, language: 'fr' }));
                       }}
@@ -870,8 +871,8 @@ export default function Settings() {
                       }`}
                     >
                       🇫🇷 Français
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() => {
                         setSettings((prev) => ({ ...prev, language: 'en' }));
                       }}
@@ -882,7 +883,7 @@ export default function Settings() {
                       }`}
                     >
                       🇬🇧 English
-                    </button>
+                    </Button>
                   </div>
                 </div>
 
@@ -890,9 +891,9 @@ export default function Settings() {
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                     {t('settings.languageTheme.theme')}
                   </label>
-                  <div className="flex gap-4">
+                  <div className="flex flex-wrap gap-2 sm:gap-4">
                     {(['light', 'dark', 'auto'] as const).map((theme) => (
-                      <button
+                      <Button
                         key={theme}
                         onClick={() => {
                           setThemePreference(theme as ThemePreference);
@@ -908,7 +909,7 @@ export default function Settings() {
                         {theme === 'dark' && '🌙 '}
                         {theme === 'auto' && '🔄 '}
                         {t(`settings.languageTheme.${theme}`)}
-                      </button>
+                      </Button>
                     ))}
                   </div>
                 </div>
@@ -1016,13 +1017,13 @@ export default function Settings() {
                 💾 {t('settings.data.backupTitle')}
               </h2>
               <div className="space-y-3">
-                <button
+                <Button
                   onClick={exportData}
                   className="w-full px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2"
                 >
                   <span>📥</span>
                   {t('settings.data.export')}
-                </button>
+                </Button>
                 <label className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2 cursor-pointer">
                   <span>📤</span>
                   {t('settings.data.import')}
@@ -1044,12 +1045,12 @@ export default function Settings() {
               <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
                 🗑️ {t('settings.data.resetTitle')}
               </h2>
-              <button
+              <Button
                 onClick={clearData}
                 className="w-full px-6 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all"
               >
                 {t('settings.data.resetAll')}
-              </button>
+              </Button>
               <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200">
                 ⚠️ {t('settings.data.resetWarning')}
               </div>
@@ -1075,7 +1076,7 @@ export default function Settings() {
 
       {/* Save Button */}
       <div className="mt-6 sticky bottom-4 z-10">
-        <button
+        <Button
           onClick={saveSettings}
           className={`w-full px-6 py-4 rounded-xl font-bold text-lg shadow-lg transition-all ${
             saved
@@ -1086,7 +1087,7 @@ export default function Settings() {
           {saved
             ? '✅ ' + t('settings.saved')
             : '💾 ' + t('settings.saveButton')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/Sites.stories.tsx
+++ b/apps/frontend/src/pages/Sites.stories.tsx
@@ -225,7 +225,7 @@ Default.test(
       await userEvent.click(
         within(await canvas.findByRole('row', { name: 'Arguel' })).getByRole(
           'button',
-          { name: '🗑️' }
+          { name: 'Supprimer le site' }
         )
       );
       await userEvent.click(

--- a/apps/frontend/src/pages/Sites.tsx
+++ b/apps/frontend/src/pages/Sites.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
-import { Button, Input, TextField } from 'react-aria-components';
+import { Input, TextField } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   useReactTable,
@@ -158,11 +159,11 @@ export const Sites: React.FC = () => {
   return (
     <div className="container mx-auto px-4 py-8">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
         <h1 className="text-3xl font-bold">{t('sites.management')}</h1>
         <Button
           onPress={handleOpenCreateModal}
-          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
+          className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
         >
           ➕ {t('sites.newSite')}
         </Button>
@@ -223,7 +224,7 @@ export const Sites: React.FC = () => {
         <div className="text-center mt-4">
           <Button
             onPress={handleOpenCreateModal}
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
           >
             ➕ {t('sites.createFirstSite')}
           </Button>
@@ -250,7 +251,7 @@ export const Sites: React.FC = () => {
         title={t('sites.deleteSiteConfirm', { name: siteToDelete?.name })}
         size="sm"
       >
-        <div className="flex gap-3 pt-2">
+        <div className="flex flex-col sm:flex-row gap-3 pt-2">
           <Button
             onPress={() => setSiteToDelete(null)}
             isDisabled={deleteSite.isPending}

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -19,7 +19,7 @@ import {
 import { useSite } from '../hooks/sites/useSites';
 import { parseAlerts, getScoreColor } from '../types/emagram';
 import type { EmagramListItem } from '../types/emagram';
-import { DataTable } from '@dashboard-parapente/design-system';
+import { DataTable, Button } from '@dashboard-parapente/design-system';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
 
@@ -155,7 +155,7 @@ export default function ThermalAnalysis() {
           <p className="text-gray-600 dark:text-gray-300 mb-4">
             Aucune analyse récente disponible
           </p>
-          <button
+          <Button
             onClick={handleRefresh}
             disabled={triggerMutation.isPending}
             className="px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
@@ -163,7 +163,7 @@ export default function ThermalAnalysis() {
             {triggerMutation.isPending
               ? 'Analyse en cours...'
               : 'Lancer une analyse'}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -176,15 +176,15 @@ export default function ThermalAnalysis() {
   return (
     <div className="p-4 max-w-7xl mx-auto">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
         <h1 className="text-3xl font-bold">🌡️ Analyse Thermique</h1>
-        <button
+        <Button
           onClick={handleRefresh}
           disabled={triggerMutation.isPending}
           className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
         >
           {triggerMutation.isPending ? '⏳ En cours...' : '🔄 Actualiser'}
-        </button>
+        </Button>
       </div>
 
       {/* Main Analysis Card */}

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -9,6 +9,7 @@ import HourlyForecast from '../components/weather/HourlyForecast';
 import EmagramWidget from '../components/dashboard/EmagramWidget';
 import WeatherMultiLanding from '../components/weather/WeatherMultiLanding';
 import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
+import { Button } from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import { useAuthStore } from '../stores/authStore';
 import { useNavigate } from '@tanstack/react-router';
@@ -43,12 +44,12 @@ export default function WeatherPage() {
               'Ajoutez votre premier site de vol pour commencer.'
             )}
           </p>
-          <button
+          <Button
             onClick={() => void navigate({ to: '/sites' })}
             className="px-6 py-3 bg-sky-600 text-white rounded-lg font-semibold hover:bg-sky-700 transition-all"
           >
             {t('dashboard.addSite', 'Ajouter un site')}
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/libs/design-system/src/Button.stories.tsx
+++ b/libs/design-system/src/Button.stories.tsx
@@ -1,0 +1,88 @@
+import preview from '../.storybook/preview';
+import { Button } from './Button';
+
+const meta = preview.meta({
+  title: 'Components/UI/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Shared responsive button primitive used across the app. It keeps touch targets large on mobile and exposes tones for common actions.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    tone: {
+      control: 'select',
+      options: [
+        'primary',
+        'secondary',
+        'success',
+        'warning',
+        'danger',
+        'accent',
+        'cyan',
+        'ghost',
+        'outline',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'icon'],
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
+    children: {
+      control: 'text',
+    },
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    children: 'Primary action',
+    tone: 'primary',
+    size: 'md',
+  },
+});
+
+export const Variants = meta.story({
+  name: 'Variants',
+  render: () => (
+    <div className="flex flex-wrap gap-3">
+      <Button tone="primary">Primary</Button>
+      <Button tone="secondary">Secondary</Button>
+      <Button tone="success">Success</Button>
+      <Button tone="warning">Warning</Button>
+      <Button tone="danger">Danger</Button>
+      <Button tone="ghost">Ghost</Button>
+      <Button tone="outline">Outline</Button>
+    </div>
+  ),
+});
+
+export const Sizes = meta.story({
+  name: 'Sizes',
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+      <Button size="icon" aria-label="Action icon">
+        ⟳
+      </Button>
+    </div>
+  ),
+});
+
+export const FullWidth = meta.story({
+  name: 'Full Width',
+  args: {
+    children: 'Full width action',
+    fullWidth: true,
+  },
+});

--- a/libs/design-system/src/Button.tsx
+++ b/libs/design-system/src/Button.tsx
@@ -1,0 +1,87 @@
+import {
+  Button as AriaButton,
+  type ButtonProps as AriaButtonProps,
+} from 'react-aria-components';
+import { tv } from 'tailwind-variants';
+import { twMerge } from 'tailwind-merge';
+
+const buttonStyles = tv({
+  base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 disabled:pointer-events-none disabled:opacity-50',
+  variants: {
+    tone: {
+      primary:
+        'bg-sky-600 text-white hover:bg-sky-700 pressed:bg-sky-800 shadow-sm',
+      secondary:
+        'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600',
+      success:
+        'bg-green-600 text-white hover:bg-green-700 pressed:bg-green-800 shadow-sm',
+      warning:
+        'bg-orange-600 text-white hover:bg-orange-700 pressed:bg-orange-800 shadow-sm',
+      danger:
+        'bg-red-600 text-white hover:bg-red-700 pressed:bg-red-800 shadow-sm',
+      accent:
+        'bg-purple-600 text-white hover:bg-purple-700 pressed:bg-purple-800 shadow-sm',
+      cyan: 'bg-cyan-500 text-white hover:bg-cyan-600 pressed:bg-cyan-700 shadow-sm',
+      ghost:
+        'bg-transparent text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700',
+      outline:
+        'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700',
+    },
+    size: {
+      sm: 'min-h-10 px-3 py-2 text-xs sm:min-h-0 sm:py-1.5',
+      md: 'min-h-11 px-4 py-2.5 text-sm sm:min-h-0 sm:py-2',
+      lg: 'min-h-12 px-5 py-3 text-base sm:min-h-0 sm:py-3',
+      icon: 'min-h-10 min-w-10 px-0 py-0 text-sm sm:min-h-0',
+    },
+    fullWidth: {
+      true: 'w-full',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    tone: 'primary',
+    size: 'md',
+    fullWidth: false,
+  },
+});
+
+export interface ButtonProps extends AriaButtonProps {
+  tone?:
+    | 'primary'
+    | 'secondary'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'accent'
+    | 'cyan'
+    | 'ghost'
+    | 'outline';
+  size?: 'sm' | 'md' | 'lg' | 'icon';
+  fullWidth?: boolean;
+  className?: string;
+  disabled?: boolean;
+  isDisabled?: boolean;
+  title?: string;
+}
+
+export function Button({
+  className,
+  tone,
+  size,
+  fullWidth,
+  isDisabled,
+  disabled,
+  ...props
+}: ButtonProps) {
+  const type = props.type ?? 'button';
+  const finalDisabled = isDisabled ?? disabled;
+
+  return (
+    <AriaButton
+      {...props}
+      type={type}
+      isDisabled={finalDisabled}
+      className={twMerge(buttonStyles({ tone, size, fullWidth }), className)}
+    />
+  );
+}

--- a/libs/design-system/src/Button.tsx
+++ b/libs/design-system/src/Button.tsx
@@ -10,18 +10,18 @@ const buttonStyles = tv({
   variants: {
     tone: {
       primary:
-        'bg-sky-600 text-white hover:bg-sky-700 pressed:bg-sky-800 shadow-sm',
+        'bg-sky-600 text-white hover:bg-sky-700 [&[data-pressed]]:bg-sky-800 shadow-sm',
       secondary:
         'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600',
       success:
-        'bg-green-600 text-white hover:bg-green-700 pressed:bg-green-800 shadow-sm',
+        'bg-green-600 text-white hover:bg-green-700 [&[data-pressed]]:bg-green-800 shadow-sm',
       warning:
-        'bg-orange-600 text-white hover:bg-orange-700 pressed:bg-orange-800 shadow-sm',
+        'bg-orange-600 text-white hover:bg-orange-700 [&[data-pressed]]:bg-orange-800 shadow-sm',
       danger:
-        'bg-red-600 text-white hover:bg-red-700 pressed:bg-red-800 shadow-sm',
+        'bg-red-600 text-white hover:bg-red-700 [&[data-pressed]]:bg-red-800 shadow-sm',
       accent:
-        'bg-purple-600 text-white hover:bg-purple-700 pressed:bg-purple-800 shadow-sm',
-      cyan: 'bg-cyan-500 text-white hover:bg-cyan-600 pressed:bg-cyan-700 shadow-sm',
+        'bg-purple-600 text-white hover:bg-purple-700 [&[data-pressed]]:bg-purple-800 shadow-sm',
+      cyan: 'bg-cyan-500 text-white hover:bg-cyan-600 [&[data-pressed]]:bg-cyan-700 shadow-sm',
       ghost:
         'bg-transparent text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700',
       outline:

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -4,6 +4,8 @@
 export { Lightbox } from './Lightbox';
 export { Modal } from './Modal';
 export { Toast, ToastContainer } from './Toast';
+export { Button } from './Button';
+export type { ButtonProps } from './Button';
 export { DatePicker } from './components/DatePicker/DatePicker';
 export { Select } from './Select';
 export type { SelectOption } from './Select';


### PR DESCRIPTION
## Summary
- Add a shared `Button` primitive in the design system with consistent variants and mobile-friendly sizing.
- Migrate the main app screens and interactive controls to the shared button styles.
- Improve mobile layouts for button groups and compact actions.

## Verification
- `pnpm exec nx run frontend:type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A unified design-system Button is now used across the app for consistent controls.

* **Style**
  * Updated button visuals, interactive states, and spacing for a cleaner UI.
  * Many action areas now use responsive layouts that stack on small screens and align on larger viewports.

* **Accessibility**
  * Improved button labeling and aria attributes for clearer screen-reader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->