### PR TITLE
Stabilize manual video export workflow

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -20,6 +20,7 @@ import models  # noqa: F401 - imported for side effects (model registration)
 from database import Base, SessionLocal, engine
 from models import Site  # Needed for database initialization
 from routes import public_router, router
+from video_export_manual import start_video_export_worker, stop_video_export_worker
 from scheduler import scheduler, start_scheduler, stop_scheduler
 from webhooks import router as webhooks_router
 
@@ -577,10 +578,14 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("📅 Scheduler disabled, skipping cache warmup")
 
+    # Start manual video export worker
+    start_video_export_worker()
+
     yield
 
     # Shutdown
     logger.info("⏹️ Shutting down Dashboard Parapente API...")
+    stop_video_export_worker()
     stop_scheduler()
 
     # Close Redis connection

--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -164,6 +164,37 @@ class Flight(Base):
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     site = relationship("Site", back_populates="flights")
+    export_jobs = relationship(
+        "VideoExportJob",
+        back_populates="flight",
+        cascade="all, delete-orphan",
+        order_by="VideoExportJob.created_at",
+    )
+
+
+class VideoExportJob(Base):
+    __tablename__ = "video_export_jobs"
+
+    id = Column(String, primary_key=True)
+    flight_id = Column(String, ForeignKey("flights.id"), nullable=False, index=True)
+    status = Column(String, nullable=False, index=True)
+    mode = Column(String, default="manual")
+    quality = Column(String, default="1080p")
+    fps = Column(Integer, default=15)
+    speed = Column(Integer, default=1)
+    progress = Column(Integer, default=0)
+    message = Column(Text)
+    frontend_url = Column(String)
+    video_path = Column(String)
+    total_frames = Column(Integer)
+    error = Column(Text)
+    started_at = Column(DateTime, default=datetime.utcnow)
+    completed_at = Column(DateTime)
+    cancelled_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    flight = relationship("Flight", back_populates="export_jobs")
 
 
 class WeatherForecast(Base):

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -17,6 +17,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+import config
 from auth import authenticate_user, create_access_token, get_current_user
 from database import get_db
 from models import User
@@ -59,10 +60,40 @@ from video_export import start_video_export_background
 from video_export_manual import cancel_video_export as cancel_video_export_manual
 from video_export_manual import get_export_status as get_export_status_manual
 from video_export_manual import list_exports as list_exports_manual
+from video_export_manual import resolve_frontend_url
 from video_export_manual import start_video_export_manual
 from weather_pipeline import get_daily_aggregate, get_normalized_forecast
 
 logger = logging.getLogger(__name__)
+
+
+_VIDEO_EXPORT_IN_PROGRESS_STATUSES = {
+    "processing",
+    "queued",
+    "running",
+    "initializing",
+    "capturing",
+    "encoding",
+}
+
+
+def _start_video_export_stream(
+    flight_id: str, quality: str, fps: int, speed: int, frontend_url: str
+) -> str:
+    """Start stream export mode and keep API response compatible."""
+    return start_video_export_background(
+        flight_id=flight_id, quality=quality, fps=fps, speed=speed, frontend_url=frontend_url
+    )
+
+
+def _mark_flight_export_processing(db: Session, flight: Flight, job_id: str):
+    """Mark flight as having a processing export when not updated via DB job hooks."""
+    flight.video_export_job_id = job_id
+    flight.video_export_status = "processing"
+    flight.video_file_path = None
+    db.commit()
+    db.refresh(flight)
+
 
 # Public routes: no authentication required (weather, spots read, auth)
 public_router = APIRouter(prefix="/api", tags=["api"])
