### PR TITLE
fix(ci): keep compose project name in SSH deploy fallback

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -178,6 +178,7 @@ jobs:
             STACK_ID=""
             TARGET_SHA="${{ github.sha }}"
             REPO_SLUG="${{ github.repository }}"
+            COMPOSE_PROJECT_NAME="dashboard-parapente"
 
             deploy_from_host_path() {
               path="$1"
@@ -193,8 +194,8 @@ jobs:
               git checkout --detach "$TARGET_SHA"
               test "$(git rev-parse HEAD)" = "$TARGET_SHA"
 
-              docker compose build backend
-              docker compose up -d backend redis
+              docker compose -p "$COMPOSE_PROJECT_NAME" build backend
+              docker compose -p "$COMPOSE_PROJECT_NAME" up -d backend redis
             }
 
             if [ -n "$DEPLOY_PATH" ] && [ -d "$DEPLOY_PATH" ]; then
@@ -237,7 +238,7 @@ jobs:
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v portainer_data:/data \
                 -w "/data/compose/$STACK_ID" \
-                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose \$env_opt build backend; docker compose \$env_opt up -d backend redis"
+                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose -p dashboard-parapente \$env_opt build backend; docker compose -p dashboard-parapente \$env_opt up -d backend redis"
               exit 0
             fi
 

--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -237,7 +237,7 @@ jobs:
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v portainer_data:/data \
                 -w "/data/compose/$STACK_ID" \
-                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; docker compose build backend; docker compose up -d backend redis"
+                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose \$env_opt build backend; docker compose \$env_opt up -d backend redis"
               exit 0
             fi
 


### PR DESCRIPTION
## Summary
- Force `docker compose -p dashboard-parapente` in both SSH deploy paths.
- Prevent fallback deployments from creating conflicting containers under a different Compose project name.

## Why
Without a fixed project name, fallback runs try to create new `parapente-*` containers and fail on name conflicts instead of updating the existing stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment automation with consistent Docker Compose project naming and enhanced environment file handling during build and startup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->