### PR TITLE
fix(emagram): show failed hourly analyses with error tooltip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,7 @@ jobs:
           set -o pipefail
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm exec nx e2e e2e --configuration=ci --skipInstall 2>&1 | tee /tmp/e2e.log
         env:
+          DEBUG: pw:webserver
           TESTING: false
           BACKEND_DATABASE_URL: sqlite:///./test.db
           BACKEND_WEATHERAPI_KEY: test_key
@@ -298,6 +299,7 @@ jobs:
             exit 1
           fi
         env:
+          DEBUG: pw:webserver
           GH_TOKEN: ${{ github.token }}
           TESTING: false
           BACKEND_DATABASE_URL: sqlite:///./test.db

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4367,6 +4367,7 @@ async def get_emagram_hours(
                 EmagramAnalysis.forecast_hour,
                 EmagramAnalysis.score_volabilite,
                 EmagramAnalysis.analysis_status,
+                EmagramAnalysis.error_message,
                 EmagramAnalysis.id,
                 EmagramAnalysis.analysis_datetime,
             )
@@ -4375,7 +4376,6 @@ async def get_emagram_hours(
                 EmagramAnalysis.forecast_date == target_date,
                 EmagramAnalysis.forecast_hour.isnot(None),
                 EmagramAnalysis.analysis_method == "llm_vision",
-                EmagramAnalysis.analysis_status == "completed",
                 EmagramAnalysis.analysis_datetime >= cutoff_time,
             )
             .order_by(EmagramAnalysis.forecast_hour, EmagramAnalysis.analysis_datetime.desc())
