### PR TITLE
refactor(frontend): split Login with TanStack Query and Storybook coverage

### DIFF
--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -10,15 +10,15 @@ type LoginFormProps = {
   errorMessage?: string;
 };
 
-type LoginFormViewProps = {
-  form: ReturnType<typeof useForm>;
-  isPending: boolean;
-  errorMessage?: string;
-  emailLabel: string;
-  passwordLabel: string;
-  title: string;
-  loadingLabel: string;
-  submitLabel: string;
+type LoginFieldViewProps = {
+  id: 'email' | 'password';
+  type: 'email' | 'password';
+  autoComplete: 'username' | 'current-password';
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  inputClassName: string;
+  labelClassName: string;
 };
 
 const styles = tv({
@@ -38,104 +38,26 @@ const styles = tv({
   },
 });
 
-type LoginFieldProps = {
-  form: ReturnType<typeof useForm>;
-  label: string;
-  name: 'email' | 'password';
-  type: 'email' | 'password';
-  autoComplete: 'username' | 'current-password';
-  inputClassName: string;
-  labelClassName: string;
-};
-
-function LoginField({
-  form,
-  label,
-  name,
+function LoginFieldView({
+  id,
   type,
   autoComplete,
+  label,
+  value,
+  onChange,
   inputClassName,
   labelClassName,
-}: LoginFieldProps) {
+}: LoginFieldViewProps) {
   return (
-    <form.Field name={name}>
-      {(field) => (
-        <TextField
-          isRequired
-          value={field.state.value}
-          onChange={field.handleChange}
-        >
-          <Label className={labelClassName}>{label}</Label>
-          <Input
-            id={name}
-            type={type}
-            autoComplete={autoComplete}
-            className={inputClassName}
-          />
-        </TextField>
-      )}
-    </form.Field>
-  );
-}
-
-function LoginFormView({
-  form,
-  isPending,
-  errorMessage,
-  emailLabel,
-  passwordLabel,
-  title,
-  loadingLabel,
-  submitLabel,
-}: LoginFormViewProps) {
-  const s = styles();
-
-  return (
-    <div className={s.page()}>
-      <div className={s.container()}>
-        <div className={s.card()}>
-          <h1 className={s.title()}>{title}</h1>
-
-          <Form
-            onSubmit={(e) => {
-              e.preventDefault();
-              void form.handleSubmit();
-            }}
-            className={s.form()}
-          >
-            <LoginField
-              form={form}
-              label={emailLabel}
-              name="email"
-              type="email"
-              autoComplete="username"
-              inputClassName={s.input()}
-              labelClassName={s.label()}
-            />
-
-            <LoginField
-              form={form}
-              label={passwordLabel}
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              inputClassName={s.input()}
-              labelClassName={s.label()}
-            />
-
-            {errorMessage ? <p className={s.error()}>{errorMessage}</p> : null}
-
-            <Button
-              type="submit"
-              isDisabled={isPending}
-              className={s.submitButton()}
-            >
-              {isPending ? loadingLabel : submitLabel}
-            </Button>
-          </Form>
-        </div>
-      </div>
-    </div>
+    <TextField isRequired value={value} onChange={onChange}>
+      <Label className={labelClassName}>{label}</Label>
+      <Input
+        id={id}
+        type={type}
+        autoComplete={autoComplete}
+        className={inputClassName}
+      />
+    </TextField>
   );
 }
 
@@ -145,6 +67,7 @@ export function LoginForm({
   errorMessage,
 }: LoginFormProps) {
   const { t } = useTranslation();
+  const s = styles();
 
   const form = useForm({
     defaultValues: { email: '', password: '' },
@@ -154,15 +77,60 @@ export function LoginForm({
   });
 
   return (
-    <LoginFormView
-      form={form}
-      isPending={isPending}
-      errorMessage={errorMessage}
-      emailLabel={t('login.email')}
-      passwordLabel={t('login.password')}
-      title={t('login.title')}
-      loadingLabel={t('login.loading')}
-      submitLabel={t('login.submit')}
-    />
+    <div className={s.page()}>
+      <div className={s.container()}>
+        <div className={s.card()}>
+          <h1 className={s.title()}>{t('login.title')}</h1>
+
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void form.handleSubmit();
+            }}
+            className={s.form()}
+          >
+            <form.Field name="email">
+              {(field) => (
+                <LoginFieldView
+                  id="email"
+                  type="email"
+                  autoComplete="username"
+                  label={t('login.email')}
+                  value={String(field.state.value ?? '')}
+                  onChange={(value) => field.handleChange(value)}
+                  inputClassName={s.input()}
+                  labelClassName={s.label()}
+                />
+              )}
+            </form.Field>
+
+            <form.Field name="password">
+              {(field) => (
+                <LoginFieldView
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  label={t('login.password')}
+                  value={String(field.state.value ?? '')}
+                  onChange={(value) => field.handleChange(value)}
+                  inputClassName={s.input()}
+                  labelClassName={s.label()}
+                />
+              )}
+            </form.Field>
+
+            {errorMessage ? <p className={s.error()}>{errorMessage}</p> : null}
+
+            <Button
+              type="submit"
+              isDisabled={isPending}
+              className={s.submitButton()}
+            >
+              {isPending ? t('login.loading') : t('login.submit')}
+            </Button>
+          </Form>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -11,7 +11,7 @@ type LoginFormProps = {
 };
 
 type LoginFormViewProps = {
-  form: ReturnType<typeof useForm<{ email: string; password: string }>>;
+  form: ReturnType<typeof useForm>;
   isPending: boolean;
   errorMessage?: string;
   emailLabel: string;
@@ -39,7 +39,7 @@ const styles = tv({
 });
 
 type LoginFieldProps = {
-  form: ReturnType<typeof useForm<{ email: string; password: string }>>;
+  form: ReturnType<typeof useForm>;
   label: string;
   name: 'email' | 'password';
   type: 'email' | 'password';

--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -1,0 +1,168 @@
+import { useForm } from '@tanstack/react-form';
+import { tv } from 'tailwind-variants';
+import { useTranslation } from 'react-i18next';
+import { TextField, Label, Input, Form } from 'react-aria-components';
+import { Button } from '@dashboard-parapente/design-system';
+
+type LoginFormProps = {
+  onSubmit: (value: { email: string; password: string }) => Promise<void>;
+  isPending: boolean;
+  errorMessage?: string;
+};
+
+type LoginFormViewProps = {
+  form: ReturnType<typeof useForm<{ email: string; password: string }>>;
+  isPending: boolean;
+  errorMessage?: string;
+  emailLabel: string;
+  passwordLabel: string;
+  title: string;
+  loadingLabel: string;
+  submitLabel: string;
+};
+
+const styles = tv({
+  slots: {
+    page: 'min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4',
+    container: 'w-full max-w-sm',
+    card: 'bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8',
+    title:
+      'text-2xl font-semibold text-center text-sky-600 dark:text-sky-400 mb-6',
+    form: 'space-y-4',
+    label: 'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1',
+    input:
+      'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-sky-500 focus:border-transparent outline-none',
+    error: 'text-sm text-red-500 dark:text-red-400',
+    submitButton:
+      'w-full py-2.5 bg-sky-600 hover:bg-sky-700 disabled:bg-sky-400 text-white font-medium rounded-lg transition-colors pressed:bg-sky-800',
+  },
+});
+
+type LoginFieldProps = {
+  form: ReturnType<typeof useForm<{ email: string; password: string }>>;
+  label: string;
+  name: 'email' | 'password';
+  type: 'email' | 'password';
+  autoComplete: 'username' | 'current-password';
+  inputClassName: string;
+  labelClassName: string;
+};
+
+function LoginField({
+  form,
+  label,
+  name,
+  type,
+  autoComplete,
+  inputClassName,
+  labelClassName,
+}: LoginFieldProps) {
+  return (
+    <form.Field name={name}>
+      {(field) => (
+        <TextField
+          isRequired
+          value={field.state.value}
+          onChange={field.handleChange}
+        >
+          <Label className={labelClassName}>{label}</Label>
+          <Input
+            id={name}
+            type={type}
+            autoComplete={autoComplete}
+            className={inputClassName}
+          />
+        </TextField>
+      )}
+    </form.Field>
+  );
+}
+
+function LoginFormView({
+  form,
+  isPending,
+  errorMessage,
+  emailLabel,
+  passwordLabel,
+  title,
+  loadingLabel,
+  submitLabel,
+}: LoginFormViewProps) {
+  const s = styles();
+
+  return (
+    <div className={s.page()}>
+      <div className={s.container()}>
+        <div className={s.card()}>
+          <h1 className={s.title()}>{title}</h1>
+
+          <Form
+            onSubmit={(e) => {
+              e.preventDefault();
+              void form.handleSubmit();
+            }}
+            className={s.form()}
+          >
+            <LoginField
+              form={form}
+              label={emailLabel}
+              name="email"
+              type="email"
+              autoComplete="username"
+              inputClassName={s.input()}
+              labelClassName={s.label()}
+            />
+
+            <LoginField
+              form={form}
+              label={passwordLabel}
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              inputClassName={s.input()}
+              labelClassName={s.label()}
+            />
+
+            {errorMessage ? <p className={s.error()}>{errorMessage}</p> : null}
+
+            <Button
+              type="submit"
+              isDisabled={isPending}
+              className={s.submitButton()}
+            >
+              {isPending ? loadingLabel : submitLabel}
+            </Button>
+          </Form>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function LoginForm({
+  onSubmit,
+  isPending,
+  errorMessage,
+}: LoginFormProps) {
+  const { t } = useTranslation();
+
+  const form = useForm({
+    defaultValues: { email: '', password: '' },
+    onSubmit: async ({ value }) => {
+      await onSubmit(value);
+    },
+  });
+
+  return (
+    <LoginFormView
+      form={form}
+      isPending={isPending}
+      errorMessage={errorMessage}
+      emailLabel={t('login.email')}
+      passwordLabel={t('login.password')}
+      title={t('login.title')}
+      loadingLabel={t('login.loading')}
+      submitLabel={t('login.submit')}
+    />
+  );
+}

--- a/apps/frontend/src/hooks/auth/useLogin.ts
+++ b/apps/frontend/src/hooks/auth/useLogin.ts
@@ -1,0 +1,47 @@
+import { useMutation } from '@tanstack/react-query';
+import { isHTTPError } from 'ky';
+import { api } from '../../lib/api';
+
+type LoginResponse = {
+  access_token?: string;
+};
+
+export type LoginPayload = {
+  email: string;
+  password: string;
+};
+
+export function useLogin() {
+  return useMutation({
+    mutationFn: async ({ email, password }: LoginPayload) => {
+      try {
+        const body = new URLSearchParams();
+        body.append('username', email);
+        body.append('password', password);
+
+        const data = await api
+          .post('auth/login', {
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body,
+          })
+          .json<LoginResponse>();
+
+        if (!data.access_token) {
+          throw new Error('login.unexpectedError');
+        }
+
+        return data.access_token;
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith('login.')) {
+          throw error;
+        }
+
+        if (isHTTPError(error) && error.response.status === 401) {
+          throw new Error('login.invalidCredentials', { cause: error });
+        }
+
+        throw new Error('login.connectionError', { cause: error });
+      }
+    },
+  });
+}

--- a/apps/frontend/src/hooks/auth/useLogin.ts
+++ b/apps/frontend/src/hooks/auth/useLogin.ts
@@ -1,34 +1,45 @@
 import { useMutation } from '@tanstack/react-query';
 import { isHTTPError } from 'ky';
+import { z } from 'zod';
 import { api } from '../../lib/api';
 
-type LoginResponse = {
-  access_token?: string;
-};
+const LoginPayloadSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+const LoginResponseSchema = z.object({
+  access_token: z.string().min(1),
+});
 
 export type LoginPayload = {
   email: string;
   password: string;
 };
 
+function withCause(message: string, cause: unknown): Error {
+  const error = new Error(message) as Error & { cause?: unknown };
+  error.cause = cause;
+  return error;
+}
+
 export function useLogin() {
   return useMutation({
     mutationFn: async ({ email, password }: LoginPayload) => {
       try {
+        const payload = LoginPayloadSchema.parse({ email, password });
         const body = new URLSearchParams();
-        body.append('username', email);
-        body.append('password', password);
+        body.append('username', payload.email);
+        body.append('password', payload.password);
 
-        const data = await api
+        const raw = await api
           .post('auth/login', {
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body,
           })
-          .json<LoginResponse>();
+          .json<unknown>();
 
-        if (!data.access_token) {
-          throw new Error('login.unexpectedError');
-        }
+        const data = LoginResponseSchema.parse(raw);
 
         return data.access_token;
       } catch (error) {
@@ -36,11 +47,15 @@ export function useLogin() {
           throw error;
         }
 
-        if (isHTTPError(error) && error.response.status === 401) {
-          throw new Error('login.invalidCredentials', { cause: error });
+        if (error instanceof z.ZodError) {
+          throw withCause('login.unexpectedError', error);
         }
 
-        throw new Error('login.connectionError', { cause: error });
+        if (isHTTPError(error) && error.response.status === 401) {
+          throw withCause('login.invalidCredentials', error);
+        }
+
+        throw withCause('login.connectionError', error);
       }
     },
   });

--- a/apps/frontend/src/pages/Login.stories.tsx
+++ b/apps/frontend/src/pages/Login.stories.tsx
@@ -1,5 +1,5 @@
 import { delay, http, HttpResponse } from 'msw';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '../../.storybook/preview';
 import Login from './Login';
 import { useAuthStore } from '../stores/authStore';
@@ -134,6 +134,8 @@ SubmitSuccess.test('logs user in after submit', async ({ canvasElement }) => {
     await canvas.findByRole('button', { name: /se connecter|sign in/i })
   );
 
-  await expect(useAuthStore.getState().token).toBe('storybook-jwt-token');
-  await expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  await waitFor(() => {
+    expect(useAuthStore.getState().token).toBe('storybook-jwt-token');
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
 });

--- a/apps/frontend/src/pages/Login.stories.tsx
+++ b/apps/frontend/src/pages/Login.stories.tsx
@@ -1,0 +1,139 @@
+import { delay, http, HttpResponse } from 'msw';
+import { expect, userEvent, within } from 'storybook/test';
+import preview from '../../.storybook/preview';
+import Login from './Login';
+import { useAuthStore } from '../stores/authStore';
+
+const meta = preview.meta({
+  title: 'Pages/Login',
+  component: Login,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+});
+
+const successHandler = http.post('*/api/auth/login', async () => {
+  await delay(200);
+  return HttpResponse.json({ access_token: 'storybook-jwt-token' });
+});
+
+export const Default = meta.story({
+  name: 'Default',
+  beforeEach: () => {
+    useAuthStore.setState({ token: null, isAuthenticated: false });
+    localStorage.removeItem('parapente-auth');
+  },
+  parameters: {
+    msw: {
+      handlers: [successHandler],
+    },
+  },
+});
+
+Default.test('renders login form', async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await canvas.findByLabelText(/email/i);
+  await canvas.findByLabelText(/mot de passe|password/i);
+  await canvas.findByRole('button', { name: /se connecter|sign in/i });
+});
+
+export const Loading = meta.story({
+  name: 'Loading',
+  beforeEach: () => {
+    useAuthStore.setState({ token: null, isAuthenticated: false });
+    localStorage.removeItem('parapente-auth');
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('*/api/auth/login', async () => {
+          await new Promise(() => {});
+        }),
+      ],
+    },
+  },
+});
+
+Loading.test('shows pending state after submit', async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.type(await canvas.findByLabelText(/email/i), 'test@test.dev');
+  await userEvent.type(
+    await canvas.findByLabelText(/mot de passe|password/i),
+    'secret123'
+  );
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /se connecter|sign in/i })
+  );
+
+  await canvas.findByRole('button', { name: /connexion|signing in/i });
+});
+
+export const InvalidCredentials = meta.story({
+  name: 'Invalid Credentials',
+  beforeEach: () => {
+    useAuthStore.setState({ token: null, isAuthenticated: false });
+    localStorage.removeItem('parapente-auth');
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('*/api/auth/login', () => {
+          return new HttpResponse(null, { status: 401 });
+        }),
+      ],
+    },
+  },
+});
+
+InvalidCredentials.test(
+  'shows API error message',
+  async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(
+      await canvas.findByLabelText(/email/i),
+      'wrong@test.dev'
+    );
+    await userEvent.type(
+      await canvas.findByLabelText(/mot de passe|password/i),
+      'wrong-pass'
+    );
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /se connecter|sign in/i })
+    );
+
+    await canvas.findByText(/incorrect|invalid/i);
+  }
+);
+
+export const SubmitSuccess = meta.story({
+  name: 'Submit Success',
+  beforeEach: () => {
+    useAuthStore.setState({ token: null, isAuthenticated: false });
+    localStorage.removeItem('parapente-auth');
+  },
+  parameters: {
+    msw: {
+      handlers: [successHandler],
+    },
+  },
+});
+
+SubmitSuccess.test('logs user in after submit', async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+
+  await userEvent.type(
+    await canvas.findByLabelText(/email/i),
+    'pilot@test.dev'
+  );
+  await userEvent.type(
+    await canvas.findByLabelText(/mot de passe|password/i),
+    'very-secret'
+  );
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /se connecter|sign in/i })
+  );
+
+  await expect(useAuthStore.getState().token).toBe('storybook-jwt-token');
+  await expect(useAuthStore.getState().isAuthenticated).toBe(true);
+});

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -1,122 +1,36 @@
 import { useNavigate } from '@tanstack/react-router';
