### PR TITLE
fix(ci): pass stack env file during Portainer fallback

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -237,7 +237,7 @@ jobs:
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v portainer_data:/data \
                 -w "/data/compose/$STACK_ID" \
-                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; docker compose build backend; docker compose up -d backend redis"
+                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose \$env_opt build backend; docker compose \$env_opt up -d backend redis"
               exit 0
             fi
 


### PR DESCRIPTION
## Summary
- Keep the Portainer volume fallback deployment flow added in #415.
- Reuse `stack.env` (or `.env` fallback) when running `docker compose` in the fallback container.
- Prevent required env interpolation failures (for example `BACKEND_METRICS_TOKEN`) during fallback deploys.

## Why
The fallback was syncing source correctly, but `docker compose` ran without Portainer-provided environment files, so required variables were missing and the deploy failed before verification.