### PR TITLE
fix(backend): make emagram freshness window configurable

### DIFF
--- a/apps/backend/app_settings.py
+++ b/apps/backend/app_settings.py
@@ -23,6 +23,7 @@ DEFAULTS: dict[str, str] = {
     "cache_ttl_default": "3600",
     "cache_ttl_summary": "3600",
     "scheduler_interval_minutes": "30",
+    "emagram_max_age_minutes": "180",
     "redis_connect_timeout": "5",
     "redis_socket_timeout": "5",
 }

--- a/apps/backend/emagram_freshness.py
+++ b/apps/backend/emagram_freshness.py
@@ -1,0 +1,18 @@
+"""Helpers for configurable emagram freshness windows."""
+
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app_settings import get_setting_int
+
+
+def get_emagram_max_age_minutes(db: Session | None = None) -> int:
+    """Return max allowed age for emagram analyses in minutes."""
+    max_age_minutes = get_setting_int("emagram_max_age_minutes", db=db, default=180)
+    return max_age_minutes if max_age_minutes > 0 else 180
+
+
+def get_emagram_cutoff_utc(db: Session | None = None) -> datetime:
+    """Return UTC cutoff datetime used to consider an emagram as fresh."""
+    return datetime.utcnow() - timedelta(minutes=get_emagram_max_age_minutes(db=db))

--- a/apps/backend/emagram_freshness.py
+++ b/apps/backend/emagram_freshness.py
@@ -16,3 +16,9 @@ def get_emagram_max_age_minutes(db: Session | None = None) -> int:
 def get_emagram_cutoff_utc(db: Session | None = None) -> datetime:
     """Return UTC cutoff datetime used to consider an emagram as fresh."""
     return datetime.utcnow() - timedelta(minutes=get_emagram_max_age_minutes(db=db))
+
+
+def get_emagram_next_update_utc(analysis_datetime: datetime, db: Session | None = None) -> datetime:
+    """Return next expected update datetime based on configured freshness."""
+    base_datetime = analysis_datetime.replace(tzinfo=None)
+    return base_datetime + timedelta(minutes=get_emagram_max_age_minutes(db=db))

--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -15,7 +15,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 import config
-from emagram_freshness import get_emagram_cutoff_utc
+from emagram_freshness import get_emagram_cutoff_utc, get_emagram_next_update_utc
 from llm.exceptions import QuotaExhaustedError
 from llm.gemini_analyzer import analyze_emagram_with_gemini
 from llm.groq_analyzer import analyze_emagram_with_groq