@@ -2845,10 +2876,9 @@ async def upload_gpx_to_flight(
 
         # 5. Trigger automatic video export
         try:
-            from config import settings
             from video_export_manual import trigger_auto_export
 
-            frontend_url = f"http://localhost:{settings.PORT}"
+            frontend_url = resolve_frontend_url()
             trigger_auto_export(flight_id, db, frontend_url)
         except Exception as e:
             logger.warning(f"Failed to trigger auto video export: {e}")
@@ -2999,10 +3029,9 @@ async def create_flight_from_gpx(
 
         # 8. Trigger automatic video export
         try:
-            from config import settings
             from video_export_manual import trigger_auto_export
 
-            frontend_url = f"http://localhost:{settings.PORT}"
+            frontend_url = resolve_frontend_url()
             trigger_auto_export(flight_id, db, frontend_url)
         except Exception as e:
             logger.warning(f"Failed to trigger auto video export: {e}")
@@ -3532,6 +3561,10 @@ def start_flight_video_export(
     """
     logger.info(f"🎥 Video export requested: flight_id={flight_id}, mode={mode}")
 
+    selected_mode = mode.lower().strip()
+    if selected_mode not in ["manual", "stream"]:
+        raise HTTPException(status_code=400, detail="mode must be 'manual' or 'stream'")
+
     # Verify flight exists
     flight = db.query(Flight).filter(Flight.id == flight_id).first()
     if not flight:
@@ -3541,36 +3574,55 @@ def start_flight_video_export(
     logger.info(f" Flight found: {flight.title} (date: {flight.flight_date})")
 
     # Determine frontend URL
-    # In production, frontend is served on same server (port 8001)
-    # In development, frontend is on Vite dev server (port 5173)
-    frontend_url = os.getenv("FRONTEND_URL")
-    if not frontend_url:
-        # Auto-detect: check if static dir exists (production) or use dev server
-        static_dir = Path(__file__).parent / "static"
-        if static_dir.exists() and (static_dir / "index.html").exists():
-            frontend_url = "http://localhost:8001"  # Production: same server
-        else:
-            frontend_url = "http://localhost:5173"  # Development: Vite dev server
+    frontend_url = resolve_frontend_url(config.FRONTEND_URL)
 
     # Start export with selected mode
-    if mode == "manual":
+    job_id: str
+    effective_mode = selected_mode
+
+    if selected_mode == "manual":
         logger.info("Using Cesium Manual Render (slow but perfect quality)")
-        job_id = start_video_export_manual(
-            flight_id=flight_id, quality=quality, fps=fps, speed=speed, frontend_url=frontend_url
-        )
-        export_method = "manual render"
+        try:
+            job_id = start_video_export_manual(
+                flight_id=flight_id,
+                quality=quality,
+                fps=fps,
+                speed=speed,
+                frontend_url=frontend_url,
+            )
+        except Exception as e:
+            logger.warning(
+                "⚠️ Manual export failed, falling back to stream for flight %s: %s",
+                flight_id,
+                e,
+            )
+            job_id = _start_video_export_stream(
+                flight_id=flight_id,
+                quality=quality,
+                fps=fps,
+                speed=speed,
+                frontend_url=frontend_url,
+            )
+            effective_mode = "stream"
+            _mark_flight_export_processing(db=db, flight=flight, job_id=job_id)
+
     else:  # stream mode
         logger.info("Using MediaRecorder stream (fast but may stutter)")
-        job_id = start_video_export_background(
-            flight_id=flight_id, quality=quality, fps=fps, speed=speed, frontend_url=frontend_url
+        job_id = _start_video_export_stream(
+            flight_id=flight_id,
+            quality=quality,
+            fps=fps,
+            speed=speed,
+            frontend_url=frontend_url,
         )
-        export_method = "stream"
+        effective_mode = "stream"
+        _mark_flight_export_processing(db=db, flight=flight, job_id=job_id)
 
     return {
         "job_id": job_id,
-        "message": f"Video export started ({export_method})",
-        "mode": mode,
-        "status_url": f"/exports/{job_id}/status",
+        "message": f"Video export started ({'media stream' if effective_mode == 'stream' else 'manual render'})",
+        "mode": effective_mode,
+        "status_url": f"/api/exports/{job_id}/status",
     }
 
 
@@ -3596,29 +3648,44 @@ def generate_flight_video(flight_id: str, db: Session = Depends(get_db)):
     if flight.video_export_status == "completed":
         raise HTTPException(status_code=400, detail="Video already exists")
 
-    if flight.video_export_status == "processing":
+    if flight.video_export_status in _VIDEO_EXPORT_IN_PROGRESS_STATUSES:
         raise HTTPException(status_code=400, detail="Video conversion already in progress")
 
     # Determine frontend URL
-    from config import API_PORT
+    frontend_url = resolve_frontend_url(config.FRONTEND_URL)
 
-    frontend_url = f"http://localhost:{API_PORT}"
-
-    # Start conversion with optimal settings
-    job_id = start_video_export_manual(
-        flight_id=flight_id,
-        quality="1080p",
-        fps=15,
-        speed=1,
-        frontend_url=frontend_url,
-        update_db=True,
-    )
+    # Prefer manual render (high quality), fallback to stream if needed
+    try:
+        job_id = start_video_export_manual(
+            flight_id=flight_id,
+            quality="1080p",
+            fps=15,
+            speed=1,
+            frontend_url=frontend_url,
+            update_db=True,
+        )
+        started_message = "Video generation started (Manual Render, ~60-90 min)"
+    except Exception as e:
+        logger.warning(
+            "⚠️ Manual generation failed, falling back to stream for flight %s: %s",
+            flight_id,
+            e,
+        )
+        job_id = _start_video_export_stream(
+            flight_id=flight_id,
+            quality="1080p",
+            fps=15,
+            speed=1,
+            frontend_url=frontend_url,
+        )
+        started_message = "Video generation started (MediaRecorder stream fallback)"
+        _mark_flight_export_processing(db=db, flight=flight, job_id=job_id)
 
     logger.info(f" Video generation started: job_id={job_id}")
 
     return {
         "job_id": job_id,
-        "message": "Video generation started (Manual Render, ~60-90 min)",
+        "message": started_message,
         "status_url": f"/api/exports/{job_id}/status",
     }
 

--- a/apps/backend/sql_migrations/009_add_video_export_jobs.sql
+++ b/apps/backend/sql_migrations/009_add_video_export_jobs.sql
@@ -1,0 +1,26 @@
+-- Video export jobs: durable background export queue/state
+CREATE TABLE IF NOT EXISTS video_export_jobs (
+    id VARCHAR PRIMARY KEY,
+    flight_id VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    mode VARCHAR DEFAULT 'manual',
+    quality VARCHAR DEFAULT '1080p',
+    fps INTEGER DEFAULT 15,
+    speed INTEGER DEFAULT 1,
+    progress INTEGER DEFAULT 0,
+    message TEXT,
+    frontend_url VARCHAR,
+    video_path VARCHAR,
+    total_frames INTEGER,
+    error TEXT,
+    started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    completed_at DATETIME,
+    cancelled_at DATETIME,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (flight_id) REFERENCES flights (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_video_export_jobs_flight_id ON video_export_jobs (flight_id);
+CREATE INDEX IF NOT EXISTS idx_video_export_jobs_status ON video_export_jobs (status);
+CREATE INDEX IF NOT EXISTS idx_video_export_jobs_created_at ON video_export_jobs (created_at);

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -1,0 +1,158 @@
+"""
+Tests for video export API endpoints.
+
+Covers fallback behavior between manual/stream modes and internal status guards.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+API_PREFIX = "/api"
+
+
+class TestVideoExportStartEndpoint:
+    """Tests for POST /flights/{flight_id}/export-video"""
+
+    def test_start_video_export_prefers_manual_when_available(
+        self, client: TestClient, sample_flight
+    ):
+        """Manual mode should be used when start_video_export_manual succeeds."""
+        with patch("routes.start_video_export_manual", return_value="job-manual"):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/export-video?mode=manual")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["job_id"] == "job-manual"
+        assert payload["mode"] == "manual"
+        assert payload["message"] == "Video export started (manual render)"
+        assert payload["status_url"] == "/api/exports/job-manual/status"
+
+    def test_start_video_export_falls_back_to_stream_on_manual_error(
+        self,
+        client: TestClient,
+        db_session,
+        sample_flight,
+    ):
+        """Manual errors should be captured and stream mode used instead."""
+        with (
+            patch(
+                "routes.start_video_export_manual", side_effect=RuntimeError("manual unavailable")
+            ),
+            patch("routes._start_video_export_stream", return_value="job-stream"),
+        ):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/export-video?mode=manual")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["job_id"] == "job-stream"
+        assert payload["mode"] == "stream"
+        assert payload["message"] == "Video export started (media stream)"
+
+        db_session.refresh(sample_flight)
+        assert sample_flight.video_export_status == "processing"
+        assert sample_flight.video_export_job_id == "job-stream"
+
+    def test_start_video_export_rejects_invalid_mode(self, client: TestClient, sample_flight):
+        """Unsupported export mode should return HTTP 400."""
+        response = client.post(f"{API_PREFIX}/flights/flight-test-001/export-video?mode=invalid")
+        assert response.status_code == 400
+        assert "mode must be 'manual' or 'stream'" in response.json()["detail"]
+
+
+class TestGenerateVideoEndpoint:
+    """Tests for POST /flights/{flight_id}/generate-video"""
+
+    def test_generate_video_uses_manual_by_default(
+        self, client: TestClient, sample_flight, db_session
+    ):
+        """Generation should default to manual render when available."""
+        sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+        db_session.commit()
+
+        with patch("routes.start_video_export_manual", return_value="job-manual"):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["job_id"] == "job-manual"
+        assert payload["message"] == "Video generation started (Manual Render, ~60-90 min)"
+
+    def test_generate_video_falls_back_to_stream_on_manual_error(
+        self,
+        client: TestClient,
+        db_session,
+        sample_flight,
+    ):
+        """Generation should fallback to stream mode if manual start fails."""
+        sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+        db_session.commit()
+
+        with (
+            patch(
+                "routes.start_video_export_manual", side_effect=RuntimeError("manual unavailable")
+            ),
+            patch("routes._start_video_export_stream", return_value="job-stream"),
+        ):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["job_id"] == "job-stream"
+        assert payload["message"] == "Video generation started (MediaRecorder stream fallback)"
+
+        db_session.refresh(sample_flight)
+        assert sample_flight.video_export_status == "processing"
+        assert sample_flight.video_export_job_id == "job-stream"
+
+    def test_generate_video_rejects_internal_in_progress_status(
+        self, client: TestClient, db_session, sample_flight
+    ):
+        """In-progress internal states must be treated as running conversions."""
+        sample_flight.video_export_status = "capturing"
+        sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+        db_session.commit()
+
+        response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Video conversion already in progress"
+
+
+class TestExportStatusAndCancel:
+    """Tests for export status/cancel endpoints."""
+
+    def test_export_status_prefers_manual_status(self, client: TestClient):
+        """If manual has a status, stream fallback should not be used."""
+        manual_status = {"status": "running", "message": "Manual running", "progress": 10}
+
+        with (
+            patch("routes.get_export_status_manual", return_value=manual_status) as mock_manual,
+            patch(
+                "routes.get_export_status_stream", return_value={"status": "completed"}
+            ) as mock_stream,
+        ):
+            response = client.get(f"{API_PREFIX}/exports/job-abc/status")
+
+        assert response.status_code == 200
+        assert response.json() == manual_status
+        mock_manual.assert_called_once_with("job-abc")
+        mock_stream.assert_not_called()
+
+    def test_export_cancel_propagates_manual_cancel_result(self, client: TestClient):
+        """Cancel endpoint returns a 400 when manual cancellation fails."""
+        with patch("routes.cancel_video_export_manual", return_value=False):
+            response = client.delete(f"{API_PREFIX}/exports/job-abc/cancel")
+
+        assert response.status_code == 400
+        assert "Export job not found or cannot be cancelled" in response.json()["detail"]
+
+    def test_export_download_missing_file_returns_not_found(self, client: TestClient):
+        """Completed status without existing file should return 404."""
+        with patch(
+            "routes.get_export_status_manual",
+            return_value={"status": "completed", "video_path": "/tmp/does-not-exist.mp4"},
+        ):
+            response = client.get(f"{API_PREFIX}/exports/job-missing/download")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Video file not found"

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -2,29 +2,61 @@
 Video export using Cesium Manual Render approach
 Based on: https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/
 
-This approach renders frame-by-frame with full control over Cesium's render loop.
-Slower but guarantees perfect quality with 0 stuttering.
+This module now stores export jobs in the database and runs from a single background
+worker while keeping a small in-memory status snapshot for compatibility.
 """
 
 import asyncio
 import shutil
 import subprocess
 import threading
+import uuid
+import traceback
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 from sqlalchemy.orm import Session
 
-# Storage for export jobs
-export_jobs: dict[str, dict] = {}
+import config
+from database import SessionLocal
+from models import Flight, VideoExportJob
+
+# Storage for export jobs (compatibility snapshot)
+export_jobs: dict[str, dict[str, Any]] = {}
 
 EXPORTS_DIR = Path(__file__).parent / "exports" / "videos"
 EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
 
+_STATUS_QUEUED = "queued"
+_STATUS_RUNNING = "running"
+_STATUS_CAPTURING = "capturing"
+_STATUS_ENCODING = "encoding"
+_STATUS_INITIALIZING = "initializing"
+_STATUS_COMPLETED = "completed"
+_STATUS_FAILED = "failed"
+_STATUS_CANCELLED = "cancelled"
+
+_ACTIVE_STATUSES = {
+    _STATUS_QUEUED,
+    _STATUS_RUNNING,
+    _STATUS_CAPTURING,
+    _STATUS_ENCODING,
+    _STATUS_INITIALIZING,
+}
+
+_TERMINAL_STATUSES = {_STATUS_COMPLETED, _STATUS_FAILED, _STATUS_CANCELLED}
+
+_WORKER_THREAD: threading.Thread | None = None
+_WORKER_STOP = threading.Event()
+_WORKER_LOCK = threading.Lock()
+_JOB_UPDATE_DB: dict[str, bool] = {}
+
+
 def check_dependencies():
-    """Check if required system dependencies are installed"""
+    """Check if required system dependencies are installed."""
     missing = []
 
     if not shutil.which("ffmpeg"):
@@ -42,6 +74,251 @@ def check_dependencies():
 _dependencies_ok = check_dependencies()
 
 
+def _to_public_status(status: str) -> str:
+    """Map internal job status to frontend-compatible status."""
+    if status == _STATUS_COMPLETED:
+        return "completed"
+    if status in {_STATUS_FAILED, _STATUS_CANCELLED}:
+        return "failed"
+    return "processing"
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _default_frontend_url() -> str:
+    if config.FRONTEND_URL:
+        return config.FRONTEND_URL.rstrip("/")
+
+    static_index = Path(__file__).parent / "static" / "index.html"
+    if static_index.exists():
+        host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
+        return f"http://{host}:{config.API_PORT}"
+
+    return "http://localhost:5173"
+
+
+def resolve_frontend_url(frontend_url: str | None = None) -> str:
+    """Return a usable frontend base URL for browser automation."""
+    if frontend_url:
+        return _normalize_frontend_url(frontend_url)
+    return _default_frontend_url()
+
+
+def _normalize_frontend_url(frontend_url: str) -> str:
+    candidate = frontend_url.rstrip("/") if frontend_url else _default_frontend_url()
+    static_index = Path(__file__).parent / "static" / "index.html"
+
+    if not candidate and static_index.exists():
+        host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
+        return f"http://{host}:{config.API_PORT}"
+
+    if not candidate:
+        return "http://localhost:5173"
+
+    if "/export-viewer" in candidate:
+        candidate = candidate.split("/export-viewer")[0]
+
+    return candidate.rstrip("/")
+
+
+def _snapshot_from_job(job: VideoExportJob) -> dict[str, Any]:
+    return {
+        "job_id": job.id,
+        "flight_id": job.flight_id,
+        "status": _to_public_status(job.status),
+        "internal_status": job.status,
+        "progress": job.progress or 0,
+        "message": job.message,
+        "started_at": _to_iso(job.started_at),
+        "completed_at": _to_iso(job.completed_at),
+        "video_path": job.video_path,
+        "error": job.error,
+        "total_frames": job.total_frames,
+        "fps": job.fps,
+        "quality": job.quality,
+        "speed": job.speed,
+    }
+
+
+def _set_memory_snapshot(job_id: str, data: dict[str, Any] | None):
+    if data is None:
+        export_jobs.pop(job_id, None)
+    else:
+        export_jobs[job_id] = data
+
+
+def _get_job(job_id: str, db: Session | None = None) -> VideoExportJob | None:
+    owns_session = False
+    if db is None:
+        db = SessionLocal()
+        owns_session = True
+    try:
+        return db.query(VideoExportJob).filter(VideoExportJob.id == job_id).first()
+    finally:
+        if owns_session:
+            db.close()
+
+
+def _update_flight_from_job(db: Session, job: VideoExportJob):
+    flight = db.query(Flight).filter(Flight.id == job.flight_id).first()
+    if not flight:
+        return
+
+    flight.video_export_job_id = job.id
+    flight.video_export_status = _to_public_status(job.status)
+
+    if job.status == _STATUS_COMPLETED:
+        flight.video_file_path = job.video_path
+    elif job.status == _STATUS_QUEUED:
+        flight.video_file_path = None
+
+
+def _update_job(
+    job_id: str,
+    *,
+    update_db: bool | None = None,
+    **kwargs,
+) -> VideoExportJob | None:
+    with SessionLocal() as db:
+        job = db.query(VideoExportJob).filter(VideoExportJob.id == job_id).first()
+        if not job:
+            return None
+
+        for key, value in kwargs.items():
+            setattr(job, key, value)
+
+        job.updated_at = datetime.utcnow()
+        if job.status in _TERMINAL_STATUSES:
+            if job.status == _STATUS_COMPLETED:
+                if not job.completed_at:
+                    job.completed_at = datetime.utcnow()
+            if job.status == _STATUS_CANCELLED and not job.cancelled_at:
+                job.cancelled_at = datetime.utcnow()
+
+            _JOB_UPDATE_DB.pop(job_id, None)
+
+        should_update_flight = _JOB_UPDATE_DB.get(job_id, True) if update_db is None else update_db
+        if should_update_flight:
+            _update_flight_from_job(db, job)
+        db.commit()
+
+        snapshot = _snapshot_from_job(job)
+        _set_memory_snapshot(job_id, snapshot)
+        return job
+
+
+def _is_cancelled(job_id: str) -> bool:
+    job = _get_job(job_id)
+    return bool(job and job.status == _STATUS_CANCELLED)
+
+
+def _mark_stale_jobs_as_queued():
+    with SessionLocal() as db:
+        cutoff = datetime.utcnow() - timedelta(minutes=2)
+        stale_jobs = (
+            db.query(VideoExportJob)
+            .filter(VideoExportJob.status.in_(list(_ACTIVE_STATUSES)))
+            .filter(VideoExportJob.updated_at < cutoff)
+            .all()
+        )
+
+        for job in stale_jobs:
+            if job.status in {_STATUS_QUEUED, _STATUS_RUNNING}:
+                job.status = _STATUS_QUEUED if job.status != _STATUS_QUEUED else job.status
+            else:
+                job.status = _STATUS_QUEUED
+            job.message = "Recovered from restart"
+            job.updated_at = datetime.utcnow()
+            db.commit()
+
+            _set_memory_snapshot(job.id, _snapshot_from_job(job))
+
+
+def _acquire_next_job() -> str | None:
+    with SessionLocal() as db:
+        job = (
+            db.query(VideoExportJob)
+            .filter(VideoExportJob.status == _STATUS_QUEUED)
+            .order_by(VideoExportJob.created_at)
+            .first()
+        )
+        if not job:
+            return None
+
+        job.status = _STATUS_RUNNING
+        job.message = "Starting manual export"
+        job.updated_at = datetime.utcnow()
+        db.commit()
+        _set_memory_snapshot(job.id, _snapshot_from_job(job))
+        return job.id
+
+
+def _cleanup_frames(frames_dir: Path):
+    if not frames_dir.exists():
+        return
+
+    for frame_file in frames_dir.glob("*.png"):
+        frame_file.unlink()
+    try:
+        frames_dir.rmdir()
+    except OSError:
+        pass
+
+
+def _worker_loop():
+    print("🚀 Manual video export worker started")
+    while not _WORKER_STOP.is_set():
+        job_id = None
+        try:
+            job_id = _acquire_next_job()
+
+            if not job_id:
+                _WORKER_STOP.wait(1)
+                continue
+
+            asyncio.run(_export_video_manual_render(job_id))
+        except Exception as e:
+            if job_id:
+                print(f"❌ Worker failed for job {job_id}: {e}")
+                traceback.print_exc()
+                _update_job(
+                    job_id,
+                    status=_STATUS_FAILED,
+                    error=str(e),
+                    message="Worker internal error",
+                )
+            else:
+                print(f"❌ Worker error: {e}")
+            traceback.print_exc()
+
+
+def start_video_export_worker():
+    """Start the singleton background worker for manual exports."""
+    global _WORKER_THREAD
+    with _WORKER_LOCK:
+        if _WORKER_THREAD and _WORKER_THREAD.is_alive():
+            return
+
+        _WORKER_STOP.clear()
+        _mark_stale_jobs_as_queued()
+
+        _WORKER_THREAD = threading.Thread(
+            target=_worker_loop,
+            name="video-export-manual-worker",
+            daemon=True,
+        )
+        _WORKER_THREAD.start()
+
+
+def stop_video_export_worker():
+    """Stop the manual export worker (used during shutdown)."""
+    _WORKER_STOP.set()
+    if _WORKER_THREAD and _WORKER_THREAD.is_alive():
+        _WORKER_THREAD.join(timeout=5)
+
+
 def start_video_export_manual(
     flight_id: str,
     quality: str = "1080p",
@@ -51,108 +328,89 @@ def start_video_export_manual(
     update_db: bool = True,
 ):
     """
-    Start video export using Cesium manual render approach
-
-    Args:
-        flight_id: ID of the flight to export
-        quality: Video quality (720p, 1080p, 4K)
-        fps: Frames per second (default 15)
-        speed: Playback speed multiplier (default 1)
-        frontend_url: URL of the frontend
-        update_db: Whether to update database (default True)
+    Create a new export job and enqueue it for the singleton worker.
     """
-    job_id = f"{flight_id}-{int(time.time())}"
+    if not _dependencies_ok:
+        raise RuntimeError("Missing dependencies for video export")
 
-    export_jobs[job_id] = {
-        "flight_id": flight_id,
-        "status": "started",
-        "progress": 0,
-        "message": "Initializing manual render export...",
-        "started_at": datetime.now().isoformat(),
-        "video_path": None,
-        "error": None,
-        "total_frames": None,
-        "cancelled": False,
-    }
+    job_id = str(uuid.uuid4())
+    now = datetime.utcnow()
 
-    # Update flight status in database if requested
-    if update_db:
-        from database import SessionLocal
-        from models import Flight
-
-        db = SessionLocal()
-        try:
-            flight = db.query(Flight).filter(Flight.id == flight_id).first()
-            if flight:
-                flight.video_export_job_id = job_id
-                flight.video_export_status = "processing"
-                flight.video_file_path = None
-                db.commit()
-        finally:
-            db.close()
-
-    # Start export in background thread (will create its own DB session)
-    thread = threading.Thread(
-        target=lambda: asyncio.run(
-            _export_video_manual_render(
-                job_id, flight_id, quality, fps, speed, frontend_url, update_db
-            )
+    with SessionLocal() as db:
+        job = VideoExportJob(
+            id=job_id,
+            flight_id=flight_id,
+            status=_STATUS_QUEUED,
+            mode="manual",
+            quality=quality,
+            fps=fps,
+            speed=speed,
+            progress=0,
+            message="Job enqueued",
+            frontend_url=frontend_url,
+            started_at=now,
+            updated_at=now,
+            created_at=now,
         )
-    )
-    thread.start()
+        db.add(job)
 
+        if update_db:
+            _JOB_UPDATE_DB[job_id] = True
+        else:
+            _JOB_UPDATE_DB[job_id] = False
+
+        flight = db.query(Flight).filter(Flight.id == flight_id).first()
+        if flight:
+            if update_db:
+                flight.video_export_job_id = job_id
+                flight.video_export_status = _to_public_status(_STATUS_QUEUED)
+                flight.video_file_path = None
+
+        db.commit()
+        _set_memory_snapshot(job_id, _snapshot_from_job(job))
+
+    start_video_export_worker()
     return job_id
 
 
-async def _export_video_manual_render(
-    job_id: str,
-    flight_id: str,
-    quality: str,
-    fps: int,
-    speed: int,
-    frontend_url: str,
-    update_db: bool = True,
-):
-    """
-    Export video using Cesium manual render - frame by frame
-    """
+async def _export_video_manual_render(job_id: str):
+    """Export video using Cesium manual render - frame by frame."""
+    job = _get_job(job_id)
+    if not job:
+        return
+
+    quality = job.quality or "1080p"
+    fps = job.fps or 15
+    speed = job.speed or 1
+    flight_id = job.flight_id
+    frontend_url = resolve_frontend_url(job.frontend_url)
+
     try:
         from playwright.async_api import async_playwright
 
-        export_jobs[job_id]["status"] = "initializing"
-        export_jobs[job_id]["message"] = "Setting up Cesium manual render..."
+        _update_job(job_id, status=_STATUS_INITIALIZING, message="Setting up manual render")
 
         # Resolution mapping
         resolutions = {"720p": (1280, 720), "1080p": (1920, 1080), "4K": (3840, 2160)}
         width, height = resolutions.get(quality, (1920, 1080))
 
-        # Check if frontend is built for production
-        static_index = Path(__file__).parent / "static" / "index.html"
-        if static_index.exists():
-            frontend_url = "http://localhost:8001"
-            print(f"📦 Using production frontend at {frontend_url}")
-
         async with async_playwright() as p:
-            # Launch browser with maximum resources
             browser = await p.chromium.launch(
                 headless=True,
                 args=[
-                    # GPU acceleration
                     "--enable-gpu",
                     "--use-gl=egl",
                     "--enable-webgl",
                     "--enable-webgl2",
                     "--ignore-gpu-blocklist",
                     "--disable-gpu-vsync",
-                    # Performance
                     "--disable-dev-shm-usage",
                     "--no-sandbox",
                     "--disable-setuid-sandbox",
-                    "--js-flags=--max-old-space-size=8192",  # 8GB heap
+                    "--js-flags=--max-old-space-size=8192",
                     "--disable-background-timer-throttling",
                     "--disable-backgrounding-occluded-windows",
                     "--disable-renderer-backgrounding",
-                    # Rendering
                     "--force-device-scale-factor=1",
                     "--high-dpi-support=1",
                 ],
@@ -165,60 +423,46 @@ async def _export_video_manual_render(
             )
             page = await context.new_page()
 
-            # Console logging
             page.on("console", lambda msg: print(f"🖥️  [{msg.type}]: {msg.text}"))
             page.on("pageerror", lambda err: print(f"❌ Browser error: {err}"))
 
-            # Navigate to export viewer
             url = f"{frontend_url}/export-viewer?flightId={flight_id}"
             print(f"📺 Opening {url}")
 
-            export_jobs[job_id]["message"] = "Loading page..."
+            _update_job(job_id, message="Loading export viewer")
             response = await page.goto(url, wait_until="networkidle", timeout=60000)
             if response.status >= 400:
                 raise Exception(f"Page returned HTTP {response.status}")
 
-            # Wait for Cesium viewer
-            export_jobs[job_id]["message"] = "Waiting for Cesium viewer..."
-            print("⏳ Waiting for Cesium viewer...")
-
+            _update_job(job_id, message="Waiting for Cesium viewer")
             await page.wait_for_selector("canvas", timeout=60000, state="attached")
-            await asyncio.sleep(3)  # Let Cesium initialize
+            await asyncio.sleep(3)
 
             print("✅ Cesium viewer found")
 
-            # Setup Cesium in manual render mode
-            export_jobs[job_id]["message"] = "Configuring Cesium manual render mode..."
-            print("🔧 Configuring Cesium for manual render...")
+            _update_job(job_id, message="Configuring manual render mode")
 
             setup_result = await page.evaluate("""
                 () => {
-                    // Find Cesium viewer
                     const cesiumContainer = document.querySelector('.cesium-viewer');
                     if (!cesiumContainer) {
                         throw new Error('Cesium viewer container not found');
                     }
 
-                    // Wait for viewer to be ready
                     return new Promise((resolve) => {
                         const checkViewer = () => {
-                            // Try to find viewer in window or container
                             const viewer = window._cesiumViewer ||
                                           window.viewer ||
                                           cesiumContainer._viewer;
 
                             if (viewer && viewer.scene) {
-                                // Disable automatic render loop
                                 viewer.useDefaultRenderLoop = false;
                                 viewer.clock.shouldAnimate = false;
 
-                                // Store viewer globally
                                 window._cesiumViewer = viewer;
                                 window._exportMode = 'manual_render';
 
                                 console.log('✅ Cesium configured for manual render');
-                                console.log('  - useDefaultRenderLoop: false');
-                                console.log('  - shouldAnimate: false');
 
                                 resolve({ success: true });
                             } else {
@@ -235,10 +479,7 @@ async def _export_video_manual_render(
 
             print("✅ Cesium manual render mode configured")
 
-            # Wait for terrain to load
-            export_jobs[job_id]["message"] = "Waiting for terrain..."
-            print("⏳ Waiting for terrain to load...")
-
+            _update_job(job_id, message="Waiting for terrain")
             try:
                 await asyncio.wait_for(
                     page.evaluate("""
@@ -265,16 +506,10 @@ async def _export_video_manual_render(
 
             await asyncio.sleep(2)
 
-            # Get GPS points and flight duration
-            export_jobs[job_id]["message"] = "Extracting GPS data..."
-            print("📍 Extracting GPS points...")
+            _update_job(job_id, message="Extracting GPS data")
 
             flight_data = await page.evaluate("""
                 () => {
-                    const viewer = window._cesiumViewer;
-
-                    // Try to get GPS data from the page
-                    // This depends on how FlightViewer3D stores the data
                     const gpxData = window._gpxData || {};
                     const coordinates = gpxData.coordinates || [];
 
@@ -282,7 +517,7 @@ async def _export_video_manual_render(
 
                     return {
                         totalPoints: coordinates.length,
-                        duration: coordinates.length > 0 ? coordinates.length : 300 // Default 5min
+                        duration: coordinates.length > 0 ? coordinates.length : 300
                     };
                 }
             """)
@@ -291,36 +526,35 @@ async def _export_video_manual_render(
             duration_seconds = flight_data["duration"]
 
             if total_gps_points == 0:
-                # Fallback: estimate from video duration
                 total_gps_points = duration_seconds
                 print(f"⚠️  No GPS data found, using estimated {total_gps_points} points")
 
             print(f"📊 GPS Points: {total_gps_points}")
             print(f"📊 Duration: {duration_seconds}s")
 
-            # Calculate frames needed
-            video_duration = duration_seconds / speed
+            video_duration = float(duration_seconds) / max(speed, 1)
             total_frames = int(video_duration * fps)
+            if total_frames <= 0:
+                total_frames = 1
 
             print(f"🎬 Will capture {total_frames} frames at {fps} FPS")
 
-            export_jobs[job_id]["total_frames"] = total_frames
-            export_jobs[job_id]["message"] = f"Preparing to capture {total_frames} frames..."
+            _update_job(
+                job_id,
+                status=_STATUS_INITIALIZING,
+                total_frames=total_frames,
+                message=f"Preparing to capture {total_frames} frames",
+            )
 
-            # Create frames directory
             frames_dir = EXPORTS_DIR / f"frames_{job_id}"
             frames_dir.mkdir(exist_ok=True)
 
             print(f"📁 Frames directory: {frames_dir}")
 
-            # Start playback
-            export_jobs[job_id]["status"] = "capturing"
-            export_jobs[job_id]["message"] = "Starting frame capture..."
-            print("▶️  Starting frame-by-frame capture...")
+            _update_job(job_id, status=_STATUS_CAPTURING, message="Starting frame capture")
 
             await page.evaluate("""
                 () => {
-                    // Click play button
                     const playButton = Array.from(document.querySelectorAll('button'))
                         .find(btn => btn.textContent.includes('Play') || btn.textContent.includes('▶'));
                     if (playButton) {
@@ -330,64 +564,56 @@ async def _export_video_manual_render(
                 }
             """)
 
-            # Capture frames manually
             frame_count = 0
-            ms_per_frame = (duration_seconds * 1000) / total_frames
-
+            ms_per_frame = (duration_seconds * 1000) / max(total_frames, 1)
             print(f"⏱️  Capturing 1 frame every {ms_per_frame:.1f}ms")
-
             start_time = time.time()
 
             for i in range(total_frames):
-                # Check for cancellation
-                if export_jobs[job_id].get("cancelled"):
+                if _is_cancelled(job_id):
                     print("🛑 Export cancelled by user")
                     await browser.close()
-                    # Cleanup frames
-                    for frame_file in frames_dir.glob("*.png"):
-                        frame_file.unlink()
-                    frames_dir.rmdir()
+                    _cleanup_frames(frames_dir)
+                    _update_job(
+                        job_id,
+                        status=_STATUS_CANCELLED,
+                        message="Export cancelled by user",
+                    )
                     return
 
-                # Render this frame in Cesium
                 tiles_loaded = await page.evaluate("""
                     () => {
                         const viewer = window._cesiumViewer;
-
-                        // Force render
                         viewer.scene.render(viewer.clock.currentTime);
-
-                        // Check if tiles are loaded
                         return viewer.scene.globe.tilesLoaded;
                     }
                 """)
 
-                # Wait a bit if tiles not loaded
                 if not tiles_loaded:
                     await asyncio.sleep(0.1)
 
-                # Capture screenshot
                 frame_path = frames_dir / f"frame{i:05d}.png"
                 await page.screenshot(path=str(frame_path), timeout=60000)
 
                 frame_count += 1
-
-                # Update progress every 10 frames
                 if frame_count % 10 == 0:
-                    progress = int((frame_count / total_frames) * 50)  # 0-50% for capture
-                    export_jobs[job_id]["progress"] = progress
-                    export_jobs[job_id]["message"] = f"Captured {frame_count}/{total_frames} frames"
-
+                    progress = int((frame_count / total_frames) * 50)
                     elapsed = time.time() - start_time
                     fps_actual = frame_count / elapsed if elapsed > 0 else 0
                     eta_seconds = (total_frames - frame_count) / fps_actual if fps_actual > 0 else 0
+
+                    _update_job(
+                        job_id,
+                        status=_STATUS_CAPTURING,
+                        progress=progress,
+                        message=f"Captured {frame_count}/{total_frames} frames",
+                    )
 
                     print(
                         f"📸 {frame_count}/{total_frames} frames ({fps_actual:.1f} fps, ETA: {int(eta_seconds/60)}min)"
                     )
 
-                # Wait for next frame time
-                await asyncio.sleep(ms_per_frame / 1000 / 10)  # Advance slowly
+                await asyncio.sleep(ms_per_frame / 1000 / 10)
 
             total_capture_time = time.time() - start_time
             print(
@@ -396,25 +622,23 @@ async def _export_video_manual_render(
 
             await browser.close()
 
-            # Check for cancellation before encoding
-            if export_jobs[job_id].get("cancelled"):
+            if _is_cancelled(job_id):
                 print("🛑 Export cancelled by user before encoding")
-                # Cleanup frames
-                for frame_file in frames_dir.glob("*.png"):
-                    frame_file.unlink()
-                frames_dir.rmdir()
+                _cleanup_frames(frames_dir)
+                _update_job(
+                    job_id,
+                    status=_STATUS_CANCELLED,
+                    message="Export cancelled before encoding",
+                )
                 return
 
-            # Encode with FFmpeg
-            export_jobs[job_id]["status"] = "encoding"
-            export_jobs[job_id]["progress"] = 50
-            export_jobs[job_id]["message"] = "Encoding video with FFmpeg..."
-
-            print("🎬 Encoding video with FFmpeg...")
-
-            output_file = (
-                EXPORTS_DIR / f"flight-{flight_id}-{datetime.now().strftime('%Y%m%d-%H%M%S')}.mp4"
+            _update_job(
+                job_id, status=_STATUS_ENCODING, progress=50, message="Encoding with FFmpeg"
             )
+
+            timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+            filename = f"flight-{flight_id}-{timestamp}.mp4"
+            output_file = EXPORTS_DIR / filename
 
             ffmpeg_cmd = [
                 "ffmpeg",
@@ -427,7 +651,7 @@ async def _export_video_manual_render(
                 "-preset",
                 "medium",
                 "-crf",
-                "18",  # Higher quality (lower CRF)
+                "18",
                 "-pix_fmt",
                 "yuv420p",
                 "-y",
@@ -435,7 +659,6 @@ async def _export_video_manual_render(
             ]
 
             print(f"🎬 FFmpeg command: {' '.join(ffmpeg_cmd)}")
-
             result = subprocess.run(ffmpeg_cmd, capture_output=True, text=True)
 
             if result.returncode != 0:
@@ -443,133 +666,94 @@ async def _export_video_manual_render(
 
             print(f"✅ Video encoded: {output_file}")
 
-            # Cleanup frames
-            print("🗑️  Cleaning up frames...")
-            for frame_file in frames_dir.glob("*.png"):
-                frame_file.unlink()
-            frames_dir.rmdir()
+            _cleanup_frames(frames_dir)
 
-            # Success
             file_size_mb = output_file.stat().st_size / (1024 * 1024)
-            export_jobs[job_id]["status"] = "completed"
-            export_jobs[job_id]["progress"] = 100
-            export_jobs[job_id]["message"] = f"Video ready! ({file_size_mb:.1f} MB)"
-            export_jobs[job_id]["video_path"] = str(output_file)
-            export_jobs[job_id]["completed_at"] = datetime.now().isoformat()
-
-            # Update flight status in database
-            if update_db:
-                from database import SessionLocal
-                from models import Flight
-
-                db = SessionLocal()
-                try:
-                    flight = db.query(Flight).filter(Flight.id == flight_id).first()
-                    if flight:
-                        flight.video_export_status = "completed"
-                        flight.video_file_path = f"exports/videos/flight_{flight_id}.mp4"
-                        db.commit()
-                finally:
-                    db.close()
+            _update_job(
+                job_id,
+                status=_STATUS_COMPLETED,
+                progress=100,
+                message=f"Video ready! ({file_size_mb:.1f} MB)",
+                video_path=str(output_file),
+            )
 
             capture_time_min = int(total_capture_time / 60)
-            print(f"✅ Export completed in {capture_time_min} minutes!")
+            print(f"✅ Export completed in {capture_time_min} minutes")
             print(f"📹 Video: {output_file} ({file_size_mb:.1f} MB)")
 
     except Exception as e:
-        print(f"❌ Export failed: {str(e)}")
-        import traceback
-
+        print(f"❌ Export failed: {e}")
         traceback.print_exc()
-
-        export_jobs[job_id]["status"] = "failed"
-        export_jobs[job_id]["error"] = str(e)
-        export_jobs[job_id]["message"] = f"Error: {str(e)}"
-
-        # Update flight status in database
-        if update_db:
-            from database import SessionLocal
-            from models import Flight
-
-            db = SessionLocal()
-            try:
-                flight = db.query(Flight).filter(Flight.id == flight_id).first()
-                if flight:
-                    flight.video_export_status = "failed"
-                    db.commit()
-            finally:
-                db.close()
+        _update_job(
+            job_id,
+            status=_STATUS_FAILED,
+            error=str(e),
+            message=f"Error: {e}",
+        )
 
 
-def get_export_status(job_id: str) -> dict | None:
-    """Get status of an export job"""
+def get_export_status(job_id: str) -> dict[str, Any] | None:
+    """Get status of an export job."""
+    job = _get_job(job_id)
+    if job:
+        snapshot = _snapshot_from_job(job)
+        _set_memory_snapshot(job_id, snapshot)
+        return snapshot
     return export_jobs.get(job_id)
 
 
 def cancel_video_export(job_id: str, update_db: bool = True) -> bool:
-    """
-    Cancel an ongoing video export
-
-    Args:
-        job_id: ID of the export job to cancel
-        update_db: Whether to update database (default True)
-
-    Returns:
-        True if cancellation was successful, False if job not found or already completed
-    """
-    job = export_jobs.get(job_id)
+    """Cancel an ongoing video export."""
+    job = _get_job(job_id)
     if not job:
         return False
 
-    # Can only cancel jobs that are in progress
-    if job["status"] in ["completed", "failed"]:
+    if job.status in _TERMINAL_STATUSES:
         return False
 
-    # Set cancellation flag
-    job["cancelled"] = True
-    job["status"] = "cancelled"
-    job["message"] = "Export cancelled by user"
-
-    # Update flight status in database
-    if update_db:
-        from database import SessionLocal
-        from models import Flight
-
-        db = SessionLocal()
-        try:
-            flight = db.query(Flight).filter(Flight.id == job["flight_id"]).first()
-            if flight:
-                flight.video_export_status = "failed"  # Reset to failed
-                flight.video_export_job_id = None
-                db.commit()
-        finally:
-            db.close()
+    _update_job(
+        job_id,
+        status=_STATUS_CANCELLED,
+        message="Export cancelled by user",
+        error=None,
+        update_db=update_db,
+    )
 
     print(f"🛑 Video export {job_id} cancelled")
     return True
 
 
-def list_exports(flight_id: str) -> list:
-    """List all exports for a flight"""
-    return [job for job_id, job in export_jobs.items() if job["flight_id"] == flight_id]
+def list_exports(flight_id: str) -> list[dict[str, Any]]:
+    """List all exports for a flight from DB and in-memory snapshots."""
+    with SessionLocal() as db:
+        jobs = (
+            db.query(VideoExportJob)
+            .filter(VideoExportJob.flight_id == flight_id)
+            .order_by(VideoExportJob.created_at.desc())
+            .all()
+        )
+
+    results = [_snapshot_from_job(job) for job in jobs]
+
+    for job_id, snapshot in export_jobs.items():
+        if snapshot.get("flight_id") != flight_id:
+            continue
+        if not any(item.get("job_id") == job_id for item in results):
+            results.append(snapshot)
+
+    return results
 
 
-def trigger_auto_export(flight_id: str, db: Session, frontend_url: str = "http://localhost:5173"):
+def trigger_auto_export(
+    flight_id: str,
+    db: Session,
+    frontend_url: str = "http://localhost:5173",
+):
     """
-    Automatically trigger video export for a flight with GPX
-    Called after GPX upload/processing
+    Automatically trigger video export for a flight with GPX.
 
-    Args:
-        flight_id: ID of the flight
-        db: Database session (only used to check if export needed)
-        frontend_url: URL of the frontend
-
-    Returns:
-        job_id if export started, None otherwise
+    Called after GPX upload/processing.
     """
-    from models import Flight
-
-    # Check if flight has GPX and doesn't already have a video export in progress
     flight = db.query(Flight).filter(Flight.id == flight_id).first()
 
     if not flight:
@@ -580,23 +764,46 @@ def trigger_auto_export(flight_id: str, db: Session, frontend_url: str = "http:/
         print(f"⚠️  Flight {flight_id} has no GPX, skipping auto-export")
         return None
 
-    if flight.video_export_status in ["processing", "completed"]:
+    if flight.video_export_status in [
+        "processing",
+        "completed",
+        "queued",
+        "running",
+        "initializing",
+        "capturing",
+        "encoding",
+    ]:
         print(
             f"ℹ️  Flight {flight_id} already has video export status: {flight.video_export_status}"
         )
         return None
 
     print(f"🚀 Auto-triggering video export for flight {flight_id}")
+    try:
+        job_id = start_video_export_manual(
+            flight_id=flight_id,
+            quality="1080p",
+            fps=15,
+            speed=1,
+            frontend_url=frontend_url,
+            update_db=True,
+        )
+        print(f"✅ Manual auto export job {job_id} started for flight {flight_id}")
+        return job_id
+    except Exception as e:
+        print(f"⚠️ Manual auto-export failed for flight {flight_id}, fallback stream: {e}")
+        from video_export import start_video_export_background
 
-    # Start export with optimal settings (creates its own DB session in thread)
-    job_id = start_video_export_manual(
-        flight_id=flight_id,
-        quality="1080p",  # Optimal quality
-        fps=15,  # Optimal FPS for smooth playback
-        speed=1,  # Real-time speed
-        frontend_url=frontend_url,
-        update_db=True,  # Update DB from within the thread
-    )
-
-    print(f"✅ Video export job {job_id} started for flight {flight_id}")
-    return job_id
+        job_id = start_video_export_background(
+            flight_id=flight_id,
+            quality="1080p",
+            fps=15,
+            speed=1,
+            frontend_url=frontend_url,
+        )
+        flight.video_export_job_id = job_id
+        flight.video_export_status = "processing"
+        flight.video_file_path = None
+        db.commit()
+        print(f"✅ Stream fallback auto export job {job_id} started for flight {flight_id}")
+        return job_id

--- a/apps/backend/webhooks.py
+++ b/apps/backend/webhooks.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
-from config import STRAVA_CLIENT_SECRET, STRAVA_VERIFY_TOKEN, TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID
+import config
 from database import SessionLocal, get_db
 from models import Flight, Site
 from routes import calculate_max_speed, parse_gpx_file_from_string
@@ -27,6 +27,22 @@ from strava import download_gpx, get_activity_details, parse_gpx
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+TELEGRAM_BOT_TOKEN = config.TELEGRAM_BOT_TOKEN
+TELEGRAM_CHAT_ID = config.TELEGRAM_CHAT_ID
+
+
+def _get_telegram_config() -> tuple[str | None, str | None]:
+    """Resolve Telegram credentials with env and compatibility aliases."""
+    bot_token = TELEGRAM_BOT_TOKEN
+    if bot_token is None:
+        bot_token = config.TELEGRAM_BOT_TOKEN
+
+    chat_id = TELEGRAM_CHAT_ID
+    if chat_id is None:
+        chat_id = config.TELEGRAM_CHAT_ID
+
+    return bot_token, chat_id
 
 
 @router.get("/strava")
@@ -45,7 +61,7 @@ async def strava_webhook_verification(
     if hub_mode != "subscribe":
         raise HTTPException(status_code=400, detail="Invalid hub.mode")
 
-    if hub_verify_token != STRAVA_VERIFY_TOKEN:
+    if hub_verify_token != config.STRAVA_VERIFY_TOKEN:
         raise HTTPException(status_code=403, detail="Invalid verify token")
 
     # Return challenge
@@ -72,10 +88,12 @@ async def strava_webhook_handler(request: Request, db: Session = Depends(get_db)
     body = await request.body()
 
     # Validate signature (optional but recommended)
-    if STRAVA_CLIENT_SECRET:
+    if config.STRAVA_CLIENT_SECRET:
         signature = request.headers.get("X-Hub-Signature")
         if signature:
-            expected = hmac.new(STRAVA_CLIENT_SECRET.encode(), body, hashlib.sha256).hexdigest()
+            expected = hmac.new(
+                config.STRAVA_CLIENT_SECRET.encode(), body, hashlib.sha256
+            ).hexdigest()
 
             if signature != f"sha256={expected}":
                 logger.warning("Invalid webhook signature")
@@ -320,10 +338,9 @@ async def process_strava_activity(activity_id: str, db: Session = None):
         # Trigger automatic video export if GPX available
         if gpx_file_path:
             try:
-                from config import settings
-                from video_export_manual import trigger_auto_export
+                from video_export_manual import trigger_auto_export, resolve_frontend_url
 
-                frontend_url = f"http://localhost:{settings.PORT}"
+                frontend_url = resolve_frontend_url(config.FRONTEND_URL)
                 trigger_auto_export(flight.id, db, frontend_url)
             except Exception as e:
                 logger.warning(f"Failed to trigger auto video export: {e}")
@@ -489,7 +506,9 @@ async def send_telegram_notification(flight: Flight, is_new: bool = True):
         flight: Flight object
         is_new: True if new flight, False if update
     """
-    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+    bot_token, chat_id = _get_telegram_config()
+
+    if not bot_token or not chat_id:
         logger.warning("Telegram not configured, skipping notification")
         return
 
@@ -521,11 +540,16 @@ async def send_telegram_notification(flight: Flight, is_new: bool = True):
             message += f"\n🔗 [Voir sur Strava]({flight.external_url})"
 
         # Send via Telegram Bot API
-        url = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+        url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                url, json={"chat_id": TELEGRAM_CHAT_ID, "text": message, "parse_mode": "Markdown"}
+                url,
+                json={
+                    "chat_id": chat_id,
+                    "text": message,
+                    "parse_mode": "Markdown",
+                },
             )
 
             response.raise_for_status()

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -27,7 +27,19 @@ import { api } from '../../lib/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
 
-import {GPXData} from "@dashboard-parapente/shared-types";
+import { GPXData } from '@dashboard-parapente/shared-types';
+
+const VIDEO_EXPORT_IN_PROGRESS = new Set([
+  'processing',
+  'queued',
+  'running',
+  'initializing',
+  'capturing',
+  'encoding',
+]);
+
+const isVideoExportInProgress = (status?: string | null) =>
+  Boolean(status && VIDEO_EXPORT_IN_PROGRESS.has(status));
 
 declare global {
   interface Window {
@@ -1028,7 +1040,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         <div className="absolute inset-0 flex items-center justify-center bg-blue-50 dark:bg-blue-900/20 z-20">
           <div className="text-center p-8">
             <p className="text-lg dark:text-white">⏳ Chargement du vol...</p>
-            <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">Flight ID: {flightId}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
+              Flight ID: {flightId}
+            </p>
           </div>
         </div>
       );
@@ -1044,7 +1058,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
             <p className="text-sm text-yellow-700 dark:text-yellow-300">
               Les données GPS ne sont pas disponibles pour ce vol.
             </p>
-            <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">Error: {String(error)}</p>
+            <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
+              Error: {String(error)}
+            </p>
           </div>
         </div>
       );
@@ -1054,7 +1070,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       return (
         <div className="absolute inset-0 flex items-center justify-center bg-red-50 dark:bg-red-900/20 z-20">
           <div className="text-center p-8">
-            <p className="text-lg dark:text-white">❌ Aucune donnée GPS disponible</p>
+            <p className="text-lg dark:text-white">
+              ❌ Aucune donnée GPS disponible
+            </p>
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
               GPX Data: {JSON.stringify(gpxData)}
             </p>
@@ -1242,7 +1260,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                               if (!response.ok) {
                                 const error = await response.json();
                                 toast.error(
-                                  error.detail || 'Impossible de lancer la génération'
+                                  error.detail ||
+                                    'Impossible de lancer la génération'
                                 );
                                 return;
                               }
@@ -1262,7 +1281,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                             }
                           }
                         }}
-                        disabled={flight.video_export_status === 'processing'}
+                        disabled={isVideoExportInProgress(
+                          flight.video_export_status
+                        )}
                         className={`w-full px-3 py-2 text-white rounded ${
                           flight.video_export_status === 'completed'
                             ? 'mb-2'
@@ -1270,12 +1291,14 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         } ${
                           flight.video_export_status === 'completed'
                             ? 'bg-green-600 hover:bg-green-700'
-                            : flight.video_export_status === 'processing'
+                            : isVideoExportInProgress(
+                                  flight.video_export_status
+                                )
                               ? 'bg-gray-400 cursor-not-allowed'
                               : 'bg-blue-600 hover:bg-blue-700'
                         }`}
                         title={
-                          flight.video_export_status === 'processing'
+                          isVideoExportInProgress(flight.video_export_status)
                             ? 'Génération vidéo en cours... (~60-90 min)'
                             : flight.video_export_status === 'completed'
                               ? 'Télécharger la vidéo'
@@ -1284,7 +1307,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                                 : 'Générer la vidéo du vol'
                         }
                       >
-                        {flight.video_export_status === 'processing' &&
+                        {isVideoExportInProgress(flight.video_export_status) &&
                           '⏳ Génération en cours...'}
                         {flight.video_export_status === 'completed' &&
                           '📥 Télécharger la vidéo'}
@@ -1293,8 +1316,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         {!flight.video_export_status && '🎥 Générer la vidéo'}
                       </button>
 
-                      {/* Cancel Button (only when processing) */}
-                      {flight.video_export_status === 'processing' &&
+                      {/* Cancel Button (only when export is active) */}
+                      {isVideoExportInProgress(flight.video_export_status) &&
                         flight.video_export_job_id && (
                           <button
                             onClick={async () => {
@@ -1317,7 +1340,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                                 if (!response.ok) {
                                   const error = await response.json();
                                   toast.error(
-                                    error.detail || "Impossible d'annuler la génération"
+                                    error.detail ||
+                                      "Impossible d'annuler la génération"
                                   );
                                   return;
                                 }
@@ -1364,7 +1388,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                               if (!response.ok) {
                                 const error = await response.json();
                                 toast.error(
-                                  error.detail || 'Impossible de lancer la régénération'
+                                  error.detail ||
+                                    'Impossible de lancer la régénération'
                                 );
                                 return;
                               }

--- a/apps/frontend/src/hooks/flights/useFlight.ts
+++ b/apps/frontend/src/hooks/flights/useFlight.ts
@@ -3,6 +3,18 @@ import { api } from '../../lib/api';
 import { getStaleTime } from '../../lib/cacheConfig';
 import type { Flight } from '@dashboard-parapente/shared-types';
 
+const IN_PROGRESS_STATUSES = new Set([
+  'processing',
+  'queued',
+  'running',
+  'initializing',
+  'capturing',
+  'encoding',
+]);
+
+const isExportInProgress = (status?: string | null) =>
+  status ? IN_PROGRESS_STATUSES.has(status) : false;
+
 /**
  * Fetch flight details including video export status
  */
@@ -17,7 +29,7 @@ export const useFlight = (flightId: string) => {
     refetchInterval: (query) => {
       // Auto-refresh every 10 seconds if video is processing
       const data = query.state.data as Flight | undefined;
-      return data?.video_export_status === 'processing' ? 10000 : false;
+      return isExportInProgress(data?.video_export_status) ? 10000 : false;
     },
   });
 };

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -14,9 +14,9 @@ import { Route as ThermalRouteImport } from './routes/thermal'
 import { Route as SitesRouteImport } from './routes/sites'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as InfrastructureRouteImport } from './routes/infrastructure'
 import { Route as FlightsRouteImport } from './routes/flights'
 import { Route as ExportViewerRouteImport } from './routes/export-viewer'
-import { Route as InfrastructureRouteImport } from './routes/infrastructure'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ViewerFlightIdRouteImport } from './routes/viewer.$flightId'
@@ -46,6 +46,13 @@ const LoginRoute = LoginRouteImport.update({
   path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
+const InfrastructureRoute = InfrastructureRouteImport.update({
+  id: '/infrastructure',
+  path: '/infrastructure',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/infrastructure.lazy').then((d) => d.Route),
+)
 const FlightsRoute = FlightsRouteImport.update({
   id: '/flights',
   path: '/flights',
@@ -56,11 +63,6 @@ const ExportViewerRoute = ExportViewerRouteImport.update({
   path: '/export-viewer',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/export-viewer.lazy').then((d) => d.Route))
-const InfrastructureRoute = InfrastructureRouteImport.update({
-  id: '/infrastructure',
-  path: '/infrastructure',
-  getParentRoute: () => rootRouteImport,
-} as any).lazy(() => import('./routes/infrastructure.lazy').then((d) => d.Route))
 const AnalyticsRoute = AnalyticsRouteImport.update({
   id: '/analytics',
   path: '/analytics',
@@ -82,9 +84,9 @@ const ViewerFlightIdRoute = ViewerFlightIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
@@ -95,9 +97,9 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
@@ -109,9 +111,9 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
-  '/infrastructure': typeof InfrastructureRoute
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRoute
+  '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
@@ -124,9 +126,9 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/analytics'
-    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
+    | '/infrastructure'
     | '/login'
     | '/settings'
     | '/sites'
@@ -137,9 +139,9 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/analytics'
-    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
+    | '/infrastructure'
     | '/login'
     | '/settings'
     | '/sites'
@@ -150,9 +152,9 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/analytics'
-    | '/infrastructure'
     | '/export-viewer'
     | '/flights'
+    | '/infrastructure'
     | '/login'
     | '/settings'
     | '/sites'
@@ -164,9 +166,9 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AnalyticsRoute: typeof AnalyticsRoute
-  InfrastructureRoute: typeof InfrastructureRoute
   ExportViewerRoute: typeof ExportViewerRoute
   FlightsRoute: typeof FlightsRoute
+  InfrastructureRoute: typeof InfrastructureRoute
   LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
   SitesRoute: typeof SitesRoute
@@ -212,6 +214,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/infrastructure': {
+      id: '/infrastructure'
+      path: '/infrastructure'
+      fullPath: '/infrastructure'
+      preLoaderRoute: typeof InfrastructureRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/flights': {
       id: '/flights'
       path: '/flights'
@@ -224,13 +233,6 @@ declare module '@tanstack/react-router' {
       path: '/export-viewer'
       fullPath: '/export-viewer'
       preLoaderRoute: typeof ExportViewerRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/infrastructure': {
-      id: '/infrastructure'
-      path: '/infrastructure'
-      fullPath: '/infrastructure'
-      preLoaderRoute: typeof InfrastructureRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/analytics': {
@@ -260,9 +262,9 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRoute,
-  InfrastructureRoute: InfrastructureRoute,
   ExportViewerRoute: ExportViewerRoute,
   FlightsRoute: FlightsRoute,
+  InfrastructureRoute: InfrastructureRoute,
   LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,
   SitesRoute: SitesRoute,

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -67,7 +67,19 @@ export const FlightSchema = z.object({
   gpx_elevation_gain_m: z.number().nullish(),
   external_url: z.string().nullish(),
   video_export_job_id: z.string().nullish(),
-  video_export_status: z.enum(['processing', 'completed', 'failed']).nullish(),
+  video_export_status: z
+    .enum([
+      'processing',
+      'completed',
+      'failed',
+      'queued',
+      'running',
+      'initializing',
+      'capturing',
+      'encoding',
+      'cancelled',
+    ])
+    .nullish(),
   video_file_path: z.string().nullish(),
   site: SiteSchema.optional(),
   created_at: z.string().optional(),


### PR DESCRIPTION
## Summary
- Add a DB-backed manual video export workflow and route integration for flight export.
- Prioritize manual video export with resilient fallback to stream mode.
- Persist and expose manual export jobs from backend and reflect expanded in-progress statuses in frontend types/UI.
- Add API-level coverage for new manual-export endpoints and status/cancel/download behavior.
- Restore backward compatibility for Telegram webhook notification configuration so existing tests and callers keep working.

## Validation
- Ran `pnpm exec nx run backend:test -- -k test_send_telegram_notification_new_flight --maxfail=1 -q`
- Ran `pnpm exec nx run backend:test -- -k test_webhooks --maxfail=1 -q`
- Ran `pnpm exec nx run backend:test -- -k test_video_export --maxfail=1 -q`
- Ran `pnpm exec nx run backend:test -- --maxfail=1 -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent video export jobs with detailed multi-stage statuses and a singleton worker; DB migration to add export jobs table.
  * Worker starts/stops with the backend lifecycle; manual export enqueues jobs and may fall back to streaming.

* **Bug Fixes**
  * UI and polling handle multiple in-progress statuses for accurate buttons, tooltips, and refresh behavior.

* **Tests**
  * Expanded endpoint tests covering manual/stream fallback, validation, status, cancel, and download scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->