### PR TITLE
fix(ci): trigger Portainer deployment on main pushes

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -1,8 +1,7 @@
 name: Deploy to Portainer
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
   workflow_dispatch:
 
@@ -18,7 +17,6 @@ concurrency:
 jobs:
   deploy:
     name: Trigger Portainer webhook
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
## Summary
- switch the `Deploy to Portainer` workflow trigger from `pull_request.closed` to `push` on `main`
- remove the PR-only job guard so deployments always run for `push` and manual dispatch

## Why
Portainer should redeploy after the merge commit is actually on `main`. Triggering on PR close can run before the target branch state is ready for Git-based update checks.