### PR TITLE
fix: clean Docker images after successful deploy

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -411,6 +411,7 @@ jobs:
 
       - name: Cleanup unused Docker images
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
+        continue-on-error: true
         uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -420,8 +421,10 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           command_timeout: 5m
           script: |
-            set -eu
-            docker image prune -f
+            set -u
+            if ! docker image prune -f; then
+              echo "Docker image cleanup failed; deployment remains successful"
+            fi
 
       - name: Label merged PRs with deployed version
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'

--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -409,6 +409,20 @@ jobs:
               }
             }
 
+      - name: Cleanup unused Docker images
+        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          fingerprint: ${{ secrets.SSH_FINGERPRINT }}
+          port: ${{ secrets.SSH_PORT }}
+          command_timeout: 5m
+          script: |
+            set -eu
+            docker image prune -f
+
       - name: Label merged PRs with deployed version
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
         uses: actions/github-script@v9

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,6 +35,9 @@ docker compose build --no-cache backend
 echo "Démarrage des conteneurs..."
 docker compose up -d
 
+echo "Nettoyage des images Docker inutilisées..."
+docker image prune -f
+
 echo "✅ Docker redémarré"
 echo ""
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,7 +36,9 @@ echo "Démarrage des conteneurs..."
 docker compose up -d
 
 echo "Nettoyage des images Docker inutilisées..."
-docker image prune -f
+if ! docker image prune -f; then
+  echo "⚠️  Nettoyage des images ignoré (échec non bloquant)"
+fi
 
 echo "✅ Docker redémarré"
 echo ""


### PR DESCRIPTION
## Summary
- Add a production SSH cleanup step that prunes unused Docker images only after deployment verification succeeds.
- Apply the same image cleanup after successful manual Docker startup in deploy.sh.

## Validation
- bash -n deploy.sh
- git diff --check -- .github/workflows/deploy-portainer.yml deploy.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment process with automated cleanup of unused Docker images. The deployment workflow now includes a post-deployment cleanup step to optimize resource usage on the deployment host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->