### PR TITLE
feat(app): add SSE-based update banner for new versions

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3,6 +3,7 @@ import json
 import logging
 import math
 import os
+import time
 import uuid
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -11,7 +12,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -3259,6 +3260,28 @@ def health_check():
 @public_router.get("/version")
 def version_info():
     return get_version_payload()
+
+
+@public_router.get("/version/stream")
+def version_stream() -> StreamingResponse:
+    def event_stream():
+        yield "retry: 5000\n\n"
+        yield f"event: version\ndata: {json.dumps(get_version_payload())}\n\n"
+
+        while True:
+            heartbeat = {"timestamp": datetime.utcnow().isoformat()}
+            yield f"event: ping\ndata: {json.dumps(heartbeat)}\n\n"
+            time.sleep(25)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 # ============================================================================

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3,7 +3,6 @@ import json
 import logging
 import math
 import os
-import time
 import uuid
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -11,7 +10,7 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
@@ -3262,16 +3261,20 @@ def version_info():
     return get_version_payload()
 
 
-@public_router.get("/version/stream")
-def version_stream() -> StreamingResponse:
-    def event_stream():
-        yield "retry: 5000\n\n"
-        yield f"event: version\ndata: {json.dumps(get_version_payload())}\n\n"
+def serialize_sse_event(event_name: str, payload: dict[str, Any]) -> str:
+    return f"event: {event_name}\ndata: {json.dumps(payload)}\n\n"
 
-        while True:
+
+@public_router.get("/version/stream")
+async def version_stream(request: Request) -> StreamingResponse:
+    async def event_stream():
+        yield "retry: 5000\n\n"
+        yield serialize_sse_event("version", get_version_payload())
+
+        while not await request.is_disconnected():
             heartbeat = {"timestamp": datetime.utcnow().isoformat()}
