### PR TITLE
refactor(frontend): migrate core UI interactions to React Aria

### DIFF
--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import {
   Button as AriaButton,
   Dialog,
   DialogTrigger,
+  Menu,
+  MenuItem,
+  MenuTrigger,
   Modal,
   ModalOverlay,
+  Popover,
 } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
 import { useAuthStore } from '../../stores/authStore';
@@ -32,9 +36,6 @@ export default function Header() {
   const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [isThemeMenuOpenDesktop, setIsThemeMenuOpenDesktop] = useState(false);
-  const [isThemeMenuOpenMobile, setIsThemeMenuOpenMobile] = useState(false);
-  const [themeAnimationIndex, setThemeAnimationIndex] = useState(0);
   const { preference: themePreference, setPreference: setThemePreference } =
     useThemeStore();
 
@@ -91,68 +92,7 @@ export default function Header() {
 
   function handleThemeSelect(next: ThemePreference) {
     setThemePreference(next);
-    setIsThemeMenuOpenDesktop(false);
-    setIsThemeMenuOpenMobile(false);
   }
-
-  function openDesktopThemeMenu() {
-    setIsThemeMenuOpenDesktop((isOpen) => !isOpen);
-    setIsThemeMenuOpenMobile(false);
-  }
-
-  function openMobileThemeMenu() {
-    setIsThemeMenuOpenMobile((isOpen) => !isOpen);
-    setIsThemeMenuOpenDesktop(false);
-  }
-
-  function closeThemeMenus() {
-    setIsThemeMenuOpenDesktop(false);
-    setIsThemeMenuOpenMobile(false);
-  }
-
-  const isAnyThemeMenuOpen = isThemeMenuOpenDesktop || isThemeMenuOpenMobile;
-
-  useEffect(() => {
-    setThemeAnimationIndex((value) => value + 1);
-  }, [themePreference]);
-
-  useEffect(() => {
-    if (!isAnyThemeMenuOpen) {
-      return;
-    }
-
-    function handlePointerDown(event: MouseEvent | TouchEvent) {
-      const target = event.target;
-      if (
-        target instanceof HTMLElement &&
-        target.closest(
-          '[data-theme-selector="desktop"], [data-theme-selector="mobile"]'
-        )
-      ) {
-        return;
-      }
-      closeThemeMenus();
-    }
-
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape') {
-        closeThemeMenus();
-      }
-    }
-
-    document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('touchstart', handlePointerDown);
-    document.addEventListener('keydown', handleEscape);
-
-    return () => {
-      document.removeEventListener('mousedown', handlePointerDown);
-      document.removeEventListener('touchstart', handlePointerDown);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [isAnyThemeMenuOpen]);
-
-  const desktopThemeMenuId = `theme-desktop-menu-${themeAnimationIndex}`;
-  const mobileThemeMenuId = `theme-mobile-menu-${themeAnimationIndex}`;
 
   const themeLabel = `${themeIcons[themePreference]} ${t(
     `settings.languageTheme.${themePreference}`
@@ -170,34 +110,25 @@ export default function Header() {
       {/* Desktop navigation */}
       <nav className="hidden sm:flex gap-2 flex-wrap items-center">
         {navLinks(linkClass)}
-        <div className="relative" data-theme-selector="desktop">
-          <button
-            type="button"
-            onClick={openDesktopThemeMenu}
+        <MenuTrigger>
+          <AriaButton
             className="px-3 py-1.5 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-100 text-sm font-medium transition-all hover:bg-gray-300 dark:hover:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
             aria-label={`${t('settings.languageTheme.theme')} : ${t(
               `settings.languageTheme.${themePreference}`
             )}`}
-            aria-expanded={isThemeMenuOpenDesktop}
-            aria-controls={desktopThemeMenuId}
             title={themeTooltip}
-            data-theme-trigger="desktop"
           >
             {themeLabel}
-          </button>
-          {isThemeMenuOpenDesktop && (
-            <div
-              id={desktopThemeMenuId}
-              className="absolute right-0 top-full mt-2 z-40 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin"
-            >
+          </AriaButton>
+          <Popover className="z-40 mt-2 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin">
+            <Menu className="outline-none">
               {themeOptions.map((theme) => {
                 const isActive = theme === themePreference;
                 return (
-                  <button
+                  <MenuItem
                     key={theme}
-                    type="button"
-                    onClick={() => handleThemeSelect(theme)}
-                    className={`w-full rounded-md px-3 py-2 text-sm text-left transition-all min-h-10 flex items-center justify-between ${
+                    onAction={() => handleThemeSelect(theme)}
+                    className={`w-full rounded-md px-3 py-2 text-sm transition-all min-h-10 flex items-center justify-between cursor-pointer ${
                       isActive
                         ? 'bg-sky-600 text-white'
                         : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
@@ -207,12 +138,12 @@ export default function Header() {
                       {themeIcons[theme]} {t(`settings.languageTheme.${theme}`)}
                     </span>
                     {isActive && <span aria-hidden="true">✓</span>}
-                  </button>
+                  </MenuItem>
                 );
               })}
-            </div>
-          )}
-        </div>
+            </Menu>
+          </Popover>
+        </MenuTrigger>
         {isAuthenticated ? (
           <Button
             onClick={handleLogout}
@@ -233,55 +164,41 @@ export default function Header() {
       </nav>
 
       {/* Mobile theme quick toggle + menu */}
-      <div
-        className="sm:hidden flex items-center gap-2 relative"
-        data-theme-selector="mobile"
-      >
-        <button
-          type="button"
-          onClick={openMobileThemeMenu}
+      <div className="sm:hidden flex items-center gap-2 relative">
+        <MenuTrigger>
+          <AriaButton
           className="min-h-11 min-w-11 flex items-center justify-center rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
           aria-label={themeTooltip}
-          aria-expanded={isThemeMenuOpenMobile}
-          aria-controls={mobileThemeMenuId}
           title={themeTooltip}
-          data-theme-trigger="mobile"
         >
-          <span
-            aria-hidden="true"
-            key={`theme-switch-icon-${themeAnimationIndex}`}
-            className="text-lg leading-none inline-block theme-change-pop"
-          >
+          <span aria-hidden="true" className="text-lg leading-none inline-block">
             {themeIcons[themePreference]}
           </span>
-        </button>
-        {isThemeMenuOpenMobile && (
-          <div
-            id={mobileThemeMenuId}
-            className="absolute right-0 top-full mt-2 z-40 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin"
-          >
-            {themeOptions.map((theme) => {
-              const isActive = theme === themePreference;
-              return (
-                <button
-                  key={theme}
-                  type="button"
-                  onClick={() => handleThemeSelect(theme)}
-                  className={`w-full rounded-md px-3 py-2 text-sm text-left transition-all min-h-10 flex items-center justify-between ${
-                    isActive
-                      ? 'bg-sky-600 text-white'
-                      : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
-                  }`}
-                >
-                  <span>
-                    {themeIcons[theme]} {t(`settings.languageTheme.${theme}`)}
-                  </span>
-                  {isActive && <span aria-hidden="true">✓</span>}
-                </button>
-              );
-            })}
-          </div>
-        )}
+          </AriaButton>
+          <Popover className="z-40 mt-2 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin">
+            <Menu className="outline-none">
+              {themeOptions.map((theme) => {
+                const isActive = theme === themePreference;
+                return (
+                  <MenuItem
+                    key={theme}
+                    onAction={() => handleThemeSelect(theme)}
+                    className={`w-full rounded-md px-3 py-2 text-sm transition-all min-h-10 flex items-center justify-between cursor-pointer ${
+                      isActive
+                        ? 'bg-sky-600 text-white'
+                        : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    <span>
+                      {themeIcons[theme]} {t(`settings.languageTheme.${theme}`)}
+                    </span>
+                    {isActive && <span aria-hidden="true">✓</span>}
+                  </MenuItem>
+                );
+              })}
+            </Menu>
+          </Popover>
+        </MenuTrigger>
         <DialogTrigger isOpen={isMenuOpen} onOpenChange={setIsMenuOpen}>
           <AriaButton
             aria-label={t('header.openMenu', 'Ouvrir le menu')}

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { TextField, TextArea } from 'react-aria-components';
+import { Tab, TabList, TabPanel, Tabs, TextField, TextArea } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
 import {
   useUpdateFlight,
@@ -371,49 +371,47 @@ export function FlightDetails({
       <div className="space-y-4">
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
           <div className="flex items-center gap-2 mb-4">
-            <button
-              type="button"
-              className="px-3 py-2 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md"
-              onClick={onCloseMobile}
+            <Button
+              tone="secondary"
+              size="sm"
+              className="px-3 py-2 text-sm"
+              onPress={onCloseMobile}
             >
               {t('flights.backToList')}
-            </button>
+            </Button>
             <h2 className="text-base font-bold text-gray-900 dark:text-white truncate">
               {flightTitle}
             </h2>
           </div>
-
-          <div className="grid grid-cols-2 gap-2 mb-4" role="tablist">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'infos'}
-              className={`px-3 py-2 text-sm rounded-md transition-colors ${
-                activeTab === 'infos'
-                  ? 'bg-sky-600 text-white'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200'
-              }`}
-              onClick={() => setActiveTab('infos')}
-            >
-              {t('flights.infoTab')}
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={activeTab === 'replay'}
-              className={`px-3 py-2 text-sm rounded-md transition-colors ${
-                activeTab === 'replay'
-                  ? 'bg-sky-600 text-white'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200'
-              }`}
-              onClick={() => setActiveTab('replay')}
-            >
-              {t('flights.replayTab')}
-            </button>
-          </div>
         </div>
 
-        {activeTab === 'infos' ? infoCard : replayCard}
+        <Tabs
+          selectedKey={activeTab}
+          onSelectionChange={(key) => setActiveTab(key as FlightDetailsTab)}
+          className="space-y-4"
+        >
+          <TabList className="grid grid-cols-2 gap-2 mb-4 bg-white dark:bg-gray-800 rounded-xl p-2 shadow-md">
+            <Tab
+              id="infos"
+              className="px-3 py-2 text-sm rounded-md transition-colors cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 selected:bg-sky-600 selected:text-white outline-none"
+            >
+              {t('flights.infoTab')}
+            </Tab>
+            <Tab
+              id="replay"
+              className="px-3 py-2 text-sm rounded-md transition-colors cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 selected:bg-sky-600 selected:text-white outline-none"
+            >
+              {t('flights.replayTab')}
+            </Tab>
+          </TabList>
+
+          <TabPanel id="infos" className="outline-none">
+            {infoCard}
+          </TabPanel>
+          <TabPanel id="replay" className="outline-none">
+            {replayCard}
+          </TabPanel>
+        </Tabs>
       </div>
     );
   }

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -36,6 +36,7 @@ import { api } from '../../lib/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
 import { Button } from '@dashboard-parapente/design-system';
+import { Disclosure, DisclosurePanel } from 'react-aria-components';
 import { HTTPError } from 'ky';
 import { useTranslation } from 'react-i18next';
 
@@ -110,27 +111,34 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
   defaultOpen = false,
   children,
 }) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-
   return (
-    <div className="border-b border-gray-200 dark:border-gray-700 last:border-0">
-      <Button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between py-2 px-1 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded"
-      >
-        <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
-          {emoji && <span className="mr-1.5">{emoji}</span>}
-          {title}
-        </span>
-        <span
-          className="text-gray-400 dark:text-gray-400 text-xs transition-transform"
-          style={{ transform: isOpen ? 'rotate(90deg)' : 'rotate(0deg)' }}
-        >
-          ▶
-        </span>
-      </Button>
-      {isOpen && <div className="pb-3 pt-1 space-y-3">{children}</div>}
-    </div>
+    <Disclosure
+      defaultExpanded={defaultOpen}
+      className="border-b border-gray-200 dark:border-gray-700 last:border-0"
+    >
+      {({ isExpanded }) => (
+        <>
+          <Button
+            slot="trigger"
+            className="w-full flex items-center justify-between py-2 px-1 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors rounded"
+          >
+            <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              {emoji && <span className="mr-1.5">{emoji}</span>}
+              {title}
+            </span>
+            <span
+              className="text-gray-400 dark:text-gray-400 text-xs transition-transform"
+              style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+            >
+              ▶
+            </span>
+          </Button>
+          <DisclosurePanel className="pb-3 pt-1 space-y-3">
+            {children}
+          </DisclosurePanel>
+        </>
+      )}
+    </Disclosure>
   );
 };
 

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Tooltip, TooltipTrigger } from 'react-aria-components';
+import { Button, Tooltip, TooltipTrigger } from 'react-aria-components';
 import {
   Clock,
   Gauge,
@@ -874,15 +874,14 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`${t('weather.paraIndex')} ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-sky-100 dark:hover:bg-sky-900/30 transition-colors"
                         >
                           <strong className="text-sky-600 dark:text-sky-400">
                             {hour.para_index}/100
                           </strong>
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('para-index', hour)}
                         </Tooltip>
@@ -891,13 +890,12 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Vent ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
                         >
                           {hour.wind}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('wind', hour)}
                         </Tooltip>
@@ -906,15 +904,14 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Rafales ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                         >
                           {gustValue !== null && gustValue !== undefined
                             ? gustValue.toFixed(1)
                             : '—'}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('gust', hour)}
                         </Tooltip>
@@ -923,8 +920,7 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Direction ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-violet-50 dark:hover:bg-violet-900/20 transition-colors flex justify-center"
                         >
@@ -936,7 +932,7 @@ export default function HourlyForecast({
                           ) : (
                             '—'
                           )}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('direction', hour)}
                         </Tooltip>
@@ -945,13 +941,12 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Temperature ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                         >
                           {hour.temp}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('temperature', hour)}
                         </Tooltip>
@@ -960,8 +955,7 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Precipitations ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-cyan-50 dark:hover:bg-cyan-900/20 transition-colors"
                         >
@@ -969,7 +963,7 @@ export default function HourlyForecast({
                           hour.precipitation !== undefined
                             ? hour.precipitation.toFixed(1)
                             : '—'}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('precipitation', hour)}
                         </Tooltip>
@@ -978,15 +972,14 @@ export default function HourlyForecast({
 
                     <td className="py-2.5 px-2 text-center">
                       <TooltipTrigger delay={150} closeDelay={100}>
-                        <button
-                          type="button"
+                        <Button
                           aria-label={`Nuages ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-slate-50 dark:hover:bg-slate-900/20 transition-colors"
                         >
                           {cloudCover !== null && cloudCover !== undefined
                             ? Math.round(cloudCover)
                             : '—'}
-                        </button>
+                        </Button>
                         <Tooltip offset={8} className="z-50">
                           {renderTooltipContent('cloud-cover', hour)}
                         </Tooltip>
@@ -1011,15 +1004,14 @@ export default function HourlyForecast({
                         );
                         return (
                           <TooltipTrigger delay={150} closeDelay={100}>
-                            <button
-                              type="button"
+                            <Button
                               aria-label={`Verdict ${hour.hour}`}
                               className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
                             >
                               <span className={`font-medium ${display.color}`}>
                                 {display.emoji} {display.text}
                               </span>
-                            </button>
+                            </Button>
                             <Tooltip offset={8} className="z-50">
                               {renderTooltipContent('verdict', hour)}
                             </Tooltip>

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -751,19 +751,12 @@ function GroupSection({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden">
-      <div
-        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-        onClick={onToggle}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onToggle();
-          }
-        }}
-      >
-        <div className="flex items-center gap-3 min-w-0">
+      <div className="flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+        <Button
+          onPress={onToggle}
+          tone="ghost"
+          className="flex-1 flex items-center gap-3 min-w-0 justify-start"
+        >
           <span
             className={`text-gray-400 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
           >
@@ -775,16 +768,14 @@ function GroupSection({
           <span className="text-xs bg-sky-100 dark:bg-sky-900 text-sky-700 dark:text-sky-300 px-2 py-0.5 rounded-full">
             {group.count}
           </span>
-        </div>
-        <div onClick={(e) => e.stopPropagation()}>
-          <Button
-            onPress={onClearPattern}
-            isDisabled={isPending}
-            className="px-3 py-2 sm:px-2 sm:py-1 rounded text-xs bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-800 transition-colors disabled:opacity-50 cursor-pointer"
-          >
-            {t('cache.clearPattern')}
-          </Button>
-        </div>
+        </Button>
+        <Button
+          onPress={onClearPattern}
+          isDisabled={isPending}
+          className="px-3 py-2 sm:px-2 sm:py-1 rounded text-xs bg-red-100 dark:bg-red-900 text-red-700 dark:text-red-300 hover:bg-red-200 dark:hover:bg-red-800 transition-colors disabled:opacity-50 cursor-pointer"
+        >
+          {t('cache.clearPattern')}
+        </Button>
       </div>
 
       {isExpanded && (

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { Switch, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import {
@@ -52,6 +53,8 @@ interface AppSettings {
   };
   favoriteSites: string[];
 }
+
+type SettingsTabKey = 'general' | 'sites' | 'weather' | 'data';
 
 const DEFAULT_SETTINGS: AppSettings = {
   units: {
@@ -941,9 +944,7 @@ export default function Settings() {
     return DEFAULT_SETTINGS;
   });
   const [saved, setSaved] = useState(false);
-  const [activeTab, setActiveTab] = useState<
-    'general' | 'sites' | 'weather' | 'data'
-  >('general');
+  const [activeTab, setActiveTab] = useState<SettingsTabKey>('general');
 
   useEffect(() => {
     void i18n.changeLanguage(settings.language);
@@ -1066,55 +1067,31 @@ export default function Settings() {
         </p>
       </div>
 
-      {/* Tabs Navigation */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md mb-4 p-2 grid grid-cols-2 gap-2 sm:flex">
-        <Button
-          onClick={() => setActiveTab('general')}
-          className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
-            activeTab === 'general'
-              ? 'bg-sky-600 text-white shadow-md'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-          }`}
-        >
-          🎛️ {t('settings.tabs.general')}
-        </Button>
-        <Button
-          onClick={() => setActiveTab('sites')}
-          className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
-            activeTab === 'sites'
-              ? 'bg-sky-600 text-white shadow-md'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-          }`}
-        >
-          📍 {t('settings.tabs.favoriteSites')}
-        </Button>
-        <Button
-          onClick={() => setActiveTab('weather')}
-          className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
-            activeTab === 'weather'
-              ? 'bg-sky-600 text-white shadow-md'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-          }`}
-        >
-          🌦️ {t('settings.tabs.weatherSources')}
-        </Button>
-        <Button
-          onClick={() => setActiveTab('data')}
-          className={`flex-1 px-4 py-2 rounded-lg font-medium transition-all ${
-            activeTab === 'data'
-              ? 'bg-sky-600 text-white shadow-md'
-              : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-          }`}
-        >
-          💾 {t('settings.tabs.data')}
-        </Button>
-      </div>
+      <Tabs
+        selectedKey={activeTab}
+        onSelectionChange={(key) => setActiveTab(key as SettingsTabKey)}
+        className="space-y-4"
+      >
+        {/* Tabs Navigation */}
+        <TabList className="bg-white dark:bg-gray-800 rounded-xl shadow-md mb-4 p-2 grid grid-cols-2 gap-2 sm:flex">
+          {(['general', 'sites', 'weather', 'data'] as const).map((tabKey) => (
+            <Tab
+              key={tabKey}
+              id={tabKey}
+              className="flex-1 px-4 py-2 rounded-lg font-medium transition-all cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 selected:bg-sky-600 selected:text-white selected:shadow-md outline-none"
+            >
+              {tabKey === 'general' && `🎛️ ${t('settings.tabs.general')}`}
+              {tabKey === 'sites' && `📍 ${t('settings.tabs.favoriteSites')}`}
+              {tabKey === 'weather' && `🌦️ ${t('settings.tabs.weatherSources')}`}
+              {tabKey === 'data' && `💾 ${t('settings.tabs.data')}`}
+            </Tab>
+          ))}
+        </TabList>
 
