### PR TITLE
refactor(frontend): use Trans for rich i18n rendering

### DIFF
--- a/apps/frontend/src/components/analytics/FilterBar.tsx
+++ b/apps/frontend/src/components/analytics/FilterBar.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useFiltersStore } from '../../stores/filtersStore';
 import { DatePicker, Select, Button } from '@dashboard-parapente/design-system';
 import type { Site } from '@dashboard-parapente/shared-types';
@@ -79,14 +79,26 @@ export function FilterBar({ sites }: FilterBarProps) {
             )}
             {filters.dateFrom && (
               <span className="px-2 py-1 bg-sky-100 dark:bg-sky-900/20 text-sky-700 dark:text-sky-400 rounded">
-                {t('filters.from')}{' '}
-                {new Date(filters.dateFrom).toLocaleDateString(dateLocale)}
+                <Trans
+                  i18nKey="filters.fromDate"
+                  values={{
+                    date: new Date(filters.dateFrom).toLocaleDateString(
+                      dateLocale
+                    ),
+                  }}
+                />
               </span>
             )}
             {filters.dateTo && (
               <span className="px-2 py-1 bg-sky-100 dark:bg-sky-900/20 text-sky-700 dark:text-sky-400 rounded">
-                {t('filters.to')}{' '}
-                {new Date(filters.dateTo).toLocaleDateString(dateLocale)}
+                <Trans
+                  i18nKey="filters.toDate"
+                  values={{
+                    date: new Date(filters.dateTo).toLocaleDateString(
+                      dateLocale
+                    ),
+                  }}
+                />
               </span>
             )}
           </div>

--- a/apps/frontend/src/components/flights/CreateFlightModal.tsx
+++ b/apps/frontend/src/components/flights/CreateFlightModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Modal, Button } from '@dashboard-parapente/design-system';
 import { useCreateFlightFromGPX } from '../../hooks/flights/useFlights';
 import { useToast } from '../../hooks/useToast';
