### PR TITLE
feat(flights): mobile flight replay lazy loading

### DIFF
--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -282,6 +282,7 @@ def _acquire_next_job() -> str | None:
         job = (
             db.query(VideoExportJob)
             .filter(VideoExportJob.status == _STATUS_QUEUED)
+            .with_for_update(skip_locked=True)
             .order_by(VideoExportJob.created_at)
             .first()
         )
@@ -425,6 +426,7 @@ async def _export_video_manual_render(job_id: str):
     speed = job.speed or 1
     flight_id = job.flight_id
     frontend_url = resolve_frontend_url(job.frontend_url)
+    frames_dir: Path | None = None
 
     try:
         from playwright.async_api import async_playwright
@@ -654,7 +656,7 @@ async def _export_video_manual_render(job_id: str):
                         f"📸 {frame_count}/{total_frames} frames ({fps_actual:.1f} fps, ETA: {int(eta_seconds/60)}min)"
                     )
 
-                await asyncio.sleep(ms_per_frame / 1000 / 10)
+                await asyncio.sleep(ms_per_frame / 1000)
 
             total_capture_time = time.time() - start_time
             print(
@@ -700,7 +702,17 @@ async def _export_video_manual_render(job_id: str):
             ]
 
             print(f"🎬 FFmpeg command: {' '.join(ffmpeg_cmd)}")
-            result = subprocess.run(ffmpeg_cmd, capture_output=True, text=True)
+            try:
+                result = subprocess.run(
+                    ffmpeg_cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30 * 60,
+                )
+            except subprocess.TimeoutExpired as timeout_error:
+                raise Exception(
+                    f"FFmpeg timeout after 1800s: {' '.join(ffmpeg_cmd)}"
+                ) from timeout_error
 
             if result.returncode != 0:
                 raise Exception(f"FFmpeg encoding failed: {result.stderr}")
@@ -723,6 +735,8 @@ async def _export_video_manual_render(job_id: str):
             print(f"📹 Video: {output_file} ({file_size_mb:.1f} MB)")
 
     except Exception as e:
+        if frames_dir is not None:
+            _cleanup_frames(frames_dir)
         print(f"❌ Export failed: {e}")
         traceback.print_exc()
         _update_job(

--- a/apps/backend/webhooks.py
+++ b/apps/backend/webhooks.py
@@ -61,6 +61,10 @@ async def strava_webhook_verification(
     if hub_mode != "subscribe":
         raise HTTPException(status_code=400, detail="Invalid hub.mode")
 
+    if not config.STRAVA_VERIFY_TOKEN:
+        logger.error("STRAVA_VERIFY_TOKEN is not configured")
+        raise HTTPException(status_code=500, detail="Webhook not configured")
+
     if hub_verify_token != config.STRAVA_VERIFY_TOKEN:
         raise HTTPException(status_code=403, detail="Invalid verify token")
 

--- a/apps/frontend/.storybook/vitest.setup.ts
+++ b/apps/frontend/.storybook/vitest.setup.ts
@@ -9,6 +9,7 @@ beforeAll(async () => {
   await preview.composed.beforeAll();
   const worker = getWorker();
   await worker.context.activationPromise;
+  // Mock Cesium terrain heights file so 3D stories/tests avoid network JSON errors.
   worker.use(
     http.get(/approximateTerrainHeights\.json(?:\?.*)?$/, () =>
       HttpResponse.json({})

--- a/apps/frontend/.storybook/vitest.setup.ts
+++ b/apps/frontend/.storybook/vitest.setup.ts
@@ -2,9 +2,16 @@ import { beforeAll } from 'vitest';
 import preview from './preview';
 import { getWorker } from 'msw-storybook-addon';
 import { overrideApi } from '../src/lib/api';
+import { http, HttpResponse } from 'msw';
 
 beforeAll(async () => {
   overrideApi({ retry: 0, logs: false });
   await preview.composed.beforeAll();
-  await getWorker().context.activationPromise;
+  const worker = getWorker();
+  await worker.context.activationPromise;
+  worker.use(
+    http.get(/approximateTerrainHeights\.json(?:\?.*)?$/, () =>
+      HttpResponse.json({})
+    )
+  );
 });

--- a/apps/frontend/src/components/flights/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.stories.tsx
@@ -187,6 +187,45 @@ export const WithoutGpx = meta.story({
   args: { flight: flightWithoutGpx },
 });
 
+export const Mobile = meta.story({
+  name: 'Mobile',
+  args: { flight: fullFlight, mobileMode: true },
+});
+
+Mobile.test('shows compact mobile infos tab by default', async ({ canvas }) => {
+  await expect(canvas.getByText(fullFlight.title ?? '')).toBeInTheDocument();
+  await expect(
+    canvas.getByRole('button', { name: i18n.t('flights.backToList') })
+  ).toBeInTheDocument();
+  await expect(
+    canvas.getByRole('button', { name: i18n.t('flights.infoTab') })
+  ).toBeInTheDocument();
+  await expect(
+    canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
+  ).toBeInTheDocument();
+  await expect(
+    canvas.queryByText(i18n.t('flights.loading3dViewer'))
+  ).not.toBeInTheDocument();
+});
+
+export const MobileWithoutGpx = meta.story({
+  name: 'Mobile Without GPX',
+  args: { flight: flightWithoutGpx, mobileMode: true },
+});
+
+MobileWithoutGpx.test(
+  'displays unavailable replay state when GPX is missing',
+  async ({ canvas, userEvent }) => {
+    const replayTab = await canvas.findByRole('button', {
+      name: i18n.t('flights.replayTab'),
+    });
+    await userEvent.click(replayTab);
+    await expect(
+      await canvas.findByText(i18n.t('flights.replayUnavailable'))
+    ).toBeInTheDocument();
+  }
+);
+
 export const MinimalFlight = meta.story({
   name: 'Minimal Flight',
   args: { flight: minimalFlight },

--- a/apps/frontend/src/components/flights/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.stories.tsx
@@ -126,6 +126,9 @@ const meta = preview.meta({
   title: 'Components/Flights/FlightDetails',
   component: FlightDetails,
   decorators: [ToastDecorator],
+  beforeEach: () => {
+    useToastStore.setState({ toasts: [] });
+  },
   parameters: {
     layout: 'padded',
     msw: { handlers: defaultHandlers },
@@ -139,7 +142,7 @@ const meta = preview.meta({
 
 export const Default = meta.story({
   name: 'Default',
-  args: { flight: fullFlight },
+  args: { flight: fullFlight, mobileMode: true },
 });
 Default.test(
   'The flight can be edited',
@@ -193,15 +196,17 @@ export const Mobile = meta.story({
 });
 
 Mobile.test('shows compact mobile infos tab by default', async ({ canvas }) => {
-  await expect(canvas.getByText(fullFlight.title ?? '')).toBeInTheDocument();
+  await expect(
+    canvas.getAllByRole('heading', { name: fullFlight.title ?? '' }).length
+  ).toBeGreaterThan(0);
   await expect(
     canvas.getByRole('button', { name: i18n.t('flights.backToList') })
   ).toBeInTheDocument();
   await expect(
-    canvas.getByRole('button', { name: i18n.t('flights.infoTab') })
+    canvas.getByRole('tab', { name: i18n.t('flights.infoTab') })
   ).toBeInTheDocument();
   await expect(
-    canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
+    canvas.getByRole('tab', { name: i18n.t('flights.replayTab') })
   ).toBeInTheDocument();
   await expect(
     canvas.queryByText(i18n.t('flights.loading3dViewer'))
@@ -216,7 +221,7 @@ export const MobileWithoutGpx = meta.story({
 MobileWithoutGpx.test(
   'displays unavailable replay state when GPX is missing',
   async ({ canvas, userEvent }) => {
-    const replayTab = await canvas.findByRole('button', {
+    const replayTab = await canvas.findByRole('tab', {
       name: i18n.t('flights.replayTab'),
     });
     await userEvent.click(replayTab);

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, lazy, Suspense, ChangeEvent } from 'react';
+import { useState, useRef, lazy, Suspense, ChangeEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { TextField, TextArea } from 'react-aria-components';
@@ -21,7 +21,11 @@ interface FlightDetailsProps {
   flight: Flight;
   sites: Site[];
   onShowCreateSiteModal: () => void;
+  mobileMode?: boolean;
+  onCloseMobile?: () => void;
 }
+
+type FlightDetailsTab = 'infos' | 'replay';
 
 const labelClass = 'text-xs text-gray-600 dark:text-gray-300';
 const valueClass =
@@ -31,6 +35,8 @@ export function FlightDetails({
   flight,
   sites,
   onShowCreateSiteModal,
+  mobileMode = false,
+  onCloseMobile,
 }: FlightDetailsProps) {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
@@ -42,6 +48,22 @@ export function FlightDetails({
   const [editingMode, setEditingMode] = useState(false);
   const [editingNotes, setEditingNotes] = useState(false);
   const [notesText, setNotesText] = useState(flight.notes ?? '');
+  const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
+
+  const hasGpx = Boolean(flight.gpx_file_path);
+  const flightTitle =
+    flight.title ??
+    (() => {
+      const [y, m, d] = flight.flight_date.split('-');
+      const localDate = new Date(Number(y), Number(m) - 1, Number(d));
+      return t('flights.flightOf', {
+        date: localDate.toLocaleDateString(i18n.language),
+      });
+    })();
+
+  useEffect(() => {
+    setActiveTab('infos');
+  }, [flight.id]);
 
   const handleSubmitEdit = async (values: FlightFormData) => {
     await updateFlight.mutateAsync(values);
@@ -89,262 +111,297 @@ export function FlightDetails({
     }
   };
 
-  return (
-    <>
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        {editingMode ? (
-          <FlightEditForm
-            flight={flight}
-            sites={sites}
-            onSubmit={handleSubmitEdit}
-            onCancel={() => setEditingMode(false)}
-            onShowCreateSiteModal={onShowCreateSiteModal}
-          />
-        ) : (
-          <>
-            {/* Header */}
-            <div className="flex flex-col sm:flex-row justify-between items-start gap-2 mb-4">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white">
-                {flight.title ?? t('flights.untitledFlight')}
-              </h2>
-              <div className="flex flex-col sm:flex-row gap-2 ml-0 sm:ml-4 w-full sm:w-auto">
-                <Button
-                  className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-sky-600 text-white rounded-md hover:bg-sky-700 transition-all"
-                  onPress={() => setEditingMode(true)}
-                  aria-label={t('flights.editFlight')}
-                >
-                  {t('flights.editButton')}
-                </Button>
-                <Button
-                  className={`px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm rounded-md transition-all ${
-                    flight.gpx_file_path
-                      ? 'bg-green-600 text-white hover:bg-green-700'
-                      : 'bg-orange-600 text-white hover:bg-orange-700'
-                  }`}
-                  onPress={() => fileInputRef.current?.click()}
-                  isDisabled={uploadGPXMutation.isPending}
-                >
-                  {uploadGPXMutation.isPending
-                    ? t('flights.uploadInProgress')
-                    : flight.gpx_file_path
-                      ? t('flights.replaceGpx')
-                      : t('flights.addGpx')}
-                </Button>
-              </div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".gpx"
-                aria-label={t('flights.gpxFileInput')}
-                onChange={handleGPXUpload}
-                className="hidden"
-              />
-            </div>
-
-            {/* Read-only fields */}
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
-              <div>
-                <span className={labelClass}>{t('flights.dateLabel')}</span>
-                <span className={valueClass}>
-                  {(() => {
-                    const [year, month, day] = flight.flight_date.split('-');
-                    const localDate = new Date(
-                      Number(year),
-                      Number(month) - 1,
-                      Number(day)
-                    );
-                    return localDate.toLocaleDateString(i18n.language, {
-                      weekday: 'long',
-                      day: 'numeric',
-                      month: 'long',
-                      year: 'numeric',
-                    });
-                  })()}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>{t('flights.departureTime')}</span>
-                <span className={valueClass}>
-                  {flight.departure_time
-                    ? new Date(flight.departure_time).toLocaleTimeString(
-                        i18n.language,
-                        { hour: '2-digit', minute: '2-digit' }
-                      )
-                    : 'N/A'}
-                </span>
-              </div>
-
-              <div className="col-span-2 md:col-span-3">
-                <span className={labelClass}>{t('flights.siteLabel')}</span>
-                <span className={valueClass}>
-                  {flight.site_name ??
-                    flight.site_id ??
-                    t('flights.notSpecified')}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>{t('flights.durationLabel')}</span>
-                <span className={valueClass}>
-                  {flight.duration_minutes != null ? (
-                    <>
-                      {Math.floor(flight.duration_minutes / 60)}h{' '}
-                      {flight.duration_minutes % 60}m
-                    </>
-                  ) : (
-                    'N/A'
-                  )}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>{t('flights.distanceLabel')}</span>
-                <span className={valueClass}>
-                  {flight.distance_km != null
-                    ? `${flight.distance_km.toFixed(2)} km`
-                    : 'N/A'}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>
-                  {t('flights.maxAltitudeLabel')}
-                </span>
-                <span className={valueClass}>
-                  {flight.max_altitude_m != null
-                    ? `${flight.max_altitude_m} m`
-                    : 'N/A'}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>
-                  {t('flights.elevationGainLabel')}
-                </span>
-                <span className={valueClass}>
-                  {flight.elevation_gain_m != null
-                    ? `${flight.elevation_gain_m} m`
-                    : 'N/A'}
-                </span>
-              </div>
-
-              <div>
-                <span className={labelClass}>{t('flights.maxSpeedLabel')}</span>
-                <span className={valueClass}>
-                  {flight.max_speed_kmh != null
-                    ? `${flight.max_speed_kmh.toFixed(2)} km/h`
-                    : 'N/A'}
-                </span>
-              </div>
-            </div>
-
-            {/* Notes */}
-            <div>
-              <label
-                htmlFor="flight-notes"
-                className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 block"
+  const infoCard = (
+    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+      {editingMode ? (
+        <FlightEditForm
+          flight={flight}
+          sites={sites}
+          onSubmit={handleSubmitEdit}
+          onCancel={() => setEditingMode(false)}
+          onShowCreateSiteModal={onShowCreateSiteModal}
+        />
+      ) : (
+        <>
+          <div className="flex justify-between items-start mb-4">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+              {flightTitle}
+            </h2>
+            <div className="flex gap-2 ml-4">
+              <Button
+                className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-sky-600 text-white rounded-md hover:bg-sky-700 transition-all"
+                onPress={() => setEditingMode(true)}
+                aria-label={t('flights.editFlight')}
               >
-                {t('flights.notesLabel')}
-              </label>
-              {editingNotes ? (
-                <div className="space-y-2">
-                  <TextField value={notesText} onChange={setNotesText}>
-                    <TextArea
-                      id="flight-notes"
-                      placeholder={t('flights.notesPlaceholder')}
-                      rows={4}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-600 resize-none dark:bg-gray-700 dark:text-gray-100"
-                    />
-                  </TextField>
-                  <div className="flex flex-col sm:flex-row gap-2">
-                    <Button
-                      className="px-4 py-2 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 transition-all disabled:opacity-50"
-                      onPress={handleSaveNotes}
-                      isDisabled={updateFlight.isPending}
-                    >
-                      {updateFlight.isPending
-                        ? t('flights.saving')
-                        : t('flights.saveButton')}
-                    </Button>
-                    <Button
-                      className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
-                      onPress={() => {
-                        setNotesText(flight.notes ?? '');
-                        setEditingNotes(false);
-                      }}
-                    >
-                      {t('flights.cancel')}
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <p className="text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 p-3 rounded-lg">
-                  {flight.notes ?? t('flights.noNotes')}
-                </p>
-              )}
+                {t('flights.editButton')}
+              </Button>
+              <Button
+                className={`px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm rounded-md transition-all ${
+                  flight.gpx_file_path
+                    ? 'bg-green-600 text-white hover:bg-green-700'
+                    : 'bg-orange-600 text-white hover:bg-orange-700'
+                }`}
+                onPress={() => fileInputRef.current?.click()}
+                isDisabled={uploadGPXMutation.isPending}
+              >
+                {uploadGPXMutation.isPending
+                  ? t('flights.uploadInProgress')
+                  : flight.gpx_file_path
+                    ? t('flights.replaceGpx')
+                    : t('flights.addGpx')}
+              </Button>
             </div>
-
-            {/* GPX status */}
-            <div className="mt-4 pt-4 border-t dark:border-gray-700">
-              {flight.gpx_file_path ? (
-                <div className="flex items-center gap-2 text-sm text-green-700 bg-green-50 p-3 rounded-lg">
-                  <span className="text-xl">✅</span>
-                  <div>
-                    <p className="font-medium">{t('flights.gpxAvailable')}</p>
-                    <p className="text-xs text-green-600">
-                      {t('flights.viewer3dActive')}
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 text-sm text-orange-700 bg-orange-50 p-3 rounded-lg">
-                  <span className="text-xl">⚠️</span>
-                  <div>
-                    <p className="font-medium">
-                      {t('flights.gpxMissingDetail')}
-                    </p>
-                    <p className="text-xs text-orange-600">
-                      {t('flights.gpxMissingHint')}
-                    </p>
-                  </div>
-                </div>
-              )}
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* 3D Viewer — only when GPX is available */}
-      {flight.gpx_file_path && (
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden">
-          <Suspense
-            fallback={
-              <div className="h-96 flex items-center justify-center text-gray-500 dark:text-gray-400">
-                {t('flights.loading3dViewer')}
-              </div>
-            }
-          >
-            <FlightViewer3D
-              flightId={flight.id}
-              flightTitle={
-                flight.title ??
-                (() => {
-                  const [y, m, d] = flight.flight_date.split('-');
-                  const localDate = new Date(
-                    Number(y),
-                    Number(m) - 1,
-                    Number(d)
-                  );
-                  return t('flights.flightOf', {
-                    date: localDate.toLocaleDateString(i18n.language),
-                  });
-                })()
-              }
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".gpx"
+              aria-label={t('flights.gpxFileInput')}
+              onChange={handleGPXUpload}
+              className="hidden"
             />
-          </Suspense>
-        </div>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
+            <div>
+              <span className={labelClass}>{t('flights.dateLabel')}</span>
+              <span className={valueClass}>
+                {(() => {
+                  const [year, month, day] = flight.flight_date.split('-');
+                  const localDate = new Date(
+                    Number(year),
+                    Number(month) - 1,
+                    Number(day)
+                  );
+                  return localDate.toLocaleDateString(i18n.language, {
+                    weekday: 'long',
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                  });
+                })()}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.departureTime')}</span>
+              <span className={valueClass}>
+                {flight.departure_time
+                  ? new Date(flight.departure_time).toLocaleTimeString(
+                      i18n.language,
+                      { hour: '2-digit', minute: '2-digit' }
+                    )
+                  : 'N/A'}
+              </span>
+            </div>
+
+            <div className="col-span-2 md:col-span-3">
+              <span className={labelClass}>{t('flights.siteLabel')}</span>
+              <span className={valueClass}>
+                {flight.site_name ??
+                  flight.site_id ??
+                  t('flights.notSpecified')}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.durationLabel')}</span>
+              <span className={valueClass}>
+                {flight.duration_minutes != null ? (
+                  <>
+                    {Math.floor(flight.duration_minutes / 60)}h{' '}
+                    {flight.duration_minutes % 60}m
+                  </>
+                ) : (
+                  'N/A'
+                )}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.distanceLabel')}</span>
+              <span className={valueClass}>
+                {flight.distance_km != null
+                  ? `${flight.distance_km.toFixed(2)} km`
+                  : 'N/A'}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.maxAltitudeLabel')}</span>
+              <span className={valueClass}>
+                {flight.max_altitude_m != null
+                  ? `${flight.max_altitude_m} m`
+                  : 'N/A'}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.elevationGainLabel')}</span>
+              <span className={valueClass}>
+                {flight.elevation_gain_m != null
+                  ? `${flight.elevation_gain_m} m`
+                  : 'N/A'}
+              </span>
+            </div>
+
+            <div>
+              <span className={labelClass}>{t('flights.maxSpeedLabel')}</span>
+              <span className={valueClass}>
+                {flight.max_speed_kmh != null
+                  ? `${flight.max_speed_kmh.toFixed(2)} km/h`
+                  : 'N/A'}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="flight-notes"
+              className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 block"
+            >
+              {t('flights.notesLabel')}
+            </label>
+            {editingNotes ? (
+              <div className="space-y-2">
+                <TextField value={notesText} onChange={setNotesText}>
+                  <TextArea
+                    id="flight-notes"
+                    placeholder={t('flights.notesPlaceholder')}
+                    rows={4}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-sky-600 resize-none dark:bg-gray-700 dark:text-gray-100"
+                  />
+                </TextField>
+                <div className="flex gap-2">
+                  <Button
+                    className="px-4 py-2 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 transition-all disabled:opacity-50"
+                    onPress={handleSaveNotes}
+                    isDisabled={updateFlight.isPending}
+                  >
+                    {updateFlight.isPending
+                      ? t('flights.saving')
+                      : t('flights.saveButton')}
+                  </Button>
+                  <Button
+                    className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
+                    onPress={() => {
+                      setNotesText(flight.notes ?? '');
+                      setEditingNotes(false);
+                    }}
+                  >
+                    {t('flights.cancel')}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-900 p-3 rounded-lg">
+                {flight.notes ?? t('flights.noNotes')}
+              </p>
+            )}
+          </div>
+
+          <div className="mt-4 pt-4 border-t dark:border-gray-700">
+            {flight.gpx_file_path ? (
+              <div className="flex items-center gap-2 text-sm text-green-700 bg-green-50 p-3 rounded-lg">
+                <span className="text-xl">✅</span>
+                <div>
+                  <p className="font-medium">{t('flights.gpxAvailable')}</p>
+                  <p className="text-xs text-green-600">
+                    {t('flights.viewer3dActive')}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 text-sm text-orange-700 bg-orange-50 p-3 rounded-lg">
+                <span className="text-xl">⚠️</span>
+                <div>
+                  <p className="font-medium">{t('flights.gpxMissingDetail')}</p>
+                  <p className="text-xs text-orange-600">
+                    {t('flights.gpxMissingHint')}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </>
       )}
-    </>
+    </div>
   );
+
+  const replayCard = hasGpx ? (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden">
+      <Suspense
+        fallback={
+          <div className="h-96 flex items-center justify-center text-gray-500 dark:text-gray-400">
+            {t('flights.loading3dViewer')}
+          </div>
+        }
+      >
+        <FlightViewer3D
+          flightId={flight.id}
+          flightTitle={flightTitle}
+          compact={mobileMode}
+        />
+      </Suspense>
+    </div>
+  ) : (
+    <div className="bg-white dark:bg-gray-800 rounded-xl p-8 shadow-md text-center">
+      <p className="text-sm text-gray-700 dark:text-gray-300">
+        {t('flights.replayUnavailable')}
+      </p>
+    </div>
+  );
+
+  if (mobileMode) {
+    return (
+      <div className="space-y-4">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+          <div className="flex items-center gap-2 mb-4">
+            <button
+              type="button"
+              className="px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md"
+              onClick={onCloseMobile}
+            >
+              {t('flights.backToList')}
+            </button>
+            <h2 className="text-base font-bold text-gray-900 dark:text-white truncate">
+              {flightTitle}
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 mb-4" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'infos'}
+              className={`px-3 py-2 text-sm rounded-md transition-colors ${
+                activeTab === 'infos'
+                  ? 'bg-sky-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200'
+              }`}
+              onClick={() => setActiveTab('infos')}
+            >
+              {t('flights.infoTab')}
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={activeTab === 'replay'}
+              className={`px-3 py-2 text-sm rounded-md transition-colors ${
+                activeTab === 'replay'
+                  ? 'bg-sky-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200'
+              }`}
+              onClick={() => setActiveTab('replay')}
+            >
+              {t('flights.replayTab')}
+            </button>
+          </div>
+        </div>
+
+        {activeTab === 'infos' ? infoCard : replayCard}
+      </div>
+    );
+  }
+
+  return <>{infoCard}{hasGpx ? replayCard : null}</>;
 }

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -1,4 +1,11 @@
-import { useState, useRef, lazy, Suspense, ChangeEvent, useEffect } from 'react';
+import {
+  useState,
+  useRef,
+  lazy,
+  Suspense,
+  ChangeEvent,
+  useEffect,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { TextField, TextArea } from 'react-aria-components';
@@ -51,8 +58,9 @@ export function FlightDetails({
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
 
   const hasGpx = Boolean(flight.gpx_file_path);
+  const normalizedTitle = flight.title?.trim();
   const flightTitle =
-    flight.title ??
+    normalizedTitle ||
     (() => {
       const [y, m, d] = flight.flight_date.split('-');
       const localDate = new Date(Number(y), Number(m) - 1, Number(d));
@@ -63,7 +71,10 @@ export function FlightDetails({
 
   useEffect(() => {
     setActiveTab('infos');
-  }, [flight.id]);
+    setEditingMode(false);
+    setEditingNotes(false);
+    setNotesText(flight.notes ?? '');
+  }, [flight.id, flight.notes]);
 
   const handleSubmitEdit = async (values: FlightFormData) => {
     await updateFlight.mutateAsync(values);
@@ -74,7 +85,7 @@ export function FlightDetails({
   const handleSaveNotes = async () => {
     try {
       await updateFlight.mutateAsync({
-        title: flight.title ?? '',
+        title: normalizedTitle ?? '',
         site_id: flight.site_id ?? null,
         flight_date: flight.flight_date,
         duration_minutes: flight.duration_minutes ?? 0,
@@ -227,7 +238,9 @@ export function FlightDetails({
             </div>
 
             <div>
-              <span className={labelClass}>{t('flights.maxAltitudeLabel')}</span>
+              <span className={labelClass}>
+                {t('flights.maxAltitudeLabel')}
+              </span>
               <span className={valueClass}>
                 {flight.max_altitude_m != null
                   ? `${flight.max_altitude_m} m`
@@ -236,7 +249,9 @@ export function FlightDetails({
             </div>
 
             <div>
-              <span className={labelClass}>{t('flights.elevationGainLabel')}</span>
+              <span className={labelClass}>
+                {t('flights.elevationGainLabel')}
+              </span>
               <span className={valueClass}>
                 {flight.elevation_gain_m != null
                   ? `${flight.elevation_gain_m} m`
@@ -403,5 +418,10 @@ export function FlightDetails({
     );
   }
 
-  return <>{infoCard}{hasGpx ? replayCard : null}</>;
+  return (
+    <>
+      {infoCard}
+      {hasGpx ? replayCard : null}
+    </>
+  );
 }

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -52,6 +52,7 @@ declare global {
 interface FlightViewer3DProps {
   flightId: string;
   flightTitle?: string;
+  compact?: boolean;
 }
 
 /**
@@ -100,6 +101,7 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
 export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   flightId,
   flightTitle = 'Flight View',
+  compact = false,
 }) => {
   const { data: gpxData, isLoading, error } = useFlightGPX(flightId);
   const { data: flight } = useFlight(flightId);
@@ -116,7 +118,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const [autoOffset, setAutoOffset] = useState(0);
   const [isCalculatingOffset, setIsCalculatingOffset] = useState(false);
   const [currentProgress, setCurrentProgress] = useState(0);
-  const [isPanelCollapsed, setIsPanelCollapsed] = useState(false);
+  const [isPanelCollapsed, setIsPanelCollapsed] = useState(compact);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [currentElapsedTime, setCurrentElapsedTime] = useState(0);
 
@@ -679,6 +681,27 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     };
   }, []);
 
+  useEffect(() => {
+    setIsPanelCollapsed(compact);
+  }, [compact]);
+
+  const panelClassName = compact
+    ? isPanelCollapsed
+      ? 'p-1.5'
+      : 'p-2 max-w-[220px]'
+    : isPanelCollapsed
+      ? 'p-2'
+      : 'p-4 max-w-xs';
+
+  const fullscreenButtonClassName = compact ? 'px-2 py-1.5 text-xs' : 'px-3 py-2';
+  const compactControlButtonClassName = compact
+    ? 'px-2 py-1.5 text-xs'
+    : 'px-3 py-2 text-sm';
+  const compactTitleClass = compact ? 'text-sm font-bold' : 'text-lg font-bold';
+  const compactToggleButtonClassName = compact
+    ? 'px-1.5 py-0.5 text-xs'
+    : 'px-2 py-1 text-sm';
+
   // Cleanup export polling on unmount
   useEffect(() => {
     return () => {
@@ -1151,7 +1174,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     <div
       ref={containerDivRef}
       className="relative w-full bg-gray-900"
-      style={{ height: isFullscreen ? '100vh' : '600px' }}
+      style={{ height: isFullscreen ? '100vh' : compact ? '420px' : '600px' }}
     >
       {/* Overlay for loading/error states */}
       {renderOverlay()}
@@ -1160,7 +1183,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       {gpxData?.coordinates && (
         <Button
           onClick={toggleFullscreen}
-          className="absolute top-4 right-4 z-10 px-3 py-2 bg-gray-800 text-white rounded-lg shadow-lg hover:bg-gray-700"
+          className={`absolute top-4 right-4 z-10 bg-gray-800 text-white rounded-lg shadow-lg hover:bg-gray-700 ${fullscreenButtonClassName}`}
           title={isFullscreen ? 'Quitter le plein écran' : 'Plein écran'}
         >
           {isFullscreen ? '🗗 Quitter' : '⛶ Plein écran'}
@@ -1170,17 +1193,15 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       {/* Controls - only show when data is loaded */}
       {gpxData?.coordinates && (
         <div
-          className={`absolute top-4 left-4 z-10 bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all ${
-            isPanelCollapsed ? 'p-2' : 'p-4 max-w-xs'
-          }`}
+          className={`absolute top-4 left-4 z-10 bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all ${panelClassName}`}
         >
           <div className="flex items-center justify-between mb-2">
             {!isPanelCollapsed && (
-              <h3 className="text-lg font-bold">🪂 {flightTitle}</h3>
+              <h3 className={compactTitleClass}>🪂 {flightTitle}</h3>
             )}
             <Button
               onClick={() => setIsPanelCollapsed(!isPanelCollapsed)}
-              className="px-2 py-1 bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300 dark:hover:bg-gray-600 text-sm dark:text-gray-200"
+              className={`${compactToggleButtonClassName} bg-gray-200 dark:bg-gray-600 rounded hover:bg-gray-300 dark:hover:bg-gray-600 dark:text-gray-200`}
               title={
                 isPanelCollapsed ? 'Ouvrir le panneau' : 'Réduire le panneau'
               }
@@ -1211,14 +1232,14 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                   <div className="flex gap-2">
                     <Button
                       onClick={togglePlayPause}
-                      className="px-3 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400"
+                      className={`${compactControlButtonClassName} bg-blue-600 text-white rounded hover:bg-blue-700 disabled:bg-gray-400`}
                       data-testid="flight-play-toggle"
                     >
                       {isPlaying ? '⏸ Pause' : '▶ Play'}
                     </Button>
                     <Button
                       onClick={reset}
-                      className="px-3 py-2 bg-gray-600 text-white rounded hover:bg-gray-700 disabled:bg-gray-400"
+                      className={`${compactControlButtonClassName} bg-gray-600 text-white rounded hover:bg-gray-700 disabled:bg-gray-400`}
                     >
                       ⏮ Reset
                     </Button>
@@ -1328,7 +1349,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         disabled={isVideoExportInProgress(
                           flight.video_export_status
                         )}
-                        className={`w-full px-3 py-2 text-white rounded ${
+                        className={`w-full ${compactControlButtonClassName} text-white rounded ${
                           flight.video_export_status === 'completed'
                             ? 'mb-2'
                             : 'mb-3'
@@ -1559,7 +1580,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                       <div className="space-y-2">
                         <Button
                           onClick={() => applyCameraToCurrentPlayback()}
-                          className="w-full px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+                          className={`w-full ${compactControlButtonClassName} bg-blue-600 text-white rounded hover:bg-blue-700`}
                           data-testid="camera-apply-button"
                         >
                           👁️ Appliquer à la lecture
@@ -1567,7 +1588,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         <Button
                           onClick={saveCameraSettings}
                           disabled={isUpdatingCamera}
-                          className="w-full px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                          className={`w-full ${compactControlButtonClassName} bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed`}
                           data-testid="camera-save-button"
                         >
                           {isUpdatingCamera

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -28,19 +28,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
 import { Button } from '@dashboard-parapente/design-system';
 
-import { GPXData, type Flight } from '@dashboard-parapente/shared-types';
-
-const VIDEO_EXPORT_IN_PROGRESS = new Set([
-  'processing',
-  'queued',
-  'running',
-  'initializing',
-  'capturing',
-  'encoding',
-]);
+import {
+  GPXData,
+  VIDEO_EXPORT_IN_PROGRESS_STATUSES,
+  type Flight,
+} from '@dashboard-parapente/shared-types';
 
 const isVideoExportInProgress = (status?: string | null) =>
-  Boolean(status && VIDEO_EXPORT_IN_PROGRESS.has(status));
+  Boolean(status && VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status));
 
 declare global {
   interface Window {
@@ -693,7 +688,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       ? 'p-2'
       : 'p-4 max-w-xs';
 
-  const fullscreenButtonClassName = compact ? 'px-2 py-1.5 text-xs' : 'px-3 py-2';
+  const fullscreenButtonClassName = compact
+    ? 'px-2 py-1.5 text-xs'
+    : 'px-3 py-2';
   const compactControlButtonClassName = compact
     ? 'px-2 py-1.5 text-xs'
     : 'px-3 py-2 text-sm';
@@ -1106,7 +1103,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           <div className="text-center p-8">
             <p className="text-lg dark:text-white">⏳ Chargement du vol...</p>
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
-              Flight ID: {flightId}
+              Chargement des donnees GPS et du relief...
             </p>
           </div>
         </div>
@@ -1124,7 +1121,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
               Les données GPS ne sont pas disponibles pour ce vol.
             </p>
             <p className="text-xs text-gray-600 dark:text-gray-300 mt-2">
-              Error: {String(error)}
+              Reessayez dans quelques instants.
             </p>
           </div>
         </div>
@@ -1139,7 +1136,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
               ❌ Aucune donnée GPS disponible
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
-              GPX Data: {JSON.stringify(gpxData)}
+              Les informations de trace sont indisponibles pour ce vol.
             </p>
           </div>
         </div>
@@ -1367,7 +1364,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                             ? 'Génération vidéo en cours... (~60-90 min)'
                             : flight.video_export_status === 'completed'
                               ? 'Télécharger la vidéo'
-                              : flight.video_export_status === 'failed'
+                              : flight.video_export_status === 'failed' ||
+                                  flight.video_export_status === 'cancelled'
                                 ? 'Relancer la génération'
                                 : 'Générer la vidéo du vol'
                         }
@@ -1376,7 +1374,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           '⏳ Génération en cours...'}
                         {flight.video_export_status === 'completed' &&
                           '📥 Télécharger la vidéo'}
-                        {flight.video_export_status === 'failed' &&
+                        {(flight.video_export_status === 'failed' ||
+                          flight.video_export_status === 'cancelled') &&
                           '🔄 Relancer la génération'}
                         {!flight.video_export_status && '🎥 Générer la vidéo'}
                       </Button>

--- a/apps/frontend/src/hooks/flights/useFlight.ts
+++ b/apps/frontend/src/hooks/flights/useFlight.ts
@@ -1,19 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from '../../lib/api';
 import { getStaleTime } from '../../lib/cacheConfig';
-import type { Flight } from '@dashboard-parapente/shared-types';
-
-const IN_PROGRESS_STATUSES = new Set([
-  'processing',
-  'queued',
-  'running',
-  'initializing',
-  'capturing',
-  'encoding',
-]);
+import {
+  type Flight,
+  VIDEO_EXPORT_IN_PROGRESS_STATUSES,
+} from '@dashboard-parapente/shared-types';
 
 const isExportInProgress = (status?: string | null) =>
-  status ? IN_PROGRESS_STATUSES.has(status) : false;
+  status ? VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status) : false;
 
 /**
  * Fetch flight details including video export status

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -415,7 +415,11 @@
     "deleteButton": "🗑️ Delete",
     "deleteButtonCount_one": "🗑️ Delete {{count}} flight",
     "deleteButtonCount_other": "🗑️ Delete {{count}} flights",
-    "gpxFileInput": "GPX file"
+    "gpxFileInput": "GPX file",
+    "infoTab": "Info",
+    "replayTab": "Replay",
+    "backToList": "← Back",
+    "replayUnavailable": "No GPX available for this flight"
   },
   "createSite": {
     "title": "Create a new site",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -415,7 +415,11 @@
     "deleteButton": "🗑️ Supprimer",
     "deleteButtonCount_one": "🗑️ Supprimer {{count}} vol",
     "deleteButtonCount_other": "🗑️ Supprimer {{count}} vols",
-    "gpxFileInput": "Fichier GPX"
+    "gpxFileInput": "Fichier GPX",
+    "infoTab": "Infos",
+    "replayTab": "Replay",
+    "backToList": "← Retour",
+    "replayUnavailable": "Aucun GPX disponible pour ce vol"
   },
   "createSite": {
     "title": "Créer un nouveau site",

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -4,6 +4,31 @@ import preview from '../../.storybook/preview';
 import FlightHistory from './FlightHistory';
 import i18n from 'i18next';
 
+type MediaQueryCallback = (event: MediaQueryListEvent) => void;
+
+function installMatchMediaMock(isMobile: boolean) {
+  const originalMatchMedia = window.matchMedia;
+
+  const createMediaQueryList = (query: string): MediaQueryList => {
+    return {
+      matches: query === '(max-width: 639px)' ? isMobile : false,
+      media: query,
+      onchange: null,
+      addEventListener: (_event: string, _listener: MediaQueryCallback) => {},
+      removeEventListener: (_event: string, _listener: MediaQueryCallback) => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList;
+  };
+
+  window.matchMedia = ((query: string) => createMediaQueryList(query)) as typeof window.matchMedia;
+
+  return () => {
+    window.matchMedia = originalMatchMedia;
+  };
+}
+
 const meta = preview.meta({
   title: 'Pages/FlightHistory',
   component: FlightHistory,
@@ -95,13 +120,45 @@ const mockSites = {
 
 const flightsDb: Record<string, unknown>[] = [...mockFlights];
 
+let gpxRequestCount = 0;
+
+const mockGPXData = {
+  coordinates: [
+    {
+      lat: 47.2,
+      lon: 6.0,
+      elevation: 800,
+      time: '2026-03-15T14:00:00.000Z',
+    },
+    {
+      lat: 47.21,
+      lon: 6.01,
+      elevation: 900,
+      time: '2026-03-15T14:01:00.000Z',
+    },
+  ],
+  max_altitude_m: 1850,
+  min_altitude_m: 700,
+  elevation_gain_m: 1200,
+  elevation_loss_m: 300,
+  total_distance_km: 18.5,
+  flight_duration_seconds: 5700,
+};
+
 const resetFlightsDb = () => {
   flightsDb.length = 0;
   flightsDb.push(...mockFlights);
 };
 
-const defaultHandlers = [
+const createHandlers = (gpxDelayMs = 0) => [
   http.get('*/api/flights', () => HttpResponse.json({ flights: flightsDb })),
+  http.get('*/api/flights/:id/gpx-data', async () => {
+    if (gpxDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, gpxDelayMs));
+    }
+    gpxRequestCount += 1;
+    return HttpResponse.json({ data: mockGPXData });
+  }),
   http.get('*/api/flights/:id', ({ params }) => {
     const flight = flightsDb.find((f) => f.id === params.id);
     return flight
@@ -126,6 +183,8 @@ const defaultHandlers = [
     return HttpResponse.json({ success: true, message: 'Flight deleted' });
   }),
 ];
+
+const defaultHandlers = createHandlers();
 
 export const Default = meta.story({
   name: 'Default',
@@ -222,6 +281,123 @@ Default.test(
     });
   }
 );
+export const MobileFlow = meta.story({
+  name: 'Mobile Flow',
+  parameters: { msw: { handlers: defaultHandlers } },
+  beforeEach: resetFlightsDb,
+});
+
+MobileFlow.test(
+  'opens a flight, switches tabs, and returns to list on mobile',
+  async ({ canvas, userEvent, step }) => {
+    const cleanup = installMatchMediaMock(true);
+
+    try {
+      await step('has the flight list', async () => {
+        const flightList = await canvas.findByRole('grid', {
+          name: i18n.t('flights.listAriaLabel'),
+        });
+        await expect(flightList).toBeInTheDocument();
+      });
+
+      await step('opens a flight in mobile detail mode', async () => {
+        await userEvent.click(canvas.getByText('Chalais 10-03 11h00'));
+        await expect(
+          await canvas.findByRole('button', { name: i18n.t('flights.backToList') })
+        ).toBeInTheDocument();
+      });
+
+      await step('switches to Replay and shows unavailable state', async () => {
+        await userEvent.click(
+          canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
+        );
+        await expect(
+          await canvas.findByText(i18n.t('flights.replayUnavailable'))
+        ).toBeInTheDocument();
+      });
+
+      await step('returns to the list', async () => {
+        await userEvent.click(
+          canvas.getByRole('button', { name: i18n.t('flights.backToList') })
+        );
+        await expect(
+          await canvas.findByRole('grid', {
+            name: i18n.t('flights.listAriaLabel'),
+          })
+        ).toBeInTheDocument();
+        await expect(
+          canvas.queryByRole('button', { name: i18n.t('flights.infoTab') })
+        ).not.toBeInTheDocument();
+      });
+    } finally {
+      cleanup();
+    }
+  }
+);
+
+export const MobileFlowWithReplay = meta.story({
+  name: 'Mobile Flow With Replay',
+  parameters: {
+    msw: {
+      handlers: createHandlers(150),
+    },
+  },
+  beforeEach: () => {
+    resetFlightsDb();
+    gpxRequestCount = 0;
+  },
+});
+
+MobileFlowWithReplay.test(
+  'loads GPX data only when Replay tab is selected',
+  async ({ canvas, userEvent, step }) => {
+    const cleanup = installMatchMediaMock(true);
+
+    try {
+      await step('has the flight list', async () => {
+        const flightList = await canvas.findByRole('grid', {
+          name: i18n.t('flights.listAriaLabel'),
+        });
+        await expect(flightList).toBeInTheDocument();
+      });
+
+      await step('opens a flight with GPX', async () => {
+        await userEvent.click(canvas.getByText('Vol thermique Arguel'));
+        await expect(
+          await canvas.findByRole('button', { name: i18n.t('flights.backToList') })
+        ).toBeInTheDocument();
+      });
+
+      await step('does not load GPX while Infos tab is active', () => {
+        expect(gpxRequestCount).toBe(0);
+      });
+
+      await step('switches to Replay and shows loading state', async () => {
+        await userEvent.click(
+          canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
+        );
+
+        await expect(
+          await canvas.findByText(i18n.t('flights.loading3dViewer'))
+        ).toBeInTheDocument();
+      });
+
+      await step('triggers GPX loading once Replay is active', async () => {
+        await waitFor(() => {
+          expect(gpxRequestCount).toBeGreaterThan(0);
+        });
+        await waitFor(() => {
+          expect(
+            canvas.queryByText(i18n.t('flights.loading3dViewer'))
+          ).not.toBeInTheDocument();
+        });
+      });
+    } finally {
+      cleanup();
+    }
+  }
+);
+
 // clique sur un vol => les détails du vol
 // supprimer plusieurs vols
 // annuler la suppression de plusieurs vols

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -3,6 +3,7 @@ import { expect, screen, waitFor, within } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import FlightHistory from './FlightHistory';
 import i18n from 'i18next';
+import { useToastStore } from '../hooks/useToast';
 
 type MediaQueryCallback = (event: MediaQueryListEvent) => void;
 
@@ -15,14 +16,18 @@ function installMatchMediaMock(isMobile: boolean) {
       media: query,
       onchange: null,
       addEventListener: (_event: string, _listener: MediaQueryCallback) => {},
-      removeEventListener: (_event: string, _listener: MediaQueryCallback) => {},
+      removeEventListener: (
+        _event: string,
+        _listener: MediaQueryCallback
+      ) => {},
       addListener: () => {},
       removeListener: () => {},
       dispatchEvent: () => false,
     } as unknown as MediaQueryList;
   };
 
-  window.matchMedia = ((query: string) => createMediaQueryList(query)) as typeof window.matchMedia;
+  window.matchMedia = ((query: string) =>
+    createMediaQueryList(query)) as typeof window.matchMedia;
 
   return () => {
     window.matchMedia = originalMatchMedia;
@@ -32,6 +37,7 @@ function installMatchMediaMock(isMobile: boolean) {
 const meta = preview.meta({
   title: 'Pages/FlightHistory',
   component: FlightHistory,
+  decorators: [(Story, context) => <Story key={context.id} />],
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],
 });
@@ -150,6 +156,12 @@ const resetFlightsDb = () => {
   flightsDb.push(...mockFlights);
 };
 
+const resetStoryState = () => {
+  resetFlightsDb();
+  gpxRequestCount = 0;
+  useToastStore.setState({ toasts: [] });
+};
+
 const createHandlers = (gpxDelayMs = 0) => [
   http.get('*/api/flights', () => HttpResponse.json({ flights: flightsDb })),
   http.get('*/api/flights/:id/gpx-data', async () => {
@@ -189,7 +201,7 @@ const defaultHandlers = createHandlers();
 export const Default = meta.story({
   name: 'Default',
   parameters: { msw: { handlers: defaultHandlers } },
-  beforeEach: resetFlightsDb,
+  beforeEach: resetStoryState,
 });
 
 Default.test(
@@ -284,54 +296,53 @@ Default.test(
 export const MobileFlow = meta.story({
   name: 'Mobile Flow',
   parameters: { msw: { handlers: defaultHandlers } },
-  beforeEach: resetFlightsDb,
+  beforeEach: () => {
+    resetStoryState();
+    return installMatchMediaMock(true);
+  },
 });
 
 MobileFlow.test(
   'opens a flight, switches tabs, and returns to list on mobile',
   async ({ canvas, userEvent, step }) => {
-    const cleanup = installMatchMediaMock(true);
+    await step('has the flight list', async () => {
+      const flightList = await canvas.findByRole('grid', {
+        name: i18n.t('flights.listAriaLabel'),
+      });
+      await expect(flightList).toBeInTheDocument();
+    });
 
-    try {
-      await step('has the flight list', async () => {
-        const flightList = await canvas.findByRole('grid', {
+    await step('opens a flight in mobile detail mode', async () => {
+      await userEvent.click(await canvas.findByTestId('flight-row-flight-002'));
+      await expect(
+        await canvas.findByRole('button', {
+          name: i18n.t('flights.backToList'),
+        })
+      ).toBeInTheDocument();
+    });
+
+    await step('switches to Replay and shows unavailable state', async () => {
+      await userEvent.click(
+        canvas.getByRole('tab', { name: i18n.t('flights.replayTab') })
+      );
+      await expect(
+        await canvas.findByText(i18n.t('flights.replayUnavailable'))
+      ).toBeInTheDocument();
+    });
+
+    await step('returns to the list', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: i18n.t('flights.backToList') })
+      );
+      await expect(
+        await canvas.findByRole('grid', {
           name: i18n.t('flights.listAriaLabel'),
-        });
-        await expect(flightList).toBeInTheDocument();
-      });
-
-      await step('opens a flight in mobile detail mode', async () => {
-        await userEvent.click(canvas.getByText('Chalais 10-03 11h00'));
-        await expect(
-          await canvas.findByRole('button', { name: i18n.t('flights.backToList') })
-        ).toBeInTheDocument();
-      });
-
-      await step('switches to Replay and shows unavailable state', async () => {
-        await userEvent.click(
-          canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
-        );
-        await expect(
-          await canvas.findByText(i18n.t('flights.replayUnavailable'))
-        ).toBeInTheDocument();
-      });
-
-      await step('returns to the list', async () => {
-        await userEvent.click(
-          canvas.getByRole('button', { name: i18n.t('flights.backToList') })
-        );
-        await expect(
-          await canvas.findByRole('grid', {
-            name: i18n.t('flights.listAriaLabel'),
-          })
-        ).toBeInTheDocument();
-        await expect(
-          canvas.queryByRole('button', { name: i18n.t('flights.infoTab') })
-        ).not.toBeInTheDocument();
-      });
-    } finally {
-      cleanup();
-    }
+        })
+      ).toBeInTheDocument();
+      await expect(
+        canvas.queryByRole('tab', { name: i18n.t('flights.infoTab') })
+      ).not.toBeInTheDocument();
+    });
   }
 );
 
@@ -343,58 +354,49 @@ export const MobileFlowWithReplay = meta.story({
     },
   },
   beforeEach: () => {
-    resetFlightsDb();
-    gpxRequestCount = 0;
+    resetStoryState();
+    return installMatchMediaMock(true);
   },
 });
 
 MobileFlowWithReplay.test(
   'loads GPX data only when Replay tab is selected',
   async ({ canvas, userEvent, step }) => {
-    const cleanup = installMatchMediaMock(true);
-
-    try {
-      await step('has the flight list', async () => {
-        const flightList = await canvas.findByRole('grid', {
-          name: i18n.t('flights.listAriaLabel'),
-        });
-        await expect(flightList).toBeInTheDocument();
+    await step('has the flight list', async () => {
+      const flightList = await canvas.findByRole('grid', {
+        name: i18n.t('flights.listAriaLabel'),
       });
+      await expect(flightList).toBeInTheDocument();
+    });
 
-      await step('opens a flight with GPX', async () => {
-        await userEvent.click(canvas.getByText('Vol thermique Arguel'));
-        await expect(
-          await canvas.findByRole('button', { name: i18n.t('flights.backToList') })
-        ).toBeInTheDocument();
+    await step('opens a flight with GPX', async () => {
+      await userEvent.click(await canvas.findByTestId('flight-row-flight-001'));
+      await expect(
+        await canvas.findByRole('button', {
+          name: i18n.t('flights.backToList'),
+        })
+      ).toBeInTheDocument();
+    });
+
+    await step('does not load GPX while Infos tab is active', () => {
+      expect(gpxRequestCount).toBe(0);
+    });
+
+    await step('switches to Replay and shows loading state', async () => {
+      await userEvent.click(
+        canvas.getByRole('tab', { name: i18n.t('flights.replayTab') })
+      );
+
+      await expect(
+        await canvas.findByText(i18n.t('flights.loading3dViewer'))
+      ).toBeInTheDocument();
+    });
+
+    await step('triggers GPX loading once Replay is active', async () => {
+      await waitFor(() => {
+        expect(gpxRequestCount).toBeGreaterThan(0);
       });
-
-      await step('does not load GPX while Infos tab is active', () => {
-        expect(gpxRequestCount).toBe(0);
-      });
-
-      await step('switches to Replay and shows loading state', async () => {
-        await userEvent.click(
-          canvas.getByRole('button', { name: i18n.t('flights.replayTab') })
-        );
-
-        await expect(
-          await canvas.findByText(i18n.t('flights.loading3dViewer'))
-        ).toBeInTheDocument();
-      });
-
-      await step('triggers GPX loading once Replay is active', async () => {
-        await waitFor(() => {
-          expect(gpxRequestCount).toBeGreaterThan(0);
-        });
-        await waitFor(() => {
-          expect(
-            canvas.queryByText(i18n.t('flights.loading3dViewer'))
-          ).not.toBeInTheDocument();
-        });
-      });
-    } finally {
-      cleanup();
-    }
+    });
   }
 );
 

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -18,12 +18,15 @@ import {
 import { useToast, useToastStore } from '../hooks/useToast';
 import { HTTPError } from 'ky';
 import { api } from '../lib/api';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 export default function FlightHistory() {
   const { t } = useTranslation();
   const { data: flights } = useSuspenseQuery(
     flightsQueryOptions({ limit: 50 })
   );
+
+  const isMobile = useIsMobile();
 
   const [selectedFlightId, setSelectedFlightId] = useState<string | null>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -33,6 +36,7 @@ export default function FlightHistory() {
   const [showStravaSyncModal, setShowStravaSyncModal] = useState(false);
   const [showCreateFlightModal, setShowCreateFlightModal] = useState(false);
   const [showCreateSiteModal, setShowCreateSiteModal] = useState(false);
+  const [showMobileDetail, setShowMobileDetail] = useState(false);
 
   const selectedFlight = flights.find((f: Flight) => f.id === selectedFlightId);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -43,12 +47,21 @@ export default function FlightHistory() {
 
   const handleSelectFlight = useCallback((flight: Flight) => {
     setSelectedFlightId(flight.id);
+    if (isMobile) {
+      setShowMobileDetail(true);
+    }
+  }, [isMobile]);
+
+  const handleCloseMobileDetail = useCallback(() => {
+    setShowMobileDetail(false);
+    setSelectedFlightId(null);
   }, []);
 
   const handleToggleSelectionMode = useCallback(() => {
     setSelectionMode((prev) => !prev);
     setRowSelection({});
     setSelectedFlightId(null);
+    setShowMobileDetail(false);
   }, []);
 
   const selectedFlightIds = Object.keys(rowSelection);
@@ -108,16 +121,17 @@ export default function FlightHistory() {
 
         setRowSelection({});
         setShowMultiDeleteConfirm(false);
-      } else if (flightToDelete) {
-        await api.delete(`flights/${flightToDelete.id}`);
-        queryClient.invalidateQueries({ queryKey: ['flights'] });
-        queryClient.invalidateQueries({ queryKey: ['flights', 'stats'] });
-        toast.success(t('flights.deletedSuccess'));
-        if (selectedFlightId === flightToDelete.id) {
-          setSelectedFlightId(null);
+        } else if (flightToDelete) {
+          await api.delete(`flights/${flightToDelete.id}`);
+          queryClient.invalidateQueries({ queryKey: ['flights'] });
+          queryClient.invalidateQueries({ queryKey: ['flights', 'stats'] });
+          toast.success(t('flights.deletedSuccess'));
+          if (selectedFlightId === flightToDelete.id) {
+            setSelectedFlightId(null);
+            setShowMobileDetail(false);
+          }
+          setFlightToDelete(null);
         }
-        setFlightToDelete(null);
-      }
     } catch (err) {
       console.error('Failed to delete flight:', err);
       let errorMessage = t('flights.unknownError');
@@ -227,35 +241,61 @@ export default function FlightHistory() {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* Flight List */}
-        <div className="lg:col-span-1">
-          <FlightsTable
-            flights={flights}
-            selectedFlightId={selectedFlightId}
-            selectionMode={selectionMode}
-            onSelectFlight={handleSelectFlight}
-            onDeleteFlight={setFlightToDelete}
-            rowSelection={rowSelection}
-            onRowSelectionChange={setRowSelection}
-          />
-        </div>
-
-        {/* Detail Panel + 3D Viewer */}
-        <div className="lg:col-span-2 space-y-4">
-          {selectedFlightId && selectedFlight ? (
-            <FlightDetails
-              key={selectedFlightId}
-              flight={selectedFlight}
-              sites={sites}
-              onShowCreateSiteModal={() => setShowCreateSiteModal(true)}
+        {(!isMobile || !showMobileDetail) && (
+          <div className={isMobile ? '' : 'lg:col-span-1'}>
+            <FlightsTable
+              flights={flights}
+              selectedFlightId={selectedFlightId}
+              selectionMode={selectionMode}
+              onSelectFlight={handleSelectFlight}
+              onDeleteFlight={setFlightToDelete}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
             />
-          ) : (
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-12 shadow-md text-center">
-              <p className="text-gray-600 dark:text-gray-300">
-                {t('flights.selectFlightHint')}
-              </p>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
+
+        {/* Detail Panel + 3D Viewer (desktop) */}
+        {!isMobile && (
+          <div className="lg:col-span-2 space-y-4">
+            {selectedFlightId && selectedFlight ? (
+              <FlightDetails
+                key={selectedFlightId}
+                flight={selectedFlight}
+                sites={sites}
+                onShowCreateSiteModal={() => setShowCreateSiteModal(true)}
+              />
+            ) : (
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-12 shadow-md text-center">
+                <p className="text-gray-600 dark:text-gray-300">
+                  {t('flights.selectFlightHint')}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Detail Panel + 3D Viewer (mobile) */}
+        {isMobile && showMobileDetail ? (
+          <div className="space-y-4">
+            {selectedFlightId && selectedFlight ? (
+              <FlightDetails
+                key={selectedFlightId}
+                flight={selectedFlight}
+                sites={sites}
+                onShowCreateSiteModal={() => setShowCreateSiteModal(true)}
+                mobileMode
+                onCloseMobile={handleCloseMobileDetail}
+              />
+            ) : (
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-12 shadow-md text-center">
+                <p className="text-gray-600 dark:text-gray-300">
+                  {t('flights.selectFlightHint')}
+                </p>
+              </div>
+            )}
+          </div>
+        ) : null}
       </div>
 
       {/* Modal Sync Strava */}

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -5,6 +5,19 @@
 
 import { z } from 'zod';
 
+const VIDEO_EXPORT_IN_PROGRESS_STATUS_VALUES = [
+  'processing',
+  'queued',
+  'running',
+  'initializing',
+  'capturing',
+  'encoding',
+] as const;
+
+export const VIDEO_EXPORT_IN_PROGRESS_STATUSES = new Set<string>(
+  VIDEO_EXPORT_IN_PROGRESS_STATUS_VALUES
+);
+
 // ============================================================================
 // CORE DOMAIN SCHEMAS
 // ============================================================================


### PR DESCRIPTION
## Summary
- Add mobile-only list/detail flow for FlightHistory with dedicated `showMobileDetail` state and mobile transition controls.
- Add mobile tabs in `FlightDetails` (`Infos` / `Replay`) and mount `FlightViewer3D` only when Replay is active.
- Add `compact` mode in `FlightViewer3D` to render a denser mobile layout.
- Add French/English i18n labels for new mobile controls and messages.
- Add Storybook coverage for mobile flows, including a specific test asserting GPX is fetched only after opening Replay.

## Validation
- `pnpm nx lint frontend`
- `pnpm nx type-check frontend`
- `pnpm nx build frontend`
- `pnpm nx test:unit frontend`

## Notes
- Existing desktop behavior is preserved; mobile now uses a two-step detail flow with lazy replay load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized flight details with tabbed Info/Replay UI, back button, and compact 3D viewer layout.
  * Clear "Replay unavailable" message when GPX data is missing.
  * Localized labels for the mobile flight viewer (Info, Replay, Back, Replay unavailable).

* **Tests**
  * Added interactive mobile-focused stories and tests verifying tab behavior, replay availability messaging, and 3D viewer loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->