-            yield f"event: ping\ndata: {json.dumps(heartbeat)}\n\n"
-            time.sleep(25)
+            yield serialize_sse_event("ping", heartbeat)
+            await asyncio.sleep(25)
 
     return StreamingResponse(
         event_stream(),

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -6,7 +6,7 @@ import os
 import uuid
 import xml.etree.ElementTree as ET
 from typing import Any
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -3280,10 +3280,13 @@ async def version_stream(request: Request) -> StreamingResponse:
         yield "retry: 5000\n\n"
         yield serialize_sse_event("version", get_version_payload())
 
-        while not await request.is_disconnected():
-            heartbeat = {"timestamp": datetime.utcnow().isoformat()}
-            yield serialize_sse_event("ping", heartbeat)
-            await asyncio.sleep(25)
+        while True:
+            try:
+                await asyncio.wait_for(request.is_disconnected(), timeout=25)
+                break
+            except TimeoutError:
+                heartbeat = {"timestamp": datetime.now(timezone.utc).isoformat()}
+                yield serialize_sse_event("ping", heartbeat)
 
     return StreamingResponse(
         event_stream(),

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -10,7 +10,16 @@ from datetime import date, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    File,
+    HTTPException,
+    Query,
+    Request,
+    UploadFile,
+)
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func

--- a/apps/backend/tests/api/test_routes_version.py
+++ b/apps/backend/tests/api/test_routes_version.py
@@ -20,9 +20,7 @@ def reset_version_cache_fixture():
 
 def test_get_version_includes_release_notes_url(client, monkeypatch):
     monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.21.7")
-    monkeypatch.setenv(
-        "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.21.7"
-    )
+    monkeypatch.setenv("BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.21.7")
     response = client.get(f"{API_PREFIX}/version")
 
     assert response.status_code == 200
@@ -33,9 +31,7 @@ def test_get_version_includes_release_notes_url(client, monkeypatch):
 
 def test_version_stream_sends_initial_version_event(monkeypatch):
     monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.22.1")
-    monkeypatch.setenv(
-        "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.22.1"
-    )
+    monkeypatch.setenv("BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.22.1")
     payload = versioning.get_version_payload()
     chunk = serialize_sse_event("version", payload)
 

--- a/apps/backend/tests/api/test_routes_version.py
+++ b/apps/backend/tests/api/test_routes_version.py
@@ -1,0 +1,52 @@
+import json
+
+import versioning
+
+API_PREFIX = "/api"
+
+
+def _reset_version_cache() -> None:
+    versioning._current_version_payload = None
+
+
+def test_get_version_includes_release_notes_url(client, monkeypatch):
+    monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.21.7")
+    monkeypatch.setenv(
+        "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.21.7"
+    )
+    _reset_version_cache()
+
+    response = client.get(f"{API_PREFIX}/version")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["version"] == "2026.04.21.7"
+    assert payload["release_notes_url"] == "https://example.com/releases/2026.04.21.7"
+
+
+def test_version_stream_sends_initial_version_event(client, monkeypatch):
+    monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.22.1")
+    monkeypatch.setenv(
+        "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.22.1"
+    )
+    _reset_version_cache()
+
+    with client.stream("GET", f"{API_PREFIX}/version/stream") as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        event_name = None
+        event_data = None
+
+        for line in response.iter_lines():
+            raw_line = line.decode() if isinstance(line, bytes) else line
+            if raw_line.startswith("event: "):
+                event_name = raw_line.replace("event: ", "", 1)
+            if raw_line.startswith("data: ") and event_name == "version":
+                event_data = json.loads(raw_line.replace("data: ", "", 1))
+                break
+
+        assert event_name == "version"
+        assert event_data is not None
+        assert event_data["version"] == "2026.04.22.1"
+        assert event_data["release_notes_url"] == "https://example.com/releases/2026.04.22.1"

--- a/apps/backend/tests/api/test_routes_version.py
+++ b/apps/backend/tests/api/test_routes_version.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+from routes import serialize_sse_event
 import versioning
 
 API_PREFIX = "/api"
@@ -9,13 +11,18 @@ def _reset_version_cache() -> None:
     versioning._current_version_payload = None
 
 
+@pytest.fixture(autouse=True)
+def reset_version_cache_fixture():
+    _reset_version_cache()
+    yield
+    _reset_version_cache()
+
+
 def test_get_version_includes_release_notes_url(client, monkeypatch):
     monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.21.7")
     monkeypatch.setenv(
         "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.21.7"
     )
-    _reset_version_cache()
-
     response = client.get(f"{API_PREFIX}/version")
 
     assert response.status_code == 200
@@ -24,29 +31,24 @@ def test_get_version_includes_release_notes_url(client, monkeypatch):
     assert payload["release_notes_url"] == "https://example.com/releases/2026.04.21.7"
 
 
-def test_version_stream_sends_initial_version_event(client, monkeypatch):
+def test_version_stream_sends_initial_version_event(monkeypatch):
     monkeypatch.setenv("BACKEND_DEPLOY_VERSION", "2026.04.22.1")
     monkeypatch.setenv(
         "BACKEND_RELEASE_NOTES_URL", "https://example.com/releases/2026.04.22.1"
     )
-    _reset_version_cache()
+    payload = versioning.get_version_payload()
+    chunk = serialize_sse_event("version", payload)
 
-    with client.stream("GET", f"{API_PREFIX}/version/stream") as response:
-        assert response.status_code == 200
-        assert response.headers["content-type"].startswith("text/event-stream")
+    event_name = None
+    event_data = None
 
-        event_name = None
-        event_data = None
+    for raw_line in chunk.splitlines():
+        if raw_line.startswith("event: "):
+            event_name = raw_line.replace("event: ", "", 1)
+        if raw_line.startswith("data: ") and event_name == "version":
+            event_data = json.loads(raw_line.replace("data: ", "", 1))
 
-        for line in response.iter_lines():
-            raw_line = line.decode() if isinstance(line, bytes) else line
-            if raw_line.startswith("event: "):
-                event_name = raw_line.replace("event: ", "", 1)
-            if raw_line.startswith("data: ") and event_name == "version":
-                event_data = json.loads(raw_line.replace("data: ", "", 1))
-                break
-
-        assert event_name == "version"
-        assert event_data is not None
-        assert event_data["version"] == "2026.04.22.1"
-        assert event_data["release_notes_url"] == "https://example.com/releases/2026.04.22.1"
+    assert event_name == "version"
+    assert event_data is not None
+    assert event_data["version"] == "2026.04.22.1"
+    assert event_data["release_notes_url"] == "https://example.com/releases/2026.04.22.1"

--- a/apps/backend/versioning.py
+++ b/apps/backend/versioning.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 import fcntl
 
@@ -29,7 +30,15 @@ def _is_testing_mode() -> bool:
 
 def _release_notes_url() -> str | None:
     value = os.getenv("BACKEND_RELEASE_NOTES_URL", "").strip()
-    return value or None
+    if not value:
+        return None
+
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        logger.warning("Ignoring invalid BACKEND_RELEASE_NOTES_URL: %s", value)
+        return None
+
+    return value
 
 
 def _load_state() -> dict[str, int | str] | None:

--- a/apps/backend/versioning.py
+++ b/apps/backend/versioning.py
@@ -16,7 +16,7 @@ VERSION_STATE_FILE = Path(
     )
 )
 
