### PR TITLE
fix(backend): avoid false FFmpeg stall detection

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -152,9 +152,7 @@ def test_ffmpeg_timeout_scales_for_long_videos():
 def test_ffmpeg_output_file_activity_tracks_size_and_mtime(tmp_path):
     output_file = tmp_path / "export.mp4"
 
-    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
-        output_file, -1, -1
-    )
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(output_file, -1, -1)
     assert activity is False
     assert size == -1
     assert mtime_ns == -1
@@ -165,6 +163,20 @@ def test_ffmpeg_output_file_activity_tracks_size_and_mtime(tmp_path):
     )
     assert activity is True
     assert size == 5
+
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, size, mtime_ns
+    )
+    assert activity is False
+
+    same_size_mtime_ns = mtime_ns + 1_000_000_000
+    os.utime(output_file, ns=(same_size_mtime_ns, same_size_mtime_ns))
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, size, mtime_ns
+    )
+    assert activity is True
+    assert size == 5
+    assert mtime_ns == same_size_mtime_ns
 
     activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
         output_file, size, mtime_ns

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -149,6 +149,36 @@ def test_ffmpeg_timeout_scales_for_long_videos():
     assert video_export_manual._ffmpeg_timeout_seconds(duration_seconds) == duration_seconds * 20
 
 
+def test_ffmpeg_output_file_activity_tracks_size_and_mtime(tmp_path):
+    output_file = tmp_path / "export.mp4"
+
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, -1, -1
+    )
+    assert activity is False
+    assert size == -1
+    assert mtime_ns == -1
+
+    output_file.write_bytes(b"first")
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, size, mtime_ns
+    )
+    assert activity is True
+    assert size == 5
+
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, size, mtime_ns
+    )
+    assert activity is False
+
+    output_file.write_bytes(b"second-pass")
+    activity, size, mtime_ns = video_export_manual._ffmpeg_output_file_activity(
+        output_file, size, mtime_ns
+    )
+    assert activity is True
+    assert size == 11
+
+
 def test_encoding_progress_percent_spans_encoding_phase_range():
     assert video_export_manual._encoding_progress_percent(0, 100) == 80
     assert video_export_manual._encoding_progress_percent(50, 100) == 89

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -630,6 +630,19 @@ def _ffmpeg_timeout_seconds(video_duration_seconds: float) -> int:
     return max(6 * 60 * 60, dynamic_timeout)
 
 
+def _ffmpeg_output_file_activity(
+    output_file: Path, last_size: int, last_mtime_ns: int
+) -> tuple[bool, int, int]:
+    try:
+        stat = output_file.stat()
+    except FileNotFoundError:
+        return False, last_size, last_mtime_ns
+
+    size = stat.st_size
+    mtime_ns = stat.st_mtime_ns
+    return size != last_size or mtime_ns != last_mtime_ns, size, mtime_ns
+
+
 def _encoding_progress_percent(encoded_seconds: float, total_duration_seconds: float) -> int:
     if total_duration_seconds <= 0:
         return 80
@@ -1203,6 +1216,8 @@ async def _export_video_manual_render(job_id: str):
             ffmpeg_stderr: list[str] = []
             total_duration_seconds = max(video_duration, 1e-6)
             ffmpeg_timeout_seconds = _ffmpeg_timeout_seconds(total_duration_seconds)
+            last_output_file_size = -1
+            last_output_file_mtime_ns = -1
 
             try:
                 assert process.stderr is not None
@@ -1219,6 +1234,18 @@ async def _export_video_manual_render(job_id: str):
                         return
 
                     now = time.monotonic()
+                    (
+                        has_output_file_activity,
+                        last_output_file_size,
+                        last_output_file_mtime_ns,
+                    ) = _ffmpeg_output_file_activity(
+                        output_file,
+                        last_output_file_size,
+                        last_output_file_mtime_ns,
+                    )
+                    if has_output_file_activity:
+                        last_ffmpeg_output_at = now
+
                     if now - last_ffmpeg_output_at > _FFMPEG_STALL_TIMEOUT_SECONDS:
                         process.kill()
                         await process.wait()


### PR DESCRIPTION
## Summary
- Treat MP4 output file creation, size changes, or mtime updates as FFmpeg activity during manual video encoding.
- Keep the existing stderr-based progress handling and global encode timeout, while avoiding false 600s stall failures for quiet-but-active encodes.
- Add unit coverage for output-file activity tracking.

## Tests
- `python3 -m py_compile apps/backend/video_export_manual.py apps/backend/tests/unit/test_video_export_manual.py`
- Not run: `pnpm nx test backend -- test_video_export_manual.py` because `pnpm` is unavailable in this shell.
- Not run: `python3 -m pytest tests/unit/test_video_export_manual.py` because `pytest` is not installed for `python3` in this shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export stability by detecting real output-file activity (size/mtime) during encoding, yielding more accurate and timely stall detection.

* **Tests**
  * Added a unit test that validates tracking of output-file size and modification time across an encoding lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->