### PR TITLE
feat(frontend): rename Para-Index labels to flight conditions

### DIFF
--- a/apps/frontend/src/components/dashboard/MultiOrientationSelector.stories.tsx
+++ b/apps/frontend/src/components/dashboard/MultiOrientationSelector.stories.tsx
@@ -1,7 +1,7 @@
 import preview from '../../../.storybook/preview';
-import {expect, fn, waitFor} from 'storybook/test';
-import {MultiOrientationSelector} from './MultiOrientationSelector';
-import type {Site} from '@dashboard-parapente/shared-types';
+import { expect, fn, waitFor } from 'storybook/test';
+import { MultiOrientationSelector } from './MultiOrientationSelector';
+import type { Site } from '@dashboard-parapente/shared-types';
 
 const meta = preview.meta({
   title: 'Components/Forms/MultiOrientationSelector',
@@ -11,8 +11,6 @@ const meta = preview.meta({
   },
   tags: ['autodocs'],
 });
-
-
 
 // Mock sites with multiple orientations
 const mockSitesMontPoupet: Site[] = [
@@ -316,7 +314,7 @@ DisplaysWeatherData.test(
     await userEvent.click(button);
 
     await waitFor(() => {
-      expect(canvas.getByText(/Para-Index: 85/)).toBeInTheDocument();
+      expect(canvas.getByText(/Conditions de vol: 85/)).toBeInTheDocument();
     });
   }
 );

--- a/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
+++ b/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Site } from '../../types';
 import { WindIndicatorCompact } from '../common/WindIndicator';
 import { Button } from '@dashboard-parapente/design-system';
