### PR TITLE
feat(video-export): add temporary file cleanup

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -69,6 +69,7 @@ from video_export import list_exports as list_exports_stream
 from video_export import cancel_video_export as cancel_video_export_stream
 from video_export import start_video_export_background
 from video_export_manual import cancel_video_export as cancel_video_export_manual
+from video_export_manual import cleanup_video_export_temp_files
 from video_export_manual import get_export_status as get_export_status_manual
 from video_export_manual import list_exports as list_exports_manual
 from video_export_manual import resolve_frontend_url
@@ -4106,6 +4107,12 @@ def list_video_export_jobs(
         jobs = [job for job in jobs if job.get("can_cancel")]
 
     return {"jobs": jobs}
+
+
+@router.delete("/video-export-jobs/temp-files")
+def delete_video_export_temp_files():
+    """Delete temporary files left by completed, failed, or cancelled video exports."""
+    return cleanup_video_export_temp_files(list_exports_manual() + list_exports_stream())
 
 
 @router.get("/exports/{job_id}/stream")

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -63,6 +63,7 @@ from schemas import (
     WeatherSourceConfigUpdate,
     WeatherSourceStats,
     WeatherSourceTestResult,
+    VideoExportTempCleanupResponse,
 )
 from video_export import get_export_status as get_export_status_stream
 from video_export import list_exports as list_exports_stream
@@ -4109,10 +4110,15 @@ def list_video_export_jobs(
     return {"jobs": jobs}
 
 
-@router.delete("/video-export-jobs/temp-files")
-def delete_video_export_temp_files():
+@router.delete(
+    "/video-export-jobs/temp-files",
+    response_model=VideoExportTempCleanupResponse,
+)
+def delete_video_export_temp_files() -> VideoExportTempCleanupResponse:
     """Delete temporary files left by completed, failed, or cancelled video exports."""
-    return cleanup_video_export_temp_files(list_exports_manual() + list_exports_stream())
+    return VideoExportTempCleanupResponse.model_validate(
+        cleanup_video_export_temp_files(list_exports_manual() + list_exports_stream())
+    )
 
 
 @router.get("/exports/{job_id}/stream")

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -558,3 +558,16 @@ class EmagramTriggerRequest(BaseModel):
         if v is not None and not -180 <= v <= 180:
             raise ValueError("Longitude must be between -180 and 180")
         return v
+
+
+class VideoExportTempCleanupError(BaseModel):
+    path: str
+    error: str
+
+
+class VideoExportTempCleanupResponse(BaseModel):
+    files_deleted: int
+    dirs_deleted: int
+    bytes_deleted: int
+    paths_deleted: list[str]
+    errors: list[VideoExportTempCleanupError]

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -384,3 +384,28 @@ class TestVideoExportJobsEndpoint:
         jobs = response.json()["jobs"]
         assert {job["job_id"] for job in jobs} == {"job-queued", "job-stream-encoding"}
         assert all(job["can_cancel"] is True for job in jobs)
+
+    def test_video_export_jobs_temp_files_endpoint_cleans_known_exports(self, client: TestClient):
+        manual_jobs = [{"job_id": "job-failed", "internal_status": "failed"}]
+        stream_jobs = [{"job_id": "job-stream", "status": "completed"}]
+        cleanup_payload = {
+            "files_deleted": 2,
+            "dirs_deleted": 2,
+            "bytes_deleted": 10,
+            "paths_deleted": ["/tmp/job-failed", "/tmp/job-stream"],
+            "errors": [],
+        }
+
+        with (
+            patch("routes.list_exports_manual", return_value=manual_jobs),
+            patch("routes.list_exports_stream", return_value=stream_jobs),
+            patch(
+                "routes.cleanup_video_export_temp_files",
+                return_value=cleanup_payload,
+            ) as cleanup,
+        ):
+            response = client.delete(f"{API_PREFIX}/video-export-jobs/temp-files")
+
+        assert response.status_code == 200
+        assert response.json() == cleanup_payload
+        cleanup.assert_called_once_with(manual_jobs + stream_jobs)

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -1,5 +1,7 @@
 """Unit tests for video export helpers."""
 
+import os
+import time
 from datetime import datetime
 
 from models import VideoExportJob
@@ -259,11 +261,29 @@ def test_cleanup_video_export_temp_files_removes_configured_orphan_temp_dirs(tmp
     orphan_temp_dir = temp_root / "orphan-job"
     orphan_temp_dir.mkdir(parents=True)
     (orphan_temp_dir / "frame00001.png").write_bytes(b"frame")
+    old_timestamp = time.time() - video_export_manual._ORPHAN_TEMP_CLEANUP_GRACE_SECONDS - 1
+    os.utime(orphan_temp_dir, (old_timestamp, old_timestamp))
 
     result = video_export_manual.cleanup_video_export_temp_files([])
 
     assert result["files_deleted"] == 1
     assert not orphan_temp_dir.exists()
+
+
+def test_cleanup_video_export_temp_files_keeps_fresh_orphan_temp_dirs(tmp_path, monkeypatch):
+    temp_root = tmp_path / "configured-temp-images"
+    export_root = tmp_path / "configured-video-exports"
+    monkeypatch.setattr(video_export_manual, "VIDEO_TEMP_IMAGES_DIR", temp_root)
+    monkeypatch.setattr(video_export_manual, "VIDEO_EXPORT_DIR", export_root)
+
+    fresh_temp_dir = temp_root / "fresh-job"
+    fresh_temp_dir.mkdir(parents=True)
+    (fresh_temp_dir / "frame00001.png").write_bytes(b"frame")
+
+    result = video_export_manual.cleanup_video_export_temp_files([])
+
+    assert result["files_deleted"] == 0
+    assert fresh_temp_dir.exists()
 
 
 def test_cleanup_video_export_temp_files_removes_legacy_frames_for_inactive_job(

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -223,3 +223,64 @@ def test_stream_export_cleanup_removes_temp_dir_on_error(tmp_path):
         video_export._cleanup_temp_dir(temp_dir)
 
     assert not temp_dir.exists()
+
+
+def test_cleanup_video_export_temp_files_uses_configured_temp_dir(tmp_path, monkeypatch):
+    temp_root = tmp_path / "configured-temp-images"
+    export_root = tmp_path / "configured-video-exports"
+    monkeypatch.setattr(video_export_manual, "VIDEO_TEMP_IMAGES_DIR", temp_root)
+    monkeypatch.setattr(video_export_manual, "VIDEO_EXPORT_DIR", export_root)
+
+    inactive_temp_dir = temp_root / "job-failed"
+    active_temp_dir = temp_root / "job-active"
+    inactive_temp_dir.mkdir(parents=True)
+    active_temp_dir.mkdir(parents=True)
+    (inactive_temp_dir / "frame00001.png").write_bytes(b"frame")
+    (active_temp_dir / "frame00001.png").write_bytes(b"frame")
+
+    result = video_export_manual.cleanup_video_export_temp_files(
+        [
+            {"job_id": "job-failed", "internal_status": "failed"},
+            {"job_id": "job-active", "internal_status": "capturing"},
+        ]
+    )
+
+    assert result["files_deleted"] == 1
+    assert not inactive_temp_dir.exists()
+    assert active_temp_dir.exists()
+
+
+def test_cleanup_video_export_temp_files_removes_configured_orphan_temp_dirs(tmp_path, monkeypatch):
+    temp_root = tmp_path / "configured-temp-images"
+    export_root = tmp_path / "configured-video-exports"
+    monkeypatch.setattr(video_export_manual, "VIDEO_TEMP_IMAGES_DIR", temp_root)
+    monkeypatch.setattr(video_export_manual, "VIDEO_EXPORT_DIR", export_root)
+
+    orphan_temp_dir = temp_root / "orphan-job"
+    orphan_temp_dir.mkdir(parents=True)
+    (orphan_temp_dir / "frame00001.png").write_bytes(b"frame")
+
+    result = video_export_manual.cleanup_video_export_temp_files([])
+
+    assert result["files_deleted"] == 1
+    assert not orphan_temp_dir.exists()
+
+
+def test_cleanup_video_export_temp_files_removes_legacy_frames_for_inactive_job(
+    tmp_path, monkeypatch
+):
+    temp_root = tmp_path / "configured-temp-images"
+    export_root = tmp_path / "configured-video-exports"
+    monkeypatch.setattr(video_export_manual, "VIDEO_TEMP_IMAGES_DIR", temp_root)
+    monkeypatch.setattr(video_export_manual, "VIDEO_EXPORT_DIR", export_root)
+
+    legacy_frames_dir = export_root / "frames_job-cancelled"
+    legacy_frames_dir.mkdir(parents=True)
+    (legacy_frames_dir / "frame00001.png").write_bytes(b"frame")
+
+    result = video_export_manual.cleanup_video_export_temp_files(
+        [{"job_id": "job-cancelled", "internal_status": "cancelled"}]
+    )
+
+    assert result["files_deleted"] == 1
+    assert not legacy_frames_dir.exists()

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -61,6 +61,7 @@ _JOB_RUNTIME: dict[str, dict[str, Any]] = {}
 
 _CANCEL_CHECK_INTERVAL = 10
 _FFMPEG_STALL_TIMEOUT_SECONDS = 10 * 60
+_ORPHAN_TEMP_CLEANUP_GRACE_SECONDS = 30
 
 
 def check_dependencies():
@@ -472,6 +473,13 @@ def _is_export_active(export: dict[str, Any]) -> bool:
     return export.get("status") in {"started", "processing", *_ACTIVE_STATUSES}
 
 
+def _is_path_older_than(path: Path, age_seconds: int) -> bool:
+    try:
+        return time.time() - path.stat().st_mtime >= age_seconds
+    except OSError:
+        return False
+
+
 def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, Any]:
     """Delete non-active video export temporary files from configured storage."""
     active_job_ids = {
@@ -497,13 +505,17 @@ def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, 
 
     if temp_root.exists():
         for child in temp_root.iterdir():
-            if child.name not in active_job_ids:
+            if child.name not in active_job_ids and _is_path_older_than(
+                child, _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS
+            ):
                 candidates.append((child, temp_root))
 
     if export_root.exists():
         for child in export_root.glob("frames_*"):
             job_id = child.name.removeprefix("frames_")
-            if job_id not in active_job_ids:
+            if job_id not in active_job_ids and _is_path_older_than(
+                child, _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS
+            ):
                 candidates.append((child, export_root))
 
     seen: set[str] = set()

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -394,6 +394,149 @@ def _cleanup_temp_dir(temp_dir: Path | None) -> None:
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 
+def _is_path_inside(path: Path, directory: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(directory.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _path_usage(path: Path) -> tuple[int, int, int]:
+    if not path.exists():
+        return 0, 0, 0
+
+    if path.is_file() or path.is_symlink():
+        try:
+            return 1, 0, path.stat().st_size
+        except OSError:
+            return 1, 0, 0
+
+    files_count = 0
+    dirs_count = 1
+    bytes_count = 0
+    for item in path.rglob("*"):
+        if item.is_dir() and not item.is_symlink():
+            dirs_count += 1
+            continue
+        files_count += 1
+        try:
+            bytes_count += item.stat().st_size
+        except OSError:
+            pass
+    return files_count, dirs_count, bytes_count
+
+
+def _delete_temp_path(path: Path, allowed_root: Path) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "path": str(path),
+        "deleted": False,
+        "files_deleted": 0,
+        "dirs_deleted": 0,
+        "bytes_deleted": 0,
+        "error": None,
+    }
+
+    if not path.exists():
+        return result
+
+    if not _is_path_inside(path, allowed_root):
+        result["error"] = "Refusing to delete outside configured temp directory"
+        return result
+
+    files_count, dirs_count, bytes_count = _path_usage(path)
+    try:
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    except OSError as exc:
+        result["error"] = str(exc)
+        return result
+
+    result.update(
+        {
+            "deleted": True,
+            "files_deleted": files_count,
+            "dirs_deleted": dirs_count,
+            "bytes_deleted": bytes_count,
+        }
+    )
+    return result
+
+
+def _is_export_active(export: dict[str, Any]) -> bool:
+    internal_status = export.get("internal_status")
+    if isinstance(internal_status, str):
+        return internal_status in _ACTIVE_STATUSES
+    return export.get("status") in {"started", "processing", *_ACTIVE_STATUSES}
+
+
+def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, Any]:
+    """Delete non-active video export temporary files from configured storage."""
+    active_job_ids = {
+        str(export["job_id"])
+        for export in exports
+        if export.get("job_id") and _is_export_active(export)
+    }
+    known_inactive_job_ids = {
+        str(export["job_id"])
+        for export in exports
+        if export.get("job_id") and not _is_export_active(export)
+    }
+
+    candidates: list[tuple[Path, Path]] = []
+    temp_root = VIDEO_TEMP_IMAGES_DIR
+    export_root = VIDEO_EXPORT_DIR
+
+    for job_id in known_inactive_job_ids:
+        candidates.append((_job_temp_dir(job_id), temp_root))
+        candidates.append((export_root / f"frames_{job_id}", export_root))
+        candidates.append((Path("/tmp") / f"playwright-debug-{job_id}.png", Path("/tmp")))
+        candidates.append((Path("/tmp") / f"playwright-error-{job_id}.png", Path("/tmp")))
+
+    if temp_root.exists():
+        for child in temp_root.iterdir():
+            if child.name not in active_job_ids:
+                candidates.append((child, temp_root))
+
+    if export_root.exists():
+        for child in export_root.glob("frames_*"):
+            job_id = child.name.removeprefix("frames_")
+            if job_id not in active_job_ids:
+                candidates.append((child, export_root))
+
+    seen: set[str] = set()
+    deleted_paths: list[str] = []
+    errors: list[dict[str, str]] = []
+    files_deleted = 0
+    dirs_deleted = 0
+    bytes_deleted = 0
+
+    for path, allowed_root in candidates:
+        resolved_key = str(path.resolve(strict=False))
+        if resolved_key in seen:
+            continue
+        seen.add(resolved_key)
+
+        deletion = _delete_temp_path(path, allowed_root)
+        if deletion["deleted"]:
+            deleted_paths.append(str(deletion["path"]))
+            files_deleted += int(deletion["files_deleted"])
+            dirs_deleted += int(deletion["dirs_deleted"])
+            bytes_deleted += int(deletion["bytes_deleted"])
+        elif deletion["error"]:
+            errors.append({"path": str(deletion["path"]), "error": str(deletion["error"])})
+
+    return {
+        "files_deleted": files_deleted,
+        "dirs_deleted": dirs_deleted,
+        "bytes_deleted": bytes_deleted,
+        "paths_deleted": deleted_paths,
+        "errors": errors,
+    }
+
+
 def _prepare_export_dirs(temp_dir: Path, frames_dir: Path) -> None:
     try:
         VIDEO_EXPORT_DIR.mkdir(parents=True, exist_ok=True)

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -5,9 +5,10 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoExportJobsPanel } from './VideoExportJobsPanel';
 
-const { cancelJob, toastError, toastSuccess, refetch, jobs } = vi.hoisted(
-  () => ({
+const { cancelJob, cleanupTempFiles, toastError, toastSuccess, refetch, jobs } =
+  vi.hoisted(() => ({
     cancelJob: vi.fn(),
+    cleanupTempFiles: vi.fn(),
     toastError: vi.fn(),
     toastSuccess: vi.fn(),
     refetch: vi.fn(),
@@ -31,8 +32,7 @@ const { cancelJob, toastError, toastSuccess, refetch, jobs } = vi.hoisted(
         can_cancel: false,
       },
     ],
-  })
-);
+  }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -60,6 +60,10 @@ vi.mock('../../hooks/flights/useVideoExportJobs', () => ({
   }),
   useCancelVideoExportJob: () => ({
     mutateAsync: cancelJob,
+    isPending: false,
+  }),
+  useCleanupVideoExportTempFiles: () => ({
+    mutateAsync: cleanupTempFiles,
     isPending: false,
   }),
 }));
@@ -110,6 +114,26 @@ describe('VideoExportJobsPanel', () => {
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
+  });
+
+  it('cleans temporary files after confirmation', async () => {
+    cleanupTempFiles.mockResolvedValue({
+      files_deleted: 2,
+      dirs_deleted: 1,
+      bytes_deleted: 123,
+      paths_deleted: ['/tmp/export-temp'],
+      errors: [],
+    });
+
+    render(<VideoExportJobsPanel />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Nettoyer les temporaires' })
+    );
+
+    await waitFor(() => expect(cleanupTempFiles).toHaveBeenCalled());
+    expect(toastSuccess).toHaveBeenCalledWith(
+      '3 élément(s) temporaire(s) supprimé(s)'
+    );
   });
 
   it('shows an empty state when there are no jobs', () => {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -3,6 +3,7 @@ import { Button } from '@dashboard-parapente/design-system';
 import {
   type VideoExportJob,
   useCancelVideoExportJob,
+  useCleanupVideoExportTempFiles,
   useVideoExportJobs,
 } from '../../hooks/flights/useVideoExportJobs';
 import { useToast } from '../../hooks/useToast';
@@ -77,6 +78,7 @@ export function VideoExportJobsPanel() {
   const toast = useToast();
   const { data: jobs = [], isLoading, isError, refetch } = useVideoExportJobs();
   const cancelJob = useCancelVideoExportJob();
+  const cleanupTempFiles = useCleanupVideoExportTempFiles();
   const visibleJobs = jobs.slice(0, 6);
   const activeCount = jobs.filter((job) => job.can_cancel).length;
 
@@ -92,10 +94,52 @@ export function VideoExportJobsPanel() {
     try {
       await cancelJob.mutateAsync(job.job_id);
       toast.success(t('videoJobs.stopSuccess', 'Génération stoppée'));
-    } catch (error) {
-      console.error('Failed to cancel video export job:', error);
+    } catch {
       toast.error(
         t('videoJobs.stopError', 'Impossible de stopper la génération')
+      );
+    }
+  }
+
+  async function handleCleanupTempFiles() {
+    if (
+      !window.confirm(
+        t(
+          'videoJobs.confirmCleanupTempFiles',
+          'Supprimer les fichiers temporaires des générations terminées, échouées ou annulées ?'
+        )
+      )
+    ) {
+      return;
+    }
+
+    try {
+      const result = await cleanupTempFiles.mutateAsync();
+      const deletedCount = result.files_deleted + result.dirs_deleted;
+      if (result.errors.length > 0) {
+        toast.error(
+          t(
+            'videoJobs.cleanupPartialError',
+            '{{count}} élément(s) supprimé(s), mais certains fichiers n’ont pas pu être supprimés',
+            { count: deletedCount }
+          )
+        );
+        return;
+      }
+
+      toast.success(
+        t(
+          'videoJobs.cleanupSuccess',
+          '{{count}} élément(s) temporaire(s) supprimé(s)',
+          { count: deletedCount }
+        )
+      );
+    } catch {
+      toast.error(
+        t(
+          'videoJobs.cleanupError',
+          'Impossible de supprimer les fichiers temporaires'
+        )
       );
     }
   }
@@ -115,12 +159,23 @@ export function VideoExportJobsPanel() {
               : t('videoJobs.noActive', 'Aucune génération en cours')}
           </p>
         </div>
-        <Button
-          onClick={() => refetch()}
-          className="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
-        >
-          {t('common.retry', 'Rafraîchir')}
-        </Button>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <Button
+            onClick={handleCleanupTempFiles}
+            disabled={cleanupTempFiles.isPending}
+            className="rounded-lg bg-amber-100 px-3 py-2 text-sm font-medium text-amber-800 hover:bg-amber-200 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 dark:bg-amber-900/40 dark:text-amber-200 dark:hover:bg-amber-900/60 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+          >
+            {cleanupTempFiles.isPending
+              ? t('videoJobs.cleaningTempFiles', 'Nettoyage...')
+              : t('videoJobs.cleanupTempFiles', 'Nettoyer les temporaires')}
+          </Button>
+          <Button
+            onClick={() => refetch()}
+            className="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+          >
+            {t('common.retry', 'Rafraîchir')}
+          </Button>
+        </div>
       </div>
 
       {isError && (

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -29,6 +29,14 @@ type VideoExportJobsResponse = {
   jobs: VideoExportJob[];
 };
 
+export type VideoExportTempCleanupResult = {
+  files_deleted: number;
+  dirs_deleted: number;
+  bytes_deleted: number;
+  paths_deleted: string[];
+  errors: { path: string; error: string }[];
+};
+
 const hasActiveJob = (jobs: VideoExportJob[] | undefined) =>
   Boolean(jobs?.some((job) => job.can_cancel));
 
@@ -58,6 +66,21 @@ export function useCancelVideoExportJob() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });
       queryClient.invalidateQueries({ queryKey: ['flights'] });
+    },
+  });
+}
+
+export function useCleanupVideoExportTempFiles() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      return await api
+        .delete('video-export-jobs/temp-files')
+        .json<VideoExportTempCleanupResult>();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });
     },
   });
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -76,6 +76,12 @@
     "stopping": "Stopping...",
     "stopSuccess": "Generation stopped",
     "stopError": "Unable to stop generation",
