### PR TITLE
fix(backend): surface emagram cache markers in infrastructure view

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -180,6 +180,7 @@ jobs:
             TARGET_VERSION="${{ steps.version.outputs.version }}"
             REPO_SLUG="${{ github.repository }}"
             COMPOSE_PROJECT_NAME="dashboard-parapente"
+            VITE_CESIUM_ION_TOKEN="${{ secrets.VITE_CESIUM_ION_TOKEN }}"
 
             deploy_from_host_path() {
               path="$1"
@@ -192,11 +193,26 @@ jobs:
 
               git fetch origin main --tags
               git fetch --no-tags origin "$TARGET_SHA"
-              git checkout --detach "$TARGET_SHA"
+              git checkout --force --detach "$TARGET_SHA"
               test "$(git rev-parse HEAD)" = "$TARGET_SHA"
 
-              docker compose -p "$COMPOSE_PROJECT_NAME" build backend
-              BACKEND_DEPLOY_VERSION="$TARGET_VERSION" docker compose -p "$COMPOSE_PROJECT_NAME" up -d backend redis
+              if [ -f stack.env ]; then
+                compose_cmd() { VITE_CESIUM_ION_TOKEN="$VITE_CESIUM_ION_TOKEN" docker compose -p "$COMPOSE_PROJECT_NAME" --env-file stack.env "$@"; }
+                echo "Using stack.env for docker compose"
+              elif [ -f .env ]; then
+                compose_cmd() { VITE_CESIUM_ION_TOKEN="$VITE_CESIUM_ION_TOKEN" docker compose -p "$COMPOSE_PROJECT_NAME" --env-file .env "$@"; }
+                echo "Using .env for docker compose"
+              else
+                if [ -z "$VITE_CESIUM_ION_TOKEN" ]; then
+                  echo "Missing VITE_CESIUM_ION_TOKEN secret and no stack.env/.env fallback"
+                  return 1
+                fi
+                compose_cmd() { VITE_CESIUM_ION_TOKEN="$VITE_CESIUM_ION_TOKEN" docker compose -p "$COMPOSE_PROJECT_NAME" "$@"; }
+                echo "No env file found (stack.env/.env), using shell environment"
+              fi
+
+              compose_cmd build --pull backend
+              BACKEND_DEPLOY_VERSION="$TARGET_VERSION" compose_cmd up -d --force-recreate --remove-orphans backend redis
             }
 
             if [ -n "$DEPLOY_PATH" ] && [ -d "$DEPLOY_PATH" ]; then