-import { useForm } from '@tanstack/react-form';
 import { useTranslation } from 'react-i18next';
-import { TextField, Label, Input, Form } from 'react-aria-components';
-import { Button } from '@dashboard-parapente/design-system';
+import { useState } from 'react';
+import { LoginForm } from '../components/auth/LoginForm';
+import { useLogin } from '../hooks/auth/useLogin';
 import { useAuthStore } from '../stores/authStore';
 
 export default function Login() {
   const { t } = useTranslation();
   const login = useAuthStore((s) => s.login);
   const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const loginMutation = useLogin();
 
-  const form = useForm({
-    defaultValues: { email: '', password: '' },
-    onSubmit: async ({ value }) => {
-      const body = new URLSearchParams();
-      body.append('username', value.email);
-      body.append('password', value.password);
+  const handleSubmit = async (value: { email: string; password: string }) => {
+    setErrorMessage(undefined);
 
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body,
-      });
-
-      if (!res.ok) {
-        throw new Error(t('login.invalidCredentials'));
-      }
-
-      const data = await res.json();
-      if (!data.access_token) {
-        throw new Error(t('login.unexpectedError'));
-      }
-
-      login(data.access_token);
-      navigate({ to: '/' });
-    },
-  });
-
-  const inputClass =
-    'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-sky-500 focus:border-transparent outline-none';
-  const labelClass =
-    'block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1';
+    try {
+      const token = await loginMutation.mutateAsync(value);
+      login(token);
+      await navigate({ to: '/' });
+    } catch (error) {
+      const key =
+        error instanceof Error ? error.message : 'login.unexpectedError';
+      setErrorMessage(t(key));
+    }
+  };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
-      <div className="w-full max-w-sm">
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8">
-          <h1 className="text-2xl font-semibold text-center text-sky-600 dark:text-sky-400 mb-6">
-            {t('login.title')}
-          </h1>
-
-          <Form
-            onSubmit={(e) => {
-              e.preventDefault();
-              form.handleSubmit();
-            }}
-            className="space-y-4"
-          >
-            <form.Field name="email">
-              {(field) => (
-                <TextField
-                  isRequired
-                  value={field.state.value}
-                  onChange={field.handleChange}
-                >
-                  <Label className={labelClass}>{t('login.email')}</Label>
-                  <Input
-                    id="email"
-                    type="email"
-                    autoComplete="username"
-                    className={inputClass}
-                  />
-                </TextField>
-              )}
-            </form.Field>
-
-            <form.Field name="password">
-              {(field) => (
-                <TextField
-                  isRequired
-                  value={field.state.value}
-                  onChange={field.handleChange}
-                >
-                  <Label className={labelClass}>{t('login.password')}</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    autoComplete="current-password"
-                    className={inputClass}
-                  />
-                </TextField>
-              )}
-            </form.Field>
-
-            <form.Subscribe selector={(state) => state.errorMap.onSubmit}>
-              {(errorMap) =>
-                errorMap ? (
-                  <p className="text-sm text-red-500 dark:text-red-400">
-                    {String(errorMap)}
-                  </p>
-                ) : null
-              }
-            </form.Subscribe>
-
-            <form.Subscribe selector={(state) => state.isSubmitting}>
-              {(isSubmitting) => (
-                <Button
-                  type="submit"
-                  isDisabled={isSubmitting}
-                  className="w-full py-2.5 bg-sky-600 hover:bg-sky-700 disabled:bg-sky-400 text-white font-medium rounded-lg transition-colors pressed:bg-sky-800"
-                >
-                  {isSubmitting ? t('login.loading') : t('login.submit')}
-                </Button>
-              )}
-            </form.Subscribe>
-          </Form>
-        </div>
-      </div>
-    </div>
+    <LoginForm
+      onSubmit={handleSubmit}
+      isPending={loginMutation.isPending}
+      errorMessage={errorMessage}
+    />
   );
 }

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -909,7 +909,7 @@ function PerformanceSection() {
                       onBlur={(event) =>
                         handleBackendSetting(item.key, event.target.value)
                       }
-                      className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm"
+                      className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
                     />
                   </label>
                 ))}
