### PR TITLE
fix(frontend): correct emagram update time timezone parsing

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -16,6 +16,7 @@ import {
   getScoreCategory,
 } from '../../types/emagram';
 import { useState, useMemo } from 'react';
+import { parseApiUtcDate } from '../../lib/date';
 import { Lightbox } from '@dashboard-parapente/design-system';
 import {
   Slider,
@@ -335,7 +336,7 @@ export default function EmagramWidget({
   const alerts = parseAlerts(emagram.alertes_securite);
 
   // Format analysis time
-  const analysisDate = new Date(emagram.analysis_datetime);
+  const analysisDate = parseApiUtcDate(emagram.analysis_datetime);
   const timeAgo = getTimeAgo(analysisDate);
 
   return (

--- a/apps/frontend/src/lib/date.test.ts
+++ b/apps/frontend/src/lib/date.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseApiUtcDate } from './date';
+
+describe('parseApiUtcDate', () => {
+  it('treats ISO datetime without timezone as UTC', () => {
+    expect(parseApiUtcDate('2026-04-15T10:00:00').toISOString()).toBe(
+      '2026-04-15T10:00:00.000Z'
+    );
+  });
+
+  it('preserves ISO datetime with Z suffix', () => {
+    expect(parseApiUtcDate('2026-04-15T10:00:00Z').toISOString()).toBe(
+      '2026-04-15T10:00:00.000Z'
+    );
+  });
+
+  it('preserves ISO datetime with numeric offset', () => {
+    expect(parseApiUtcDate('2026-04-15T10:00:00+02:00').toISOString()).toBe(
+      '2026-04-15T08:00:00.000Z'
+    );
+  });
+});

--- a/apps/frontend/src/lib/date.ts
+++ b/apps/frontend/src/lib/date.ts
@@ -1,0 +1,11 @@
+const ISO_TZ_SUFFIX_RE = /(Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Parses API datetimes that may be serialized without timezone offset.
+ * If an ISO datetime string has no timezone suffix, it is treated as UTC.
+ */
+export function parseApiUtcDate(value: string | Date): Date {
+  if (value instanceof Date) return value;
+  if (ISO_TZ_SUFFIX_RE.test(value)) return new Date(value);
+  return new Date(`${value}Z`);
+}

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -20,13 +20,14 @@ import { useSite } from '../hooks/sites/useSites';
 import { parseAlerts, getScoreColor } from '../types/emagram';
 import type { EmagramListItem } from '../types/emagram';
 import { DataTable, Button } from '@dashboard-parapente/design-system';
+import { parseApiUtcDate } from '../lib/date';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
 
 const historyColumns = [
   historyColumnHelper.accessor('created_at', {
     header: 'Date',
-    cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+    cell: (info) => parseApiUtcDate(info.getValue()).toLocaleDateString(),
     sortingFn: 'alphanumeric',
   }),
   historyColumnHelper.accessor('score_volabilite', {
@@ -293,7 +294,7 @@ export default function ThermalAnalysis() {
               />
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
                 {latest.station_name} • {latest.sounding_time} •{' '}
-                {new Date(latest.analysis_datetime).toLocaleDateString()}
+                {parseApiUtcDate(latest.analysis_datetime).toLocaleDateString()}
               </p>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- parse emagram API datetimes without timezone suffix as UTC to avoid 1-hour display shifts in local time
- apply the UTC-safe parser in `EmagramWidget` and `ThermalAnalysis` where emagram timestamps are rendered
- add unit tests for the new date parser covering naive, `Z`, and offset ISO datetime strings

## Verification
- `pnpm nx lint frontend` ✅
- `pnpm nx test frontend -- src/lib/date.test.ts` ✅
- `pnpm nx test frontend` ❌ (existing unrelated Storybook/browser test timeouts/failures)