+    "cleanupTempFiles": "Clean temp files",
+    "cleaningTempFiles": "Cleaning...",
+    "confirmCleanupTempFiles": "Delete temporary files for completed, failed, or cancelled generations?",
+    "cleanupSuccess": "{{count}} temporary item(s) deleted",
+    "cleanupPartialError": "{{count}} item(s) deleted, but some files could not be removed",
+    "cleanupError": "Unable to delete temporary files",
     "loadError": "Unable to load video generations",
     "empty": "No video generation yet.",
     "status": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -76,6 +76,12 @@
     "stopping": "Arrêt...",
     "stopSuccess": "Génération stoppée",
     "stopError": "Impossible de stopper la génération",
+    "cleanupTempFiles": "Nettoyer les temporaires",
+    "cleaningTempFiles": "Nettoyage...",
+    "confirmCleanupTempFiles": "Supprimer les fichiers temporaires des générations terminées, échouées ou annulées ?",
+    "cleanupSuccess": "{{count}} élément(s) temporaire(s) supprimé(s)",
+    "cleanupPartialError": "{{count}} élément(s) supprimé(s), mais certains fichiers n’ont pas pu être supprimés",
+    "cleanupError": "Impossible de supprimer les fichiers temporaires",
     "loadError": "Impossible de charger les générations vidéo",
     "empty": "Aucune génération vidéo pour le moment.",
     "status": {


### PR DESCRIPTION
## Summary
- Add a protected endpoint to clean video export temporary files for non-active jobs.
- Clean configured temporary/export directories safely while preserving active jobs and final videos.
- Add a video exports tab action with user feedback and coverage for backend/frontend behavior.

## Validation
- `uvx ruff check video_export_manual.py routes.py tests/unit/test_video_export_manual.py tests/api/test_video_export_endpoints.py`
- `uvx black --check video_export_manual.py routes.py tests/unit/test_video_export_manual.py tests/api/test_video_export_endpoints.py`
- `oxfmt -c .oxfmtrc.json apps/frontend/src/hooks/flights/useVideoExportJobs.ts apps/frontend/src/components/flights/VideoExportJobsPanel.tsx apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx`
- `oxlint -c .oxlintrc.json apps/frontend/src/hooks/flights/useVideoExportJobs.ts apps/frontend/src/components/flights/VideoExportJobsPanel.tsx apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx` (passes with existing max-lines-per-function warnings)

## Notes
- Full Nx/Pytest test runs could not be executed in the worktree because local workspace dependencies are unavailable there (`pnpm`/`pytest` missing; Nx requires `node_modules/.modules.yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary file cleanup capability for completed and cancelled video exports with a dedicated button in the video export jobs panel
  * Results reported via toast notifications showing success status and count of deleted items
  * Includes user confirmation dialog before cleanup proceeds

* **Tests**
  * Added unit and integration tests for cleanup functionality

* **Chores**
  * Added English and French translations supporting the cleanup feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->