### PR TITLE
fix(ci): align production version endpoint with deploy version

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -177,6 +177,7 @@ jobs:
             INSPECT_PATH=""
             STACK_ID=""
             TARGET_SHA="${{ github.sha }}"
+            TARGET_VERSION="${{ steps.version.outputs.version }}"
             REPO_SLUG="${{ github.repository }}"
             COMPOSE_PROJECT_NAME="dashboard-parapente"
 
@@ -195,7 +196,7 @@ jobs:
               test "$(git rev-parse HEAD)" = "$TARGET_SHA"
 
               docker compose -p "$COMPOSE_PROJECT_NAME" build backend
-              docker compose -p "$COMPOSE_PROJECT_NAME" up -d backend redis
+              BACKEND_DEPLOY_VERSION="$TARGET_VERSION" docker compose -p "$COMPOSE_PROJECT_NAME" up -d backend redis
             }
 
             if [ -n "$DEPLOY_PATH" ] && [ -d "$DEPLOY_PATH" ]; then
@@ -233,12 +234,13 @@ jobs:
               echo "Host path unavailable, deploying from Portainer volume (stack $STACK_ID)"
               docker run --rm \
                 -e TARGET_SHA="$TARGET_SHA" \
+                -e TARGET_VERSION="$TARGET_VERSION" \
                 -e REPO_SLUG="$REPO_SLUG" \
                 -e STACK_ID="$STACK_ID" \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v portainer_data:/data \
                 -w "/data/compose/$STACK_ID" \
-                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose -p dashboard-parapente \$env_opt build backend; docker compose -p dashboard-parapente \$env_opt up -d backend redis"
+                docker:27-cli sh -ceu "apk add --no-cache curl tar docker-cli-compose >/dev/null; temp_dir=\$(mktemp -d); archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; find \"/data/compose/\$STACK_ID\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"/data/compose/\$STACK_ID\" --strip-components=1; rm -rf \"\$temp_dir\"; cd \"/data/compose/\$STACK_ID\"; env_opt=\"\"; if [ -f stack.env ]; then env_opt=\"--env-file stack.env\"; elif [ -f .env ]; then env_opt=\"--env-file .env\"; fi; docker compose -p dashboard-parapente \$env_opt build backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" docker compose -p dashboard-parapente \$env_opt up -d backend redis"
               exit 0
             fi
 

--- a/apps/backend/versioning.py
+++ b/apps/backend/versioning.py
@@ -67,6 +67,18 @@ def initialize_deployment_version() -> dict[str, int | str]:
     global _current_version_payload
 
     today = _today_string()
+    forced_version = os.getenv("BACKEND_DEPLOY_VERSION", "").strip()
+
+    if forced_version:
+        forced_parts = forced_version.split(".")
+        build_number = int(forced_parts[-1]) if forced_parts and forced_parts[-1].isdigit() else 0
+        _current_version_payload = {
+            "version": forced_version,
+            "build_date": ".".join(forced_parts[:3]) if len(forced_parts) >= 3 else today,
+            "build_number": build_number,
+        }
+        logger.info("Deployment version forced from BACKEND_DEPLOY_VERSION: %s", forced_version)
+        return _current_version_payload
 
     if _is_testing_mode() and "BACKEND_VERSION_STATE_FILE" not in os.environ:
         _current_version_payload = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,9 @@ services:
 
       # Backend - Frontend URL
       - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
+
+      # Backend - Deployment metadata
+      - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Pass the computed workflow deployment version into compose as `BACKEND_DEPLOY_VERSION` during SSH deployment.
- Expose `BACKEND_DEPLOY_VERSION` to the backend service via `docker-compose.yml`.
- Update backend versioning logic to prefer `BACKEND_DEPLOY_VERSION` when present instead of auto-incrementing local state.

## Why
Deployment now succeeds, but verification fails because the runtime `/api/version` value is generated from local state and does not match the workflow tag version. This change makes runtime version reporting deterministic and consistent with deployment tags.