### PR TITLE
Add dedicated video exports page

### DIFF
--- a/apps/frontend/src/components/common/Header.test.tsx
+++ b/apps/frontend/src/components/common/Header.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-i18next', () => ({
         'header.weather': 'Weather',
         'header.dashboard': 'Dashboard',
         'header.flights': 'Flights',
+        'header.exports': 'Exports',
         'header.analytics': 'Analytics',
         'header.sites': 'Sites',
         'header.settings': 'Settings',
@@ -106,7 +107,9 @@ vi.mock('react-aria-components', async () => {
     DialogTrigger: ({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     ),
-    Menu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Menu: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
     MenuItem,
     MenuTrigger,
     Modal: ({ children }: { children: React.ReactNode }) => (
@@ -180,5 +183,16 @@ describe('Header theme controls', () => {
     fireEvent.click(autoOption);
 
     expect(useThemeStore.getState().preference).toBe('auto');
+  });
+
+  it('shows the exports navigation link when authenticated', () => {
+    useAuthStore.setState({ isAuthenticated: true, token: 'token' });
+
+    render(<Header />);
+
+    expect(screen.getAllByRole('link', { name: 'Exports' })[0]).toHaveAttribute(
+      'href',
+      '/exports'
+    );
   });
 });

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -59,6 +59,9 @@ export default function Header() {
           <Link to="/flights" className={linkClassName} onClick={onNavigate}>
             {t('header.flights')}
           </Link>
+          <Link to="/exports" className={linkClassName} onClick={onNavigate}>
+            {t('header.exports')}
+          </Link>
           <Link to="/analytics" className={linkClassName} onClick={onNavigate}>
             {t('header.analytics')}
           </Link>
@@ -169,7 +172,10 @@ export default function Header() {
             className="min-h-11 min-w-11 flex items-center justify-center rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
             aria-label={themeTooltip}
           >
-            <span aria-hidden="true" className="text-lg leading-none inline-block">
+            <span
+              aria-hidden="true"
+              className="text-lg leading-none inline-block"
+            >
               {themeIcons[themePreference]}
             </span>
           </AriaButton>

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -5,12 +5,34 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoExportJobsPanel } from './VideoExportJobsPanel';
 
-const { cancelJob, toastError, toastSuccess, refetch } = vi.hoisted(() => ({
-  cancelJob: vi.fn(),
-  toastError: vi.fn(),
-  toastSuccess: vi.fn(),
-  refetch: vi.fn(),
-}));
+const { cancelJob, toastError, toastSuccess, refetch, jobs } = vi.hoisted(
+  () => ({
+    cancelJob: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+    refetch: vi.fn(),
+    jobs: [
+      {
+        job_id: 'job-active',
+        flight_title: 'Vol test',
+        status: 'processing',
+        internal_status: 'capturing',
+        progress: 42,
+        message: 'Capturing frames',
+        mode: 'manual_fast',
+        can_cancel: true,
+      },
+      {
+        job_id: 'job-done',
+        flight_title: 'Vol terminé',
+        status: 'completed',
+        internal_status: 'completed',
+        progress: 100,
+        can_cancel: false,
+      },
+    ],
+  })
+);
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -31,7 +53,23 @@ vi.mock('../../hooks/useToast', () => ({
 
 vi.mock('../../hooks/flights/useVideoExportJobs', () => ({
   useVideoExportJobs: () => ({
-    data: [
+    data: jobs,
+    isLoading: false,
+    isError: false,
+    refetch,
+  }),
+  useCancelVideoExportJob: () => ({
+    mutateAsync: cancelJob,
+    isPending: false,
+  }),
+}));
+
+describe('VideoExportJobsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    jobs.splice(
+      0,
+      jobs.length,
       {
         job_id: 'job-active',
         flight_title: 'Vol test',
@@ -49,21 +87,8 @@ vi.mock('../../hooks/flights/useVideoExportJobs', () => ({
         internal_status: 'completed',
         progress: 100,
         can_cancel: false,
-      },
-    ],
-    isLoading: false,
-    isError: false,
-    refetch,
-  }),
-  useCancelVideoExportJob: () => ({
-    mutateAsync: cancelJob,
-    isPending: false,
-  }),
-}));
-
-describe('VideoExportJobsPanel', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+      }
+    );
     window.confirm = vi.fn(() => true);
   });
 
@@ -85,5 +110,15 @@ describe('VideoExportJobsPanel', () => {
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
+  });
+
+  it('shows an empty state when there are no jobs', () => {
+    jobs.splice(0, jobs.length);
+
+    render(<VideoExportJobsPanel />);
+
+    expect(
+      screen.getByText('Aucune génération vidéo pour le moment.')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -100,10 +100,6 @@ export function VideoExportJobsPanel() {
     }
   }
 
-  if (!isLoading && !isError && visibleJobs.length === 0) {
-    return null;
-  }
-
   return (
     <section className="mb-4 overflow-hidden rounded-xl border border-sky-100 bg-white shadow-md dark:border-sky-900/60 dark:bg-gray-800">
       <div className="flex flex-col gap-3 border-b border-gray-100 p-4 dark:border-gray-700 sm:flex-row sm:items-center sm:justify-between">
@@ -142,7 +138,13 @@ export function VideoExportJobsPanel() {
         </div>
       )}
 
-      {!isLoading && !isError && (
+      {!isLoading && !isError && visibleJobs.length === 0 && (
+        <div className="p-4 text-sm text-gray-600 dark:text-gray-300">
+          {t('videoJobs.empty', 'Aucune génération vidéo pour le moment.')}
+        </div>
+      )}
+
+      {!isLoading && !isError && visibleJobs.length > 0 && (
         <div className="divide-y divide-gray-100 dark:divide-gray-700">
           {visibleJobs.map((job) => {
             const progress = getProgress(job);

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -3,6 +3,7 @@
     "title": "Paragliding Dashboard",
     "dashboard": "Dashboard",
     "flights": "Flights",
+    "exports": "Exports",
     "analytics": "Analytics",
     "sites": "Sites",
     "settings": "Settings",
@@ -65,6 +66,8 @@
   },
   "videoJobs": {
     "title": "Video generations",
+    "pageTitle": "Video exports",
+    "pageSubtitle": "Track running video generations and recent exports.",
     "activeCount_one": "{{count}} generation running",
     "activeCount_other": "{{count}} generations running",
     "noActive": "No generations running",
@@ -74,6 +77,7 @@
     "stopSuccess": "Generation stopped",
     "stopError": "Unable to stop generation",
     "loadError": "Unable to load video generations",
+    "empty": "No video generation yet.",
     "status": {
       "queued": "Queued",
       "running": "Starting",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -3,6 +3,7 @@
     "title": "Tableau de Bord Parapente",
     "dashboard": "Dashboard",
     "flights": "Vols",
+    "exports": "Exportations",
     "analytics": "Analyses",
     "sites": "Sites",
     "settings": "Paramètres",
@@ -65,6 +66,8 @@
   },
   "videoJobs": {
     "title": "Générations vidéo",
+    "pageTitle": "Exportations vidéo",
+    "pageSubtitle": "Suivez les générations vidéo en cours et les derniers exports.",
     "activeCount_one": "{{count}} génération en cours",
     "activeCount_other": "{{count}} générations en cours",
     "noActive": "Aucune génération en cours",
@@ -74,6 +77,7 @@
     "stopSuccess": "Génération stoppée",
     "stopError": "Impossible de stopper la génération",
     "loadError": "Impossible de charger les générations vidéo",
+    "empty": "Aucune génération vidéo pour le moment.",
     "status": {
       "queued": "En attente",
       "running": "Démarrage",

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -9,7 +9,6 @@ import { CreateFlightModal } from '../components/flights/CreateFlightModal';
 import { CreateSiteModal } from '../components/flights/CreateSiteModal';
 import { FlightsTable } from '../components/flights/FlightsTable';
 import { FlightDetails } from '../components/flights/FlightDetails';
-import { VideoExportJobsPanel } from '../components/flights/VideoExportJobsPanel';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import {
   ToastContainer,
@@ -168,8 +167,6 @@ export default function FlightHistory() {
     <div>
       {/* Toast notifications */}
       <ToastContainer toasts={toasts} onClose={removeToast} />
-
-      <VideoExportJobsPanel />
 
       <div className="mb-4 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-3">

--- a/apps/frontend/src/pages/VideoExports.tsx
+++ b/apps/frontend/src/pages/VideoExports.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import { VideoExportJobsPanel } from '../components/flights/VideoExportJobsPanel';
+import { ToastContainer } from '@dashboard-parapente/design-system';
+import { useToastStore } from '../hooks/useToast';
+
+export default function VideoExports() {
+  const { t } = useTranslation();
+  const { toasts, removeToast } = useToastStore();
+
+  return (
+    <div>
+      <ToastContainer toasts={toasts} onClose={removeToast} />
+
+      <div className="mb-4 rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">
+          {t('videoJobs.pageTitle', 'Exportations vidéo')}
+        </h1>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+          {t(
+            'videoJobs.pageSubtitle',
+            'Suivez les générations vidéo en cours et les derniers exports.'
+          )}
+        </p>
+      </div>
+
+      <VideoExportJobsPanel />
+    </div>
+  );
+}

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as InfrastructureRouteImport } from './routes/infrastructure'
 import { Route as FlightsRouteImport } from './routes/flights'
+import { Route as ExportsRouteImport } from './routes/exports'
 import { Route as ExportViewerRouteImport } from './routes/export-viewer'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
@@ -58,6 +59,11 @@ const FlightsRoute = FlightsRouteImport.update({
   path: '/flights',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/flights.lazy').then((d) => d.Route))
+const ExportsRoute = ExportsRouteImport.update({
+  id: '/exports',
+  path: '/exports',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/exports.lazy').then((d) => d.Route))
 const ExportViewerRoute = ExportViewerRouteImport.update({
   id: '/export-viewer',
   path: '/export-viewer',
@@ -85,6 +91,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
+  '/exports': typeof ExportsRoute
   '/flights': typeof FlightsRoute
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
@@ -98,6 +105,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
+  '/exports': typeof ExportsRoute
   '/flights': typeof FlightsRoute
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
@@ -112,6 +120,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
+  '/exports': typeof ExportsRoute
   '/flights': typeof FlightsRoute
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
@@ -127,6 +136,7 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics'
     | '/export-viewer'
+    | '/exports'
     | '/flights'
     | '/infrastructure'
     | '/login'
@@ -140,6 +150,7 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics'
     | '/export-viewer'
+    | '/exports'
     | '/flights'
     | '/infrastructure'
     | '/login'
@@ -153,6 +164,7 @@ export interface FileRouteTypes {
     | '/'
     | '/analytics'
     | '/export-viewer'
+    | '/exports'
     | '/flights'
     | '/infrastructure'
     | '/login'
@@ -167,6 +179,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AnalyticsRoute: typeof AnalyticsRoute
   ExportViewerRoute: typeof ExportViewerRoute
+  ExportsRoute: typeof ExportsRoute
   FlightsRoute: typeof FlightsRoute
   InfrastructureRoute: typeof InfrastructureRoute
   LoginRoute: typeof LoginRoute
@@ -228,6 +241,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FlightsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/exports': {
+      id: '/exports'
+      path: '/exports'
+      fullPath: '/exports'
+      preLoaderRoute: typeof ExportsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/export-viewer': {
       id: '/export-viewer'
       path: '/export-viewer'
@@ -263,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRoute,
   ExportViewerRoute: ExportViewerRoute,
+  ExportsRoute: ExportsRoute,
   FlightsRoute: FlightsRoute,
   InfrastructureRoute: InfrastructureRoute,
   LoginRoute: LoginRoute,

--- a/apps/frontend/src/routes/exports.lazy.tsx
+++ b/apps/frontend/src/routes/exports.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import VideoExports from '../pages/VideoExports';
+
+export const Route = createLazyFileRoute('/exports')({
+  component: VideoExports,
+});

--- a/apps/frontend/src/routes/exports.tsx
+++ b/apps/frontend/src/routes/exports.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { queryClient } from '../lib/queryClient';
+import { videoExportJobsQueryOptions } from '../hooks/flights/useVideoExportJobs';
+import { requireAuth } from '../lib/authGuard';
+
+export const Route = createFileRoute('/exports')({
+  beforeLoad: requireAuth,
+  loader: () => queryClient.ensureQueryData(videoExportJobsQueryOptions()),
+});


### PR DESCRIPTION
## Summary
- Add a dedicated `/exports` page for video export job tracking.
- Remove the export jobs panel from the flight history page.
- Add navigation and i18n entries for the dedicated exports page.

## Validation
- `git diff --check origin/main...HEAD`
- Pre-commit previously ran `oxlint` and `oxfmt` on the staged frontend files when creating the original commit.
- `pnpm nx lint/test/build frontend` not run because `pnpm` is unavailable in this shell PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Exports" navigation link in the header
  * Created a dedicated video exports page to track running video generations
  * Added empty state messaging when no video exports exist

* **Localization**
  * Added English and French translations for exports navigation and video exports page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->