### PR TITLE
fix(frontend): use form submitting state for login

### DIFF
--- a/apps/frontend/src/components/auth/LoginForm.tsx
+++ b/apps/frontend/src/components/auth/LoginForm.tsx
@@ -6,7 +6,6 @@ import { Button } from '@dashboard-parapente/design-system';
 
 type LoginFormProps = {
   onSubmit: (value: { email: string; password: string }) => Promise<void>;
-  isPending: boolean;
   errorMessage?: string;
 };
 
@@ -63,7 +62,6 @@ function LoginFieldView({
 
 export function LoginForm({
   onSubmit,
-  isPending,
   errorMessage,
 }: LoginFormProps) {
   const { t } = useTranslation();
@@ -125,13 +123,17 @@ export function LoginForm({
               </p>
             ) : null}
 
-            <Button
-              type="submit"
-              isDisabled={isPending}
-              className={s.submitButton()}
-            >
-              {isPending ? t('login.loading') : t('login.submit')}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button
+                  type="submit"
+                  isDisabled={isSubmitting}
+                  className={s.submitButton()}
+                >
+                  {isSubmitting ? t('login.loading') : t('login.submit')}
+                </Button>
+              )}
+            </form.Subscribe>
           </Form>
         </div>
       </div>

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -31,7 +31,6 @@ export default function Login() {
   return (
     <LoginForm
       onSubmit={handleSubmit}
-      isPending={loginMutation.isPending}
       errorMessage={errorMessage}
     />
   );


### PR DESCRIPTION
## Summary
- Remove the external `isPending` prop from `LoginForm`.
- Drive the login submit button loading/disabled state from TanStack Form `isSubmitting`.

## Validation
- Not run: `pnpm`, `npm`, `npx`, and `corepack` are unavailable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized login form loading state management for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->