-      {/* Content */}
-      <div className="space-y-4">
-        {/* GENERAL TAB */}
-        {activeTab === 'general' && (
-          <>
+        {/* Content */}
+        <div className="space-y-4">
+          {/* GENERAL TAB */}
+          <TabPanel id="general" className="space-y-4 outline-none">
             {/* Units Section */}
             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
               <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
@@ -1314,69 +1291,83 @@ export default function Settings() {
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                     {t('settings.notifications.weatherAlerts')}
                   </span>
-                  <input
-                    type="checkbox"
-                    checked={settings.notifications.weather}
-                    onChange={(e) =>
+                  <Switch
+                    isSelected={settings.notifications.weather}
+                    onChange={(isSelected) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,
-                          weather: e.target.checked,
+                          weather: isSelected,
                         },
                       }))
                     }
-                    className="w-5 h-5 text-sky-600 rounded focus:ring-2 focus:ring-sky-600"
-                  />
+                    className="group"
+                  >
+                    <div className="relative inline-flex items-center cursor-pointer">
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      </div>
+                    </div>
+                  </Switch>
                 </label>
                 <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                     {t('settings.notifications.newFlights')}
                   </span>
-                  <input
-                    type="checkbox"
-                    checked={settings.notifications.flights}
-                    onChange={(e) =>
+                  <Switch
+                    isSelected={settings.notifications.flights}
+                    onChange={(isSelected) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,
-                          flights: e.target.checked,
+                          flights: isSelected,
                         },
                       }))
                     }
