### PR TITLE
fix(video-export): handle auth for download and SSE status

### DIFF
--- a/apps/backend/auth.py
+++ b/apps/backend/auth.py
@@ -8,8 +8,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Depends, HTTPException, Request, status
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
@@ -19,9 +18,25 @@ from models import User
 
 logger = logging.getLogger(__name__)
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/login")
-
 ALGORITHM = "HS256"
+
+
+def _extract_access_token(request: Request) -> str | None:
+    """Read bearer token from Authorization header or access_token query param."""
+    auth_header = request.headers.get("authorization", "")
+    scheme, _, value = auth_header.partition(" ")
+    if scheme.lower() == "bearer":
+        token = value.strip()
+        if token:
+            return token
+
+    query_token = request.query_params.get("access_token")
+    if query_token:
+        token = query_token.strip()
+        if token:
+            return token
+
+    return None
 
 
 def hash_password(password: str) -> str:
@@ -38,7 +53,7 @@ def create_access_token(email: str) -> str:
 
 
 def get_current_user(
-    token: str = Depends(oauth2_scheme),
+    request: Request,
     db: Session = Depends(get_db),
 ) -> User:
     """FastAPI dependency: decode JWT and return the authenticated User."""
@@ -47,6 +62,10 @@ def get_current_user(
         detail="Invalid or expired token",
         headers={"WWW-Authenticate": "Bearer"},
     )
+    token = _extract_access_token(request)
+    if not token:
+        raise credentials_exception
+
     try:
         payload = jwt.decode(token, config.JWT_SECRET, algorithms=[ALGORITHM])
         email: str | None = payload.get("sub")

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1464,11 +1464,32 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                             flight.video_export_status === 'completed' &&
                             flight.video_file_path
                           ) {
-                            // Download video
-                            window.open(
-                              `/api/exports/${flight.video_export_job_id}/download`,
-                              '_blank'
-                            );
+                            // Download video with authenticated API client
+                            try {
+                              const blob = await api
+                                .get(
+                                  `exports/${flight.video_export_job_id}/download`
+                                )
+                                .blob();
+
+                              const url = URL.createObjectURL(blob);
+                              const a = document.createElement('a');
+                              a.href = url;
+                              a.download = `flight-${flightId}.mp4`;
+                              a.click();
+                              URL.revokeObjectURL(url);
+                            } catch (error) {
+                              if (error instanceof HTTPError) {
+                                const detail = await getHttpErrorDetail(error);
+                                toast.error(
+                                  detail || t('flights.viewer.videoDownloadError')
+                                );
+                                return;
+                              }
+
+                              console.error('Failed to download video:', error);
+                              toast.error(t('flights.viewer.videoDownloadError'));
+                            }
                           } else if (
                             !flight.video_export_status ||
                             flight.video_export_status === 'failed'

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAuthStore } from '../../stores/authStore';
 
 export type VideoExportPhase =
   | 'queued'
@@ -90,6 +91,7 @@ export function formatEta(etaSeconds?: number): string | null {
 
 export function useVideoExportStatus(jobId?: string | null, enabled = true) {
   const [state, setState] = useState<HookState>(initialState);
+  const token = useAuthStore((s) => s.token);
 
   useEffect(() => {
     setState(initialState);
@@ -98,7 +100,12 @@ export function useVideoExportStatus(jobId?: string | null, enabled = true) {
       return;
     }
 
-    const eventSource = new EventSource(`/api/exports/${jobId}/stream`);
+    const streamUrl = new URL(`/api/exports/${jobId}/stream`, window.location.origin);
+    if (token) {
+      streamUrl.searchParams.set('access_token', token);
+    }
+
+    const eventSource = new EventSource(streamUrl.toString());
 
     const handleStatusEvent = (event: MessageEvent<string>) => {
       let parsed: unknown;
@@ -136,7 +143,7 @@ export function useVideoExportStatus(jobId?: string | null, enabled = true) {
       eventSource.removeEventListener('error', handleError);
       eventSource.close();
     };
-  }, [enabled, jobId]);
+  }, [enabled, jobId, token]);
 
   return state;
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -602,6 +602,7 @@
       "videoSection": "Video",
       "videoStartError": "Unable to start generation",
       "videoStartGenericError": "Error starting generation",
+      "videoDownloadError": "Unable to download video",
       "videoGeneratingTitle": "Video generation in progress... (~60-90 min)",
       "videoDownloadTitle": "Download video",
       "videoRegenerateTitle": "Restart generation",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -602,6 +602,7 @@
       "videoSection": "Vidéo",
       "videoStartError": "Impossible de lancer la génération",
       "videoStartGenericError": "Erreur lors du lancement de la génération",
+      "videoDownloadError": "Impossible de télécharger la vidéo",
       "videoGeneratingTitle": "Génération vidéo en cours... (~60-90 min)",
       "videoDownloadTitle": "Télécharger la vidéo",
       "videoRegenerateTitle": "Relancer la génération",


### PR DESCRIPTION
## Summary
- fix video download in flight viewer by using authenticated API requests instead of `window.open`
- add SSE auth support by attaching `access_token` to export status stream URL in the frontend hook
- allow backend auth dependency to read JWT from either `Authorization: Bearer` or `access_token` query param
- add localized user-facing error messages for failed video downloads (FR/EN)

## Verification
- Build could not be fully validated in this environment due local package-manager/tooling constraints in the fresh worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video download functionality with enhanced error handling and user-facing error messages when downloads fail.

* **Localization**
  * Added French and English translations for video download error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->