@@ -4398,6 +4398,7 @@ async def get_emagram_hours(
                     "hour": a.forecast_hour,
                     "score": a.score_volabilite,
                     "status": a.analysis_status,
+                    "error_message": a.error_message,
                     "id": a.id,
                 }
                 for a in unique_analyses

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4271,6 +4271,24 @@ async def get_latest_emagram(
         target_date = (datetime.utcnow() + timedelta(days=day_index)).date()
         cutoff_time = get_emagram_cutoff_utc(db=db)
 
+        # For explicit hourly queries on a specific site, return the most recent
+        # attempt regardless of status to stay consistent with /emagram/hours.
+        if site_id and hour is not None:
+            latest_attempt_for_hour = (
+                db.query(EmagramAnalysis)
+                .filter(
+                    EmagramAnalysis.forecast_date == target_date,
+                    EmagramAnalysis.station_code == site_id,
+                    EmagramAnalysis.analysis_method == "llm_vision",
+                    EmagramAnalysis.forecast_hour == hour,
+                    EmagramAnalysis.analysis_datetime >= cutoff_time,
+                )
+                .order_by(EmagramAnalysis.analysis_datetime.desc())
+                .first()
+            )
+            if latest_attempt_for_hour:
+                return latest_attempt_for_hour
+
         analysis_filters = [
             EmagramAnalysis.forecast_date == target_date,
             EmagramAnalysis.analysis_status == "completed",

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -238,6 +238,113 @@ class TestEmagramEndpoints:
         assert response.status_code == 200
         assert response.json()["hours"] == []
 
+    def test_get_emagram_hours_includes_failed_with_error(self, client, db_session):
+        """Hourly endpoint exposes failed hourly analyses and their error message."""
+        app_settings.invalidate_cache()
+
+        site = Site(
+            id="site-hours-failed",
+            code="SHF",
+            name="Failed Hours Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+
+        failed_analysis = EmagramAnalysis(
+            id="failed-hours-analysis",
+            station_code="site-hours-failed",
+            station_name="Failed Hours Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=14,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="failed",
+            error_message="LLM timeout",
+        )
+        db_session.add(failed_analysis)
+        db_session.commit()
+
+        response = client.get("/api/emagram/hours?site_id=site-hours-failed&day_index=0")
+        assert response.status_code == 200
+
+        hours = response.json()["hours"]
+        assert len(hours) == 1
+        assert hours[0]["hour"] == 14
+        assert hours[0]["status"] == "failed"
+        assert hours[0]["error_message"] == "LLM timeout"
+
+    def test_get_emagram_hours_keeps_most_recent_status_per_hour(self, client, db_session):
+        """Hourly endpoint returns latest attempt for a given hour."""
+        app_settings.invalidate_cache()
+
+        site = Site(
+            id="site-hours-most-recent",
+            code="SHR",
+            name="Most Recent Hours Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+
+        completed_old = EmagramAnalysis(
+            id="completed-old",
+            station_code="site-hours-most-recent",
+            station_name="Most Recent Hours Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(hours=2),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=15,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            score_volabilite=78,
+            analysis_status="completed",
+        )
+        failed_new = EmagramAnalysis(
+            id="failed-new",
+            station_code="site-hours-most-recent",
+            station_name="Most Recent Hours Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(minutes=20),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=15,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="failed",
+            error_message="Source scrape failed",
+        )
+        db_session.add(completed_old)
+        db_session.add(failed_new)
+        db_session.commit()
+
+        response = client.get("/api/emagram/hours?site_id=site-hours-most-recent&day_index=0")
+        assert response.status_code == 200
+
+        hours = response.json()["hours"]
+        assert len(hours) == 1
+        assert hours[0]["hour"] == 15
+        assert hours[0]["status"] == "failed"
+        assert hours[0]["error_message"] == "Source scrape failed"
+
     def test_analyze_with_site_id(self, client, db_session):
         """Trigger analysis accepts site_id without lat/lon"""
         response = client.post(

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -199,6 +199,69 @@ class TestEmagramEndpoints:
         assert response.status_code == 200
         assert response.json() is None
 
+    def test_get_latest_hour_returns_most_recent_attempt_for_site(self, client, db_session):
+        """Latest endpoint returns newest hourly attempt even if it failed."""
+        app_settings.invalidate_cache()
+
+        site = Site(
+            id="site-latest-hour-recent",
+            code="SLR",
+            name="Latest Hour Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+
+        completed_old = EmagramAnalysis(
+            id="latest-hour-completed-old",
+            station_code="site-latest-hour-recent",
+            station_name="Latest Hour Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(hours=2),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=13,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            score_volabilite=77,
+            analysis_status="completed",
+        )
+        failed_new = EmagramAnalysis(
+            id="latest-hour-failed-new",
+            station_code="site-latest-hour-recent",
+            station_name="Latest Hour Site",
+            station_latitude=47.0,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow() - timedelta(minutes=10),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=13,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="failed",
+            error_message="Recent provider timeout",
+        )
+        db_session.add(completed_old)
+        db_session.add(failed_new)
+        db_session.commit()
+
+        response = client.get("/api/emagram/latest?site_id=site-latest-hour-recent&hour=13")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data is not None
+        assert data["forecast_hour"] == 13
+        assert data["analysis_status"] == "failed"
+        assert data["error_message"] == "Recent provider timeout"
+
     def test_get_emagram_hours_ignores_stale_analysis(self, client, db_session):
         """Hourly endpoint only lists fresh analyses."""
         app_settings.invalidate_cache()

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -77,7 +77,8 @@ export default defineConfig({
       },
     },
     {
-      command: 'nx build frontend && npx vite preview --config apps/frontend/vite.config.ts',
+      command:
+        'bash -lc "set -o pipefail; echo [e2e:web] Building frontend; nx build frontend --output-style=stream; echo [e2e:web] Starting Vite preview; npx vite preview --config apps/frontend/vite.config.ts --strictPort --host 127.0.0.1 --port 5173"',
       url: 'http://localhost:5173',
       reuseExistingServer: !process.env.CI,
       cwd: '../..',

--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -1,7 +1,7 @@
 import preview from '../../../.storybook/preview';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
-import { expect } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 import EmagramWidget from './EmagramWidget';
 
 const meta = preview.meta({
@@ -290,8 +290,16 @@ export const HourFailedTooltip = meta.story({
 });
 
 HourFailedTooltip.test('shows tooltip for failed hour', async ({ canvas }) => {
-  const failedHourButton = await canvas.findByTitle(
+  const failedHourButton = await canvas.findByRole('button', {
+    name: /Échec analyse 14h : Timeout fournisseur LLM/,
+  });
+
+  await userEvent.hover(failedHourButton);
+
+  const tooltip = await within(document.body).findByText(
     /Échec analyse 14h : Timeout fournisseur LLM/
   );
+
+  await expect(tooltip).toBeInTheDocument();
   await expect(failedHourButton).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -90,6 +90,16 @@ const screenshotHandler = http.get(
 );
 
 const defaultHandlers = [
+  http.get('*/api/emagram/hours', () =>
+    HttpResponse.json({
+      site_id: 'site-arguel',
+      forecast_date: '2026-03-24',
+      hours: [
+        { hour: 11, score: 65, status: 'completed', id: 'hour-11' },
+        { hour: 14, score: 75, status: 'completed', id: 'hour-14' },
+      ],
+    })
+  ),
   http.get('*/api/emagram/latest', () => HttpResponse.json(mockEmagramData)),
   http.post('*/api/emagram/analyze', () => HttpResponse.json(mockEmagramData)),
   screenshotHandler,
@@ -131,6 +141,13 @@ export const AnalysisInProgress = meta.story({
   parameters: {
     msw: {
       handlers: [
+        http.get('*/api/emagram/hours', () =>
+          HttpResponse.json({
+            site_id: 'site-arguel',
+            forecast_date: '2026-03-24',
+            hours: [],
+          })
+        ),
         http.get('*/api/emagram/latest', () => HttpResponse.json(null)),
         http.post('*/api/emagram/analyze', () =>
           HttpResponse.json(mockEmagramData)
@@ -150,6 +167,13 @@ export const Error = meta.story({
   parameters: {
     msw: {
       handlers: [
+        http.get('*/api/emagram/hours', () =>
+          HttpResponse.json({
+            site_id: 'site-arguel',
+            forecast_date: '2026-03-24',
+            hours: [],
+          })
+        ),
         http.get('*/api/emagram/latest', () => {
           return new HttpResponse(null, { status: 500 });
         }),
@@ -187,6 +211,13 @@ export const Loading = meta.story({
   parameters: {
     msw: {
       handlers: [
+        http.get('*/api/emagram/hours', () =>
+          HttpResponse.json({
+            site_id: 'site-arguel',
+            forecast_date: '2026-03-24',
+            hours: [],
+          })
+        ),
         http.get('*/api/emagram/latest', async () => {
           await new Promise(() => {});
         }),
@@ -219,4 +250,48 @@ export const WithScreenshotPreview = meta.story({
   name: 'With Screenshot Preview (hover)',
   args: { siteId: 'site-arguel', dayIndex: 0 },
   parameters: { msw: { handlers: defaultHandlers } },
+});
+
+export const HourFailedTooltip = meta.story({
+  name: 'Hour Failed Tooltip',
+  args: { siteId: 'site-arguel', dayIndex: 0 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('*/api/emagram/hours', () =>
+          HttpResponse.json({
+            site_id: 'site-arguel',
+            forecast_date: '2026-03-24',
+            hours: [
+              { hour: 11, score: 68, status: 'completed', id: 'hour-ok' },
+              {
+                hour: 14,
+                score: null,
+                status: 'failed',
+                error_message: 'Timeout fournisseur LLM',
+                id: 'hour-failed',
+              },
+            ],
+          })
+        ),
+        http.get('*/api/emagram/latest', () =>
+          HttpResponse.json({
+            ...mockEmagramData,
+            forecast_hour: 14,
+            analysis_status: 'failed',
+            error_message: 'Timeout fournisseur LLM',
+          })
+        ),
+        http.post('*/api/emagram/analyze', () => HttpResponse.json(mockEmagramData)),
+        screenshotHandler,
+      ],
+    },
+  },
+});
+
+HourFailedTooltip.test('shows tooltip for failed hour', async ({ canvas }) => {
+  const failedHourButton = await canvas.findByTitle(
+    /Échec analyse 14h : Timeout fournisseur LLM/
+  );
+  await expect(failedHourButton).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -114,6 +114,11 @@ function HourSlider({
               onPress={() => onHourChange(h.hour)}
               className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${buttonClassName}`}
               style={{ left: `${percent}%` }}
+              aria-label={
+                isFailed
+                  ? `Échec analyse ${h.hour}h : ${errorText}`
+                  : `Analyse ${h.hour}h`
+              }
               title={
                 isFailed
                   ? `Échec analyse ${h.hour}h : ${errorText}`
@@ -215,6 +220,16 @@ export default function EmagramWidget({
       },
     ].sort((a, b) => a.hour - b.hour);
   }, [availableHours, emagram]);
+
+  useEffect(() => {
+    if (
+      selectedHour == null &&
+      !availableHours.length &&
+      emagram?.forecast_hour != null
+    ) {
+      setSelectedHour(emagram.forecast_hour);
+    }
+  }, [availableHours.length, emagram?.forecast_hour, selectedHour]);
 
   const hasHourlyData = displayHours.length > 0;
   const hourSlider = hasHourlyData ? (

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -24,6 +24,8 @@ import {
   SliderThumb,
   SliderOutput,
   Button,
+  Tooltip,
+  TooltipTrigger,
 } from 'react-aria-components';
 
 interface EmagramWidgetProps {
@@ -108,34 +110,50 @@ function HourSlider({
               ? 'text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300'
               : 'text-gray-400 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300';
 
-          return (
-            <Button
-              key={h.hour}
-              onPress={() => onHourChange(h.hour)}
-              className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${buttonClassName}`}
-              style={{ left: `${percent}%` }}
-              aria-label={
-                isFailed
-                  ? `Échec analyse ${h.hour}h : ${errorText}`
-                  : `Analyse ${h.hour}h`
-              }
-            >
-              <span
-                title={
-                  isFailed
-                    ? `Échec analyse ${h.hour}h : ${errorText}`
-                    : undefined
-                }
+          const label = isFailed
+            ? `Échec analyse ${h.hour}h : ${errorText}`
+            : `Analyse ${h.hour}h`;
+
+          if (!isFailed) {
+            return (
+              <Button
+                key={h.hour}
+                onPress={() => onHourChange(h.hour)}
+                className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${buttonClassName}`}
+                style={{ left: `${percent}%` }}
+                aria-label={label}
               >
                 {h.hour}h
-              </span>
-              {h.score != null && h.status === 'completed' && (
-                <span
-                  className="block w-1.5 h-1.5 rounded-full mx-auto mt-0.5"
-                  style={{ backgroundColor: getScoreColor(h.score) }}
-                />
-              )}
-            </Button>
+                {h.score != null && h.status === 'completed' && (
+                  <span
+                    className="block w-1.5 h-1.5 rounded-full mx-auto mt-0.5"
+                    style={{ backgroundColor: getScoreColor(h.score) }}
+                  />
+                )}
+              </Button>
+            );
+          }
+
+          return (
+            <TooltipTrigger key={h.hour}>
+              <Button
+                onPress={() => onHourChange(h.hour)}
+                className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${buttonClassName}`}
+                style={{ left: `${percent}%` }}
+                aria-label={label}
+              >
+                {h.hour}h
+                {h.score != null && h.status === 'completed' && (
+                  <span
+                    className="block w-1.5 h-1.5 rounded-full mx-auto mt-0.5"
+                    style={{ backgroundColor: getScoreColor(h.score) }}
+                  />
+                )}
+              </Button>
+              <Tooltip className="bg-red-700 text-white text-xs px-2 py-1 rounded shadow-lg max-w-56 break-words">
+                {label}
+              </Tooltip>
+            </TooltipTrigger>
           );
         })}
       </div>

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -119,13 +119,16 @@ function HourSlider({
                   ? `Échec analyse ${h.hour}h : ${errorText}`
                   : `Analyse ${h.hour}h`
               }
-              title={
-                isFailed
-                  ? `Échec analyse ${h.hour}h : ${errorText}`
-                  : undefined
-              }
             >
-              {h.hour}h
+              <span
+                title={
+                  isFailed
+                    ? `Échec analyse ${h.hour}h : ${errorText}`
+                    : undefined
+                }
+              >
+                {h.hour}h
+              </span>
               {h.score != null && h.status === 'completed' && (
                 <span
                   className="block w-1.5 h-1.5 rounded-full mx-auto mt-0.5"

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -92,18 +92,33 @@ function HourSlider({
       </Slider>
       <div className="relative mt-1 h-7">
         {hours.map((h, idx) => {
+          const isActive = h.hour === effectiveHour;
+          const isFailed = h.status === 'failed';
+          const errorText =
+            h.error_message?.trim() ||
+            'Analyse non disponible pour cette heure';
           const percent =
             hours.length > 1 ? (idx / (hours.length - 1)) * 100 : 50;
+
+          const buttonClassName = isActive
+            ? isFailed
+              ? 'font-bold text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/30'
+              : 'font-bold text-purple-700 dark:text-purple-300 bg-purple-50 dark:bg-purple-900/30'
+            : isFailed
+              ? 'text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300'
+              : 'text-gray-400 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300';
+
           return (
             <Button
               key={h.hour}
               onPress={() => onHourChange(h.hour)}
-              className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${
-                h.hour === effectiveHour
-                  ? 'font-bold text-purple-700 dark:text-purple-300 bg-purple-50 dark:bg-purple-900/30'
-                  : 'text-gray-400 dark:text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
-              }`}
+              className={`absolute -translate-x-1/2 text-[10px] px-1 py-0.5 rounded transition-colors ${buttonClassName}`}
               style={{ left: `${percent}%` }}
+              title={
+                isFailed
+                  ? `Échec analyse ${h.hour}h : ${errorText}`
+                  : undefined
+              }
             >
               {h.hour}h
               {h.score != null && h.status === 'completed' && (
@@ -157,7 +172,7 @@ export default function EmagramWidget({
     ) {
       return selectedHour;
     }
-    if (!availableHours.length) return null;
+    if (!availableHours.length) return selectedHour;
     const targetHour = dayIndex > 0 ? 14 : new Date().getHours();
     const hours = availableHours.map((h) => h.hour);
 
@@ -168,15 +183,6 @@ export default function EmagramWidget({
     );
   }, [selectedHour, availableHours, dayIndex]);
 
-  const hasHourlyData = availableHours.length > 0;
-  const hourSlider = hasHourlyData ? (
-    <HourSlider
-      hours={availableHours}
-      selectedHour={activeHour}
-      onHourChange={setSelectedHour}
-    />
-  ) : null;
-
   const {
     data: emagram,
     isLoading,
@@ -185,9 +191,40 @@ export default function EmagramWidget({
   } = useLatestEmagram(
     siteId,
     dayIndex,
-    hasHourlyData ? activeHour : undefined,
+    activeHour,
     { enabled: shouldFetchEmagram }
   );
+
+  const displayHours = useMemo(() => {
+    if (emagram?.forecast_hour == null) {
+      return availableHours;
+    }
+
+    if (availableHours.some((h) => h.hour === emagram.forecast_hour)) {
+      return availableHours;
+    }
+
+    return [
+      ...availableHours,
+      {
+        hour: emagram.forecast_hour,
+        score: emagram.score_volabilite,
+        status: emagram.analysis_status,
+        error_message: emagram.error_message,
+        id: emagram.id,
+      },
+    ].sort((a, b) => a.hour - b.hour);
+  }, [availableHours, emagram]);
+
+  const hasHourlyData = displayHours.length > 0;
+  const hourSlider = hasHourlyData ? (
+    <HourSlider
+      hours={displayHours}
+      selectedHour={activeHour}
+      onHourChange={setSelectedHour}
+    />
+  ) : null;
+
   const triggerMutation = useTriggerEmagram();
 
   const handleRefresh = async () => {

--- a/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
+++ b/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
@@ -53,6 +53,7 @@ export interface EmagramHourEntry {
   hour: number;
   score: number | null;
   status: string;
+  error_message?: string | null;
   id: string;
 }
 


### PR DESCRIPTION
## Summary
- include failed hourly analyses in `/api/emagram/hours` and return `error_message` so the UI can represent per-hour failures
- keep the most recent analysis status per hour, with backend tests covering failed entries and recency behavior
- render failed hour buttons in red in `EmagramWidget` and expose a hover tooltip with the failure reason, plus Storybook coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hourly analyses now surface detailed error messages and show failed hours with distinct styling and tooltips.
  * Hour selection falls back to the latest forecast hour when hourly data is missing.

* **Bug Fixes**
  * Latest-hour lookup for explicit hour queries returns the newest attempt (including failed attempts).
  * Hour listings no longer filter out failed attempts and include per-hour error messages.

* **Tests / Stories**
  * Added endpoint tests and a Storybook story+test covering failed-hour display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->