-                    className="w-5 h-5 text-sky-600 rounded focus:ring-2 focus:ring-sky-600"
-                  />
+                    className="group"
+                  >
+                    <div className="relative inline-flex items-center cursor-pointer">
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      </div>
+                    </div>
+                  </Switch>
                 </label>
                 <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                     {t('settings.notifications.customAlerts')}
                   </span>
-                  <input
-                    type="checkbox"
-                    checked={settings.notifications.alerts}
-                    onChange={(e) =>
+                  <Switch
+                    isSelected={settings.notifications.alerts}
+                    onChange={(isSelected) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,
-                          alerts: e.target.checked,
+                          alerts: isSelected,
                         },
                       }))
                     }
-                    className="w-5 h-5 text-sky-600 rounded focus:ring-2 focus:ring-sky-600"
-                  />
+                    className="group"
+                  >
+                    <div className="relative inline-flex items-center cursor-pointer">
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      </div>
+                    </div>
+                  </Switch>
                 </label>
               </div>
             </div>
 
             {/* Performance Section */}
             <PerformanceSection />
-          </>
-        )}
+          </TabPanel>
 
-        {/* SITES TAB */}
-        {activeTab === 'sites' && (
+          {/* SITES TAB */}
+          <TabPanel id="sites" className="outline-none">
           <Suspense
             fallback={
               <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md animate-pulse space-y-3">
@@ -1391,13 +1382,15 @@ export default function Settings() {
           >
             <SitesTab settings={settings} toggleFavorite={toggleFavorite} />
           </Suspense>
-        )}
+          </TabPanel>
 
-        {/* WEATHER SOURCES TAB */}
-        {activeTab === 'weather' && <WeatherSourcesTab />}
+          {/* WEATHER SOURCES TAB */}
+          <TabPanel id="weather" className="outline-none">
+            <WeatherSourcesTab />
+          </TabPanel>
 
-        {/* DATA TAB */}
-        {activeTab === 'data' && (
+          {/* DATA TAB */}
+          <TabPanel id="data" className="outline-none">
           <div className="space-y-4">
             {/* Export/Import Section */}
             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
@@ -1459,8 +1452,9 @@ export default function Settings() {
               </div>
             </div>
           </div>
-        )}
-      </div>
+          </TabPanel>
+        </div>
+      </Tabs>
 
       {/* Save Button */}
       <div className="mt-6 sticky bottom-4 z-10">


### PR DESCRIPTION
## Summary
- migrate hourly forecast tooltip triggers from native buttons to React Aria `Button` within `TooltipTrigger` to restore reliable tooltip behavior
- replace custom theme menu state/handlers in `Header` with React Aria `MenuTrigger`, `Popover`, `Menu`, and `MenuItem` for desktop and mobile theme pickers
- migrate key interactive patterns to React Aria primitives: mobile flight details tabs (`Tabs`) and infrastructure group toggle (`Button` with `onPress`)
- refactor settings navigation and notification toggles to React Aria `Tabs` and `Switch` components for accessibility consistency across the app

## Validation
- commit hooks passed during commit
- unable to run Nx lint/test in this environment because `pnpm`/`corepack` are unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved accessibility and interaction consistency across UI components including theme selection, tab navigation, accordions, tooltips, and settings toggles.
  * Enhanced design system component usage for better visual and behavioral consistency throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->