### PR TITLE
fix(backend): expose emagram cache in infrastructure view

### DIFF
--- a/apps/backend/cache_emagram/emagram_cache.py
+++ b/apps/backend/cache_emagram/emagram_cache.py
@@ -1,68 +1,31 @@
-"""
-Redis caching for emagram sounding data
-Avoids re-downloading same sounding multiple times
-"""
+"""Redis caching for emagram sounding data."""
 
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
-
-import redis
 
 logger = logging.getLogger(__name__)
 
 
-def _get_redis_url() -> str:
-    """Build the Redis URL from shared backend config unless explicitly overridden."""
-    redis_url = os.getenv("REDIS_URL")
-    if redis_url:
-        return redis_url
-
-    from config import REDIS_HOST, REDIS_PORT
-
-    return f"redis://{REDIS_HOST}:{REDIS_PORT}"
-
-
-def _redact_redis_url(redis_url: str) -> str:
-    """Return a safe display version of Redis URL without credentials."""
-    parsed = urlsplit(redis_url)
-    if not (parsed.username or parsed.password):
-        return redis_url
-
-    host = parsed.hostname or ""
-    if parsed.port:
-        host = f"{host}:{parsed.port}"
-
-    netloc = f"***:***@{host}"
-    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
-
-
 class EmagramCache:
-    """Redis cache for sounding data"""
+    """Redis cache for sounding data.
 
-    def __init__(self):
-        redis_url = _get_redis_url()
-        try:
-            self.redis_client = redis.from_url(redis_url, decode_responses=True)
-            self.enabled = True
-            self.redis_client.ping()  # Test connection
-        except (redis.ConnectionError, redis.TimeoutError):
-            self.enabled = False
-            self.redis_client = None
-            logger.warning(
-                "Emagram Redis cache disabled: unable to connect to %s",
-                _redact_redis_url(redis_url),
-            )
+    Uses the shared async Redis client from ``cache.get_redis`` so weather/admin
+    cache views and emagram cache always point to the same backend.
+    """
+
+    async def _get_client(self):
+        from cache import get_redis
+
+        return await get_redis()
 
     def _generate_key(self, station_code: str, sounding_time: str, date_str: str) -> str:
         """Generate cache key for sounding"""
         key_str = f"emagram:sounding:{station_code}:{sounding_time}:{date_str}"
         return key_str
 
