### PR TITLE
fix(frontend): clean up Cesium video exports

### DIFF
--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -267,6 +267,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     DEFAULT_CAMERA_TRANSITION_PERCENT
   );
   const cameraTargetRef = useRef<Cartesian3 | null>(null);
+  const currentTimestampRef = useRef<number | null>(null);
   const containerDivRef = useRef<HTMLDivElement>(null);
   const viewerUnitsRef = useRef<ViewerUnits>(viewerUnits);
 
@@ -1105,10 +1106,17 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         scenePosition.ratio >= 0.5
           ? scenePosition.nextIndex
           : scenePosition.previousIndex;
+      currentTimestampRef.current = scenePosition.timestamp;
       visiblePositionsRef.current = allPositionsRef.current.slice(
         0,
-        scenePosition.nextIndex + 1
+        scenePosition.previousIndex + 1
       );
+      if (scenePosition.ratio > 0) {
+        visiblePositionsRef.current = [
+          ...visiblePositionsRef.current,
+          scenePosition.position,
+        ];
+      }
 
       if (timestampsRef.current.length > 0) {
         const startTimestamp = timestampsRef.current[0];
@@ -1261,6 +1269,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
     realTimeStartRef.current = performance.now();
     gpxStartTimeRef.current =
+      currentTimestampRef.current ??
       timestampsRef.current[currentIndexRef.current] ??
       timestampsRef.current[0] ??
       0;
@@ -1653,11 +1662,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           .flight-viewer-export-only .cesium-viewer-timelineContainer,
           .flight-viewer-export-only .cesium-viewer-fullscreenContainer,
           .flight-viewer-export-only .cesium-infoBox,
-          .flight-viewer-export-only .cesium-selection-wrapper,
-          .flight-viewer-export-only .cesium-credit-logoContainer,
-          .flight-viewer-export-only .cesium-credit-textContainer,
-          .flight-viewer-export-only .cesium-credit-expand-link,
-          .flight-viewer-export-only .cesium-credit-lightbox-overlay {
+          .flight-viewer-export-only .cesium-selection-wrapper {
             display: none !important;
           }
         `}</style>

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -37,7 +37,7 @@ import {
   DEFAULT_CAMERA_TRANSITION_PERCENT,
   getFlightCameraDistance,
 } from '../../utils/cameraDistanceProfile';
-import { getExportFrameTargetIndex } from '../../utils/videoExportFrame';
+import { getExportFrameTarget } from '../../utils/videoExportFrame';
 import { api } from '../../lib/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
@@ -101,6 +101,7 @@ declare global {
     ) => {
       index: number;
       progress: number;
+      ratio: number;
       tilesLoaded: boolean;
     };
     _getExportMetadata?: () => {
@@ -114,7 +115,27 @@ interface FlightViewer3DProps {
   flightId: string;
   flightTitle?: string;
   compact?: boolean;
+  exportOnly?: boolean;
 }
+
+interface ScenePositionState {
+  position: Cartesian3;
+  previousIndex: number;
+  nextIndex: number;
+  ratio: number;
+  timestamp: number;
+}
+
+const interpolatePosition = (
+  start: Cartesian3,
+  end: Cartesian3,
+  ratio: number
+) =>
+  new Cartesian3(
+    start.x + (end.x - start.x) * ratio,
+    start.y + (end.y - start.y) * ratio,
+    start.z + (end.z - start.z) * ratio
+  );
 
 /**
  * AccordionSection - Collapsible section component for control panel
@@ -172,6 +193,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   flightId,
   flightTitle,
   compact = false,
+  exportOnly = false,
 }) => {
   const { t } = useTranslation();
   const resolvedFlightTitle = flightTitle || t('flights.viewer.defaultTitle');
@@ -235,7 +257,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const cursorPositionPropertyRef = useRef<ConstantPositionProperty | null>(
     null
   );
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
   const cameraHeadingRef = useRef<number>(0);
   const cameraDistanceRef = useRef<number>(500);
   const cameraCloseZoomPercentRef = useRef<number>(
@@ -354,9 +376,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           animation: false,
           timeline: false,
           baseLayerPicker: false,
+          geocoder: false,
+          homeButton: false,
           fullscreenButton: false,
           navigationHelpButton: false,
           sceneModePicker: false,
+          vrButton: false,
           infoBox: false,
           selectionIndicator: false,
         });
@@ -675,9 +700,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
     return () => {
       // Reset play state when changing flights
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
       }
       isPlayingRef.current = false;
       setIsPlaying(false);
@@ -913,6 +938,15 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const compactToggleButtonClassName = compact
     ? 'px-1.5 py-0.5 text-xs'
     : 'px-2 py-1 text-sm';
+  let viewerHeight = '600px';
+  if (exportOnly || isFullscreen) {
+    viewerHeight = '100%';
+  } else if (compact) {
+    viewerHeight = '420px';
+  }
+  const rootClassName = exportOnly
+    ? 'flight-viewer-export-only absolute inset-0 h-full w-full overflow-hidden bg-black'
+    : 'relative w-full overflow-hidden bg-gray-900';
 
   const toggleFullscreen = () => {
     if (!containerDivRef.current) return;
@@ -928,89 +962,248 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     }
   };
 
-  const setSceneToIndex = useCallback((targetIndex: number) => {
-    const lastIndex = allPositionsRef.current.length - 1;
-    if (lastIndex < 0) {
-      return { index: 0, progress: 0, tilesLoaded: false };
-    }
-
-    const safeIndex = Math.min(Math.max(targetIndex, 0), lastIndex);
-    currentIndexRef.current = safeIndex;
-    visiblePositionsRef.current = allPositionsRef.current.slice(
-      0,
-      safeIndex + 1
-    );
-
-    if (timestampsRef.current.length > 0) {
-      const currentTimestamp = timestampsRef.current[safeIndex];
-      const startTimestamp = timestampsRef.current[0];
-      setCurrentElapsedTime((currentTimestamp - startTimestamp) / 1000);
-    }
-
-    if (
-      cursorPositionPropertyRef.current &&
-      allPositionsRef.current[safeIndex]
-    ) {
-      cursorPositionPropertyRef.current.setValue(
-        allPositionsRef.current[safeIndex]
-      );
-    }
-
-    const viewer = viewerRef.current;
-    if (viewer && !viewer.isDestroyed()) {
-      const currentPosition = allPositionsRef.current[safeIndex];
-      const heading = cameraHeadingRef.current;
-      const progress = lastIndex > 0 ? safeIndex / lastIndex : 0;
-      const distance = getFlightCameraDistance({
-        progress,
-        baseDistance: cameraDistanceRef.current,
-        closeZoomPercent: cameraCloseZoomPercentRef.current,
-        transitionPercent: cameraTransitionPercentRef.current,
-      });
-      const pitch = -0.05;
-
-      cameraTargetRef.current = currentPosition;
-      viewer.camera.setView({
-        destination: currentPosition,
-        orientation: {
-          heading,
-          pitch,
-          roll: 0,
-        },
-      });
-      viewer.camera.moveBackward(distance);
-
-      const cameraCartographic = Cartographic.fromCartesian(
-        viewer.camera.position
-      );
-      const globe = viewer.scene.globe;
-      const terrainHeight = globe.getHeight(cameraCartographic);
-
-      if (
-        terrainHeight !== undefined &&
-        cameraCartographic.height < terrainHeight + 50
-      ) {
-        cameraCartographic.height = terrainHeight + 50;
-        viewer.camera.position = Cartesian3.fromRadians(
-          cameraCartographic.longitude,
-          cameraCartographic.latitude,
-          cameraCartographic.height
-        );
+  const getScenePositionFromTimestamp = useCallback(
+    (targetTimestamp: number): ScenePositionState | null => {
+      const positions = allPositionsRef.current;
+      const timestamps = timestampsRef.current;
+      const lastIndex = positions.length - 1;
+      if (lastIndex < 0) {
+        return null;
       }
 
-      viewer.scene.requestRender();
-      viewer.scene.render(viewer.clock.currentTime);
-    }
+      if (timestamps.length !== positions.length || timestamps.length < 2) {
+        const safeIndex = Math.min(
+          Math.max(currentIndexRef.current, 0),
+          lastIndex
+        );
+        return {
+          position: positions[safeIndex],
+          previousIndex: safeIndex,
+          nextIndex: safeIndex,
+          ratio: 0,
+          timestamp: timestamps[safeIndex] ?? 0,
+        };
+      }
 
-    const progress = lastIndex > 0 ? (safeIndex / lastIndex) * 100 : 0;
-    setCurrentProgress(progress);
+      if (targetTimestamp <= timestamps[0]) {
+        return {
+          position: positions[0],
+          previousIndex: 0,
+          nextIndex: 0,
+          ratio: 0,
+          timestamp: timestamps[0],
+        };
+      }
 
-    return {
-      index: safeIndex,
-      progress,
-      tilesLoaded: Boolean(viewer?.scene.globe.tilesLoaded),
-    };
-  }, []);
+      if (targetTimestamp >= timestamps[lastIndex]) {
+        return {
+          position: positions[lastIndex],
+          previousIndex: lastIndex,
+          nextIndex: lastIndex,
+          ratio: 0,
+          timestamp: timestamps[lastIndex],
+        };
+      }
+
+      let nextIndex = Math.max(currentIndexRef.current + 1, 1);
+      if (timestamps[nextIndex] < targetTimestamp) {
+        while (
+          nextIndex < timestamps.length - 1 &&
+          timestamps[nextIndex] < targetTimestamp
+        ) {
+          nextIndex += 1;
+        }
+      } else {
+        while (
+          nextIndex > 1 &&
+          timestamps[nextIndex - 1] > targetTimestamp
+        ) {
+          nextIndex -= 1;
+        }
+      }
+
+      const previousIndex = nextIndex - 1;
+      const previousTimestamp = timestamps[previousIndex];
+      const nextTimestamp = timestamps[nextIndex];
+      const segmentDuration = nextTimestamp - previousTimestamp;
+      const ratio =
+        segmentDuration > 0
+          ? Math.min(
+              Math.max(
+                (targetTimestamp - previousTimestamp) / segmentDuration,
+                0
+              ),
+              1
+            )
+          : 0;
+
+      return {
+        position: interpolatePosition(
+          positions[previousIndex],
+          positions[nextIndex],
+          ratio
+        ),
+        previousIndex,
+        nextIndex,
+        ratio,
+        timestamp: targetTimestamp,
+      };
+    },
+    []
+  );
+
+  const getScenePositionFromProgress = useCallback(
+    (targetProgress: number): ScenePositionState | null => {
+      const positions = allPositionsRef.current;
+      const lastIndex = positions.length - 1;
+      if (lastIndex < 0) {
+        return null;
+      }
+
+      const progress = Math.min(Math.max(targetProgress, 0), 1);
+      const timestamps = timestampsRef.current;
+      if (timestamps.length === positions.length && timestamps.length > 1) {
+        const startTimestamp = timestamps[0];
+        const endTimestamp = timestamps[timestamps.length - 1];
+        const durationMs = endTimestamp - startTimestamp;
+
+        if (durationMs > 0) {
+          return getScenePositionFromTimestamp(
+            startTimestamp + durationMs * progress
+          );
+        }
+      }
+
+      const exactIndex = progress * lastIndex;
+      const previousIndex = Math.floor(exactIndex);
+      const nextIndex = Math.ceil(exactIndex);
+      const ratio = exactIndex - previousIndex;
+
+      return {
+        position: interpolatePosition(
+          positions[previousIndex],
+          positions[nextIndex],
+          ratio
+        ),
+        previousIndex,
+        nextIndex,
+        ratio,
+        timestamp: timestamps[previousIndex] ?? 0,
+      };
+    },
+    [getScenePositionFromTimestamp]
+  );
+
+  const applyScenePosition = useCallback(
+    (scenePosition: ScenePositionState, smoothCamera: boolean) => {
+      const lastIndex = allPositionsRef.current.length - 1;
+      if (lastIndex < 0) {
+        return { index: 0, progress: 0, ratio: 0, tilesLoaded: false };
+      }
+
+      currentIndexRef.current =
+        scenePosition.ratio >= 0.5
+          ? scenePosition.nextIndex
+          : scenePosition.previousIndex;
+      visiblePositionsRef.current = allPositionsRef.current.slice(
+        0,
+        scenePosition.nextIndex + 1
+      );
+
+      if (timestampsRef.current.length > 0) {
+        const startTimestamp = timestampsRef.current[0];
+        setCurrentElapsedTime((scenePosition.timestamp - startTimestamp) / 1000);
+      }
+
+      if (cursorPositionPropertyRef.current) {
+        cursorPositionPropertyRef.current.setValue(scenePosition.position);
+      }
+
+      const viewer = viewerRef.current;
+      if (viewer && !viewer.isDestroyed()) {
+        const heading = cameraHeadingRef.current;
+        const progress =
+          lastIndex > 0
+            ? (scenePosition.previousIndex + scenePosition.ratio) / lastIndex
+            : 0;
+        const distance = getFlightCameraDistance({
+          progress,
+          baseDistance: cameraDistanceRef.current,
+          closeZoomPercent: cameraCloseZoomPercentRef.current,
+          transitionPercent: cameraTransitionPercentRef.current,
+        });
+        const pitch = -0.05;
+
+        if (!smoothCamera || !cameraTargetRef.current) {
+          cameraTargetRef.current = scenePosition.position;
+        } else {
+          const lerpFactor = 0.08;
+          cameraTargetRef.current = interpolatePosition(
+            cameraTargetRef.current,
+            scenePosition.position,
+            lerpFactor
+          );
+        }
+
+        viewer.camera.setView({
+          destination: cameraTargetRef.current,
+          orientation: {
+            heading,
+            pitch,
+            roll: 0,
+          },
+        });
+        viewer.camera.moveBackward(distance);
+
+        const cameraCartographic = Cartographic.fromCartesian(
+          viewer.camera.position
+        );
+        const globe = viewer.scene.globe;
+        const terrainHeight = globe.getHeight(cameraCartographic);
+
+        if (
+          terrainHeight !== undefined &&
+          cameraCartographic.height < terrainHeight + 50
+        ) {
+          cameraCartographic.height = terrainHeight + 50;
+          viewer.camera.position = Cartesian3.fromRadians(
+            cameraCartographic.longitude,
+            cameraCartographic.latitude,
+            cameraCartographic.height
+          );
+        }
+
+        viewer.scene.requestRender();
+        viewer.scene.render(viewer.clock.currentTime);
+      }
+
+      let progress = 0;
+      if (timestampsRef.current.length > 1) {
+        progress =
+          ((scenePosition.timestamp - timestampsRef.current[0]) /
+            Math.max(
+              timestampsRef.current[timestampsRef.current.length - 1] -
+                timestampsRef.current[0],
+              1
+            )) *
+          100;
+      } else if (lastIndex > 0) {
+        progress =
+          ((scenePosition.previousIndex + scenePosition.ratio) / lastIndex) *
+          100;
+      }
+      const safeProgress = Math.min(Math.max(progress, 0), 100);
+      setCurrentProgress(safeProgress);
+
+      return {
+        index: currentIndexRef.current,
+        progress: safeProgress,
+        ratio: scenePosition.ratio,
+        tilesLoaded: Boolean(viewer?.scene.globe.tilesLoaded),
+      };
+    },
+    []
+  );
 
   useEffect(() => {
     if (
@@ -1024,13 +1217,18 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     }
 
     window._setExportFrame = (frameIndex: number, totalFrames: number) => {
-      const targetIndex = getExportFrameTargetIndex(
+      const target = getExportFrameTarget(
         frameIndex,
         totalFrames,
         allPositionsRef.current.length
       );
+      const scenePosition = getScenePositionFromProgress(target.progress);
 
-      return setSceneToIndex(targetIndex);
+      if (!scenePosition) {
+        return { index: 0, progress: 0, ratio: 0, tilesLoaded: false };
+      }
+
+      return applyScenePosition(scenePosition, false);
     };
 
     window._getExportMetadata = () => ({
@@ -1048,156 +1246,67 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   }, [
     gpxData?.coordinates?.length,
     gpxData?.flight_duration_seconds,
-    setSceneToIndex,
+    applyScenePosition,
+    getScenePositionFromProgress,
     viewerReady,
   ]);
 
   const play = useCallback(() => {
-    if (intervalRef.current || allPositionsRef.current.length === 0) return;
+    if (animationFrameRef.current || allPositionsRef.current.length === 0) {
+      return;
+    }
 
     isPlayingRef.current = true;
     setIsPlaying(true);
 
-    realTimeStartRef.current = Date.now();
-    gpxStartTimeRef.current = timestampsRef.current[currentIndexRef.current];
+    realTimeStartRef.current = performance.now();
+    gpxStartTimeRef.current =
+      timestampsRef.current[currentIndexRef.current] ??
+      timestampsRef.current[0] ??
+      0;
 
-    intervalRef.current = setInterval(() => {
-      if (currentIndexRef.current >= allPositionsRef.current.length - 1) {
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-          intervalRef.current = null;
-        }
+    const step = (now: number) => {
+      const lastTimestamp =
+        timestampsRef.current[timestampsRef.current.length - 1];
+      if (!isPlayingRef.current || gpxStartTimeRef.current >= lastTimestamp) {
+        animationFrameRef.current = null;
         isPlayingRef.current = false;
         setIsPlaying(false);
         return;
       }
 
-      // Utiliser la vitesse directement (x1 = temps réel, x10 par défaut)
       const speed = speedRef.current;
-      const elapsedRealTime = Date.now() - realTimeStartRef.current;
+      const elapsedRealTime = now - realTimeStartRef.current;
       const elapsedGpxTime = elapsedRealTime * speed;
       const targetGpxTime = gpxStartTimeRef.current + elapsedGpxTime;
+      const scenePosition = getScenePositionFromTimestamp(targetGpxTime);
 
-      let targetIndex = currentIndexRef.current;
-      for (
-        let i = currentIndexRef.current;
-        i < timestampsRef.current.length;
-        i++
-      ) {
-        if (timestampsRef.current[i] <= targetGpxTime) {
-          targetIndex = i;
-        } else {
-          break;
+      if (!scenePosition || scenePosition.timestamp >= lastTimestamp) {
+        const endPosition = getScenePositionFromProgress(1);
+        if (endPosition) {
+          applyScenePosition(endPosition, true);
         }
+        animationFrameRef.current = null;
+        isPlayingRef.current = false;
+        setIsPlaying(false);
+        return;
       }
 
-      if (targetIndex > currentIndexRef.current) {
-        currentIndexRef.current = targetIndex;
-        visiblePositionsRef.current = allPositionsRef.current.slice(
-          0,
-          currentIndexRef.current + 1
-        );
+      applyScenePosition(scenePosition, true);
+      animationFrameRef.current = requestAnimationFrame(step);
+    };
 
-        // Calculate elapsed time
-        if (timestampsRef.current.length > 0) {
-          const currentTimestamp =
-            timestampsRef.current[currentIndexRef.current];
-          const startTimestamp = timestampsRef.current[0];
-          const elapsedMs = currentTimestamp - startTimestamp;
-          setCurrentElapsedTime(elapsedMs / 1000); // Convert to seconds
-        }
-
-        if (cursorPositionPropertyRef.current) {
-          cursorPositionPropertyRef.current.setValue(
-            allPositionsRef.current[currentIndexRef.current]
-          );
-        }
-
-        // Suivre le curseur avec la caméra
-        const viewer = viewerRef.current;
-        if (viewer && !viewer.isDestroyed()) {
-          const currentPosition =
-            allPositionsRef.current[currentIndexRef.current];
-          const heading = cameraHeadingRef.current;
-          const progress =
-            allPositionsRef.current.length > 1
-              ? currentIndexRef.current / (allPositionsRef.current.length - 1)
-              : 0;
-          const distance = getFlightCameraDistance({
-            progress,
-            baseDistance: cameraDistanceRef.current,
-            closeZoomPercent: cameraCloseZoomPercentRef.current,
-            transitionPercent: cameraTransitionPercentRef.current,
-          });
-          const pitch = -0.05;
-
-          // Smooth lerp vers la position actuelle
-          if (!cameraTargetRef.current) {
-            cameraTargetRef.current = currentPosition;
-          } else {
-            const lerpFactor = 0.08;
-            cameraTargetRef.current = new Cartesian3(
-              cameraTargetRef.current.x +
-                (currentPosition.x - cameraTargetRef.current.x) * lerpFactor,
-              cameraTargetRef.current.y +
-                (currentPosition.y - cameraTargetRef.current.y) * lerpFactor,
-              cameraTargetRef.current.z +
-                (currentPosition.z - cameraTargetRef.current.z) * lerpFactor
-            );
-          }
-
-          // Use setView instead of lookAt for better control
-          viewer.camera.setView({
-            destination: cameraTargetRef.current,
-            orientation: {
-              heading,
-              pitch,
-              roll: 0,
-            },
-          });
-
-          // Move camera back by distance
-          viewer.camera.moveBackward(distance);
-
-          // Check terrain collision and adjust camera height if needed
-          const cameraCartographic = Cartographic.fromCartesian(
-            viewer.camera.position
-          );
-          const globe = viewer.scene.globe;
-          const terrainHeight = globe.getHeight(cameraCartographic);
-
-          if (
-            terrainHeight !== undefined &&
-            cameraCartographic.height < terrainHeight + 50
-          ) {
-            // Camera is too low, lift it above terrain (minimum 50m above ground)
-            cameraCartographic.height = terrainHeight + 50;
-            viewer.camera.position = Cartesian3.fromRadians(
-              cameraCartographic.longitude,
-              cameraCartographic.latitude,
-              cameraCartographic.height
-            );
-          }
-        }
-
-        // Mettre à jour le slider de progression
-        const progress =
-          (currentIndexRef.current / (allPositionsRef.current.length - 1)) *
-          100;
-        setCurrentProgress(progress);
-
-        // Forcer le rendu Cesium pour mettre à jour la polyline progressive
-        if (viewerRef.current && !viewerRef.current.isDestroyed()) {
-          viewerRef.current.scene.requestRender();
-        }
-      }
-    }, 16);
-  }, []);
+    animationFrameRef.current = requestAnimationFrame(step);
+  }, [
+    applyScenePosition,
+    getScenePositionFromProgress,
+    getScenePositionFromTimestamp,
+  ]);
 
   const pause = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
     }
     isPlayingRef.current = false;
     setIsPlaying(false);
@@ -1239,32 +1348,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         pause();
       }
 
-      // Calculer le nouvel index
-      const newIndex = Math.floor(
-        (value / 100) * (allPositionsRef.current.length - 1)
-      );
-      currentIndexRef.current = newIndex;
-      setCurrentProgress(value);
-
-      // Mettre à jour la trace visible
-      visiblePositionsRef.current = allPositionsRef.current.slice(
-        0,
-        newIndex + 1
-      );
-
-      // Mettre à jour le curseur
-      if (
-        cursorPositionPropertyRef.current &&
-        allPositionsRef.current[newIndex]
-      ) {
-        cursorPositionPropertyRef.current.setValue(
-          allPositionsRef.current[newIndex]
-        );
-      }
-
-      // Forcer le rendu
-      if (viewerRef.current && !viewerRef.current.isDestroyed()) {
-        viewerRef.current.scene.requestRender();
+      const scenePosition = getScenePositionFromProgress(value / 100);
+      if (scenePosition) {
+        applyScenePosition(scenePosition, false);
       }
 
       // Reprendre la lecture si elle était active
@@ -1272,7 +1358,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         setTimeout(() => play(), 50);
       }
     },
-    [pause, play]
+    [applyScenePosition, getScenePositionFromProgress, pause, play]
   );
 
   const handleSpeedChange = (value: number) => {
@@ -1549,14 +1635,38 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   return (
     <div
       ref={containerDivRef}
-      className="relative w-full bg-gray-900"
-      style={{ height: isFullscreen ? '100vh' : compact ? '420px' : '600px' }}
+      className={rootClassName}
+      style={{ height: viewerHeight }}
+      data-testid="flight-viewer-root"
     >
+      {exportOnly && (
+        <style>{`
+          .flight-viewer-export-only .cesium-viewer,
+          .flight-viewer-export-only .cesium-widget,
+          .flight-viewer-export-only .cesium-widget canvas {
+            width: 100% !important;
+            height: 100% !important;
+          }
+
+          .flight-viewer-export-only .cesium-viewer-toolbar,
+          .flight-viewer-export-only .cesium-viewer-animationContainer,
+          .flight-viewer-export-only .cesium-viewer-timelineContainer,
+          .flight-viewer-export-only .cesium-viewer-fullscreenContainer,
+          .flight-viewer-export-only .cesium-infoBox,
+          .flight-viewer-export-only .cesium-selection-wrapper,
+          .flight-viewer-export-only .cesium-credit-logoContainer,
+          .flight-viewer-export-only .cesium-credit-textContainer,
+          .flight-viewer-export-only .cesium-credit-expand-link,
+          .flight-viewer-export-only .cesium-credit-lightbox-overlay {
+            display: none !important;
+          }
+        `}</style>
+      )}
       {/* Overlay for loading/error states */}
       {renderOverlay()}
 
       {/* Bouton plein écran */}
-      {gpxData?.coordinates && (
+      {gpxData?.coordinates && !exportOnly && (
         <Button
           onClick={toggleFullscreen}
           className={`absolute top-4 right-4 z-10 bg-gray-800 text-white rounded-lg shadow-lg hover:bg-gray-700 ${fullscreenButtonClassName}`}
@@ -1573,7 +1683,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       )}
 
       {/* Controls - only show when data is loaded */}
-      {gpxData?.coordinates && (
+      {gpxData?.coordinates && !exportOnly && (
         <div
           className={`absolute top-4 left-4 z-10 bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all ${panelClassName} max-h-[calc(100%-2rem)] overflow-hidden flex flex-col`}
         >
@@ -2233,7 +2343,10 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       )}
 
       {/* Cesium Container */}
-      <div ref={containerRef} className="w-full h-full" />
+      <div
+        ref={containerRef}
+        className={exportOnly ? 'absolute inset-0 h-full w-full' : 'h-full w-full'}
+      />
     </div>
   );
 };

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -312,7 +312,7 @@ describe('FlightViewer3D video export mode', () => {
     render(<FlightViewer3D flightId="flight-1" exportOnly />);
 
     await waitFor(() => {
-      expect(viewerOptions.at(-1)).toMatchObject({
+      expect(viewerOptions[viewerOptions.length - 1]).toMatchObject({
         animation: false,
         timeline: false,
         baseLayerPicker: false,

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -2,18 +2,20 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { apiGet, apiPost, invalidateQueries, mockFlight } = vi.hoisted(() => ({
-  apiGet: vi.fn(),
-  apiPost: vi.fn(),
-  invalidateQueries: vi.fn(),
-  mockFlight: {
-    gpx_file_path: 'sample.gpx',
-    video_export_status: null as string | null,
-    video_export_job_id: null as string | null,
-    video_file_path: null as string | null,
-    site: null,
-  },
-}));
+const { apiGet, apiPost, invalidateQueries, mockFlight, viewerOptions } =
+  vi.hoisted(() => ({
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    invalidateQueries: vi.fn(),
+    viewerOptions: [] as unknown[],
+    mockFlight: {
+      gpx_file_path: 'sample.gpx',
+      video_export_status: null as string | null,
+      video_export_job_id: null as string | null,
+      video_file_path: null as string | null,
+      site: null,
+    },
+  }));
 
 vi.mock('cesium', () => {
   class Cartesian3 {
@@ -80,6 +82,10 @@ vi.mock('cesium', () => {
     };
     shadows = false;
     terrainShadows = 0;
+
+    constructor(_container: Element, options: unknown) {
+      viewerOptions.push(options);
+    }
 
     isDestroyed() {
       return false;
@@ -219,12 +225,29 @@ import { FlightViewer3D } from './FlightViewer3D';
 describe('FlightViewer3D video export mode', () => {
   const originalCreateObjectURL = URL.createObjectURL;
   const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientHeight'
+  );
+  const originalClientWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientWidth'
+  );
 
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 768,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+      configurable: true,
+      value: 1024,
+    });
     apiPost.mockResolvedValue(undefined);
     apiGet.mockReset();
     apiPost.mockClear();
     invalidateQueries.mockClear();
+    viewerOptions.length = 0;
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
@@ -239,6 +262,20 @@ describe('FlightViewer3D video export mode', () => {
       configurable: true,
       value: originalRevokeObjectURL,
     });
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientHeight',
+        originalClientHeight
+      );
+    }
+    if (originalClientWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientWidth',
+        originalClientWidth
+      );
+    }
   });
 
   it('starts fast smooth export by default and shows its hint', async () => {
@@ -251,6 +288,42 @@ describe('FlightViewer3D video export mode', () => {
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
         searchParams: { mode: 'manual_fast' },
+      });
+    });
+  });
+
+  it('hides viewer controls in export-only mode', () => {
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    expect(screen.getByTestId('flight-viewer-root')).toHaveAttribute(
+      'style',
+      'height: 100%;'
+    );
+    expect(screen.getByTestId('flight-viewer-root')).toHaveClass(
+      'flight-viewer-export-only'
+    );
+    expect(screen.queryByText('Fast hint')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Generate video/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables Cesium interface widgets', async () => {
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(viewerOptions.at(-1)).toMatchObject({
+        animation: false,
+        timeline: false,
+        baseLayerPicker: false,
+        geocoder: false,
+        homeButton: false,
+        fullscreenButton: false,
+        navigationHelpButton: false,
+        sceneModePicker: false,
+        vrButton: false,
+        infoBox: false,
+        selectionIndicator: false,
       });
     });
   });

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -35,13 +35,14 @@ function RootComponent() {
   const { t } = useTranslation();
   const matchRoute = useMatchRoute();
   const isLoginPage = matchRoute({ to: '/login' });
+  const isExportViewerPage = matchRoute({ to: '/export-viewer' });
   const appVersion = Route.useLoaderData();
   const version = appVersion?.version ?? null;
   const { latestVersion, releaseNotesUrl } = useVersionUpdates(
-    isLoginPage ? null : version
+    isLoginPage || isExportViewerPage ? null : version
   );
 
-  if (isLoginPage) {
+  if (isLoginPage || isExportViewerPage) {
     return <Outlet />;
   }
 

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -8,7 +8,16 @@ import { appVersionQueryOptions } from '../hooks/common/useAppVersion';
 import { useVersionUpdates } from '../hooks/common/useVersionUpdates';
 
 export const Route = createRootRoute({
-  loader: () => queryClient.ensureQueryData(appVersionQueryOptions()),
+  loader: ({ location }) => {
+    if (
+      location.pathname === '/login' ||
+      location.pathname === '/export-viewer'
+    ) {
+      return null;
+    }
+
+    return queryClient.ensureQueryData(appVersionQueryOptions());
+  },
   component: RootComponent,
   pendingComponent: PendingComponent,
 });

--- a/apps/frontend/src/routes/export-viewer.lazy.tsx
+++ b/apps/frontend/src/routes/export-viewer.lazy.tsx
@@ -17,7 +17,7 @@ function ExportViewer() {
 
   if (!flightId) {
     return (
-      <div className="flex items-center justify-center h-screen">
+      <div className="fixed inset-0 flex items-center justify-center bg-black">
         <p className="text-gray-600 dark:text-gray-300">
           No flight ID provided. Use ?flightId=xxx
         </p>
@@ -26,15 +26,15 @@ function ExportViewer() {
   }
 
   return (
-    <div className="w-full h-screen">
+    <div className="fixed inset-0 overflow-hidden bg-black">
       <Suspense
         fallback={
-          <div className="h-screen flex items-center justify-center text-gray-500 dark:text-gray-400">
+          <div className="flex h-screen items-center justify-center text-gray-500 dark:text-gray-400">
             Chargement...
           </div>
         }
       >
-        <FlightViewer3D flightId={flightId} />
+        <FlightViewer3D flightId={flightId} exportOnly />
       </Suspense>
     </div>
   );

--- a/apps/frontend/src/utils/videoExportFrame.test.ts
+++ b/apps/frontend/src/utils/videoExportFrame.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getExportFrameTargetIndex } from './videoExportFrame';
+import {
+  getExportFrameTarget,
+  getExportFrameTargetIndex,
+} from './videoExportFrame';
 
 describe('getExportFrameTargetIndex', () => {
   it('maps first, middle and last frames to stable position indexes', () => {
@@ -16,5 +19,31 @@ describe('getExportFrameTargetIndex', () => {
   it('handles empty or single-position tracks', () => {
     expect(getExportFrameTargetIndex(5, 11, 0)).toBe(0);
     expect(getExportFrameTargetIndex(5, 11, 1)).toBe(0);
+  });
+});
+
+describe('getExportFrameTarget', () => {
+  it('returns interpolation data between GPS indexes', () => {
+    expect(getExportFrameTarget(1, 5, 3)).toEqual({
+      progress: 0.25,
+      previousIndex: 0,
+      nextIndex: 1,
+      ratio: 0.5,
+    });
+  });
+
+  it('clamps progress while keeping interpolation bounds valid', () => {
+    expect(getExportFrameTarget(-1, 5, 3)).toEqual({
+      progress: 0,
+      previousIndex: 0,
+      nextIndex: 0,
+      ratio: 0,
+    });
+    expect(getExportFrameTarget(8, 5, 3)).toEqual({
+      progress: 1,
+      previousIndex: 2,
+      nextIndex: 2,
+      ratio: 0,
+    });
   });
 });

--- a/apps/frontend/src/utils/videoExportFrame.ts
+++ b/apps/frontend/src/utils/videoExportFrame.ts
@@ -1,15 +1,34 @@
+export interface ExportFrameTarget {
+  progress: number;
+  previousIndex: number;
+  nextIndex: number;
+  ratio: number;
+}
+
 export function getExportFrameTargetIndex(
   frameIndex: number,
   totalFrames: number,
   totalPositions: number
 ): number {
-  const lastPositionIndex = Math.max(totalPositions - 1, 0);
-  if (lastPositionIndex === 0) {
-    return 0;
-  }
+  return getExportFrameTarget(frameIndex, totalFrames, totalPositions).nextIndex;
+}
 
+export function getExportFrameTarget(
+  frameIndex: number,
+  totalFrames: number,
+  totalPositions: number
+): ExportFrameTarget {
+  const lastPositionIndex = Math.max(totalPositions - 1, 0);
   const lastFrameIndex = Math.max(totalFrames - 1, 1);
   const progress = Math.min(Math.max(frameIndex / lastFrameIndex, 0), 1);
+  const exactIndex = progress * lastPositionIndex;
+  const previousIndex = Math.floor(exactIndex);
+  const nextIndex = Math.ceil(exactIndex);
 
-  return Math.round(progress * lastPositionIndex);
+  return {
+    progress,
+    previousIndex,
+    nextIndex,
+    ratio: exactIndex - previousIndex,
+  };
 }

--- a/apps/frontend/src/utils/videoExportFrame.ts
+++ b/apps/frontend/src/utils/videoExportFrame.ts
@@ -10,7 +10,8 @@ export function getExportFrameTargetIndex(
   totalFrames: number,
   totalPositions: number
 ): number {
-  return getExportFrameTarget(frameIndex, totalFrames, totalPositions).nextIndex;
+  const target = getExportFrameTarget(frameIndex, totalFrames, totalPositions);
+  return target.ratio >= 0.5 ? target.nextIndex : target.previousIndex;
 }
 
 export function getExportFrameTarget(


### PR DESCRIPTION
## Summary
- Make the export viewer render Cesium itself full-frame without the app shell or React controls.
- Disable and hide Cesium UI widgets/credits during video export capture.
- Smooth playback and frame export by interpolating between GPS positions.

## Validation
- `NODE_ENV=test vitest run --config vitest.config.ts FlightViewer3D.video-export.test.tsx videoExportFrame.test.ts` passes: 10 tests.
- `nx lint frontend` passes with 0 errors; existing warnings remain.
- `nx build frontend` is blocked by an existing `lucide-react` resolution error in weather components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export-only viewer mode: full-viewport layout with UI controls hidden for clean video export.
  * Export viewer route now uses the export-only presentation.

* **Improvements**
  * Smoother, more accurate video-frame targeting via interpolated scene positions.
  * Playback moved to a frame-driven loop for improved timing and performance.
  * Progress slider and camera updates use interpolation for smoother scrubbing.

* **Tests**
  * Added/updated tests covering export-only behavior and export frame interpolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->