### PR TITLE
fix(frontend): correct hourly best spot card layout

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -373,7 +373,7 @@ export const BestSpotSuggestion = ({
                         onSelectSite(hourlySpot.site.id);
                       }
                     }}
-                    className="min-w-[176px] rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-left shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/50 dark:hover:bg-gray-900"
+                    className="min-w-[176px] flex-col items-stretch justify-start gap-0 whitespace-normal rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-left shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/50 dark:hover:bg-gray-900"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <span className="text-sm font-extrabold text-gray-900 dark:text-white">


### PR DESCRIPTION
## Summary
- Fixes the hourly best spot cards so each card lays out vertically instead of inheriting the design-system Button horizontal layout.
- Preserves the existing clickable behavior and visual content for each hourly recommendation.

## Validation
- Ran targeted oxlint on `apps/frontend/src/components/weather/BestSpotSuggestion.tsx` with 0 errors.
- Full Nx lint/test could not be completed in the worktree because dependency installation on the NAS timed out before `node_modules/.modules.yaml` was finalized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hourly timeline button layout and spacing in weather spot suggestion cards for better visual presentation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->