-_current_version_payload: dict[str, int | str] | None = None
+_current_version_payload: dict[str, int | str | None] | None = None
 
 
 def _today_string() -> str:
@@ -25,6 +25,11 @@ def _today_string() -> str:
 
 def _is_testing_mode() -> bool:
     return os.getenv("TESTING", "false").lower() == "true"
+
+
+def _release_notes_url() -> str | None:
+    value = os.getenv("BACKEND_RELEASE_NOTES_URL", "").strip()
+    return value or None
 
 
 def _load_state() -> dict[str, int | str] | None:
@@ -63,7 +68,7 @@ def _write_state(date: str, number: int) -> None:
     temp_file.replace(VERSION_STATE_FILE)
 
 
-def initialize_deployment_version() -> dict[str, int | str]:
+def initialize_deployment_version() -> dict[str, int | str | None]:
     global _current_version_payload
 
     today = _today_string()
@@ -76,6 +81,7 @@ def initialize_deployment_version() -> dict[str, int | str]:
             "version": forced_version,
             "build_date": ".".join(forced_parts[:3]) if len(forced_parts) >= 3 else today,
             "build_number": build_number,
+            "release_notes_url": _release_notes_url(),
         }
         logger.info("Deployment version forced from BACKEND_DEPLOY_VERSION: %s", forced_version)
         return _current_version_payload
@@ -85,6 +91,7 @@ def initialize_deployment_version() -> dict[str, int | str]:
             "version": f"{today}.0",
             "build_date": today,
             "build_number": 0,
+            "release_notes_url": _release_notes_url(),
         }
         return _current_version_payload
 
@@ -107,13 +114,14 @@ def initialize_deployment_version() -> dict[str, int | str]:
         "version": f"{today}.{next_number}",
         "build_date": today,
         "build_number": next_number,
+        "release_notes_url": _release_notes_url(),
     }
 
     logger.info("Deployment version initialized: %s", _current_version_payload["version"])
     return _current_version_payload
 
 
-def get_version_payload() -> dict[str, int | str]:
+def get_version_payload() -> dict[str, int | str | None]:
     if _current_version_payload is not None:
         return _current_version_payload
 

--- a/apps/frontend/src/components/common/AppUpdateBanner.chromatic.stories.tsx
+++ b/apps/frontend/src/components/common/AppUpdateBanner.chromatic.stories.tsx
@@ -1,0 +1,30 @@
+import { FigureWrapper } from '../../../.storybook/FigureWrapper.tsx';
+import preview from '../../../.storybook/preview.tsx';
+import {
+  WithReleaseNotes,
+  WithoutReleaseNotes,
+} from './AppUpdateBanner.stories.tsx';
+
+const meta = preview.meta({
+  title: 'Components/Common/AppUpdateBanner/Chromatic',
+  parameters: {
+    layout: 'padded',
+    chromatic: {
+      disableSnapshot: false,
+    },
+  },
+  tags: ['!autodocs'],
+});
+
+export const AppUpdateBannerChromatic = meta.story({
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <FigureWrapper title={WithReleaseNotes.composed.name}>
+        <WithReleaseNotes.Component />
+      </FigureWrapper>
+      <FigureWrapper title={WithoutReleaseNotes.composed.name}>
+        <WithoutReleaseNotes.Component />
+      </FigureWrapper>
+    </div>
+  ),
+});

