### PR TITLE
fix(backend): persist missing flight max speed from GPX

### DIFF
--- a/apps/backend/flight_backfill.py
+++ b/apps/backend/flight_backfill.py
@@ -1,7 +1,8 @@
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 from sqlalchemy.orm import Session
 

--- a/apps/backend/flight_backfill.py
+++ b/apps/backend/flight_backfill.py
@@ -1,0 +1,52 @@
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+from models import Flight
+
+
+def calculate_and_persist_missing_max_speed(
+    db: Session,
+    flight: Flight,
+    *,
+    parse_coordinates: Callable[[Path], list[dict[str, Any]]],
+    calculate_speed_kmh: Callable[[list[dict[str, Any]]], float],
+    base_dir: Path,
+    logger: logging.Logger,
+) -> bool:
+    """Calculate and persist max speed when missing and GPX/IGC is available."""
+    if flight.max_speed_kmh is not None or not flight.gpx_file_path:
+        return False
+
+    gpx_path = base_dir / flight.gpx_file_path
+    if not gpx_path.exists():
+        logger.debug(
+            "Skipping max speed backfill for flight %s: GPX not found at %s",
+            flight.id,
+            gpx_path,
+        )
+        return False
+
+    try:
+        coordinates = parse_coordinates(gpx_path)
+        if len(coordinates) < 2:
+            return False
+
+        max_speed_kmh = calculate_speed_kmh(coordinates)
+        if max_speed_kmh <= 0:
+            return False
+
+        flight.max_speed_kmh = max_speed_kmh
+        flight.updated_at = datetime.utcnow()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Failed to backfill max speed for flight %s from %s: %s",
+            flight.id,
+            gpx_path,
+            exc,
+        )
+        return False

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -101,6 +101,39 @@ def _mark_flight_export_processing(db: Session, flight: Flight, job_id: str):
     db.refresh(flight)
 
 
+def _calculate_and_persist_missing_max_speed(db: Session, flight: Flight) -> bool:
+    """Calculate and persist max speed when missing and GPX/IGC is available."""
+    if flight.max_speed_kmh is not None or not flight.gpx_file_path:
+        return False
+
+    gpx_path = Path(__file__).parent / flight.gpx_file_path
+    if not gpx_path.exists():
+        logger.debug(
+            "Skipping max speed backfill for flight %s: GPX not found at %s",
+            flight.id,
+            gpx_path,
+        )
+        return False
+
+    try:
+        coordinates = parse_gpx_file(gpx_path)
+        if len(coordinates) < 2:
+            return False
+
+        max_speed_kmh = calculate_max_speed(coordinates)
+        flight.max_speed_kmh = max_speed_kmh
+        flight.updated_at = datetime.utcnow()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Failed to backfill max speed for flight %s from %s: %s",
+            flight.id,
+            gpx_path,
+            exc,
+        )
+        return False
+
+
 # Public routes: no authentication required (weather, spots read, auth)
 public_router = APIRouter(prefix="/api", tags=["api"])
 
