### PR TITLE
fix(backend): refresh Strava token from persisted state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
           BACKEND_METEOBLUE_API_KEY: test_key
           BACKEND_STRAVA_VERIFY_TOKEN: PARAPENTE_E2E_TEST
           BACKEND_JWT_SECRET: ci-test-secret-not-for-production
+          VITE_CESIUM_ION_TOKEN: e2e-ci-placeholder-token
 
       - name: 🔄 Retry E2E with local cache (if NX Cloud exhausted)
         if: steps.e2e.outcome == 'failure'
@@ -309,6 +310,7 @@ jobs:
           BACKEND_METEOBLUE_API_KEY: test_key
           BACKEND_STRAVA_VERIFY_TOKEN: PARAPENTE_E2E_TEST
           BACKEND_JWT_SECRET: ci-test-secret-not-for-production
+          VITE_CESIUM_ION_TOKEN: e2e-ci-placeholder-token
 
       - name: 📤 Upload E2E artifacts
         if: failure()

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -40,14 +40,14 @@ _REFRESH_INITIAL_BACKOFF_SECONDS = 1.0
 def _get_persisted_refresh_token() -> str | None:
     """Read the refresh token from DB (app_settings), fallback to env."""
     try:
-        from app_settings import get_setting
         from database import get_db_context
+        from models import AppSetting
 
         with get_db_context() as db:
-            persisted = get_setting("strava_refresh_token", db=db)
-            if persisted:
+            row = db.query(AppSetting).filter(AppSetting.key == "strava_refresh_token").first()
+            if row and row.value:
                 logger.info("Using persisted refresh token from DB")
-                return persisted
+                return row.value
     except Exception as e:
         logger.warning(f"Could not read persisted refresh token: {e}")
     return STRAVA_REFRESH_TOKEN
@@ -108,7 +108,7 @@ async def refresh_access_token(force: bool = False) -> str | None:
     """
     Refresh Strava access token.
 
-    Token priority: in-memory → DB (app_settings) → env (.env).
+    Token priority: DB (app_settings) → env (.env) → in-memory fallback.
     After refresh, persists new refresh_token to DB and logs the attempt.
 
     Args:
@@ -131,8 +131,9 @@ async def refresh_access_token(force: bool = False) -> str | None:
         if force:
             logger.info("Forcing token refresh (ignoring in-memory validity cache)")
 
-        # Resolve the refresh token: in-memory → DB → env
-        current_refresh_token = _refresh_token or _get_persisted_refresh_token()
+        # Prefer persisted state: Strava rotates refresh tokens on every exchange,
+        # so an in-memory token can become stale if another process refreshed it.
+        current_refresh_token = _get_persisted_refresh_token() or _refresh_token
 
         if not current_refresh_token:
             msg = "No refresh token available (not in memory, DB, or env)"

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -215,6 +215,46 @@ async def test_refresh_access_token_forced_refresh_ignores_cached():
 
 
 @pytest.mark.asyncio
+async def test_refresh_access_token_prefers_persisted_refresh_token():
+    """Use DB refresh token before stale in-memory token."""
+
+    import strava
+
+    strava._access_token = "expired_access_token"
+    strava._token_expires_at = datetime.now() - timedelta(hours=1)
+    strava._refresh_token = "stale_memory_refresh"
+
+    mock_response = {
+        "access_token": "refreshed_access_token",
+        "refresh_token": "rotated_refresh_token",
+        "expires_at": int((datetime.now() + timedelta(hours=6)).timestamp()),
+    }
+
+    with (
+        patch("strava.STRAVA_CLIENT_ID", "test_client_id"),
+        patch("strava.STRAVA_CLIENT_SECRET", "test_secret"),
+        patch("strava._get_persisted_refresh_token", return_value="persisted_refresh"),
+        patch("strava._persist_refresh_token") as mock_persist,
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_post = AsyncMock(
+            return_value=MagicMock(
+                status_code=200,
+                json=MagicMock(return_value=mock_response),
+                raise_for_status=MagicMock(),
+            )
+        )
+        mock_client.return_value.__aenter__.return_value.post = mock_post
+
+        token = await refresh_access_token()
+
+    assert token == "refreshed_access_token"
+    assert mock_post.await_args.kwargs["data"]["refresh_token"] == "persisted_refresh"
+    assert strava._refresh_token == "rotated_refresh_token"
+    mock_persist.assert_called_once_with("rotated_refresh_token")
+
+
+@pytest.mark.asyncio
 async def test_refresh_access_token_missing_credentials():
     """Test token refresh with missing credentials"""
 

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -78,7 +78,7 @@ export default defineConfig({
     },
     {
       command:
-        'bash -lc "set -o pipefail; echo [e2e:web] Building frontend; ./node_modules/.bin/nx build frontend --output-style=stream; echo [e2e:web] Starting Vite preview; ./node_modules/.bin/vite preview --config apps/frontend/vite.config.ts --strictPort --host 127.0.0.1 --port 5173"',
+        'bash -lc "set -o pipefail; echo [e2e:web] Building frontend; ./node_modules/.bin/nx build frontend --output-style=stream --skip-nx-cache; echo [e2e:web] Starting Vite preview; ./node_modules/.bin/vite preview --config apps/frontend/vite.config.ts --strictPort --host 127.0.0.1 --port 5173"',
       url: 'http://localhost:5173',
       reuseExistingServer: !process.env.CI,
       cwd: '../..',


### PR DESCRIPTION
## Summary
- Read the Strava refresh token directly from persisted DB state instead of the app settings cache.
- Prefer the persisted refresh token over the in-memory fallback to avoid stale token reuse after Strava token rotation.
- Add a regression test covering stale in-memory refresh tokens.

## Validation
- `python3 -m py_compile apps/backend/strava.py apps/backend/tests/unit/test_strava.py`
- Not run: `pnpm nx test backend --testPathPattern='test_strava.py|test_main.py'` (`pnpm` unavailable)
- Not run: `python3 -m pytest apps/backend/tests/unit/test_strava.py apps/backend/tests/unit/test_main.py` (`pytest` unavailable)
- Not run: `ruff` (`ruff` unavailable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Favor persisted (DB) refresh tokens over in-memory tokens to improve authentication reliability during token rotation.

* **Tests**
  * Added a unit test ensuring persisted refresh tokens are preferred over stale in-memory tokens during refresh.

* **Chores**
  * CI: added frontend token env var for E2E runs.
  * E2E: frontend build step now forces a full build (skips cache) before tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->