--- a/apps/frontend/src/components/common/AppUpdateBanner.stories.tsx
+++ b/apps/frontend/src/components/common/AppUpdateBanner.stories.tsx
@@ -1,0 +1,63 @@
+import preview from '../../../.storybook/preview';
+import { expect, fn, userEvent, within } from 'storybook/test';
+import AppUpdateBanner from './AppUpdateBanner';
+
+const meta = preview.meta({
+  title: 'Components/Common/AppUpdateBanner',
+  component: AppUpdateBanner,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+});
+
+export const WithReleaseNotes = meta.story({
+  args: {
+    title: 'Nouvelle version disponible',
+    message: 'Une nouvelle version (2026.04.22.1) est prete.',
+    viewWhatsNewLabel: 'Voir les nouveautes',
+    refreshLabel: 'Rafraichir',
+    releaseNotesUrl: 'https://example.com/releases/2026.04.22.1',
+    onRefresh: fn(),
+  },
+});
+
+WithReleaseNotes.test('shows version details and release notes link', async ({
+  canvasElement,
+}) => {
+  const canvas = within(canvasElement);
+
+  await expect(
+    canvas.getByText(/Une nouvelle version \(2026\.04\.22\.1\) est prete\./i)
+  ).toBeInTheDocument();
+  await expect(
+    canvas.getByRole('link', { name: /Voir les nouveautes/i })
+  ).toBeInTheDocument();
+});
+
+WithReleaseNotes.test('calls refresh callback', async ({ canvasElement, args }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.click(canvas.getByRole('button', { name: /Rafraichir/i }));
+  await expect(args.onRefresh).toHaveBeenCalledTimes(1);
+});
+
+export const WithoutReleaseNotes = meta.story({
+  args: {
+    title: 'New version available',
+    message: 'A new version (2026.04.22.1) is ready.',
+    viewWhatsNewLabel: "See what's new",
+    refreshLabel: 'Refresh',
+    releaseNotesUrl: null,
+    onRefresh: fn(),
+  },
+});
+
+WithoutReleaseNotes.test('hides release notes link when URL is missing', async ({
+  canvasElement,
+}) => {
+  const canvas = within(canvasElement);
+
+  await expect(canvas.queryByRole('link')).not.toBeInTheDocument();
+  await expect(canvas.getByRole('button', { name: /Refresh/i })).toBeInTheDocument();
+});