@@ -2365,6 +2398,17 @@ def get_flights(
 
     flights = query.order_by(Flight.flight_date.desc()).limit(limit).all()
 
+    updated_flights = False
+    for flight in flights:
+        updated_flights = _calculate_and_persist_missing_max_speed(db, flight) or updated_flights
+
+    if updated_flights:
+        try:
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Failed to persist calculated max speeds in /flights: %s", exc)
+
     # Convert to dict (user_id removed - not needed for single-user app)
     flights_data = []
     for flight in flights:
@@ -2534,6 +2578,13 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
     flight = db.query(Flight).filter(Flight.id == flight_id).first()
     if not flight:
         raise HTTPException(status_code=404, detail="Flight not found")
+
+    if _calculate_and_persist_missing_max_speed(db, flight):
+        try:
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Failed to persist calculated max speed for flight %s: %s", flight_id, exc)
 
     # Build response with flight data
     flight_dict = {

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -130,6 +130,9 @@ def _calculate_and_persist_missing_max_speed(db: Session, flight: Flight) -> boo
             return False
 
         max_speed_kmh = calculate_max_speed(coordinates)
+        if max_speed_kmh <= 0:
+            return False
+
         flight.max_speed_kmh = max_speed_kmh
         flight.updated_at = datetime.utcnow()
         return True
@@ -2410,6 +2413,8 @@ def get_flights(
     updated_flights = False
     for flight in flights:
         updated_flights = _calculate_and_persist_missing_max_speed(db, flight) or updated_flights
+        if updated_flights:
+            break
 
     if updated_flights:
         try:
@@ -2593,7 +2598,9 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
             db.commit()
         except Exception as exc:
             db.rollback()
-            logger.warning("Failed to persist calculated max speed for flight %s: %s", flight_id, exc)
+            logger.warning(
+                "Failed to persist calculated max speed for flight %s: %s", flight_id, exc
+            )
 
     # Build response with flight data
     flight_dict = {

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -29,6 +29,7 @@ import config
 from auth import authenticate_user, create_access_token, get_current_user
 from database import get_db
 from emagram_freshness import get_emagram_cutoff_utc
+from flight_backfill import calculate_and_persist_missing_max_speed
 from models import User
 from models import (
     EmagramAnalysis,
@@ -108,42 +109,6 @@ def _mark_flight_export_processing(db: Session, flight: Flight, job_id: str):
     flight.video_file_path = None
     db.commit()
     db.refresh(flight)
-
-
-def _calculate_and_persist_missing_max_speed(db: Session, flight: Flight) -> bool:
-    """Calculate and persist max speed when missing and GPX/IGC is available."""
-    if flight.max_speed_kmh is not None or not flight.gpx_file_path:
-        return False
-
-    gpx_path = Path(__file__).parent / flight.gpx_file_path
-    if not gpx_path.exists():
-        logger.debug(
-            "Skipping max speed backfill for flight %s: GPX not found at %s",
-            flight.id,
-            gpx_path,
-        )
-        return False
-
-    try:
-        coordinates = parse_gpx_file(gpx_path)
-        if len(coordinates) < 2:
-            return False
-
-        max_speed_kmh = calculate_max_speed(coordinates)
-        if max_speed_kmh <= 0:
-            return False
-
-        flight.max_speed_kmh = max_speed_kmh
-        flight.updated_at = datetime.utcnow()
-        return True
-    except Exception as exc:
-        logger.warning(
-            "Failed to backfill max speed for flight %s from %s: %s",
-            flight.id,
-            gpx_path,
-            exc,
-        )
-        return False
 
 
 # Public routes: no authentication required (weather, spots read, auth)
@@ -2412,7 +2377,17 @@ def get_flights(
 
     updated_flights = False
     for flight in flights:
-        updated_flights = _calculate_and_persist_missing_max_speed(db, flight) or updated_flights
+        updated_flights = (
+            calculate_and_persist_missing_max_speed(
+                db,
+                flight,
+                parse_coordinates=parse_gpx_file,
+                calculate_speed_kmh=calculate_max_speed,
+                base_dir=Path(__file__).parent,
+                logger=logger,
+            )
+            or updated_flights
+        )
         if updated_flights:
             break
 
@@ -2593,7 +2568,14 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
     if not flight:
         raise HTTPException(status_code=404, detail="Flight not found")
 
-    if _calculate_and_persist_missing_max_speed(db, flight):
+    if calculate_and_persist_missing_max_speed(
+        db,
+        flight,
+        parse_coordinates=parse_gpx_file,
+        calculate_speed_kmh=calculate_max_speed,
+        base_dir=Path(__file__).parent,
+        logger=logger,
+    ):
         try:
             db.commit()
         except Exception as exc:

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -6,6 +6,7 @@ Coverage: GET, POST, PATCH, DELETE for flights.
 """
 
 from datetime import date, timedelta
+from pathlib import Path
 
 from models import Flight
 
@@ -134,8 +135,13 @@ class TestFlightsListEndpoint:
         self, client, db_session, arguel_site, sample_gpx, tmp_path
     ):
         """GET /flights computes and persists max_speed_kmh when missing and GPX exists"""
-        gpx_file = tmp_path / "flight.gpx"
+        backend_dir = Path(__file__).resolve().parents[2]
+        gpx_dir = backend_dir / "db" / "gpx"
+        gpx_dir.mkdir(parents=True, exist_ok=True)
+        gpx_file = gpx_dir / f"test_flight_{tmp_path.name}.gpx"
         gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        relative_gpx_path = gpx_file.relative_to(backend_dir)
 
         flight = Flight(
             id="flight-missing-speed",
@@ -143,7 +149,7 @@ class TestFlightsListEndpoint:
             flight_date=date(2026, 3, 20),
             site_id="site-arguel",
             max_speed_kmh=None,
-            gpx_file_path=str(gpx_file),
+            gpx_file_path=str(relative_gpx_path),
         )
         db_session.add(flight)
         db_session.commit()
@@ -159,10 +165,19 @@ class TestFlightsListEndpoint:
         db_session.refresh(flight)
         assert flight.max_speed_kmh == returned["max_speed_kmh"]
 
-    def test_get_flights_keeps_existing_max_speed(self, client, db_session, arguel_site, sample_gpx, tmp_path):
+        gpx_file.unlink(missing_ok=True)
+
+    def test_get_flights_keeps_existing_max_speed(
+        self, client, db_session, arguel_site, sample_gpx, tmp_path
+    ):
         """GET /flights does not overwrite max_speed_kmh when already set"""
-        gpx_file = tmp_path / "flight_existing.gpx"
+        backend_dir = Path(__file__).resolve().parents[2]
+        gpx_dir = backend_dir / "db" / "gpx"
+        gpx_dir.mkdir(parents=True, exist_ok=True)
+        gpx_file = gpx_dir / f"test_flight_existing_{tmp_path.name}.gpx"
         gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        relative_gpx_path = gpx_file.relative_to(backend_dir)
 
         flight = Flight(
             id="flight-existing-speed",
@@ -170,7 +185,7 @@ class TestFlightsListEndpoint:
             flight_date=date(2026, 3, 21),
             site_id="site-arguel",
             max_speed_kmh=42.5,
-            gpx_file_path=str(gpx_file),
+            gpx_file_path=str(relative_gpx_path),
         )
         db_session.add(flight)
         db_session.commit()
@@ -185,7 +200,11 @@ class TestFlightsListEndpoint:
         db_session.refresh(flight)
         assert flight.max_speed_kmh == 42.5
 
-    def test_get_flights_missing_speed_without_gpx_stays_null(self, client, db_session, arguel_site):
+        gpx_file.unlink(missing_ok=True)
+
+    def test_get_flights_missing_speed_without_gpx_stays_null(
+        self, client, db_session, arguel_site
+    ):
         """GET /flights keeps null max_speed_kmh when there is no GPX file"""
         flight = Flight(
             id="flight-no-gpx",
@@ -207,6 +226,50 @@ class TestFlightsListEndpoint:
 
         db_session.refresh(flight)
         assert flight.max_speed_kmh is None
+
+    def test_get_flights_does_not_persist_zero_speed_when_gpx_has_no_time(
+        self, client, db_session, arguel_site, tmp_path
+    ):
+        """GET /flights keeps max_speed_kmh null when GPX has no usable timestamps"""
+        gpx_without_time = """<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<gpx version=\"1.1\" creator=\"Test\" xmlns=\"http://www.topografix.com/GPX/1/1\">
+  <trk><trkseg>
+    <trkpt lat=\"47.22356\" lon=\"6.01842\"><ele>427</ele></trkpt>
+    <trkpt lat=\"47.22400\" lon=\"6.01900\"><ele>550</ele></trkpt>
+  </trkseg></trk>
+</gpx>
+"""
+
+        backend_dir = Path(__file__).resolve().parents[2]
+        gpx_dir = backend_dir / "db" / "gpx"
+        gpx_dir.mkdir(parents=True, exist_ok=True)
+        gpx_file = gpx_dir / f"test_flight_no_time_{tmp_path.name}.gpx"
+        gpx_file.write_text(gpx_without_time, encoding="utf-8")
+
+        relative_gpx_path = gpx_file.relative_to(backend_dir)
+
+        flight = Flight(
+            id="flight-no-time",
+            name="No time",
+            flight_date=date(2026, 3, 24),
+            site_id="site-arguel",
+            max_speed_kmh=None,
+            gpx_file_path=str(relative_gpx_path),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights")
+        assert response.status_code == 200
+        data = response.json()
+
+        returned = next(f for f in data["flights"] if f["id"] == "flight-no-time")
+        assert returned["max_speed_kmh"] is None
+
+        db_session.refresh(flight)
+        assert flight.max_speed_kmh is None
+
+        gpx_file.unlink(missing_ok=True)
 
 
 class TestFlightStatsEndpoint:
@@ -368,8 +431,13 @@ class TestFlightDetailEndpoint:
         self, client, db_session, arguel_site, sample_gpx, tmp_path
     ):
         """GET /flights/{id} computes and persists max_speed_kmh when missing and GPX exists"""
-        gpx_file = tmp_path / "flight_detail.gpx"
+        backend_dir = Path(__file__).resolve().parents[2]
+        gpx_dir = backend_dir / "db" / "gpx"
+        gpx_dir.mkdir(parents=True, exist_ok=True)
+        gpx_file = gpx_dir / f"test_flight_detail_{tmp_path.name}.gpx"
         gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        relative_gpx_path = gpx_file.relative_to(backend_dir)
 
         flight = Flight(
             id="flight-detail-missing-speed",
@@ -377,7 +445,7 @@ class TestFlightDetailEndpoint:
             flight_date=date(2026, 3, 23),
             site_id="site-arguel",
             max_speed_kmh=None,
-            gpx_file_path=str(gpx_file),
+            gpx_file_path=str(relative_gpx_path),
         )
         db_session.add(flight)
         db_session.commit()
@@ -391,6 +459,8 @@ class TestFlightDetailEndpoint:
 
         db_session.refresh(flight)
         assert flight.max_speed_kmh == data["max_speed_kmh"]
+
+        gpx_file.unlink(missing_ok=True)
 
 
 class TestUpdateFlightEndpoint:

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -130,6 +130,84 @@ class TestFlightsListEndpoint:
         assert data["flights"][1]["flight_date"] == "2026-03-12"
         assert data["flights"][2]["flight_date"] == "2026-03-10"
 
+    def test_get_flights_backfills_missing_max_speed_from_gpx(
+        self, client, db_session, arguel_site, sample_gpx, tmp_path
+    ):
+        """GET /flights computes and persists max_speed_kmh when missing and GPX exists"""
+        gpx_file = tmp_path / "flight.gpx"
+        gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        flight = Flight(
+            id="flight-missing-speed",
+            name="Missing speed",
+            flight_date=date(2026, 3, 20),
+            site_id="site-arguel",
+            max_speed_kmh=None,
+            gpx_file_path=str(gpx_file),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights")
+        assert response.status_code == 200
+        data = response.json()
+
+        returned = next(f for f in data["flights"] if f["id"] == "flight-missing-speed")
+        assert returned["max_speed_kmh"] is not None
+        assert returned["max_speed_kmh"] > 0
+
+        db_session.refresh(flight)
+        assert flight.max_speed_kmh == returned["max_speed_kmh"]
+
+    def test_get_flights_keeps_existing_max_speed(self, client, db_session, arguel_site, sample_gpx, tmp_path):
+        """GET /flights does not overwrite max_speed_kmh when already set"""
+        gpx_file = tmp_path / "flight_existing.gpx"
+        gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        flight = Flight(
+            id="flight-existing-speed",
+            name="Existing speed",
+            flight_date=date(2026, 3, 21),
+            site_id="site-arguel",
+            max_speed_kmh=42.5,
+            gpx_file_path=str(gpx_file),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights")
+        assert response.status_code == 200
+        data = response.json()
+
+        returned = next(f for f in data["flights"] if f["id"] == "flight-existing-speed")
+        assert returned["max_speed_kmh"] == 42.5
+
+        db_session.refresh(flight)
+        assert flight.max_speed_kmh == 42.5
+
+    def test_get_flights_missing_speed_without_gpx_stays_null(self, client, db_session, arguel_site):
+        """GET /flights keeps null max_speed_kmh when there is no GPX file"""
+        flight = Flight(
+            id="flight-no-gpx",
+            name="No GPX",
+            flight_date=date(2026, 3, 22),
+            site_id="site-arguel",
+            max_speed_kmh=None,
+            gpx_file_path=None,
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights")
+        assert response.status_code == 200
+        data = response.json()
+
+        returned = next(f for f in data["flights"] if f["id"] == "flight-no-gpx")
+        assert returned["max_speed_kmh"] is None
+
+        db_session.refresh(flight)
+        assert flight.max_speed_kmh is None
+
 
 class TestFlightStatsEndpoint:
     """Tests for GET /flights/stats"""
@@ -285,6 +363,34 @@ class TestFlightDetailEndpoint:
         data = response.json()
         assert "site" in data
         assert data["site"]["name"] == "Arguel"
+
+    def test_get_flight_backfills_missing_max_speed_from_gpx(
+        self, client, db_session, arguel_site, sample_gpx, tmp_path
+    ):
+        """GET /flights/{id} computes and persists max_speed_kmh when missing and GPX exists"""
+        gpx_file = tmp_path / "flight_detail.gpx"
+        gpx_file.write_text(sample_gpx, encoding="utf-8")
+
+        flight = Flight(
+            id="flight-detail-missing-speed",
+            name="Detail missing speed",
+            flight_date=date(2026, 3, 23),
+            site_id="site-arguel",
+            max_speed_kmh=None,
+            gpx_file_path=str(gpx_file),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/flight-detail-missing-speed")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["max_speed_kmh"] is not None
+        assert data["max_speed_kmh"] > 0
+
+        db_session.refresh(flight)
+        assert flight.max_speed_kmh == data["max_speed_kmh"]
 
 
 class TestUpdateFlightEndpoint:


### PR DESCRIPTION
## Summary
- Compute and persist `max_speed_kmh` from GPX/IGC when it is missing on `GET /flights` and `GET /flights/{flight_id}`.
- Reuse existing GPX parsing and speed calculation helpers, with safe handling for missing/invalid files and rollback on commit failure.
- Add API tests for backfill behavior (missing speed + GPX), no-overwrite behavior, and no-GPX fallback.

## Validation
- `python3 -m py_compile apps/backend/routes.py apps/backend/tests/api/test_routes_flights.py`
- Full pytest/Nx test execution was not available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flight endpoints now compute and persist missing maximum speed values using associated GPX data when not already present.
  * Endpoints return the computed positive max speed in responses when available.

* **Tests**
  * Added tests covering speed backfill behavior, non-overwrite of existing values, and cases where no valid speed can be derived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->