@@ -58,7 +58,7 @@ export function CreateFlightModal({
         setTimeout(() => onClose(), 2000); // Fermer après 2s
       },
       onError: (error: Error) => {
-        console.log({error})
+        console.log({ error });
         const errorMessage = error.message || t('flights.createGenericError');
         setError(errorMessage);
         toast.error(t('flights.createFailure') + ` ${errorMessage}`);
@@ -125,8 +125,11 @@ export function CreateFlightModal({
 
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3">
           <p className="text-sm text-blue-800 dark:text-blue-200">
-            💡 <strong>{t('flights.autoDetection')}</strong>{' '}
-            {t('flights.autoDetectionText')}
+            💡{' '}
+            <Trans
+              i18nKey="flights.autoDetectionMessage"
+              components={{ strong: <strong /> }}
+            />
           </p>
         </div>
 

--- a/apps/frontend/src/components/settings/WeatherSourceCard.tsx
+++ b/apps/frontend/src/components/settings/WeatherSourceCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { Switch, TextField, Input, Text, Link } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
 import type { WeatherSource } from '../../types/weatherSources';
@@ -439,15 +439,19 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
         {source.last_success_at && (
           <div role="status">
             <span aria-hidden="true">✓ </span>
-            {t('settings.weatherSources.lastSuccess')}{' '}
-            {formatTimestamp(source.last_success_at)}
+            <Trans
+              i18nKey="settings.weatherSources.lastSuccessMessage"
+              values={{ date: formatTimestamp(source.last_success_at) }}
+            />
           </div>
         )}
         {source.last_error_at && (
           <div className="text-red-600 dark:text-red-400" role="alert">
             <span aria-hidden="true">✗ </span>
-            {t('settings.weatherSources.lastError')}{' '}
-            {formatTimestamp(source.last_error_at)}
+            <Trans
+              i18nKey="settings.weatherSources.lastErrorMessage"
+              values={{ date: formatTimestamp(source.last_error_at) }}
+            />
             {source.last_error_message && (
               <div
                 className="text-xs mt-1 p-1 bg-red-50 dark:bg-red-900/20 rounded truncate"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -112,7 +112,9 @@
     "dateTo": "End date",
     "activeFilters": "Active filters:",
     "from": "From",
-    "to": "To"
+    "to": "To",
+    "fromDate": "From {{date}}",
+    "toDate": "To {{date}}"
   },
   "sites": {
     "management": "Site Management",
@@ -179,7 +181,8 @@
       "favorite": "Favorite",
       "add": "Add",
       "tip": "Tip:",
-      "tipText": "Favorite sites will appear first in selectors"
+      "tipText": "Favorite sites will appear first in selectors",
+      "tipMessage": "<strong>Tip:</strong> Favorite sites will appear first in selectors"
     },
     "weatherSources": {
       "title": "Weather Sources Management",
@@ -210,6 +213,8 @@
       "calls": "Calls",
       "lastSuccess": "Last success:",
       "lastError": "Last error:",
+      "lastSuccessMessage": "Last success: {{date}}",
+      "lastErrorMessage": "Last error: {{date}}",
       "testing": "Testing...",
       "test": "Test",
       "testSuccess": "Test passed in {{time}}ms",
@@ -413,6 +418,7 @@
     "gpxFile": "GPX or IGC file",
     "autoDetection": "Auto-detection:",
     "autoDetectionText": "The takeoff site will be automatically detected from the GPS coordinates in the GPX file.",
+    "autoDetectionMessage": "<strong>Auto-detection:</strong> The takeoff site will be automatically detected from the GPS coordinates in the GPX file.",
     "createSuccess": "Flight created successfully",
     "name": "Name:",
     "date": "Date:",
@@ -491,6 +497,7 @@
     "confirmDelete": "⚠️ Confirm deletion",
     "confirmDeleteSinglePrefix": "You are about to permanently delete flight",
     "confirmDeleteSingleSuffix": "This action is irreversible.",
+    "confirmDeleteSingleMessage": "You are about to permanently delete flight <title>{{title}}</title>. This action is irreversible.",
     "confirmDeleteMulti_one": "You are about to permanently delete {{count}} flight. This action is irreversible.",
     "confirmDeleteMulti_other": "You are about to permanently delete {{count}} flights. This action is irreversible.",
     "deleting": "⏳ Deleting...",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -112,7 +112,9 @@
     "dateTo": "Date de fin",
     "activeFilters": "Filtres actifs :",
     "from": "Du",
-    "to": "Au"
+    "to": "Au",
+    "fromDate": "Du {{date}}",
+    "toDate": "Au {{date}}"
   },
   "sites": {
     "management": "Gestion des Sites",
@@ -179,7 +181,8 @@
       "favorite": "Favori",
       "add": "Ajouter",
       "tip": "Astuce :",
-      "tipText": "Les sites favoris apparaîtront en priorité dans les sélecteurs"
+      "tipText": "Les sites favoris apparaîtront en priorité dans les sélecteurs",
+      "tipMessage": "<strong>Astuce :</strong> Les sites favoris apparaîtront en priorité dans les sélecteurs"
     },
     "weatherSources": {
       "title": "Gestion des Sources Météo",
@@ -210,6 +213,8 @@
       "calls": "Appels",
       "lastSuccess": "Dernier succès:",
       "lastError": "Dernière erreur:",
+      "lastSuccessMessage": "Dernier succès: {{date}}",
+      "lastErrorMessage": "Dernière erreur: {{date}}",
       "testing": "Test en cours...",
       "test": "Tester",
       "testSuccess": "Test réussi en {{time}}ms",
@@ -413,6 +418,7 @@
     "gpxFile": "Fichier GPX ou IGC",
     "autoDetection": "Détection automatique :",
     "autoDetectionText": "Le site de décollage sera détecté automatiquement à partir des coordonnées GPS du fichier GPX.",
+    "autoDetectionMessage": "<strong>Détection automatique :</strong> Le site de décollage sera détecté automatiquement à partir des coordonnées GPS du fichier GPX.",
     "createSuccess": "Vol créé avec succès",
     "name": "Nom :",
     "date": "Date :",
@@ -491,6 +497,7 @@
     "confirmDelete": "⚠️ Confirmer la suppression",
     "confirmDeleteSinglePrefix": "Vous êtes sur le point de supprimer définitivement le vol",
     "confirmDeleteSingleSuffix": "Cette action est irréversible.",
+    "confirmDeleteSingleMessage": "Vous êtes sur le point de supprimer définitivement le vol <title>{{title}}</title>. Cette action est irréversible.",
     "confirmDeleteMulti_one": "Vous êtes sur le point de supprimer définitivement {{count}} vol. Cette action est irréversible.",
     "confirmDeleteMulti_other": "Vous êtes sur le point de supprimer définitivement {{count}} vols. Cette action est irréversible.",
     "deleting": "⏳ Suppression...",

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { flightsQueryOptions } from '../hooks/flights/useFlights';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import type { Flight, Site } from '../types';
@@ -336,11 +336,17 @@ export default function FlightHistory() {
         size="sm"
       >
         <p className="text-gray-700 dark:text-gray-300 mb-6">
-          {t('flights.confirmDeleteSinglePrefix')}{' '}
-          <span className="font-bold text-red-600 dark:text-red-400">
-            {flightToDelete?.title || t('flights.untitledFlight')}
-          </span>
-          . {t('flights.confirmDeleteSingleSuffix')}
+          <Trans
+            i18nKey="flights.confirmDeleteSingleMessage"
+            values={{
+              title: flightToDelete?.title || t('flights.untitledFlight'),
+            }}
+            components={{
+              title: (
+                <span className="font-bold text-red-600 dark:text-red-400" />
+              ),
+            }}
+          />
         </p>
         <div className="flex gap-3 justify-end">
           <Button

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
@@ -133,8 +133,11 @@ function SitesTab({
         </div>
       )}
       <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg text-sm text-blue-800 dark:text-blue-200">
-        💡 <strong>{t('settings.favorites.tip')}</strong>{' '}
-        {t('settings.favorites.tipText')}
+        💡{' '}
+        <Trans
+          i18nKey="settings.favorites.tipMessage"
+          components={{ strong: <strong /> }}
+        />
       </div>
     </div>
   );
@@ -324,7 +327,9 @@ function PerformanceSection() {
       fields: [
         {
           key: 'para_wind_very_low_max',
-          label: t('settings.thresholds.wind.fields.para_wind_very_low_max.label'),
+          label: t(
+            'settings.thresholds.wind.fields.para_wind_very_low_max.label'
+          ),
           defaultValue: '3',
           step: '1',
         },
@@ -342,7 +347,9 @@ function PerformanceSection() {
         },
         {
           key: 'para_wind_optimal_max',
-          label: t('settings.thresholds.wind.fields.para_wind_optimal_max.label'),
+          label: t(
+            'settings.thresholds.wind.fields.para_wind_optimal_max.label'
+          ),
           defaultValue: '15',
           step: '1',
         },
@@ -367,7 +374,9 @@ function PerformanceSection() {
         },
         {
           key: 'para_gust_moderate_max',
-          label: t('settings.thresholds.gust.fields.para_gust_moderate_max.label'),
+          label: t(
+            'settings.thresholds.gust.fields.para_gust_moderate_max.label'
+          ),
           defaultValue: '20',
           step: '1',
         },
@@ -386,25 +395,33 @@ function PerformanceSection() {
       fields: [
         {
           key: 'para_precip_none_max',
-          label: t('settings.thresholds.precipitation.fields.para_precip_none_max.label'),
+          label: t(
+            'settings.thresholds.precipitation.fields.para_precip_none_max.label'
+          ),
           defaultValue: '0',
           step: '0.1',
         },
         {
           key: 'para_precip_light_max',
-          label: t('settings.thresholds.precipitation.fields.para_precip_light_max.label'),
+          label: t(
+            'settings.thresholds.precipitation.fields.para_precip_light_max.label'
+          ),
           defaultValue: '1',
           step: '0.1',
         },
         {
           key: 'para_precip_heavy_min',
-          label: t('settings.thresholds.precipitation.fields.para_precip_heavy_min.label'),
+          label: t(
+            'settings.thresholds.precipitation.fields.para_precip_heavy_min.label'
+          ),
           defaultValue: '2',
           step: '0.1',
         },
         {
           key: 'para_slot_precipitation_max',
-          label: t('settings.thresholds.precipitation.fields.para_slot_precipitation_max.label'),
+          label: t(
+            'settings.thresholds.precipitation.fields.para_slot_precipitation_max.label'
+          ),
           defaultValue: '0.5',
           step: '0.1',
         },
@@ -417,19 +434,25 @@ function PerformanceSection() {
       fields: [
         {
           key: 'para_li_stable_min',
-          label: t('settings.thresholds.instability.fields.para_li_stable_min.label'),
+          label: t(
+            'settings.thresholds.instability.fields.para_li_stable_min.label'
+          ),
           defaultValue: '-1',
           step: '0.1',
         },
         {
           key: 'para_li_slightly_unstable_min',
-          label: t('settings.thresholds.instability.fields.para_li_slightly_unstable_min.label'),
+          label: t(
+            'settings.thresholds.instability.fields.para_li_slightly_unstable_min.label'
+          ),
           defaultValue: '-3',
           step: '0.1',
         },
         {
           key: 'para_li_very_unstable_max',
-          label: t('settings.thresholds.instability.fields.para_li_very_unstable_max.label'),
+          label: t(
+            'settings.thresholds.instability.fields.para_li_very_unstable_max.label'
+          ),
           defaultValue: '-5',
           step: '0.1',
         },
@@ -442,13 +465,17 @@ function PerformanceSection() {
       fields: [
         {
           key: 'para_temp_cool_min',
-          label: t('settings.thresholds.temperature.fields.para_temp_cool_min.label'),
+          label: t(
+            'settings.thresholds.temperature.fields.para_temp_cool_min.label'
+          ),
           defaultValue: '5',
           step: '1',
         },
         {
           key: 'para_temp_warm_min',
-          label: t('settings.thresholds.temperature.fields.para_temp_warm_min.label'),
+          label: t(
+            'settings.thresholds.temperature.fields.para_temp_warm_min.label'
+          ),
           defaultValue: '10',
           step: '1',
         },
@@ -461,19 +488,25 @@ function PerformanceSection() {
       fields: [
         {
           key: 'para_verdict_good_min',
-          label: t('settings.thresholds.verdict.fields.para_verdict_good_min.label'),
+          label: t(
+            'settings.thresholds.verdict.fields.para_verdict_good_min.label'
+          ),
           defaultValue: '65',
           step: '1',
         },
         {
           key: 'para_verdict_medium_min',
-          label: t('settings.thresholds.verdict.fields.para_verdict_medium_min.label'),
+          label: t(
+            'settings.thresholds.verdict.fields.para_verdict_medium_min.label'
+          ),
           defaultValue: '45',
           step: '1',
         },
         {
           key: 'para_verdict_limit_min',
-          label: t('settings.thresholds.verdict.fields.para_verdict_limit_min.label'),
+          label: t(
+            'settings.thresholds.verdict.fields.para_verdict_limit_min.label'
+          ),
           defaultValue: '30',
           step: '1',
         },
@@ -486,25 +519,33 @@ function PerformanceSection() {
       fields: [
         {
           key: 'ui_reason_wind_moderate_min',
-          label: t('settings.thresholds.ui.fields.ui_reason_wind_moderate_min.label'),
+          label: t(
+            'settings.thresholds.ui.fields.ui_reason_wind_moderate_min.label'
+          ),
           defaultValue: '25',
           step: '1',
         },
         {
           key: 'ui_reason_wind_very_strong_min',
-          label: t('settings.thresholds.ui.fields.ui_reason_wind_very_strong_min.label'),
+          label: t(
+            'settings.thresholds.ui.fields.ui_reason_wind_very_strong_min.label'
+          ),
           defaultValue: '35',
           step: '1',
         },
         {
           key: 'ui_reason_gust_high_min',
-          label: t('settings.thresholds.ui.fields.ui_reason_gust_high_min.label'),
+          label: t(
+            'settings.thresholds.ui.fields.ui_reason_gust_high_min.label'
+          ),
           defaultValue: '45',
           step: '1',
         },
         {
           key: 'ui_reason_cloud_very_cloudy_min',
-          label: t('settings.thresholds.ui.fields.ui_reason_cloud_very_cloudy_min.label'),
+          label: t(
+            'settings.thresholds.ui.fields.ui_reason_cloud_very_cloudy_min.label'
+          ),
           defaultValue: '80',
           step: '1',
         },


### PR DESCRIPTION
## Summary
- replace JSX string fragments with `Trans` in targeted frontend UI locations where rich translation rendering is needed
- add dedicated i18n keys for rich messages and date-composed labels in both French and English locales
- keep plain `t()` usage for string-only contexts (alerts, option labels, and non-rich props) to avoid unnecessary complexity