--- a/apps/frontend/src/components/common/AppUpdateBanner.tsx
+++ b/apps/frontend/src/components/common/AppUpdateBanner.tsx
@@ -1,0 +1,45 @@
+import { Button } from '@dashboard-parapente/design-system';
+
+type AppUpdateBannerProps = {
+  title: string;
+  message: string;
+  viewWhatsNewLabel: string;
+  refreshLabel: string;
+  releaseNotesUrl: string | null;
+  onRefresh: () => void;
+};
+
+export default function AppUpdateBanner({
+  title,
+  message,
+  viewWhatsNewLabel,
+  refreshLabel,
+  releaseNotesUrl,
+  onRefresh,
+}: AppUpdateBannerProps) {
+  return (
+    <div className="mb-3 rounded-xl border border-amber-300 bg-amber-50 p-3 shadow-sm dark:border-amber-700 dark:bg-amber-900/30">
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm text-amber-900 dark:text-amber-100">
+          <p className="font-semibold">{title}</p>
+          <p>{message}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          {releaseNotesUrl && (
+            <a
+              href={releaseNotesUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-10 items-center rounded-md border border-amber-500 px-3 py-2 text-sm font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-400 dark:text-amber-100 dark:hover:bg-amber-800/40"
+            >
+              {viewWhatsNewLabel}
+            </a>
+          )}
+          <Button onClick={onRefresh} size="sm">
+            {refreshLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/common/AppUpdateBanner.tsx
+++ b/apps/frontend/src/components/common/AppUpdateBanner.tsx
@@ -18,7 +18,11 @@ export default function AppUpdateBanner({
   onRefresh,
 }: AppUpdateBannerProps) {
   return (
-    <div className="mb-3 rounded-xl border border-amber-300 bg-amber-50 p-3 shadow-sm dark:border-amber-700 dark:bg-amber-900/30">
+    <div
+      role="status"
+      aria-live="polite"
+      className="mb-3 rounded-xl border border-amber-300 bg-amber-50 p-3 shadow-sm dark:border-amber-700 dark:bg-amber-900/30"
+    >
       <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
         <div className="text-sm text-amber-900 dark:text-amber-100">
           <p className="font-semibold">{title}</p>

--- a/apps/frontend/src/hooks/common/useAppVersion.ts
+++ b/apps/frontend/src/hooks/common/useAppVersion.ts
@@ -8,20 +8,49 @@ export type AppVersionPayload = {
   release_notes_url?: string | null;
 };
 
-function isAppVersionPayload(value: unknown): value is AppVersionPayload {
+function sanitizeReleaseNotesUrl(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return value;
+    }
+    return null;
+  } catch {
+    if (value.startsWith('/') && !value.startsWith('//')) {
+      return value;
+    }
+    return null;
+  }
+}
+
+function sanitizeAppVersionPayload(value: unknown): AppVersionPayload | null {
   if (!value || typeof value !== 'object') {
-    return false;
+    return null;
   }
 
   const payload = value as Record<string, unknown>;
-  return (
-    typeof payload.version === 'string' &&
-    typeof payload.build_date === 'string' &&
-    typeof payload.build_number === 'number' &&
-    (typeof payload.release_notes_url === 'string' ||
-      payload.release_notes_url === null ||
-      payload.release_notes_url === undefined)
-  );
+  if (
+    typeof payload.version !== 'string' ||
+    typeof payload.build_date !== 'string' ||
+    typeof payload.build_number !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    version: payload.version,
+    build_date: payload.build_date,
+    build_number: payload.build_number,
+    release_notes_url: sanitizeReleaseNotesUrl(payload.release_notes_url),
+  };
 }
 
 export const appVersionQueryOptions = () =>
@@ -31,9 +60,9 @@ export const appVersionQueryOptions = () =>
     retry: 0,
     queryFn: async () => {
       try {
-        const data = await api.get('version').json();
+        const data = sanitizeAppVersionPayload(await api.get('version').json());
 
-        if (!isAppVersionPayload(data)) {
+        if (!data) {
           throw new Error('Invalid version payload');
         }
 

--- a/apps/frontend/src/hooks/common/useAppVersion.ts
+++ b/apps/frontend/src/hooks/common/useAppVersion.ts
@@ -1,10 +1,11 @@
 import { queryOptions } from '@tanstack/react-query';
 import { api } from '../../lib/api';
 
-type AppVersionPayload = {
+export type AppVersionPayload = {
   version: string;
   build_date: string;
   build_number: number;
+  release_notes_url?: string | null;
 };
 
 function isAppVersionPayload(value: unknown): value is AppVersionPayload {
@@ -16,7 +17,10 @@ function isAppVersionPayload(value: unknown): value is AppVersionPayload {
   return (
     typeof payload.version === 'string' &&
     typeof payload.build_date === 'string' &&
-    typeof payload.build_number === 'number'
+    typeof payload.build_number === 'number' &&
+    (typeof payload.release_notes_url === 'string' ||
+      payload.release_notes_url === null ||
+      payload.release_notes_url === undefined)
   );
 }
 

--- a/apps/frontend/src/hooks/common/useVersionUpdates.ts
+++ b/apps/frontend/src/hooks/common/useVersionUpdates.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import type { AppVersionPayload } from './useAppVersion';
+import { isVersionNewer } from '../../lib/version';
+
+type VersionUpdateState = {
+  latestVersion: string | null;
+  releaseNotesUrl: string | null;
+};
+
+function isAppVersionPayload(value: unknown): value is AppVersionPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.version === 'string' &&
+    typeof payload.build_date === 'string' &&
+    typeof payload.build_number === 'number' &&
+    (typeof payload.release_notes_url === 'string' ||
+      payload.release_notes_url === null ||
+      payload.release_notes_url === undefined)
+  );
+}
+
+export function useVersionUpdates(
+  currentVersion: string | null
+): VersionUpdateState {
+  const [state, setState] = useState<VersionUpdateState>({
+    latestVersion: null,
+    releaseNotesUrl: null,
+  });
+
+  useEffect(() => {
+    setState({ latestVersion: null, releaseNotesUrl: null });
+
+    if (!currentVersion || typeof window === 'undefined') {
+      return;
+    }
+
+    const eventSource = new EventSource('/api/version/stream');
+
+    const handleVersionEvent = (event: MessageEvent<string>) => {
+      let parsed: unknown;
+
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      if (!isAppVersionPayload(parsed)) {
+        return;
+      }
+
+      const nextVersion = parsed.version;
+      const nextReleaseNotesUrl = parsed.release_notes_url ?? null;
+
+      setState((previous) => {
+        if (!isVersionNewer(nextVersion, currentVersion)) {
+          return previous;
+        }
+
+        if (
+          previous.latestVersion &&
+          !isVersionNewer(nextVersion, previous.latestVersion)
+        ) {
+          return previous;
+        }
+
+        return {
+          latestVersion: nextVersion,
+          releaseNotesUrl: nextReleaseNotesUrl,
+        };
+      });
+    };
+
+    eventSource.addEventListener('version', handleVersionEvent);
+
+    return () => {
+      eventSource.removeEventListener('version', handleVersionEvent);
+      eventSource.close();
+    };
+  }, [currentVersion]);
+
+  return state;
+}

--- a/apps/frontend/src/hooks/common/useVersionUpdates.ts
+++ b/apps/frontend/src/hooks/common/useVersionUpdates.ts
@@ -7,6 +7,29 @@ type VersionUpdateState = {
   releaseNotesUrl: string | null;
 };
 
+function sanitizeReleaseNotesUrl(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return value;
+    }
+    return null;
+  } catch {
+    if (value.startsWith('/') && !value.startsWith('//')) {
+      return value;
+    }
+    return null;
+  }
+}
+
 function isAppVersionPayload(value: unknown): value is AppVersionPayload {
   if (!value || typeof value !== 'object') {
     return false;
@@ -16,10 +39,7 @@ function isAppVersionPayload(value: unknown): value is AppVersionPayload {
   return (
     typeof payload.version === 'string' &&
     typeof payload.build_date === 'string' &&
-    typeof payload.build_number === 'number' &&
-    (typeof payload.release_notes_url === 'string' ||
-      payload.release_notes_url === null ||
-      payload.release_notes_url === undefined)
+    typeof payload.build_number === 'number'
   );
 }
 
@@ -54,7 +74,9 @@ export function useVersionUpdates(
       }
 
       const nextVersion = parsed.version;
-      const nextReleaseNotesUrl = parsed.release_notes_url ?? null;
+      const nextReleaseNotesUrl = sanitizeReleaseNotesUrl(
+        parsed.release_notes_url
+      );
 
       setState((previous) => {
         if (!isVersionNewer(nextVersion, currentVersion)) {

--- a/apps/frontend/src/lib/version.test.ts
+++ b/apps/frontend/src/lib/version.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions, isVersionNewer } from './version';
+
+describe('version utilities', () => {
+  it('detects a newer build number on same day', () => {
+    expect(isVersionNewer('2026.04.21.8', '2026.04.21.7')).toBe(true);
+  });
+
+  it('detects a newer date even if build number is lower', () => {
+    expect(isVersionNewer('2026.04.22.1', '2026.04.21.99')).toBe(true);
+  });
+
+  it('returns false for same version', () => {
+    expect(isVersionNewer('2026.04.21.7', '2026.04.21.7')).toBe(false);
+  });
+
+  it('returns false when candidate is older', () => {
+    expect(isVersionNewer('2026.04.20.9', '2026.04.21.1')).toBe(false);
+  });
+
+  it('treats invalid versions as equal', () => {
+    expect(compareVersions('invalid', '2026.04.21.1')).toBe(0);
+    expect(compareVersions('2026.04.21.1', 'invalid')).toBe(0);
+  });
+});

--- a/apps/frontend/src/lib/version.ts
+++ b/apps/frontend/src/lib/version.ts
@@ -1,0 +1,50 @@
+function parseVersion(version: string): number[] | null {
+  const trimmed = version.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parts = trimmed.split('.');
+  const parsed = parts.map((part) => {
+    if (!/^\d+$/.test(part)) {
+      return Number.NaN;
+    }
+    return Number.parseInt(part, 10);
+  });
+
+  if (parsed.some((part) => Number.isNaN(part))) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function compareVersions(left: string, right: string): number {
+  const leftParsed = parseVersion(left);
+  const rightParsed = parseVersion(right);
+
+  if (!leftParsed || !rightParsed) {
+    return 0;
+  }
+
+  const maxLength = Math.max(leftParsed.length, rightParsed.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftValue = leftParsed[index] ?? 0;
+    const rightValue = rightParsed[index] ?? 0;
+
+    if (leftValue > rightValue) {
+      return 1;
+    }
+
+    if (leftValue < rightValue) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+export function isVersionNewer(candidate: string, current: string): boolean {
+  return compareVersions(candidate, current) === 1;
+}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -57,6 +57,12 @@
     "siteFound_one": "{{count}} site found",
     "siteFound_other": "{{count}} sites found"
   },
+  "appUpdate": {
+    "title": "New version available",
+    "message": "A new version ({{version}}) is ready.",
+    "viewWhatsNew": "See what's new",
+    "refresh": "Refresh"
+  },
   "dashboard": {
     "loadingError": "Loading error",
     "loadingMessage": "Loading dashboard...",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -57,6 +57,12 @@
     "siteFound_one": "{{count}} site trouvé",
     "siteFound_other": "{{count}} sites trouvés"
   },
+  "appUpdate": {
+    "title": "Nouvelle version disponible",
+    "message": "Une nouvelle version ({{version}}) est prête.",
+    "viewWhatsNew": "Voir les nouveautés",
+    "refresh": "Rafraîchir"
+  },
   "dashboard": {
     "loadingError": "Erreur de chargement",
     "loadingMessage": "Chargement du tableau de bord...",

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -37,7 +37,9 @@ function RootComponent() {
   const isLoginPage = matchRoute({ to: '/login' });
   const appVersion = Route.useLoaderData();
   const version = appVersion?.version ?? null;
-  const { latestVersion, releaseNotesUrl } = useVersionUpdates(version);
+  const { latestVersion, releaseNotesUrl } = useVersionUpdates(
+    isLoginPage ? null : version
+  );
 
   if (isLoginPage) {
     return <Outlet />;

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -1,8 +1,11 @@
 import { Suspense } from 'react';
 import { createRootRoute, Outlet, useMatchRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 import Header from '../components/common/Header';
+import AppUpdateBanner from '../components/common/AppUpdateBanner';
 import { queryClient } from '../lib/queryClient';
 import { appVersionQueryOptions } from '../hooks/common/useAppVersion';
+import { useVersionUpdates } from '../hooks/common/useVersionUpdates';
 
 export const Route = createRootRoute({
   loader: () => queryClient.ensureQueryData(appVersionQueryOptions()),
@@ -29,10 +32,12 @@ function PendingComponent() {
 }
 
 function RootComponent() {
+  const { t } = useTranslation();
   const matchRoute = useMatchRoute();
   const isLoginPage = matchRoute({ to: '/login' });
   const appVersion = Route.useLoaderData();
   const version = appVersion?.version ?? null;
+  const { latestVersion, releaseNotesUrl } = useVersionUpdates(version);
 
   if (isLoginPage) {
     return <Outlet />;
@@ -41,6 +46,18 @@ function RootComponent() {
   return (
     <div className="min-h-screen p-3 md:p-4 overflow-x-clip bg-gray-50 dark:bg-gray-900 transition-colors">
       <div className="max-w-7xl mx-auto">
+        {latestVersion && (
+          <AppUpdateBanner
+            title={t('appUpdate.title')}
+            message={t('appUpdate.message', {
+              version: latestVersion,
+            })}
+            viewWhatsNewLabel={t('appUpdate.viewWhatsNew')}
+            refreshLabel={t('appUpdate.refresh')}
+            releaseNotesUrl={releaseNotesUrl}
+            onRefresh={() => window.location.reload()}
+          />
+        )}
         <Header />
         <main>
           <Suspense>


### PR DESCRIPTION
## Summary
- Add backend version streaming endpoint (`/api/version/stream`) using SSE and include optional `release_notes_url` in version payloads.
- Add frontend SSE listener + semantic version comparison helpers to detect newer deployments and show a top update banner with release notes and refresh action.
- Add regression coverage with backend API tests and frontend Storybook/Chromatic stories for the banner component, plus version utility tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App update banner that notifies users of newer versions with localized English/French text.
  * Banner shows a "what's new" link when release notes are available and includes a refresh button.
  * Real-time version push via a streaming endpoint so update notifications appear automatically.

* **Tests**
  * Added tests for version payloads, release notes URL handling, and the initial streaming version event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->