### PR TITLE
feat(frontend): show deployed version badge in app

### DIFF
--- a/apps/frontend/src/hooks/common/useAppVersion.ts
+++ b/apps/frontend/src/hooks/common/useAppVersion.ts
@@ -1,0 +1,43 @@
+import { queryOptions } from '@tanstack/react-query';
+import { api } from '../../lib/api';
+
+type AppVersionPayload = {
+  version: string;
+  build_date: string;
+  build_number: number;
+};
+
+function isAppVersionPayload(value: unknown): value is AppVersionPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.version === 'string' &&
+    typeof payload.build_date === 'string' &&
+    typeof payload.build_number === 'number'
+  );
+}
+
+export const appVersionQueryOptions = () =>
+  queryOptions<AppVersionPayload | null>({
+    queryKey: ['app-version'],
+    staleTime: Infinity,
+    retry: 0,
+    queryFn: async () => {
+      try {
+        const data = await api.get('version').json();
+
+        if (!isAppVersionPayload(data)) {
+          throw new Error('Invalid version payload');
+        }
+
+        console.log(`[Dashboard Parapente] Version ${data.version}`);
+        return data;
+      } catch (error) {
+        console.warn('[Dashboard Parapente] Version unknown', error);
+        return null;
+      }
+    },
+  });

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -15,9 +15,12 @@ async function logAppVersion() {
 
     const payload = (await response.json()) as { version?: string };
     const version = payload.version ?? 'unknown';
-    console.info(`[Dashboard Parapente] Version ${version}`);
-  } catch {
-    console.info('[Dashboard Parapente] Version unknown');
+    const appWindow = window as Window & { __APP_VERSION__?: string };
+    appWindow.__APP_VERSION__ = version;
+    window.dispatchEvent(new CustomEvent('app-version-ready', { detail: version }));
+    console.log(`[Dashboard Parapente] Version ${version}`);
+  } catch (error) {
+    console.warn('[Dashboard Parapente] Version unknown', error);
   }
 }
 

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -5,25 +5,6 @@ import App from './App';
 import './App.css';
 import { initTheme } from './stores/themeStore';
 
-async function logAppVersion() {
-  try {
-    const response = await fetch('/api/version');
-
-    if (!response.ok) {
-      throw new Error(`Version endpoint returned ${response.status}`);
-    }
-
-    const payload = (await response.json()) as { version?: string };
-    const version = payload.version ?? 'unknown';
-    const appWindow = window as Window & { __APP_VERSION__?: string };
-    appWindow.__APP_VERSION__ = version;
-    window.dispatchEvent(new CustomEvent('app-version-ready', { detail: version }));
-    console.log(`[Dashboard Parapente] Version ${version}`);
-  } catch (error) {
-    console.warn('[Dashboard Parapente] Version unknown', error);
-  }
-}
-
 // Initialiser MSW en mode développement (peut être désactivé via VITE_ENABLE_MSW=false)
 async function enableMocking() {
   const enableMSW = import.meta.env.VITE_ENABLE_MSW !== 'false';
@@ -47,7 +28,6 @@ if (!rootElement) {
 
 // Initialiser le thème avant le rendu pour éviter le FOUC
 initTheme();
-void logAppVersion();
 
 // Attendre que MSW soit prêt avant de rendre l'app
 enableMocking().then(() => {

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,8 +1,11 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense } from 'react';
 import { createRootRoute, Outlet, useMatchRoute } from '@tanstack/react-router';
 import Header from '../components/common/Header';
+import { queryClient } from '../lib/queryClient';
+import { appVersionQueryOptions } from '../hooks/common/useAppVersion';
 
 export const Route = createRootRoute({
+  loader: () => queryClient.ensureQueryData(appVersionQueryOptions()),
   component: RootComponent,
   pendingComponent: PendingComponent,
 });
@@ -28,6 +31,8 @@ function PendingComponent() {
 function RootComponent() {
   const matchRoute = useMatchRoute();
   const isLoginPage = matchRoute({ to: '/login' });
+  const appVersion = Route.useLoaderData();
+  const version = appVersion?.version ?? null;
 
   if (isLoginPage) {
     return <Outlet />;
@@ -43,45 +48,12 @@ function RootComponent() {
           </Suspense>
         </main>
       </div>
-      <VersionBadge />
+      {version && <VersionBadge version={version} />}
     </div>
   );
 }
 
-function getAppVersionFromWindow() {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const appWindow = window as Window & { __APP_VERSION__?: string };
-  return appWindow.__APP_VERSION__ ?? null;
-}
-
-function VersionBadge() {
-  const [version, setVersion] = useState<string | null>(getAppVersionFromWindow);
-
-  useEffect(() => {
-    if (version) {
-      return;
-    }
-
-    function handleVersionReady(event: Event) {
-      const customEvent = event as CustomEvent<string>;
-      if (typeof customEvent.detail === 'string' && customEvent.detail) {
-        setVersion(customEvent.detail);
-      }
-    }
-
-    window.addEventListener('app-version-ready', handleVersionReady);
-    return () => {
-      window.removeEventListener('app-version-ready', handleVersionReady);
-    };
-  }, [version]);
-
-  if (!version) {
-    return null;
-  }
-
+function VersionBadge({ version }: { version: string }) {
   return (
     <div className="fixed bottom-3 right-3 z-30 rounded-full border border-sky-200 bg-white/90 px-3 py-1 text-xs font-semibold text-sky-700 shadow-sm backdrop-blur dark:border-sky-800 dark:bg-gray-900/90 dark:text-sky-300">
       Version {version}

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { createRootRoute, Outlet, useMatchRoute } from '@tanstack/react-router';
 import Header from '../components/common/Header';
 
@@ -43,6 +43,48 @@ function RootComponent() {
           </Suspense>
         </main>
       </div>
+      <VersionBadge />
+    </div>
+  );
+}
+
+function getAppVersionFromWindow() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const appWindow = window as Window & { __APP_VERSION__?: string };
+  return appWindow.__APP_VERSION__ ?? null;
+}
+
+function VersionBadge() {
+  const [version, setVersion] = useState<string | null>(getAppVersionFromWindow);
+
+  useEffect(() => {
+    if (version) {
+      return;
+    }
+
+    function handleVersionReady(event: Event) {
+      const customEvent = event as CustomEvent<string>;
+      if (typeof customEvent.detail === 'string' && customEvent.detail) {
+        setVersion(customEvent.detail);
+      }
+    }
+
+    window.addEventListener('app-version-ready', handleVersionReady);
+    return () => {
+      window.removeEventListener('app-version-ready', handleVersionReady);
+    };
+  }, [version]);
+
+  if (!version) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-3 right-3 z-30 rounded-full border border-sky-200 bg-white/90 px-3 py-1 text-xs font-semibold text-sky-700 shadow-sm backdrop-blur dark:border-sky-800 dark:bg-gray-900/90 dark:text-sky-300">
+      Version {version}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- expose fetched deployment version on `window.__APP_VERSION__` and emit an `app-version-ready` event at startup
- keep a visible browser-console log for the deployed version and warn when version fetch fails
- add a fixed bottom-right UI badge in the root layout to display the deployed version outside the login page

## Validation
- `pnpm exec nx lint frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a version badge displayed in the application interface that shows the current app version, providing users with easy visibility of the running application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->