-    def get_sounding(
+    async def get_sounding(
         self, station_code: str, sounding_time: str, date: datetime
     ) -> dict[str, Any] | None:
         """
@@ -71,14 +34,12 @@ class EmagramCache:
         Returns:
             Cached sounding dict or None if not found/expired
         """
-        if not self.enabled:
-            return None
-
         try:
             date_str = date.strftime("%Y-%m-%d")
             key = self._generate_key(station_code, sounding_time, date_str)
 
-            cached = self.redis_client.get(key)
+            redis_client = await self._get_client()
+            cached = await redis_client.get(key)
             if cached:
                 return json.loads(cached)
 
@@ -88,7 +49,7 @@ class EmagramCache:
             logger.warning("Cache get error: %s", e)
             return None
 
-    def set_sounding(
+    async def set_sounding(
         self,
         station_code: str,
         sounding_time: str,
@@ -105,7 +66,7 @@ class EmagramCache:
         Returns:
             True if cached successfully
         """
-        if not self.enabled or not sounding_data.get("success"):
+        if not sounding_data.get("success"):
             return False
 
         try:
@@ -117,7 +78,8 @@ class EmagramCache:
 
             if isinstance(sounding_data, dict):
                 sounding_data["cached_at"] = datetime.now(timezone.utc).isoformat()
-            self.redis_client.setex(key, ttl_seconds, json.dumps(sounding_data))
+            redis_client = await self._get_client()
+            await redis_client.setex(key, ttl_seconds, json.dumps(sounding_data))
 
             return True
 
@@ -125,29 +87,27 @@ class EmagramCache:
             logger.warning("Cache set error: %s", e)
             return False
 
-    def invalidate_sounding(self, station_code: str, sounding_time: str, date: datetime) -> bool:
+    async def invalidate_sounding(
+        self, station_code: str, sounding_time: str, date: datetime
+    ) -> bool:
         """Invalidate cached sounding"""
-        if not self.enabled:
-            return False
-
         try:
             date_str = date.strftime("%Y-%m-%d")
             key = self._generate_key(station_code, sounding_time, date_str)
-            self.redis_client.delete(key)
+            redis_client = await self._get_client()
+            await redis_client.delete(key)
             return True
 
         except Exception as e:
             logger.warning("Cache invalidate error: %s", e)
             return False
 
-    def get_stats(self) -> dict[str, Any]:
+    async def get_stats(self) -> dict[str, Any]:
         """Get cache statistics"""
-        if not self.enabled:
-            return {"enabled": False}
-
         try:
-            info = self.redis_client.info("stats")
-            keys_count = self.redis_client.dbsize()
+            redis_client = await self._get_client()
+            info = await redis_client.info("stats")
+            keys_count = await redis_client.dbsize()
 
             return {
                 "enabled": True,

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4908,12 +4908,9 @@ async def clear_emagram_cache(db: Session = Depends(get_db)):
 
         # 2. Clear only emagram cache keys
         try:
-            from cache_emagram.emagram_cache import _get_redis_url, _redact_redis_url
+            from cache import get_redis
 
-            import redis.asyncio as redis_async
-
-            redis_url = _get_redis_url()
-            redis_client = redis_async.from_url(redis_url, decode_responses=True)
+            redis_client = await get_redis()
 
             keys_to_clear: list[str] = []
             async for key in redis_client.scan_iter(match="emagram:*"):
@@ -4927,12 +4924,7 @@ async def clear_emagram_cache(db: Session = Depends(get_db)):
             redis_cleared = True
             logger.info("Cleared %s emagram cache keys via Redis", deleted)
         except Exception as redis_error:
-            redis_url = _get_redis_url()
-            logger.warning(
-                "Redis clear failed (non-critical) for %s: %s",
-                _redact_redis_url(redis_url),
-                redis_error,
-            )
+            logger.warning("Redis clear failed (non-critical): %s", redis_error)
             redis_cleared = False
             deleted = 0
 

--- a/apps/backend/scrapers/wyoming.py
+++ b/apps/backend/scrapers/wyoming.py
@@ -224,7 +224,7 @@ async def fetch_wyoming_sounding(
 
             cache = get_cache()
 
-            cached_data = cache.get_sounding(station_code, sounding_time, date)
+            cached_data = await cache.get_sounding(station_code, sounding_time, date)
             if cached_data:
                 cached_data["from_cache"] = True
                 return cached_data
@@ -347,7 +347,7 @@ async def fetch_wyoming_sounding(
             from cache_emagram.emagram_cache import get_cache
 
             cache = get_cache()
-            cache.set_sounding(station_code, sounding_time, date, result)
+            await cache.set_sounding(station_code, sounding_time, date, result)
         except Exception as e:
             print(f"Cache set error: {e}")
 

--- a/apps/backend/tests/unit/test_emagram_cache.py
+++ b/apps/backend/tests/unit/test_emagram_cache.py
@@ -1,86 +1,87 @@
-"""Tests for the emagram Redis cache configuration."""
+"""Tests for emagram cache using shared backend Redis client."""
 
-import importlib
-import logging
-import sys
-from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from cache_emagram.emagram_cache import EmagramCache, get_cache
 
 
-def _install_config_stub(monkeypatch, host="redis", port=6379):
-    monkeypatch.setitem(
-        sys.modules,
-        "config",
-        SimpleNamespace(REDIS_HOST=host, REDIS_PORT=port),
+def test_get_cache_returns_singleton_instance():
+    first = get_cache()
+    second = get_cache()
+
+    assert first is second
+
+
+@pytest.mark.asyncio
+async def test_emagram_cache_reads_written_value_from_shared_backend_client(monkeypatch):
+    calls = []
+    store = {}
+
+    async def fake_get(key):
+        calls.append(("get", key))
+        return store.get(key)
+
+    async def fake_setex(key, ttl, value):
+        calls.append(("setex", key, ttl))
+        store[key] = value
+
+    fake_client = SimpleNamespace(get=fake_get, setex=fake_setex)
+
+    async def fake_get_redis():
+        return fake_client
+
+    monkeypatch.setattr("cache.get_redis", fake_get_redis)
+
+    cache = EmagramCache()
+    date = datetime(2026, 1, 15)
+
+    written = await cache.set_sounding(
+        "07145",
+        "12",
+        date,
+        {
+            "success": True,
+            "station_code": "07145",
+            "sounding_date": "2026-01-15",
+        },
+        ttl_hours=24,
     )
 
+    payload = await cache.get_sounding("07145", "12", date)
 
-def _install_redis_stub(monkeypatch, redis_client):
-    redis_module = ModuleType("redis")
-    redis_module.ConnectionError = type("ConnectionError", (Exception,), {})
-    redis_module.TimeoutError = type("TimeoutError", (Exception,), {})
-    redis_module.from_url = MagicMock(return_value=redis_client)
-    monkeypatch.setitem(sys.modules, "redis", redis_module)
-    return redis_module
-
-
-def _load_module(monkeypatch, host="redis", port=6379, redis_client=None):
-    _install_config_stub(monkeypatch, host=host, port=port)
-    module = _install_redis_stub(monkeypatch, redis_client or MagicMock())
-    sys.modules.pop("cache_emagram.emagram_cache", None)
-    emagram_cache = importlib.import_module("cache_emagram.emagram_cache")
-    return emagram_cache, module
+    assert written is True
+    assert payload is not None
+    assert payload["success"] is True
+    assert payload["cached_at"]
+    assert ("setex", "emagram:sounding:07145:12:2026-01-15", 86400) in calls
+    assert ("get", "emagram:sounding:07145:12:2026-01-15") in calls
 
 
-def test_get_redis_url_uses_backend_config(monkeypatch):
-    monkeypatch.delenv("REDIS_URL", raising=False)
-    emagram_cache, _ = _load_module(monkeypatch, host="redis", port=6379)
+@pytest.mark.asyncio
+async def test_emagram_cache_skips_failed_payloads(monkeypatch):
+    called = False
 
-    assert emagram_cache._get_redis_url() == "redis://redis:6379"
+    async def fake_setex(*args, **kwargs):
+        nonlocal called
+        called = True
 
+    fake_client = SimpleNamespace(setex=fake_setex)
 
-def test_get_redis_url_prefers_env_override(monkeypatch):
-    monkeypatch.setenv("REDIS_URL", "redis://custom-redis:6380")
-    emagram_cache, _ = _load_module(monkeypatch, host="redis", port=6379)
+    async def fake_get_redis():
+        return fake_client
 
-    assert emagram_cache._get_redis_url() == "redis://custom-redis:6380"
+    monkeypatch.setattr("cache.get_redis", fake_get_redis)
 
-
-def test_emagram_cache_initializes_with_shared_backend_redis(monkeypatch):
-    monkeypatch.delenv("REDIS_URL", raising=False)
-    redis_client = MagicMock()
-    redis_client.ping.return_value = True
-
-    emagram_cache, redis_module = _load_module(
-        monkeypatch,
-        host="redis",
-        port=6379,
-        redis_client=redis_client,
+    cache = EmagramCache()
+    result = await cache.set_sounding(
+        "07145",
+        "12",
+        datetime(2026, 1, 15),
+        {"success": False},
     )
 
-    cache = emagram_cache.EmagramCache()
-
-    redis_module.from_url.assert_called_once_with("redis://redis:6379", decode_responses=True)
-    assert cache.enabled is True
-    assert cache.redis_client is redis_client
-
-
-def test_emagram_cache_connection_failures_do_not_log_password(monkeypatch, caplog):
-    """Redis password must never appear in warning logs."""
-    monkeypatch.setenv("REDIS_URL", "redis://app_user:super-secret@redis.internal:6379")
-    redis_client = MagicMock()
-
-    emagram_cache, redis_module = _load_module(monkeypatch, redis_client=redis_client)
-    redis_client.ping.side_effect = redis_module.ConnectionError("auth failed")
-
-    with caplog.at_level(logging.WARNING):
-        cache = emagram_cache.EmagramCache()
-
-    redis_module.from_url.assert_called_once_with(
-        "redis://app_user:super-secret@redis.internal:6379",
-        decode_responses=True,
-    )
-    assert cache.enabled is False
-    assert cache.redis_client is None
-    assert any("super-secret" in record.message for record in caplog.records) is False
-    assert any("***:***@redis.internal:6379" in record.message for record in caplog.records)
+    assert result is False
+    assert called is False


### PR DESCRIPTION
## Summary
- switch emagram sounding cache to the shared backend Redis client (`cache.get_redis`) so emagram keys are stored in the same datastore read by `/api/admin/cache`
- make emagram cache operations async and update Wyoming scraper calls to await cache reads/writes
- update emagram cache unit tests to validate the shared async Redis client path

## Why
Emagram keys were written through a separate Redis configuration path, so they could be missing from the Infrastructure cache viewer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Backend caching migrated to an asynchronous, shared-client implementation for more reliable and consistent cache operations.
  * Cache-clearing endpoints updated to use the shared cache accessor and simplified error handling.

* **Tests**
  * Unit tests updated to exercise the public cache API with an async fake client, covering set/get behavior, TTL handling, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->