### PR TITLE
fix(ci): fail deploy when version verification command fails

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -303,7 +303,7 @@ jobs:
           exit 1
 
       - name: Mark deployment as successful
-        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.conclusion == 'success'
+        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
         uses: actions/github-script@v9
         env:
           TAG_NAME: ${{ steps.version.outputs.success_tag_name }}
@@ -347,7 +347,7 @@ jobs:
             }
 
       - name: Label merged PRs with deployed version
-        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.conclusion == 'success'
+        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
         uses: actions/github-script@v9
         env:
           VERSION_LABEL: ${{ steps.version.outputs.label_name }}
@@ -478,7 +478,7 @@ jobs:
             );
 
       - name: Label current PR as non deployed when deployment fails
-        if: (steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.conclusion != 'success') && github.event_name == 'pull_request'
+        if: (steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.outcome != 'success') && github.event_name == 'pull_request'
         uses: actions/github-script@v9
         env:
           UNDEPLOYED_LABEL: non déployé
@@ -529,10 +529,11 @@ jobs:
         run: |
           echo "Deployment step conclusion: ${{ steps.trigger_deploy.conclusion }}"
           echo "Verification step conclusion: ${{ steps.verify_deploy.conclusion }}"
+          echo "Verification step outcome: ${{ steps.verify_deploy.outcome }}"
           echo "Computed deployment version: ${{ steps.version.outputs.version }}"
 
       - name: Fail job when deployment failed
-        if: steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.conclusion != 'success'
+        if: steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.outcome != 'success'
         run: |
           echo "Deployment or version verification failed"
           exit 1


### PR DESCRIPTION
## Summary
- Keep `Verify deployed version` execution gated on `trigger_deploy` step conclusion.
- Gate success/labels/final failure on `verify_deploy.outcome` instead of `verify_deploy.conclusion`.
- Add explicit output of verification outcome in the confirm step for easier debugging.

## Why
`continue-on-error: true` can produce a successful step conclusion even when the verification command exits non-zero. This allowed deploy success tagging and labels to run despite version mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment verification logic to more accurately determine deployment success and failure states, enhancing reliability of deployment status tracking and PR labeling processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->