@@ -238,12 +254,13 @@ jobs:
                 -e REPO_SLUG="$REPO_SLUG" \
                 -e STACK_ID="$STACK_ID" \
                 -e COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME" \
+                -e VITE_CESIUM_ION_TOKEN="$VITE_CESIUM_ION_TOKEN" \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -v portainer_data:/data \
                 -w "/data/compose/$STACK_ID" \
-                docker:27-cli sh -ceu "apk add --no-cache curl tar >/dev/null; work_dir=/data/compose/\$STACK_ID; temp_dir=\$(mktemp -d); stage_dir=\$temp_dir/stage; extracted_dir=\$temp_dir/extracted; mkdir -p \"\$stage_dir\" \"\$extracted_dir\"; trap 'rm -rf \"\$temp_dir\"' EXIT; archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"\$extracted_dir\" --strip-components=1 --exclude='.env' --exclude='stack.env'; cp -a \"\$extracted_dir\"/. \"\$stage_dir\"/; if [ -f \"\$work_dir/stack.env\" ]; then cp -f \"\$work_dir/stack.env\" \"\$stage_dir/stack.env\"; fi; if [ -f \"\$work_dir/.env\" ]; then cp -f \"\$work_dir/.env\" \"\$stage_dir/.env\"; fi; find \"\$work_dir\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; cp -a \"\$stage_dir\"/. \"\$work_dir\"/; cd \"\$work_dir\"; if [ -f stack.env ]; then docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file stack.env build backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file stack.env up -d backend redis; elif [ -f .env ]; then docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file .env build backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file .env up -d backend redis; else docker compose -p \"\$COMPOSE_PROJECT_NAME\" build backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" up -d backend redis; fi"
-              exit 0
-            fi
+                docker:27-cli sh -ceu "apk add --no-cache curl tar >/dev/null; work_dir=/data/compose/\$STACK_ID; temp_dir=\$(mktemp -d); stage_dir=\$temp_dir/stage; extracted_dir=\$temp_dir/extracted; mkdir -p \"\$stage_dir\" \"\$extracted_dir\"; trap 'rm -rf \"\$temp_dir\"' EXIT; archive_url=\"https://codeload.github.com/\$REPO_SLUG/tar.gz/\$TARGET_SHA\"; curl -fsSL \"\$archive_url\" -o \"\$temp_dir/src.tar.gz\"; tar -xzf \"\$temp_dir/src.tar.gz\" -C \"\$extracted_dir\" --strip-components=1 --exclude='.env' --exclude='stack.env'; cp -a \"\$extracted_dir\"/. \"\$stage_dir\"/; if [ -f \"\$work_dir/stack.env\" ]; then cp -f \"\$work_dir/stack.env\" \"\$stage_dir/stack.env\"; fi; if [ -f \"\$work_dir/.env\" ]; then cp -f \"\$work_dir/.env\" \"\$stage_dir/.env\"; fi; find \"\$work_dir\" -mindepth 1 -maxdepth 1 ! -name stack.env ! -name .env -exec rm -rf {} +; cp -a \"\$stage_dir\"/. \"\$work_dir\"/; cd \"\$work_dir\"; if [ -f stack.env ]; then VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file stack.env build --pull backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file stack.env up -d --force-recreate --remove-orphans backend redis; elif [ -f .env ]; then VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file .env build --pull backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" --env-file .env up -d --force-recreate --remove-orphans backend redis; else if [ -z \"\$VITE_CESIUM_ION_TOKEN\" ]; then echo 'Missing VITE_CESIUM_ION_TOKEN secret and no stack.env/.env fallback'; exit 1; fi; VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" build --pull backend; BACKEND_DEPLOY_VERSION=\"\$TARGET_VERSION\" VITE_CESIUM_ION_TOKEN=\"\$VITE_CESIUM_ION_TOKEN\" docker compose -p \"\$COMPOSE_PROJECT_NAME\" up -d --force-recreate --remove-orphans backend redis; fi"
+                exit 0
+              fi
 
             echo "Deploy path does not exist: $DEPLOY_PATH"
             if [ -n "$REQUESTED_DEPLOY_PATH" ]; then

--- a/.packmind/standards/enforce-git-security-and-quality-baseline.md
+++ b/.packmind/standards/enforce-git-security-and-quality-baseline.md
@@ -13,7 +13,10 @@ Monorepo (`apps/*`, `libs/*`).
 * Use a dedicated `git worktree` per pull request.
 * Name each worktree with the `wt-<branch-or-pr-id>` prefix pattern.
 * Create the PR worktree from `main` (prefer `origin/main` after `git fetch`) unless a documented repository policy requires another base branch.
-* Install dependencies in the PR worktree when local execution is required (lint, test, build, bug reproduction).
+* Install dependencies in the PR worktree before running lint, tests, builds, or reproduction steps.
+* Required baseline before quality checks:
+  * Run `pnpm install` at repository root.
+  * If backend Python commands are needed, install backend dependencies (`python3 -m pip install -r apps/backend/requirements.txt` or project equivalent).
 * Run required validation checks in the same worktree before merge.
 * If a PR includes CodeRabbit review comments and you implement fixes for them, mark each addressed CodeRabbit conversation thread as resolved.
 * Si une PR contient des commentaires de review CodeRabbit et que vous les corrigez, marquez chaque conversation CodeRabbit traitée comme résolue.

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4287,7 +4287,7 @@ def _auto_emagram_analysis(site_id: str, day_index: int = 0, hour: int | None = 
     _pending_emagram_analyses.add(key)
     try:
         with get_db_context() as db:
-            asyncio.run(
+            result = asyncio.run(
                 generate_multi_source_emagram_for_spot(
                     site_id=site_id,
                     db=db,
@@ -4295,6 +4295,25 @@ def _auto_emagram_analysis(site_id: str, day_index: int = 0, hour: int | None = 
                     hour=hour,
                 )
             )
+
+            if result.get("success") and result.get("analysis_id"):
+                site = db.query(Site).filter(Site.id == site_id).first()
+                analysis = (
+                    db.query(EmagramAnalysis)
+                    .filter(EmagramAnalysis.id == result["analysis_id"])
+                    .first()
+                )
+                if site and analysis:
+                    forecast_date = (datetime.utcnow() + timedelta(days=day_index)).date()
+                    asyncio.run(
+                        _cache_emagram_analysis_marker(
+                            site,
+                            analysis,
+                            forecast_date,
+                            hour,
+                            db=db,
+                        )
+                    )
     except Exception as e:
         logger.error(
             f"Auto emagram analysis failed for {site_id} day_index={day_index} hour={hour}: {e}"
@@ -4330,6 +4349,8 @@ async def get_latest_emagram(
         max_distance_km: Maximum acceptable station distance (default: 200km)
     """
     try:
+        site: Site | None = None
+
         # Determine target coordinates
         if site_id:
             site = db.query(Site).filter(Site.id == site_id).first()
@@ -4365,6 +4386,10 @@ async def get_latest_emagram(
                 .first()
             )
             if latest_attempt_for_hour:
+                if site is not None:
+                    await _cache_emagram_analysis_marker(
+                        site, latest_attempt_for_hour, target_date, hour, db=db
+                    )
                 return latest_attempt_for_hour
 
         analysis_filters = [
@@ -4429,11 +4454,18 @@ async def get_latest_emagram(
                 .first()
             )
             if failed_analysis:
+                if site is not None:
+                    await _cache_emagram_analysis_marker(
+                        site, failed_analysis, target_date, hour, db=db
+                    )
                 return failed_analysis
 
         # Auto-trigger analysis in background if no data found
         if result is None and auto_analyze and site_id:
             background_tasks.add_task(_auto_emagram_analysis, site_id, day_index, hour)
+
+        if result is not None and site is not None:
+            await _cache_emagram_analysis_marker(site, result, target_date, hour, db=db)
 
         return result
 

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -33,6 +33,8 @@ _access_token = None
 _token_expires_at = None
 _refresh_token = None
 _refresh_lock = asyncio.Lock()
+_REFRESH_MAX_ATTEMPTS = 5
+_REFRESH_INITIAL_BACKOFF_SECONDS = 1.0
 
 
 def _get_persisted_refresh_token() -> str | None:
@@ -144,55 +146,94 @@ async def refresh_access_token(force: bool = False) -> str | None:
             _log_token_refresh(False, msg, refresh_mode=refresh_mode)
             return None
 
-        try:
-            logger.info("Refreshing Strava access token...")
-            logger.debug(f"Using CLIENT_ID: {STRAVA_CLIENT_ID}")
+        backoff_seconds = _REFRESH_INITIAL_BACKOFF_SECONDS
+        last_error_msg: str | None = None
 
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.post(
-                    TOKEN_URL,
-                    data={
-                        "client_id": STRAVA_CLIENT_ID,
-                        "client_secret": STRAVA_CLIENT_SECRET,
-                        "grant_type": "refresh_token",
-                        "refresh_token": current_refresh_token,
-                    },
+        for attempt in range(1, _REFRESH_MAX_ATTEMPTS + 1):
+            try:
+                logger.info(
+                    "Refreshing Strava access token "
+                    f"(attempt {attempt}/{_REFRESH_MAX_ATTEMPTS})..."
                 )
+                logger.debug(f"Using CLIENT_ID: {STRAVA_CLIENT_ID}")
 
-                logger.debug(f"Strava API response status: {response.status_code}")
-                response.raise_for_status()
-                data = response.json()
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    response = await client.post(
+                        TOKEN_URL,
+                        data={
+                            "client_id": STRAVA_CLIENT_ID,
+                            "client_secret": STRAVA_CLIENT_SECRET,
+                            "grant_type": "refresh_token",
+                            "refresh_token": current_refresh_token,
+                        },
+                    )
 
-            new_access_token = data["access_token"]
-            new_refresh_token = data["refresh_token"]
-            new_token_expires_at = datetime.fromtimestamp(data["expires_at"])
+                    logger.debug(f"Strava API response status: {response.status_code}")
+                    response.raise_for_status()
+                    data = response.json()
 
-            # Persist the new refresh token to DB
-            _persist_refresh_token(new_refresh_token)
+                new_access_token = data["access_token"]
+                new_refresh_token = data["refresh_token"]
+                new_token_expires_at = datetime.fromtimestamp(data["expires_at"])
 
-            _access_token = new_access_token
-            _refresh_token = new_refresh_token
-            _token_expires_at = new_token_expires_at
+                # Persist the new refresh token to DB
+                _persist_refresh_token(new_refresh_token)
 
-            msg = f"Access token refreshed (expires at {new_token_expires_at})"
-            logger.info(f"✅ {msg}")
-            _log_token_refresh(True, msg, new_token_expires_at, refresh_mode=refresh_mode)
+                _access_token = new_access_token
+                _refresh_token = new_refresh_token
+                _token_expires_at = new_token_expires_at
 
-            return _access_token
+                msg = (
+                    f"Access token refreshed (expires at {new_token_expires_at}) "
+                    f"after {attempt} attempt(s)"
+                )
+                logger.info(f"✅ {msg}")
+                _log_token_refresh(True, msg, new_token_expires_at, refresh_mode=refresh_mode)
 
-        except httpx.HTTPStatusError as e:
-            msg = f"Strava API error (HTTP {e.response.status_code}): {e.response.text}"
-            logger.error(msg)
-            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
-            return None
-        except Exception as e:
-            msg = f"Failed to refresh token: {type(e).__name__}: {e}"
-            logger.error(msg)
-            import traceback
+                return _access_token
 
-            logger.error(traceback.format_exc())
-            _log_token_refresh(False, msg, refresh_mode=refresh_mode)
-            return None
+            except httpx.HTTPStatusError as e:
+                status_code = e.response.status_code
+                last_error_msg = f"Strava API error (HTTP {status_code}): {e.response.text}"
+                is_retryable = status_code == 429 or 500 <= status_code < 600
+                if is_retryable and attempt < _REFRESH_MAX_ATTEMPTS:
+                    logger.warning(
+                        f"{last_error_msg} - retrying in {backoff_seconds:.1f}s "
+                        f"(attempt {attempt}/{_REFRESH_MAX_ATTEMPTS})"
+                    )
+                    await asyncio.sleep(backoff_seconds)
+                    backoff_seconds *= 2
+                    continue
+
+                logger.error(last_error_msg)
+                break
+            except (httpx.RequestError, asyncio.TimeoutError) as e:
+                last_error_msg = f"Failed to refresh token: {type(e).__name__}: {e}"
+                if attempt < _REFRESH_MAX_ATTEMPTS:
+                    logger.warning(
+                        f"{last_error_msg} - retrying in {backoff_seconds:.1f}s "
+                        f"(attempt {attempt}/{_REFRESH_MAX_ATTEMPTS})"
+                    )
+                    await asyncio.sleep(backoff_seconds)
+                    backoff_seconds *= 2
+                    continue
+
+                logger.error(last_error_msg)
+                break
+            except Exception as e:
+                last_error_msg = f"Failed to refresh token: {type(e).__name__}: {e}"
+                logger.error(last_error_msg)
+                import traceback
+
+                logger.error(traceback.format_exc())
+                break
+
+        final_msg = (
+            f"Strava token refresh failed after {_REFRESH_MAX_ATTEMPTS} attempts: "
+            f"{last_error_msg or 'Unknown error'}"
+        )
+        _log_token_refresh(False, final_msg, refresh_mode=refresh_mode)
+        return None
 
 
 def get_token_status() -> dict:

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -4,11 +4,20 @@ Test emagram analysis endpoints
 
 import json
 from datetime import datetime, time, timedelta
+from unittest.mock import patch
 
 import pytest
+from fakeredis import FakeAsyncRedis
 
 import app_settings
 from models import EmagramAnalysis, Site
+
+
+@pytest.fixture
+def fake_async_redis():
+    """Create a FakeAsyncRedis instance for emagram cache marker tests."""
+    redis = FakeAsyncRedis(decode_responses=True)
+    return redis
 
 
 class TestEmagramEndpoints:
@@ -112,6 +121,55 @@ class TestEmagramEndpoints:
         assert data is not None
         assert data["station_code"] == "site-arguel"
         assert data["score_volabilite"] == 72
+
+    @pytest.mark.anyio
+    async def test_get_latest_with_site_id_writes_cache_marker(
+        self, client, db_session, fake_async_redis
+    ):
+        """Site-based latest emagram writes emagram:analysis marker for Infrastructure cache view."""
+        today = datetime.utcnow().date()
+
+        site = Site(
+            id="site-cache-marker",
+            code="SCM",
+            name="Cache Marker Site",
+            latitude=47.2,
+            longitude=6.0,
+            elevation_m=427,
+        )
+        db_session.add(site)
+
+        analysis = EmagramAnalysis(
+            id="cache-marker-analysis",
+            station_code="site-cache-marker",
+            station_name="Cache Marker Site",
+            station_latitude=47.2,
+            station_longitude=6.0,
+            analysis_date=today,
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=today,
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            forecast_hour=14,
+            score_volabilite=68,
+            analysis_status="completed",
+        )
+        db_session.add(analysis)
+        db_session.commit()
+
+        async def mock_get_redis():
+            return fake_async_redis
+
+        with patch("cache.get_redis", side_effect=mock_get_redis):
+            response = client.get("/api/emagram/latest?site_id=site-cache-marker")
+
+        assert response.status_code == 200
+        marker_key = f"emagram:analysis:site-cache-marker:{today.isoformat()}:latest"
+        marker = await fake_async_redis.get(marker_key)
+        assert marker is not None
 
     def test_get_latest_with_site_id_not_found(self, client, db_session):
         """Get latest emagram with non-existent site_id returns 404"""

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -18,6 +18,7 @@ Strategy:
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from strava import (
@@ -248,6 +249,125 @@ async def test_refresh_access_token_http_error():
 
         token = await refresh_access_token()
         assert token is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_retries_transient_http_errors_then_succeeds():
+    """Retries on transient HTTP errors and succeeds on a later attempt."""
+
+    import strava
+
+    strava._access_token = None
+    strava._token_expires_at = None
+    strava._refresh_token = None
+
+    first_response = MagicMock()
+    first_response.status_code = 429
+    first_response.text = "Too Many Requests"
+    first_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "429 Too Many Requests",
+            request=httpx.Request("POST", "https://www.strava.com/oauth/token"),
+            response=first_response,
+        )
+    )
+
+    second_payload = {
+        "access_token": "retried_access_token",
+        "refresh_token": "retried_refresh_token",
+        "expires_at": int((datetime.now() + timedelta(hours=6)).timestamp()),
+    }
+    second_response = MagicMock()
+    second_response.status_code = 200
+    second_response.raise_for_status = MagicMock()
+    second_response.json = MagicMock(return_value=second_payload)
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava._get_persisted_refresh_token", return_value="test_refresh_token"),
+        patch("strava._persist_refresh_token") as mock_persist,
+        patch("strava.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_post = AsyncMock(side_effect=[first_response, second_response])
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+
+        token = await refresh_access_token(force=True)
+
+    assert token == "retried_access_token"
+    assert mock_post.await_count == 2
+    mock_sleep.assert_awaited_once_with(1.0)
+    mock_persist.assert_called_once_with("retried_refresh_token")
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_does_not_retry_non_retryable_http_error():
+    """Does not retry when Strava returns a non-retryable HTTP status."""
+
+    import strava
+
+    strava._access_token = None
+    strava._token_expires_at = None
+    strava._refresh_token = None
+
+    unauthorized_response = MagicMock()
+    unauthorized_response.status_code = 401
+    unauthorized_response.text = "Unauthorized"
+    unauthorized_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "401 Unauthorized",
+            request=httpx.Request("POST", "https://www.strava.com/oauth/token"),
+            response=unauthorized_response,
+        )
+    )
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava._get_persisted_refresh_token", return_value="test_refresh_token"),
+        patch("strava.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_post = AsyncMock(return_value=unauthorized_response)
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+
+        token = await refresh_access_token(force=True)
+
+    assert token is None
+    assert mock_post.await_count == 1
+    assert mock_sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_retries_request_error_until_exhausted():
+    """Retries request errors up to the max attempts before failing."""
+
+    import strava
+
+    strava._access_token = None
+    strava._token_expires_at = None
+    strava._refresh_token = None
+
+    network_error = httpx.RequestError(
+        "Network down", request=httpx.Request("POST", "https://www.strava.com/oauth/token")
+    )
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava._get_persisted_refresh_token", return_value="test_refresh_token"),
+        patch("strava.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_post = AsyncMock(side_effect=[network_error] * 5)
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+
+        token = await refresh_access_token(force=True)
+
+    assert token is None
+    assert mock_post.await_count == 5
+    assert mock_sleep.await_count == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- write  Redis markers when  returns a site-based analysis (completed, failed, and explicit-hour paths)
- add background auto-analysis marker write so infrastructure cache view can display auto-generated emagram analyses
- update baseline standard to require installing dependencies before quality checks ( and backend Python deps when needed)