### PR TITLE
fix(backend): resolve production frontend URL for video export

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -1,0 +1,37 @@
+"""Unit tests for frontend URL resolution in manual video export."""
+
+import video_export_manual
+
+
+def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
+    """Production should avoid localhost:5173 when static frontend is bundled."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
+
+    assert resolved == "http://localhost:8001"
+
+
+def test_resolve_frontend_url_keeps_dev_vite_url(monkeypatch):
+    """Development should keep localhost:5173 for local Vite workflow."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "development")
+
+    resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
+
+    assert resolved == "http://localhost:5173"
+
+
+def test_resolve_frontend_url_strips_export_viewer_suffix(monkeypatch):
+    """The base URL should not keep the /export-viewer route segment."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: False)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "development")
+
+    resolved = video_export_manual.resolve_frontend_url(
+        "http://frontend.example/export-viewer?flightId=abc"
+    )
+
+    assert resolved == "http://frontend.example"

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -16,6 +16,7 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 
@@ -97,10 +98,20 @@ def _default_frontend_url() -> str:
 
     static_index = Path(__file__).parent / "static" / "index.html"
     if static_index.exists():
-        host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
-        return f"http://{host}:{config.API_PORT}"
+        return _backend_base_url()
 
     return "http://localhost:5173"
+
+
+def _backend_base_url() -> str:
+    host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
+    return f"http://{host}:{config.API_PORT}"
+
+
+def _is_local_vite_url(candidate: str) -> bool:
+    parsed = urlparse(candidate)
+    hostname = (parsed.hostname or "").lower()
+    return hostname in {"localhost", "127.0.0.1", "::1"} and parsed.port == 5173
 
 
 def resolve_frontend_url(frontend_url: str | None = None) -> str:
@@ -115,14 +126,20 @@ def _normalize_frontend_url(frontend_url: str) -> str:
     static_index = Path(__file__).parent / "static" / "index.html"
 
     if not candidate and static_index.exists():
-        host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
-        return f"http://{host}:{config.API_PORT}"
+        return _backend_base_url()
 
     if not candidate:
         return "http://localhost:5173"
 
     if "/export-viewer" in candidate:
         candidate = candidate.split("/export-viewer")[0]
+
+    if (
+        static_index.exists()
+        and config.ENVIRONMENT == "production"
+        and _is_local_vite_url(candidate)
+    ):
+        return _backend_base_url()
 
     return candidate.rstrip("/")
 


### PR DESCRIPTION
## Summary
- prevent Playwright manual video export from using `localhost:5173` in production when the frontend static bundle is served by backend
- centralize backend base URL resolution and apply it as a safe fallback for local Vite URLs in production (`localhost`/`127.0.0.1`/`::1` on port 5173)
- add unit tests covering production fallback, development behavior preservation, and `/export-viewer` URL normalization

## Validation
- python syntax check: `python3 -m py_compile apps/backend/video_export_manual.py apps/backend/tests/unit/test_video_export_manual.py`
- full pytest/Nx backend tests could not be run in this environment because `pytest` and `pnpm` are not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video export to properly resolve frontend URLs based on deployment environment. When deployed to production with a static frontend, the system now correctly uses the backend server URL instead of development URLs. Development environments maintain full compatibility with the Vite development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->