@@ -32,6 +33,7 @@ export function MultiOrientationSelector({
   className = '',
   baseName,
 }: MultiOrientationSelectorProps) {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -150,7 +152,7 @@ export function MultiOrientationSelector({
                     </span>
                     {weather?.paraIndex !== undefined && (
                       <span className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
-                        Para-Index: {weather.paraIndex}
+                        {t('weather.paraIndex')}: {weather.paraIndex}
                       </span>
                     )}
                   </div>

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -153,6 +153,7 @@ export function BestSpotSuggestion({
     100,
     Math.max(0, score != null ? Math.round(score) : paraIndex)
   );
+  const localizedReason = reason.replace(/Para-Index/g, t('weather.paraIndex'));
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
 
@@ -310,7 +311,7 @@ export function BestSpotSuggestion({
 
         {/* Reason text */}
         <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 leading-relaxed">
-          {reason}
+          {localizedReason}
         </p>
 
         {/* Footer: button + cache */}

--- a/apps/frontend/src/components/weather/CurrentConditions.tsx
+++ b/apps/frontend/src/components/weather/CurrentConditions.tsx
@@ -76,7 +76,7 @@ export default function CurrentConditions({ spotId }: CurrentConditionsProps) {
       </div>
       {weather.score != null && weather.score !== weather.para_index && (
         <div className="text-xs text-gray-500 dark:text-gray-400 -mt-3 mb-3">
-          Para-Index {weather.para_index}/100
+          {t('weather.paraIndex')} {weather.para_index}/100
         </div>
       )}
 

--- a/apps/frontend/src/components/weather/HourlyForecast.stories.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.stories.tsx
@@ -329,7 +329,7 @@ GoodConditions.test('it renders the correct values', async ({ canvas }) => {
 
   // Verify table headers are present (headers now include icons and units)
   await expect(getByText('Heure')).toBeInTheDocument();
-  await expect(getByText('Para-Index')).toBeInTheDocument();
+  await expect(getByText('Conditions de vol')).toBeInTheDocument();
   await expect(getByText('Temp (°C)')).toBeInTheDocument();
   await expect(getByText('Vent (km/h)')).toBeInTheDocument();
   await expect(getByText('Rafales (km/h)')).toBeInTheDocument();

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Clock,
   Gauge,
@@ -59,6 +60,7 @@ interface SourceDataTooltipProps extends BaseTooltipProps {
 }
 
 interface ParaIndexTooltipProps extends BaseTooltipProps {
+  label: string;
   paraIndex: number;
   wind: number;
   gust: number;
@@ -67,6 +69,7 @@ interface ParaIndexTooltipProps extends BaseTooltipProps {
 }
 
 interface VerdictTooltipProps extends BaseTooltipProps {
+  label: string;
   verdict: string;
   paraIndex: number;
   wind: number;
@@ -214,6 +217,7 @@ const SOURCE_ORDER = [
 const ParaIndexTooltip = ({
   position,
   hour,
+  label,
   paraIndex,
   wind,
   gust,
@@ -252,7 +256,7 @@ const ParaIndexTooltip = ({
         </Button>
       )}
       <div className="font-bold mb-3 text-sky-700 dark:text-sky-400 flex items-center gap-2">
-        📊 Para-Index - {hour}
+        📊 {label} - {hour}
       </div>
       <div className="space-y-2 text-gray-700 dark:text-gray-300">
         <div className="text-lg font-bold text-sky-600">{paraIndex}/100</div>
@@ -287,6 +291,7 @@ const VerdictTooltip = ({
   position,
   hour,
   verdict,
+  label,
   paraIndex,
   wind,
   gust,
@@ -354,7 +359,7 @@ const VerdictTooltip = ({
           {verdict}
         </div>
         <div className="text-xs text-gray-500 dark:text-gray-400">
-          Para-Index : {paraIndex}/100
+          {label}: {paraIndex}/100
         </div>
         <div className="border-t border-gray-200 dark:border-gray-700 pt-2 mt-2">
           <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2">
@@ -584,6 +589,7 @@ export default function HourlyForecast({
   spotId,
   dayIndex = 0,
 }: HourlyForecastProps) {
+  const { t } = useTranslation();
   const { data: weather, isLoading, error } = useWeather(spotId, dayIndex);
   const [activeTooltip, setActiveTooltip] = useState<{
     type: CellType;
@@ -693,6 +699,7 @@ export default function HourlyForecast({
         return (
           <ParaIndexTooltip
             {...commonProps}
+            label={t('weather.paraIndex')}
             paraIndex={data.para_index}
             wind={data.wind_speed || 0}
             gust={
@@ -709,6 +716,7 @@ export default function HourlyForecast({
         return (
           <VerdictTooltip
             {...commonProps}
+            label={t('weather.paraIndex')}
             verdict={data.verdict}
             paraIndex={data.para_index}
             wind={data.wind_speed || 0}
@@ -840,7 +848,7 @@ export default function HourlyForecast({
               </th>
               <th className="text-center py-2 px-2 font-semibold text-gray-700 dark:text-gray-300">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Gauge size={14} /> Para-Index
+                  <Gauge size={14} /> {t('weather.paraIndex')}
                 </span>
               </th>
               <th className="text-center py-2 px-2 font-semibold text-gray-700 dark:text-gray-300">

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -86,7 +86,7 @@
     "forecast7Days": "7-Day Forecast",
     "bestSpotFor": "Best spot for {{date}}",
     "calculating": "Calculating...",
-    "paraIndex": "Para-Index:",
+    "paraIndex": "Flight Conditions",
     "viewForecast": "View forecast →",
     "recommended": "Recommended",
     "landings": "Landings",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -86,7 +86,7 @@
     "forecast7Days": "Prévisions 7 Jours",
     "bestSpotFor": "Meilleur spot pour {{date}}",
     "calculating": "Calcul en cours...",
-    "paraIndex": "Para-Index:",
+    "paraIndex": "Conditions de vol",
     "viewForecast": "Voir les prévisions →",
     "recommended": "Recommandé",
     "landings": "Atterrissages",


### PR DESCRIPTION
## Summary
- Rename the user-facing `Para-Index` label to clearer wording (`Conditions de vol` / `Flight Conditions`) in frontend translations.
- Replace hardcoded `Para-Index` UI text with `i18n` keys in weather and dashboard components, including tooltip headers/details.
- Update impacted Storybook assertions to match the new translated labels.

## Validation
- `pnpm nx lint frontend`
- `pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated weather condition labels to "Flight Conditions" (English) and "Conditions de vol" (French) for improved clarity across all weather information displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->