### PR TITLE
fix(frontend): make flight replay control panel scrollable

### DIFF
--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1218,7 +1218,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       {/* Controls - only show when data is loaded */}
       {gpxData?.coordinates && (
         <div
-          className={`absolute top-4 left-4 z-10 bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all ${panelClassName}`}
+          className={`absolute top-4 left-4 z-10 bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all ${panelClassName} max-h-[calc(100%-2rem)] overflow-hidden flex flex-col`}
         >
           <div className="flex items-center justify-between mb-2">
             {!isPanelCollapsed && (
@@ -1236,7 +1236,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           </div>
 
           {!isPanelCollapsed && (
-            <>
+            <div className="min-h-0 overflow-y-auto pr-1">
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
                 Points: {gpxData?.coordinates?.length || 0}
               </p>
@@ -1721,7 +1721,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                   </div>
                 </AccordionSection>
               </div>
-            </>
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- make the flight replay controls panel in flight history scrollable when content exceeds the viewer height
- keep the panel header fixed and only scroll the controls content for better usability
- preserve collapsed behavior while preventing controls from overflowing the 3D viewer area

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the 3D flight viewer's control panel with improved scrolling and layout constraints, ensuring all controls remain accessible without affecting the overall interface proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->