@@ -1082,7 +1082,8 @@ export default function Settings() {
             >
               {tabKey === 'general' && `🎛️ ${t('settings.tabs.general')}`}
               {tabKey === 'sites' && `📍 ${t('settings.tabs.favoriteSites')}`}
-              {tabKey === 'weather' && `🌦️ ${t('settings.tabs.weatherSources')}`}
+              {tabKey === 'weather' &&
+                `🌦️ ${t('settings.tabs.weatherSources')}`}
               {tabKey === 'data' && `💾 ${t('settings.tabs.data')}`}
             </Tab>
           ))}
@@ -1368,20 +1369,20 @@ export default function Settings() {
 
           {/* SITES TAB */}
           <TabPanel id="sites" className="outline-none">
-          <Suspense
-            fallback={
-              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md animate-pulse space-y-3">
-                {[...Array(4)].map((_, i) => (
-                  <div
-                    key={i}
-                    className="h-16 bg-gray-200 dark:bg-gray-600 rounded-lg"
-                  ></div>
-                ))}
-              </div>
-            }
-          >
-            <SitesTab settings={settings} toggleFavorite={toggleFavorite} />
-          </Suspense>
+            <Suspense
+              fallback={
+                <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md animate-pulse space-y-3">
+                  {[...Array(4)].map((_, i) => (
+                    <div
+                      key={i}
+                      className="h-16 bg-gray-200 dark:bg-gray-600 rounded-lg"
+                    ></div>
+                  ))}
+                </div>
+              }
+            >
+              <SitesTab settings={settings} toggleFavorite={toggleFavorite} />
+            </Suspense>
           </TabPanel>
 
           {/* WEATHER SOURCES TAB */}
@@ -1391,67 +1392,67 @@ export default function Settings() {
 
           {/* DATA TAB */}
           <TabPanel id="data" className="outline-none">
-          <div className="space-y-4">
-            {/* Export/Import Section */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                💾 {t('settings.data.backupTitle')}
-              </h2>
-              <div className="space-y-3">
+            <div className="space-y-4">
+              {/* Export/Import Section */}
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                  💾 {t('settings.data.backupTitle')}
+                </h2>
+                <div className="space-y-3">
+                  <Button
+                    onClick={exportData}
+                    className="w-full px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2"
+                  >
+                    <span>📥</span>
+                    {t('settings.data.export')}
+                  </Button>
+                  <label className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2 cursor-pointer">
+                    <span>📤</span>
+                    {t('settings.data.import')}
+                    <input
+                      type="file"
+                      accept=".json"
+                      onChange={importData}
+                      className="hidden"
+                    />
+                  </label>
+                </div>
+                <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg text-sm text-yellow-800 dark:text-yellow-200">
+                  ⚠️ {t('settings.data.importWarning')}
+                </div>
+              </div>
+
+              {/* Clear Data Section */}
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                  🗑️ {t('settings.data.resetTitle')}
+                </h2>
                 <Button
-                  onClick={exportData}
-                  className="w-full px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2"
+                  onClick={clearData}
+                  className="w-full px-6 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all"
                 >
-                  <span>📥</span>
-                  {t('settings.data.export')}
+                  {t('settings.data.resetAll')}
                 </Button>
-                <label className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2 cursor-pointer">
-                  <span>📤</span>
-                  {t('settings.data.import')}
-                  <input
-                    type="file"
-                    accept=".json"
-                    onChange={importData}
-                    className="hidden"
-                  />
-                </label>
+                <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200">
+                  ⚠️ {t('settings.data.resetWarning')}
+                </div>
               </div>
-              <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg text-sm text-yellow-800 dark:text-yellow-200">
-                ⚠️ {t('settings.data.importWarning')}
-              </div>
-            </div>
 
-            {/* Clear Data Section */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                🗑️ {t('settings.data.resetTitle')}
-              </h2>
-              <Button
-                onClick={clearData}
-                className="w-full px-6 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all"
-              >
-                {t('settings.data.resetAll')}
-              </Button>
-              <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200">
-                ⚠️ {t('settings.data.resetWarning')}
+              {/* User Profile Placeholder */}
+              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
+                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
+                  👤 {t('settings.profile.title')}
+                </h2>
+                <div className="p-8 bg-gray-50 dark:bg-gray-900 rounded-lg text-center">
+                  <p className="text-gray-600 dark:text-gray-300 mb-2">
+                    🚧 {t('settings.profile.wip')}
+                  </p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    {t('settings.profile.wipDetails')}
+                  </p>
+                </div>
               </div>
             </div>
-
-            {/* User Profile Placeholder */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                👤 {t('settings.profile.title')}
-              </h2>
-              <div className="p-8 bg-gray-50 dark:bg-gray-900 rounded-lg text-center">
-                <p className="text-gray-600 dark:text-gray-300 mb-2">
-                  🚧 {t('settings.profile.wip')}
-                </p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  {t('settings.profile.wipDetails')}
-                </p>
-              </div>
-            </div>
-          </div>
           </TabPanel>
         </div>
       </Tabs>


### PR DESCRIPTION
## Summary
- refactor `Login` page to keep only orchestration logic (auth store + navigation) and move network concerns to a dedicated React Query mutation hook
- add `LoginForm` component using `tailwind-variants` slots to replace inline Tailwind class strings and reduce function size
- add `Login` stories with MSW for visual states (`Default`, `Loading`, `InvalidCredentials`) and interactive submit success coverage (`SubmitSuccess`)

## Notes
- pre-commit hooks passed (`oxlint` + `oxfmt`) during commit
- full `pnpm nx lint/test/build frontend` could not be run in this environment because `pnpm` is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable login form with i18n-aware loading state, disabled submit, and clear error display.
  * Added a login hook to centralize authentication requests and standardized error mapping.

* **Refactor**
  * Login page now delegates UI to the reusable form and delegates auth logic to the new hook.

* **Bug Fixes**
  * Improved input text color contrast in Settings for light/dark modes.

* **Tests**
  * Added interactive stories/tests for success, pending, and invalid-credentials login scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->