### PR TITLE
Improve hourly best spot timeline

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.stories.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.stories.tsx
@@ -158,6 +158,30 @@ const mockHourlyBestSpots = [
     score: 88,
     flyableSlot: '13h',
   },
+  {
+    ...mockBestSpotExcellent,
+    hour: 14,
+    score: 82,
+    flyableSlot: '14h',
+  },
+  {
+    ...mockBestSpotGood,
+    hour: 15,
+    score: 68,
+    flyableSlot: '15h',
+  },
+  {
+    ...mockBestSpotModerate,
+    hour: 16,
+    score: 48,
+    flyableSlot: '16h',
+  },
+  {
+    ...mockBestSpotPoor,
+    hour: 17,
+    score: 24,
+    flyableSlot: '17h',
+  },
 ];
 
 // Default story - Excellent conditions

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -345,16 +345,25 @@ export const BestSpotSuggestion = ({
                   )
                 );
                 const hourlyScoreColor = getScoreColor(hourlyScore);
+                const hourlyVerdict = getVerdict(
+                  hourlyScore,
+                  hourlySpot.verdict ?? undefined
+                );
                 const hourLabel =
                   selectedDayIndex === 0 && hourlySpot.hour === nowHour
                     ? t('common.now')
                     : `${hourlySpot.hour}h`;
+                const roundedWindSpeed =
+                  hourlySpot.windSpeed != null
+                    ? Math.round(hourlySpot.windSpeed)
+                    : null;
                 const windLabel =
-                  hourlySpot.windDirection && hourlySpot.windSpeed != null
-                    ? `${hourlySpot.windDirection} ${Math.round(
-                        hourlySpot.windSpeed
-                      )}km/h`
+                  hourlySpot.windDirection && roundedWindSpeed != null
+                    ? `${t('common.wind')} ${hourlySpot.windDirection} ${roundedWindSpeed} km/h`
                     : '—';
+                const orientationLabel = hourlySpot.site?.orientation
+                  ? `${t('sites.orientation')} ${hourlySpot.site.orientation}`
+                  : null;
 
                 return (
                   <Button
@@ -364,22 +373,45 @@ export const BestSpotSuggestion = ({
                         onSelectSite(hourlySpot.site.id);
                       }
                     }}
-                    className="min-w-[132px] rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-left hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900/30 dark:hover:bg-gray-900/60"
+                    className="min-w-[176px] rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-left shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/50 dark:hover:bg-gray-900"
                   >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-xs font-bold text-gray-900 dark:text-white">
+                    <div className="flex items-start justify-between gap-3">
+                      <span className="text-sm font-extrabold text-gray-900 dark:text-white">
                         {hourLabel}
                       </span>
-                      <span
-                        className={`text-xs font-bold ${hourlyScoreColor.text}`}
-                      >
-                        {hourlyScore}
-                      </span>
+                      <div className="text-right">
+                        <span
+                          className={`block text-xl font-black leading-none ${hourlyScoreColor.text}`}
+                        >
+                          {hourlyScore}
+                        </span>
+                        <span className="text-[10px] font-semibold text-gray-400 dark:text-gray-500">
+                          /100
+                        </span>
+                      </div>
                     </div>
-                    <div className="mt-1 truncate text-sm font-semibold text-gray-800 dark:text-gray-100">
+                    <div className="mt-2 h-1.5 rounded-full bg-gray-100 dark:bg-gray-700">
+                      <div
+                        className={`h-full rounded-full ${hourlyScoreColor.bg}`}
+                        style={{ width: `${hourlyScore}%` }}
+                      />
+                    </div>
+                    <div className="mt-2 truncate text-base font-bold text-gray-900 dark:text-gray-50">
                       {hourlySpot.site?.name ?? '—'}
                     </div>
-                    <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <div className="mt-2 flex items-center justify-between gap-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${hourlyVerdict.className}`}
+                      >
+                        {hourlyVerdict.label}
+                      </span>
+                      {orientationLabel && (
+                        <span className="truncate text-xs font-semibold text-gray-500 dark:text-gray-400">
+                          {orientationLabel}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-2 text-xs font-medium text-gray-600 dark:text-gray-300">
                       {windLabel}
                     </div>
                   </Button>

--- a/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
+++ b/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
@@ -34,7 +34,7 @@ export const bestSpotQueryOptions = (dayIndex = 0) =>
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
   });
 
-export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 8) =>
+export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 24) =>
   queryOptions<HourlyBestSpotsResult>({
     queryKey: ['bestSpot', 'hourly', dayIndex, hours],
     queryFn: async () => {
@@ -60,7 +60,7 @@ export function useBestSpotAPI(dayIndex = 0) {
   return useQuery(bestSpotQueryOptions(dayIndex));
 }
 
-export function useHourlyBestSpotsAPI(dayIndex = 0, hours = 8) {
+export function useHourlyBestSpotsAPI(dayIndex = 0, hours = 24) {
   return useQuery(hourlyBestSpotsQueryOptions(dayIndex, hours));
 }
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -127,7 +127,7 @@
     "forecast7Days": "7-Day Forecast",
     "bestSpotFor": "Best spot for {{date}}",
     "bestSpotTimeline": "Best spot hour by hour",
-    "byHour": "h, h+1...",
+    "byHour": "H -> end of day",
     "calculating": "Calculating...",
     "paraIndex": "Flight Conditions",
     "viewForecast": "View forecast →",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -127,7 +127,7 @@
     "forecast7Days": "Prévisions 7 Jours",
     "bestSpotFor": "Meilleur spot pour {{date}}",
     "bestSpotTimeline": "Meilleur spot heure par heure",
-    "byHour": "h, h+1...",
+    "byHour": "H -> fin de journée",
     "calculating": "Calcul en cours...",
     "paraIndex": "Conditions de vol",
     "viewForecast": "Voir les prévisions →",


### PR DESCRIPTION
## Summary
- Extend hourly best spot requests to cover the remaining day instead of only eight slots.
- Make each hourly best spot card more readable with a larger score, verdict badge, wind, and orientation.
- Update timeline labels and Storybook sample data for longer hourly timelines.

## Verification
- `git diff --check`
- Not run: `pnpm nx lint frontend` because `pnpm`, `npm`, and `corepack` are unavailable in this shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended hourly weather forecast window from 8 to 24 hours
  * Hourly cards now display wind speed, direction, site orientation, and weather verdict indicators
  * Added progress bars to hourly timeline cards

* **Style**
  * Redesigned hourly timeline card layout and visual presentation
  * Updated forecast range labels in English and French

<!-- end of auto-generated comment: release notes by coderabbit.ai -->