@@ -102,7 +102,7 @@ async def generate_multi_source_emagram_for_spot(
                 logger.info(
                     f"✅ Found recent analysis from {existing.analysis_datetime}, using cache"
                 )
-                return emagram_analysis_to_dict(existing)
+                return emagram_analysis_to_dict(existing, db=db)
 
         # Step 3: Fetch screenshots from all sources
         screenshot_result = await fetch_all_emagram_screenshots(
@@ -261,7 +261,7 @@ async def generate_multi_source_emagram_for_spot(
 
         logger.info(f"✅ Multi-source emagram analysis complete for {site.name}")
 
-        return emagram_analysis_to_dict(emagram_analysis)
+        return emagram_analysis_to_dict(emagram_analysis, db=db)
 
     except Exception as e:
         logger.error(f"Error in multi-source emagram generation: {e}", exc_info=True)
@@ -419,7 +419,7 @@ def parse_time_string(time_str: str | None) -> dt_time | None:
         return None
 
 
-def emagram_analysis_to_dict(emagram: EmagramAnalysis) -> dict[str, Any]:
+def emagram_analysis_to_dict(emagram: EmagramAnalysis, db: Session | None = None) -> dict[str, Any]:
     """
     Convert EmagramAnalysis model to dictionary for API response
     """
@@ -476,11 +476,8 @@ def emagram_analysis_to_dict(emagram: EmagramAnalysis) -> dict[str, Any]:
         "sources_agreement": emagram.sources_agreement,
         "llm_provider": emagram.llm_provider,
         "llm_cost_usd": emagram.llm_cost_usd,
-        # Next update (3 hours from last update)
-        "next_update": (
-            emagram.analysis_datetime.replace(tzinfo=None)
-            + __import__("datetime").timedelta(hours=3)
-        ).isoformat(),
+        # Next update (configured freshness window from last update)
+        "next_update": get_emagram_next_update_utc(emagram.analysis_datetime, db=db).isoformat(),
     }
 
 

--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -15,6 +15,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 import config
+from emagram_freshness import get_emagram_cutoff_utc
 from llm.exceptions import QuotaExhaustedError
 from llm.gemini_analyzer import analyze_emagram_with_gemini
 from llm.groq_analyzer import analyze_emagram_with_groq
@@ -78,7 +79,7 @@ async def generate_multi_source_emagram_for_spot(
 
         # Step 2: Check for recent analysis (unless force_refresh)
         if not force_refresh:
-            cutoff_time = datetime.utcnow() - timedelta(hours=3)
+            cutoff_time = get_emagram_cutoff_utc(db=db)
 
             cache_filters = [
                 EmagramAnalysis.station_code == site_id,

--- a/apps/backend/migrations/006_add_app_settings.py
+++ b/apps/backend/migrations/006_add_app_settings.py
@@ -24,7 +24,6 @@ DEFAULT_SETTINGS = {
     "cache_ttl_default": "3600",  # 60 minutes - TTL for weather sources
     "cache_ttl_summary": "3600",  # 60 minutes - TTL for summaries
     "scheduler_interval_minutes": "30",  # 30 minutes - scheduler polling interval
-    "emagram_max_age_minutes": "180",  # 3 hours - max age for emagram freshness
     "redis_connect_timeout": "5",  # 5 seconds
     "redis_socket_timeout": "5",  # 5 seconds
 }

--- a/apps/backend/migrations/006_add_app_settings.py
+++ b/apps/backend/migrations/006_add_app_settings.py
@@ -24,6 +24,7 @@ DEFAULT_SETTINGS = {
     "cache_ttl_default": "3600",  # 60 minutes - TTL for weather sources
     "cache_ttl_summary": "3600",  # 60 minutes - TTL for summaries
     "scheduler_interval_minutes": "30",  # 30 minutes - scheduler polling interval
+    "emagram_max_age_minutes": "180",  # 3 hours - max age for emagram freshness
     "redis_connect_timeout": "5",  # 5 seconds
     "redis_socket_timeout": "5",  # 5 seconds
 }

--- a/apps/backend/migrations/007_add_emagram_max_age_setting.py
+++ b/apps/backend/migrations/007_add_emagram_max_age_setting.py
@@ -20,7 +20,7 @@ SETTING_KEY = "emagram_max_age_minutes"
 SETTING_VALUE = "180"
 
 
-def upgrade():
+def upgrade() -> None:
     """Insert emagram freshness setting if missing."""
     with engine.connect() as conn:
         conn.execute(
@@ -39,15 +39,15 @@ def upgrade():
     logger.info(f"✅ Ensured setting exists: {SETTING_KEY}={SETTING_VALUE}")
 
 
-def downgrade():
+def downgrade() -> None:
     """Safely remove seeded emagram freshness setting."""
     with engine.connect() as conn:
         conn.execute(
-            text("DELETE FROM app_settings WHERE key = :key"),
-            {"key": SETTING_KEY},
+            text("DELETE FROM app_settings WHERE key = :key AND value = :value"),
+            {"key": SETTING_KEY, "value": SETTING_VALUE},
         )
         conn.commit()
-    logger.info(f"✅ Removed setting if present: {SETTING_KEY}")
+    logger.info(f"✅ Removed seeded setting if unchanged: {SETTING_KEY}={SETTING_VALUE}")
 
 
 if __name__ == "__main__":

--- a/apps/backend/migrations/007_add_emagram_max_age_setting.py
+++ b/apps/backend/migrations/007_add_emagram_max_age_setting.py
@@ -1,0 +1,59 @@
+"""
+Migration: Add emagram max age setting
+Created: 2026-04-18
+Description: Seeds emagram_max_age_minutes in app_settings for existing deployments
+"""
+
+import logging
+import os
+from datetime import datetime
+
+from sqlalchemy import create_engine, text
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+engine = create_engine(DATABASE_URL)
+
+SETTING_KEY = "emagram_max_age_minutes"
+SETTING_VALUE = "180"
+
+
+def upgrade():
+    """Insert emagram freshness setting if missing."""
+    with engine.connect() as conn:
+        conn.execute(
+            text("""
+                INSERT INTO app_settings (key, value, updated_at)
+                VALUES (:key, :value, :updated_at)
+                ON CONFLICT(key) DO NOTHING
+                """),
+            {
+                "key": SETTING_KEY,
+                "value": SETTING_VALUE,
+                "updated_at": datetime.utcnow().isoformat(),
+            },
+        )
+        conn.commit()
+    logger.info(f"✅ Ensured setting exists: {SETTING_KEY}={SETTING_VALUE}")
+
+
+def downgrade():
+    """Safely remove seeded emagram freshness setting."""
+    with engine.connect() as conn:
+        conn.execute(
+            text("DELETE FROM app_settings WHERE key = :key"),
+            {"key": SETTING_KEY},
+        )
+        conn.commit()
+    logger.info(f"✅ Removed setting if present: {SETTING_KEY}")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "downgrade":
+        downgrade()
+    else:
+        upgrade()

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4360,6 +4360,7 @@ async def get_emagram_hours(
     """
     try:
         target_date = (datetime.utcnow() + timedelta(days=day_index)).date()
+        cutoff_time = get_emagram_cutoff_utc(db=db)
 
         analyses = (
             db.query(
@@ -4375,6 +4376,7 @@ async def get_emagram_hours(
                 EmagramAnalysis.forecast_hour.isnot(None),
                 EmagramAnalysis.analysis_method == "llm_vision",
                 EmagramAnalysis.analysis_status == "completed",
+                EmagramAnalysis.analysis_datetime >= cutoff_time,
             )
             .order_by(EmagramAnalysis.forecast_hour, EmagramAnalysis.analysis_datetime.desc())
             .all()
@@ -4818,7 +4820,7 @@ async def get_latest_emagram_for_spot(site_id: str, db: Session = Depends(get_db
             detail=f"No recent emagram analysis found for spot {site_id}. Try refreshing.",
         )
 
-    return emagram_analysis_to_dict(emagram)
+    return emagram_analysis_to_dict(emagram, db=db)
 
 
 @router.post("/emagram/spot/{site_id}/refresh", tags=["Emagram"])
@@ -5149,13 +5151,30 @@ def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db))
     allowed_keys = set(DEFAULTS.keys())
     updated = {}
     rejected = []
+    positive_int_keys = {"scheduler_interval_minutes", "emagram_max_age_minutes"}
 
     for key, value in settings.items():
         if key not in allowed_keys:
             rejected.append(key)
             continue
-        set_setting(db, key, str(value))
-        updated[key] = value
+        normalized_value = str(value)
+        if key in positive_int_keys:
+            try:
+                parsed_value = int(normalized_value)
+            except (TypeError, ValueError) as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{key} must be a positive integer",
+                ) from e
+            if parsed_value <= 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{key} must be > 0",
+                )
+            normalized_value = str(parsed_value)
+
+        set_setting(db, key, normalized_value)
+        updated[key] = normalized_value
 
     # If scheduler interval changed, reschedule dynamically
     scheduler_error = None

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 import config
 from auth import authenticate_user, create_access_token, get_current_user
 from database import get_db
+from emagram_freshness import get_emagram_cutoff_utc
 from models import User
 from models import (
     EmagramAnalysis,
@@ -4268,10 +4269,12 @@ async def get_latest_emagram(
 
         # Filter by forecast target date
         target_date = (datetime.utcnow() + timedelta(days=day_index)).date()
+        cutoff_time = get_emagram_cutoff_utc(db=db)
 
         analysis_filters = [
             EmagramAnalysis.forecast_date == target_date,
             EmagramAnalysis.analysis_status == "completed",
+            EmagramAnalysis.analysis_datetime >= cutoff_time,
         ]
         if hour is not None:
             analysis_filters.append(EmagramAnalysis.forecast_hour == hour)
@@ -4318,6 +4321,7 @@ async def get_latest_emagram(
                 EmagramAnalysis.station_code == site_id,
                 EmagramAnalysis.analysis_method == "llm_vision",
                 EmagramAnalysis.analysis_status == "failed",
+                EmagramAnalysis.analysis_datetime >= cutoff_time,
             ]
             if hour is not None:
                 failed_filters.append(EmagramAnalysis.forecast_hour == hour)
@@ -4652,11 +4656,11 @@ async def trigger_emagram_analysis(
 
         # Step 2: Check for recent analysis (unless force_refresh)
         forecast_date = (datetime.utcnow() + timedelta(days=request.day_index)).date()
+        cutoff_time = None if request.force_refresh else get_emagram_cutoff_utc(db=db)
 
         # Step 2a: If no specific hour, trigger hourly batch in background
         if request.hour is None and not request.force_refresh:
             # Check if any hourly analyses exist already
-            cutoff_time = datetime.utcnow() - timedelta(hours=3)
             existing_count = (
                 db.query(EmagramAnalysis)
                 .filter(
@@ -4690,7 +4694,6 @@ async def trigger_emagram_analysis(
 
         # Step 2b: Check cache for specific hour
         if request.hour is not None and not request.force_refresh:
-            cutoff_time = datetime.utcnow() - timedelta(hours=3)
             cache_filters = [
                 EmagramAnalysis.station_code == closest_site.id,
                 EmagramAnalysis.analysis_method == "llm_vision",
@@ -4765,7 +4768,7 @@ async def get_latest_emagram_for_spot(site_id: str, db: Session = Depends(get_db
     """
     Get latest multi-source emagram analysis for a specific spot
 
-    Returns analysis from last 3 hours if available
+    Returns analysis from configured freshness window if available
 
     Example:
         GET /api/emagram/spot/arguel/latest
@@ -4792,12 +4795,10 @@ async def get_latest_emagram_for_spot(site_id: str, db: Session = Depends(get_db
             "next_update": "2024-03-07T23:15:00"
         }
     """
-    from datetime import timedelta
-
     from emagram_multi_source import emagram_analysis_to_dict
 
-    # Find most recent analysis for this site (within 3 hours)
-    cutoff_time = datetime.utcnow() - timedelta(hours=3)
+    # Find most recent analysis for this site within freshness window
+    cutoff_time = get_emagram_cutoff_utc(db=db)
 
     emagram = (
         db.query(EmagramAnalysis)
@@ -4884,9 +4885,7 @@ async def get_all_spots_latest_emagrammes(db: Session = Depends(get_db)):
             "updated_count": 5
         }
     """
-    from datetime import timedelta
-
-    cutoff_time = datetime.utcnow() - timedelta(hours=3)
+    cutoff_time = get_emagram_cutoff_utc(db=db)
 
     # Get all sites with recent emagram
     sites = db.query(Site).all()

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5152,6 +5152,7 @@ def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db))
     updated = {}
     rejected = []
     positive_int_keys = {"scheduler_interval_minutes", "emagram_max_age_minutes"}
+    validated_updates: dict[str, str] = {}
 
     for key, value in settings.items():
         if key not in allowed_keys:
@@ -5173,6 +5174,9 @@ def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db))
                 )
             normalized_value = str(parsed_value)
 
+        validated_updates[key] = normalized_value
+
+    for key, normalized_value in validated_updates.items():
         set_setting(db, key, normalized_value)
         updated[key] = normalized_value
 

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -106,6 +106,29 @@ class TestUpdateSettings:
         assert row is not None
         assert row.value == "120"
 
+    def test_rejects_invalid_emagram_max_age_minutes(self, client, db_session):
+        """Invalid emagram freshness values are rejected with 400."""
+        response = client.put(
+            f"{API_PREFIX}/settings",
+            json={"emagram_max_age_minutes": "abc"},
+        )
+        assert response.status_code == 400
+        assert "positive integer" in response.json()["detail"]
+
+        row = (
+            db_session.query(AppSetting).filter(AppSetting.key == "emagram_max_age_minutes").first()
+        )
+        assert row is None
+
+    def test_rejects_non_positive_emagram_max_age_minutes(self, client, db_session):
+        """Zero and negative emagram freshness values are rejected."""
+        response = client.put(
+            f"{API_PREFIX}/settings",
+            json={"emagram_max_age_minutes": "0"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "emagram_max_age_minutes must be > 0"
+
     def test_update_creates_setting_if_missing(self, client, db_session):
         """Creates new row if setting key doesn't exist in DB yet."""
         response = client.put(

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -122,12 +122,41 @@ class TestUpdateSettings:
 
     def test_rejects_non_positive_emagram_max_age_minutes(self, client, db_session):
         """Zero and negative emagram freshness values are rejected."""
+        for value in ("0", "-1"):
+            response = client.put(
+                f"{API_PREFIX}/settings",
+                json={"emagram_max_age_minutes": value},
+            )
+            assert response.status_code == 400
+            assert response.json()["detail"] == "emagram_max_age_minutes must be > 0"
+
+            row = (
+                db_session.query(AppSetting)
+                .filter(AppSetting.key == "emagram_max_age_minutes")
+                .first()
+            )
+            assert row is None
+
+    def test_rejects_invalid_setting_without_partial_persist(self, client, db_session):
+        """Mixed payloads must not persist valid keys when one value is invalid."""
         response = client.put(
             f"{API_PREFIX}/settings",
-            json={"emagram_max_age_minutes": "0"},
+            json={
+                "cache_ttl_default": "1800",
+                "emagram_max_age_minutes": "abc",
+            },
         )
         assert response.status_code == 400
-        assert response.json()["detail"] == "emagram_max_age_minutes must be > 0"
+        assert "positive integer" in response.json()["detail"]
+
+        valid_row = (
+            db_session.query(AppSetting).filter(AppSetting.key == "cache_ttl_default").first()
+        )
+        invalid_row = (
+            db_session.query(AppSetting).filter(AppSetting.key == "emagram_max_age_minutes").first()
+        )
+        assert valid_row is None
+        assert invalid_row is None
 
     def test_update_creates_setting_if_missing(self, client, db_session):
         """Creates new row if setting key doesn't exist in DB yet."""

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -89,6 +89,23 @@ class TestUpdateSettings:
         data = response.json()
         assert len(data["updated"]) == 2
 
+    def test_update_emagram_max_age_minutes(self, client, db_session):
+        """Updates emagram freshness window setting."""
+        response = client.put(
+            f"{API_PREFIX}/settings",
+            json={"emagram_max_age_minutes": "120"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["updated"]["emagram_max_age_minutes"] == "120"
+
+        row = (
+            db_session.query(AppSetting).filter(AppSetting.key == "emagram_max_age_minutes").first()
+        )
+        assert row is not None
+        assert row.value == "120"
+
     def test_update_creates_setting_if_missing(self, client, db_session):
         """Creates new row if setting key doesn't exist in DB yet."""
         response = client.put(

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -3,10 +3,11 @@ Test emagram analysis endpoints
 """
 
 import json
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 import pytest
 
+import app_settings
 from models import EmagramAnalysis, Site
 
 
@@ -157,6 +158,44 @@ class TestEmagramEndpoints:
 
         # day_index=3 should not find anything (no future analyses)
         response = client.get("/api/emagram/latest?site_id=site-test-day&day_index=3")
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_get_latest_ignores_stale_analysis(self, client, db_session):
+        """Latest endpoint does not return stale analyses outside freshness window."""
+        app_settings.invalidate_cache()
+
+        site = Site(
+            id="site-stale",
+            code="STS",
+            name="Stale Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+
+        stale_analysis = EmagramAnalysis(
+            id="stale-analysis",
+            station_code="site-stale",
+            station_name="Stale Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(hours=4),
+            forecast_date=datetime.utcnow().date(),
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            score_volabilite=65,
+            analysis_status="completed",
+        )
+        db_session.add(stale_analysis)
+        db_session.commit()
+
+        response = client.get("/api/emagram/latest?site_id=site-stale")
         assert response.status_code == 200
         assert response.json() is None
 

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -199,6 +199,45 @@ class TestEmagramEndpoints:
         assert response.status_code == 200
         assert response.json() is None
 
+    def test_get_emagram_hours_ignores_stale_analysis(self, client, db_session):
+        """Hourly endpoint only lists fresh analyses."""
+        app_settings.invalidate_cache()
+
+        site = Site(
+            id="site-stale-hours",
+            code="STH",
+            name="Stale Hours Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+
+        stale_analysis = EmagramAnalysis(
+            id="stale-hours-analysis",
+            station_code="site-stale-hours",
+            station_name="Stale Hours Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(hours=4),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=14,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            score_volabilite=70,
+            analysis_status="completed",
+        )
+        db_session.add(stale_analysis)
+        db_session.commit()
+
+        response = client.get("/api/emagram/hours?site_id=site-stale-hours&day_index=0")
+        assert response.status_code == 200
+        assert response.json()["hours"] == []
+
     def test_analyze_with_site_id(self, client, db_session):
         """Trigger analysis accepts site_id without lat/lon"""
         response = client.post(


### PR DESCRIPTION
## Summary
- Add a shared backend freshness helper and new `emagram_max_age_minutes` app setting (default 180 minutes).
- Apply the configurable freshness cutoff to emagram latest/read endpoints and cache checks used before re-analysis.
- Add backend tests to cover stale-analysis filtering and settings update support for the new key.

## Validation
- `cd apps/backend && command -v .venv/bin/pytest >/dev/null 2>&1 && PYTEST=.venv/bin/pytest || PYTEST=pytest; $PYTEST tests/test_emagram_endpoints.py tests/api/test_routes_settings.py -q --tb=short --no-header`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Emagram data freshness window is now configurable via application settings (default: 180 minutes).

* **Improvements**
  * Enhanced stale data handling with configurable time filters.
  * Added stricter validation for numeric settings.

* **Tests**
  * Added test coverage for stale data scenarios and settings validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->