### PR TITLE
feat(flights): add configurable camera zoom profile

### DIFF
--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -102,6 +102,12 @@ class Site(Base):
     camera_distance = Column(
         Integer, default=500
     )  # Distance in meters from takeoff point (default: 500m)
+    camera_close_zoom_percent = Column(
+        Integer, default=75
+    )  # Percentage of camera_distance used near takeoff and landing
+    camera_transition_percent = Column(
+        Integer, default=12
+    )  # Percentage of flight used to transition between close and normal distance
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -774,6 +774,8 @@ def update_site_camera(
     site_id: str,
     angle: int | None = None,
     distance: int | None = None,
+    close_zoom_percent: int | None = None,
+    transition_percent: int | None = None,
     db: Session = Depends(get_db),
 ):
     """
@@ -783,6 +785,8 @@ def update_site_camera(
         site_id: Site ID
         angle: Camera angle in degrees (0-360) - where to position camera relative to takeoff
         distance: Camera distance from takeoff in meters (default: 500)
+        close_zoom_percent: Percentage of distance used near takeoff and landing (30-100)
+        transition_percent: Percentage of flight used to transition camera distance (1-40)
 
     Returns:
         Updated site camera settings
@@ -810,6 +814,20 @@ def update_site_camera(
             )
         site.camera_distance = distance
 
+    if close_zoom_percent is not None:
+        if close_zoom_percent < 30 or close_zoom_percent > 100:
+            raise HTTPException(
+                status_code=400, detail="Close zoom percent must be between 30 and 100"
+            )
+        site.camera_close_zoom_percent = close_zoom_percent
+
+    if transition_percent is not None:
+        if transition_percent < 1 or transition_percent > 40:
+            raise HTTPException(
+                status_code=400, detail="Transition percent must be between 1 and 40"
+            )
+        site.camera_transition_percent = transition_percent
+
     site.updated_at = datetime.utcnow()
 
     try:
@@ -825,6 +843,8 @@ def update_site_camera(
             "name": site.name,
             "camera_angle": site.camera_angle,
             "camera_distance": site.camera_distance,
+            "camera_close_zoom_percent": site.camera_close_zoom_percent,
+            "camera_transition_percent": site.camera_transition_percent,
             "message": "Camera settings updated successfully",
         }
     except Exception as e:
@@ -2677,6 +2697,8 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
                 "orientation": site.orientation,
                 "camera_angle": site.camera_angle,
                 "camera_distance": site.camera_distance,
+                "camera_close_zoom_percent": site.camera_close_zoom_percent,
+                "camera_transition_percent": site.camera_transition_percent,
                 "latitude": site.latitude,
                 "longitude": site.longitude,
                 "elevation_m": site.elevation_m,

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -35,6 +35,8 @@ class SiteUpdate(BaseModel):
     orientation: str | None = None
     camera_angle: int | None = None
     camera_distance: int | None = None
+    camera_close_zoom_percent: int | None = None
+    camera_transition_percent: int | None = None
     usage_type: Literal["takeoff", "landing", "both"] | None = None
 
     @validator("latitude")
@@ -61,6 +63,18 @@ class SiteUpdate(BaseModel):
             raise ValueError("Camera distance must be between 50 and 5000 meters")
         return v
 
+    @validator("camera_close_zoom_percent")
+    def validate_camera_close_zoom_percent(cls, v):
+        if v is not None and not 30 <= v <= 100:
+            raise ValueError("Camera close zoom percent must be between 30 and 100")
+        return v
+
+    @validator("camera_transition_percent")
+    def validate_camera_transition_percent(cls, v):
+        if v is not None and not 1 <= v <= 40:
+            raise ValueError("Camera transition percent must be between 1 and 40")
+        return v
+
     @validator("orientation")
     def validate_orientation(cls, v):
         if v is not None and v not in ["N", "NE", "E", "SE", "S", "SW", "W", "NW", ""]:
@@ -74,6 +88,8 @@ class Site(SiteBase):
     orientation: str | None = None  # N, NW, W, S, etc.
     camera_angle: int | None = None  # Camera angle in degrees (0-360)
     camera_distance: int | None = 500  # Camera distance from takeoff in meters
+    camera_close_zoom_percent: int | None = 75
+    camera_transition_percent: int | None = 12
     linked_spot_id: str | None = None  # Link to paragliding_spots table
     flight_count: int | None = 0  # Number of flights at this site
     created_at: datetime | None = None

--- a/apps/backend/sql_migrations/011_add_camera_zoom_settings.sql
+++ b/apps/backend/sql_migrations/011_add_camera_zoom_settings.sql
@@ -1,0 +1,10 @@
+ALTER TABLE sites ADD COLUMN camera_close_zoom_percent INTEGER DEFAULT 75;
+ALTER TABLE sites ADD COLUMN camera_transition_percent INTEGER DEFAULT 12;
+
+UPDATE sites
+SET camera_close_zoom_percent = 75
+WHERE camera_close_zoom_percent IS NULL;
+
+UPDATE sites
+SET camera_transition_percent = 12
+WHERE camera_transition_percent IS NULL;

--- a/apps/backend/tests/api/test_routes_spots.py
+++ b/apps/backend/tests/api/test_routes_spots.py
@@ -279,20 +279,14 @@ class TestUpdateSiteEndpoint:
         self, client, db_session, arguel_site
     ):
         """PATCH /sites/{site_id}/camera rejects invalid replay zoom settings"""
-        response = client.patch(
-            f"{API_PREFIX}/sites/site-arguel/camera?close_zoom_percent=20"
-        )
+        response = client.patch(f"{API_PREFIX}/sites/site-arguel/camera?close_zoom_percent=20")
 
         assert response.status_code == 400
 
-        response = client.patch(
-            f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=0"
-        )
+        response = client.patch(f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=0")
         assert response.status_code == 400
 
-        response = client.patch(
-            f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=41"
-        )
+        response = client.patch(f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=41")
         assert response.status_code == 400
 
     def test_update_site_multiple_fields(self, client, db_session, arguel_site):

--- a/apps/backend/tests/api/test_routes_spots.py
+++ b/apps/backend/tests/api/test_routes_spots.py
@@ -285,6 +285,16 @@ class TestUpdateSiteEndpoint:
 
         assert response.status_code == 400
 
+        response = client.patch(
+            f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=0"
+        )
+        assert response.status_code == 400
+
+        response = client.patch(
+            f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=41"
+        )
+        assert response.status_code == 400
+
     def test_update_site_multiple_fields(self, client, db_session, arguel_site):
         """PATCH /sites/{site_id} updates multiple fields"""
         response = client.patch(

--- a/apps/backend/tests/api/test_routes_spots.py
+++ b/apps/backend/tests/api/test_routes_spots.py
@@ -283,6 +283,10 @@ class TestUpdateSiteEndpoint:
 
         assert response.status_code == 400
 
+        response = client.patch(f"{API_PREFIX}/sites/site-arguel/camera?close_zoom_percent=101")
+
+        assert response.status_code == 400
+
         response = client.patch(f"{API_PREFIX}/sites/site-arguel/camera?transition_percent=0")
         assert response.status_code == 400
 

--- a/apps/backend/tests/api/test_routes_spots.py
+++ b/apps/backend/tests/api/test_routes_spots.py
@@ -261,6 +261,30 @@ class TestUpdateSiteEndpoint:
         )
         assert response.status_code in [200, 400, 404, 422]
 
+    def test_update_site_camera_zoom_settings(self, client, db_session, arguel_site):
+        """PATCH /sites/{site_id}/camera updates replay zoom settings"""
+        response = client.patch(
+            f"{API_PREFIX}/sites/site-arguel/camera"
+            "?angle=180&distance=800&close_zoom_percent=70&transition_percent=15"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["camera_angle"] == 180
+        assert body["camera_distance"] == 800
+        assert body["camera_close_zoom_percent"] == 70
+        assert body["camera_transition_percent"] == 15
+
+    def test_update_site_camera_zoom_settings_validates_bounds(
+        self, client, db_session, arguel_site
+    ):
+        """PATCH /sites/{site_id}/camera rejects invalid replay zoom settings"""
+        response = client.patch(
+            f"{API_PREFIX}/sites/site-arguel/camera?close_zoom_percent=20"
+        )
+
+        assert response.status_code == 400
+
     def test_update_site_multiple_fields(self, client, db_session, arguel_site):
         """PATCH /sites/{site_id} updates multiple fields"""
         response = client.patch(

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1854,11 +1854,15 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                       </div>
 
                       <div className="mb-2">
-                        <label className="block text-xs text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          htmlFor="camera-close-zoom-slider"
+                          className="block text-xs text-gray-600 dark:text-gray-300 mb-1"
+                        >
                           {t('editSite.closeZoom')}:{' '}
                           {tempCameraCloseZoomPercent}%
                         </label>
                         <input
+                          id="camera-close-zoom-slider"
                           type="range"
                           min="30"
                           max="100"
@@ -1879,11 +1883,15 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                       </div>
 
                       <div className="mb-2">
-                        <label className="block text-xs text-gray-600 dark:text-gray-300 mb-1">
+                        <label
+                          htmlFor="camera-transition-slider"
+                          className="block text-xs text-gray-600 dark:text-gray-300 mb-1"
+                        >
                           {t('editSite.transition')}:{' '}
                           {tempCameraTransitionPercent}%
                         </label>
                         <input
+                          id="camera-transition-slider"
                           type="range"
                           min="1"
                           max="40"

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -32,6 +32,11 @@ import {
   getOrientationLabel,
   getOrientationOptions,
 } from '../../utils/cameraOrientation';
+import {
+  DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT,
+  DEFAULT_CAMERA_TRANSITION_PERCENT,
+  getFlightCameraDistance,
+} from '../../utils/cameraDistanceProfile';
 import { api } from '../../lib/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
@@ -128,7 +133,9 @@ const AccordionSection: React.FC<AccordionSectionProps> = ({
             </span>
             <span
               className="text-gray-400 dark:text-gray-400 text-xs transition-transform"
-              style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+              style={{
+                transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
+              }}
             >
               ▶
             </span>
@@ -189,6 +196,10 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const [isUpdatingCamera, setIsUpdatingCamera] = useState(false);
   const [tempCameraAngle, setTempCameraAngle] = useState<number>(0);
   const [tempCameraDistance, setTempCameraDistance] = useState<number>(500);
+  const [tempCameraCloseZoomPercent, setTempCameraCloseZoomPercent] =
+    useState<number>(DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT);
+  const [tempCameraTransitionPercent, setTempCameraTransitionPercent] =
+    useState<number>(DEFAULT_CAMERA_TRANSITION_PERCENT);
 
   const allPositionsRef = useRef<Cartesian3[]>([]);
   const timestampsRef = useRef<number[]>([]);
@@ -208,6 +219,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const cameraHeadingRef = useRef<number>(0);
   const cameraDistanceRef = useRef<number>(500);
+  const cameraCloseZoomPercentRef = useRef<number>(
+    DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT
+  );
+  const cameraTransitionPercentRef = useRef<number>(
+    DEFAULT_CAMERA_TRANSITION_PERCENT
+  );
   const cameraTargetRef = useRef<Cartesian3 | null>(null);
   const containerDivRef = useRef<HTMLDivElement>(null);
   const viewerUnitsRef = useRef<ViewerUnits>(viewerUnits);
@@ -695,6 +712,20 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
       setTempCameraAngle(initialAngle);
       setTempCameraDistance(flight.site.camera_distance || 500);
+      setTempCameraCloseZoomPercent(
+        flight.site.camera_close_zoom_percent ||
+          DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT
+      );
+      setTempCameraTransitionPercent(
+        flight.site.camera_transition_percent ||
+          DEFAULT_CAMERA_TRANSITION_PERCENT
+      );
+      cameraCloseZoomPercentRef.current =
+        flight.site.camera_close_zoom_percent ||
+        DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT;
+      cameraTransitionPercentRef.current =
+        flight.site.camera_transition_percent ||
+        DEFAULT_CAMERA_TRANSITION_PERCENT;
     }
   }, [flight?.site]);
 
@@ -722,6 +753,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       cameraAngle = getHeadingFromOrientation(orientation);
     }
     const cameraDistance = flight?.site?.camera_distance || 500;
+    const cameraCloseZoomPercent =
+      flight?.site?.camera_close_zoom_percent ||
+      DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT;
+    const cameraTransitionPercent =
+      flight?.site?.camera_transition_percent ||
+      DEFAULT_CAMERA_TRANSITION_PERCENT;
 
     if (cameraAngle !== null && cameraAngle !== undefined) {
       // Camera is positioned at the specified angle, looking back at takeoff
@@ -731,6 +768,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       // Save camera settings for replay mode
       cameraHeadingRef.current = CesiumMath.toRadians(cameraAngle);
       cameraDistanceRef.current = cameraDistance;
+      cameraCloseZoomPercentRef.current = cameraCloseZoomPercent;
+      cameraTransitionPercentRef.current = cameraTransitionPercent;
 
       // First, position camera at takeoff looking in the OPPOSITE direction
       viewer.camera.setView({
@@ -751,6 +790,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     gpxData,
     flight?.site?.camera_angle,
     flight?.site?.camera_distance,
+    flight?.site?.camera_close_zoom_percent,
+    flight?.site?.camera_transition_percent,
     flight?.site?.orientation,
   ]);
 
@@ -935,7 +976,16 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           const currentPosition =
             allPositionsRef.current[currentIndexRef.current];
           const heading = cameraHeadingRef.current;
-          const distance = cameraDistanceRef.current;
+          const progress =
+            allPositionsRef.current.length > 1
+              ? currentIndexRef.current / (allPositionsRef.current.length - 1)
+              : 0;
+          const distance = getFlightCameraDistance({
+            progress,
+            baseDistance: cameraDistanceRef.current,
+            closeZoomPercent: cameraCloseZoomPercentRef.current,
+            transitionPercent: cameraTransitionPercentRef.current,
+          });
           const pitch = -0.05;
 
           // Smooth lerp vers la position actuelle
@@ -1116,7 +1166,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
   const updateCameraSettings = async (
     angle: number,
-    distance: number
+    distance: number,
+    closeZoomPercent: number,
+    transitionPercent: number
   ): Promise<boolean> => {
     if (!flight?.site?.id) {
       console.error('No site ID available');
@@ -1128,6 +1180,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       const params = new URLSearchParams();
       params.append('angle', angle.toString());
       params.append('distance', distance.toString());
+      params.append('close_zoom_percent', closeZoomPercent.toString());
+      params.append('transition_percent', transitionPercent.toString());
 
       await api.patch(`sites/${flight.site.id}/camera?${params.toString()}`);
 
@@ -1149,6 +1203,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
               ...previousSite,
               camera_angle: angle,
               camera_distance: distance,
+              camera_close_zoom_percent: closeZoomPercent,
+              camera_transition_percent: transitionPercent,
             },
           };
         }
@@ -1211,6 +1267,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       return;
     }
 
+    cameraCloseZoomPercentRef.current = tempCameraCloseZoomPercent;
+    cameraTransitionPercentRef.current = tempCameraTransitionPercent;
     repositionCamera(tempCameraAngle, tempCameraDistance);
     if (showToast) {
       toast.success(t('flights.viewer.cameraAppliedToPlayback'));
@@ -1220,7 +1278,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const saveCameraSettings = async () => {
     const saved = await updateCameraSettings(
       tempCameraAngle,
-      tempCameraDistance
+      tempCameraDistance,
+      tempCameraCloseZoomPercent,
+      tempCameraTransitionPercent
     );
     if (!saved) {
       return;
@@ -1490,13 +1550,16 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                               if (error instanceof HTTPError) {
                                 const detail = await getHttpErrorDetail(error);
                                 toast.error(
-                                  detail || t('flights.viewer.videoDownloadError')
+                                  detail ||
+                                    t('flights.viewer.videoDownloadError')
                                 );
                                 return;
                               }
 
                               console.error('Failed to download video:', error);
-                              toast.error(t('flights.viewer.videoDownloadError'));
+                              toast.error(
+                                t('flights.viewer.videoDownloadError')
+                              );
                             }
                           } else if (
                             !flight.video_export_status ||
@@ -1787,6 +1850,56 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
                           <span>100m</span>
                           <span>2000m</span>
+                        </div>
+                      </div>
+
+                      <div className="mb-2">
+                        <label className="block text-xs text-gray-600 dark:text-gray-300 mb-1">
+                          {t('editSite.closeZoom')}:{' '}
+                          {tempCameraCloseZoomPercent}%
+                        </label>
+                        <input
+                          type="range"
+                          min="30"
+                          max="100"
+                          step="5"
+                          value={tempCameraCloseZoomPercent}
+                          onChange={(e) =>
+                            setTempCameraCloseZoomPercent(
+                              Number(e.target.value)
+                            )
+                          }
+                          className="w-full"
+                          data-testid="camera-close-zoom-slider"
+                        />
+                        <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          <span>30%</span>
+                          <span>100%</span>
+                        </div>
+                      </div>
+
+                      <div className="mb-2">
+                        <label className="block text-xs text-gray-600 dark:text-gray-300 mb-1">
+                          {t('editSite.transition')}:{' '}
+                          {tempCameraTransitionPercent}%
+                        </label>
+                        <input
+                          type="range"
+                          min="1"
+                          max="40"
+                          step="1"
+                          value={tempCameraTransitionPercent}
+                          onChange={(e) =>
+                            setTempCameraTransitionPercent(
+                              Number(e.target.value)
+                            )
+                          }
+                          className="w-full"
+                          data-testid="camera-transition-slider"
+                        />
+                        <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+                          <span>1%</span>
+                          <span>40%</span>
                         </div>
                       </div>
 

--- a/apps/frontend/src/components/sites/EditSiteModal.tsx
+++ b/apps/frontend/src/components/sites/EditSiteModal.tsx
@@ -43,6 +43,8 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
     orientation: '',
     camera_angle: 180,
     camera_distance: 500,
+    camera_close_zoom_percent: 75,
+    camera_transition_percent: 12,
     usage_type: 'both',
     description: '',
   });
@@ -72,6 +74,8 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         orientation: site.orientation || '',
         camera_angle: site.camera_angle || 180,
         camera_distance: site.camera_distance || 500,
+        camera_close_zoom_percent: site.camera_close_zoom_percent || 75,
+        camera_transition_percent: site.camera_transition_percent || 12,
         usage_type: site.usage_type || 'both',
         description: site.description || '',
       };
@@ -93,6 +97,8 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         orientation: '',
         camera_angle: 180,
         camera_distance: 500,
+        camera_close_zoom_percent: 75,
+        camera_transition_percent: 12,
         usage_type: 'both',
         description: '',
       });
@@ -423,6 +429,54 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
             <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
               <span>100m</span>
               <span>2000m</span>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm mb-1">
+              {t('editSite.closeZoom')}: {formData.camera_close_zoom_percent}%
+            </label>
+            <input
+              type="range"
+              min="30"
+              max="100"
+              step="5"
+              value={formData.camera_close_zoom_percent ?? 75}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  camera_close_zoom_percent: parseInt(e.target.value),
+                })
+              }
+              className="w-full"
+            />
+            <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <span>30%</span>
+              <span>100%</span>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm mb-1">
+              {t('editSite.transition')}: {formData.camera_transition_percent}%
+            </label>
+            <input
+              type="range"
+              min="1"
+              max="40"
+              step="1"
+              value={formData.camera_transition_percent ?? 12}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  camera_transition_percent: parseInt(e.target.value),
+                })
+              }
+              className="w-full"
+            />
+            <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <span>1%</span>
+              <span>40%</span>
             </div>
           </div>
         </div>

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -681,6 +681,8 @@
     "camera3D": "3D Camera Position",
     "angle": "Angle",
     "distance": "Distance",
+    "closeZoom": "Takeoff/landing zoom",
+    "transition": "Zoom transition",
     "description": "Description",
     "additionalInfo": "Additional information about the site...",
     "saving": "Saving...",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -681,6 +681,8 @@
     "camera3D": "Position Caméra 3D",
     "angle": "Angle",
     "distance": "Distance",
+    "closeZoom": "Zoom décollage/atterrissage",
+    "transition": "Transition zoom",
     "description": "Description",
     "additionalInfo": "Informations complémentaires sur le site...",
     "saving": "Enregistrement...",

--- a/apps/frontend/src/utils/cameraDistanceProfile.test.ts
+++ b/apps/frontend/src/utils/cameraDistanceProfile.test.ts
@@ -70,5 +70,23 @@ describe('getFlightCameraDistance', () => {
         transitionPercent: 100,
       })
     ).toBe(300);
+
+    expect(
+      getFlightCameraDistance({
+        progress: 0.2,
+        baseDistance: 1000,
+        closeZoomPercent: 75,
+        transitionPercent: 100,
+      })
+    ).toBe(875);
+
+    expect(
+      getFlightCameraDistance({
+        progress: 0.02,
+        baseDistance: 1000,
+        closeZoomPercent: 75,
+        transitionPercent: 0,
+      })
+    ).toBe(1000);
   });
 });

--- a/apps/frontend/src/utils/cameraDistanceProfile.test.ts
+++ b/apps/frontend/src/utils/cameraDistanceProfile.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { getFlightCameraDistance } from './cameraDistanceProfile';
+
+describe('getFlightCameraDistance', () => {
+  it('zooms in at takeoff and landing', () => {
+    const baseDistance = 1000;
+
+    expect(
+      getFlightCameraDistance({
+        progress: 0,
+        baseDistance,
+        closeZoomPercent: 75,
+        transitionPercent: 12,
+      })
+    ).toBe(750);
+
+    expect(
+      getFlightCameraDistance({
+        progress: 1,
+        baseDistance,
+        closeZoomPercent: 75,
+        transitionPercent: 12,
+      })
+    ).toBe(750);
+  });
+
+  it('uses the configured distance during cruise', () => {
+    expect(
+      getFlightCameraDistance({
+        progress: 0.5,
+        baseDistance: 1000,
+        closeZoomPercent: 75,
+        transitionPercent: 12,
+      })
+    ).toBe(1000);
+  });
+
+  it('smoothly transitions between close and configured distance', () => {
+    const baseDistance = 1000;
+    const start = getFlightCameraDistance({
+      progress: 0,
+      baseDistance,
+      closeZoomPercent: 75,
+      transitionPercent: 12,
+    });
+    const duringTransition = getFlightCameraDistance({
+      progress: 0.06,
+      baseDistance,
+      closeZoomPercent: 75,
+      transitionPercent: 12,
+    });
+    const afterTransition = getFlightCameraDistance({
+      progress: 0.12,
+      baseDistance,
+      closeZoomPercent: 75,
+      transitionPercent: 12,
+    });
+
+    expect(duringTransition).toBeGreaterThan(start);
+    expect(duringTransition).toBeLessThan(afterTransition);
+    expect(afterTransition).toBe(baseDistance);
+  });
+
+  it('clamps unsafe configuration values', () => {
+    expect(
+      getFlightCameraDistance({
+        progress: 0,
+        baseDistance: 1000,
+        closeZoomPercent: 5,
+        transitionPercent: 100,
+      })
+    ).toBe(300);
+  });
+});

--- a/apps/frontend/src/utils/cameraDistanceProfile.ts
+++ b/apps/frontend/src/utils/cameraDistanceProfile.ts
@@ -1,0 +1,46 @@
+export const DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT = 75;
+export const DEFAULT_CAMERA_TRANSITION_PERCENT = 12;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const smoothstep = (value: number): number => {
+  const x = clamp(value, 0, 1);
+  return x * x * (3 - 2 * x);
+};
+
+export const getFlightCameraDistance = ({
+  progress,
+  baseDistance,
+  closeZoomPercent = DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT,
+  transitionPercent = DEFAULT_CAMERA_TRANSITION_PERCENT,
+}: {
+  progress: number;
+  baseDistance: number;
+  closeZoomPercent?: number | null;
+  transitionPercent?: number | null;
+}): number => {
+  const safeProgress = clamp(progress, 0, 1);
+  const safeBaseDistance = Math.max(0, baseDistance);
+  const safeCloseZoomPercent = clamp(
+    closeZoomPercent ?? DEFAULT_CAMERA_CLOSE_ZOOM_PERCENT,
+    30,
+    100
+  );
+  const safeTransitionPercent = clamp(
+    transitionPercent ?? DEFAULT_CAMERA_TRANSITION_PERCENT,
+    1,
+    40
+  );
+
+  const transitionProgress = safeTransitionPercent / 100;
+  const distanceFromEdge = Math.min(safeProgress, 1 - safeProgress);
+  const normalDistanceWeight = smoothstep(
+    distanceFromEdge / transitionProgress
+  );
+  const closeDistance = safeBaseDistance * (safeCloseZoomPercent / 100);
+
+  return (
+    closeDistance + (safeBaseDistance - closeDistance) * normalDistanceWeight
+  );
+};

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -35,6 +35,8 @@ export const SiteSchema = z.object({
   orientation: z.string().nullish(),
   camera_angle: z.number().nullish(),
   camera_distance: z.number().nullish().default(500),
+  camera_close_zoom_percent: z.number().nullish().optional(),
+  camera_transition_percent: z.number().nullish().optional(),
   linked_spot_id: z.string().nullish(),
   flight_count: z.number().optional().default(0),
   created_at: z.string().nullish(),
@@ -385,6 +387,8 @@ export const SiteUpdateSchema = z
     orientation: z.string(),
     camera_angle: z.number().nullable(),
     camera_distance: z.number().nullable(),
+    camera_close_zoom_percent: z.number().nullable(),
+    camera_transition_percent: z.number().nullable(),
     usage_type: z.enum(['takeoff', 'landing', 'both']),
     description: z.string(),
   })
@@ -394,6 +398,8 @@ export const CreateSiteSchema = SiteUpdateSchema.omit({
   orientation: true,
   camera_angle: true,
   camera_distance: true,
+  camera_close_zoom_percent: true,
+  camera_transition_percent: true,
 }).required({
   name: true,
   latitude: true,


### PR DESCRIPTION
## Summary
- Add per-site camera zoom profile settings for takeoff/landing close zoom and transition duration.
- Apply a smooth distance profile during 3D flight playback while preserving existing camera angle/distance controls.
- Add backend persistence, migration, shared types, UI sliders, and targeted behavior tests.

## Verification
- `python3 -m compileall apps/backend/models.py apps/backend/schemas.py apps/backend/routes.py apps/backend/tests/api/test_routes_spots.py`
- `/media/nas/usb2/developement/moi/dashboard-parapente/node_modules/.bin/oxfmt -c .oxfmtrc.json --check apps/frontend/src/components/flights/FlightViewer3D.tsx apps/frontend/src/components/sites/EditSiteModal.tsx apps/frontend/src/utils/cameraDistanceProfile.ts apps/frontend/src/utils/cameraDistanceProfile.test.ts libs/shared-types/src/index.ts`
- `/media/nas/usb2/developement/moi/dashboard-parapente/node_modules/.bin/oxlint -c .oxlintrc.json apps/frontend/src/components/flights/FlightViewer3D.tsx apps/frontend/src/components/sites/EditSiteModal.tsx apps/frontend/src/utils/cameraDistanceProfile.ts apps/frontend/src/utils/cameraDistanceProfile.test.ts libs/shared-types/src/index.ts`
- `/media/nas/usb2/developement/moi/dashboard-parapente/node_modules/.bin/vitest run --config vitest.config.ts --project unit src/utils/cameraDistanceProfile.test.ts` using a temporary `node_modules` symlink in the clean worktree.

## Notes
- Full frontend `tsc` was not usable from the separate clean worktree because workspace package aliases (`@dashboard-parapente/*`) did not resolve with the temporary symlinked `node_modules` setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable camera zoom for takeoff/landing (default 75%) and configurable transition window (default 12%).
  * UI sliders to adjust these camera settings; settings persist and apply to playback.

* **Backend**
  * API and database updated to store and return the new camera settings with validation.

* **Tests**
  * Added endpoint validation tests and unit tests for camera distance calculations.

* **Localization**
  * Added English and French labels for the new camera settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->