### PR TITLE
fix(frontend): render Cesium entities during video export

### DIFF
--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -1114,7 +1114,8 @@ async def _export_video_manual_render(job_id: str):
                     tiles_loaded = await page.evaluate("""
                         () => {
                             const viewer = window._cesiumViewer;
-                            viewer.scene.render(viewer.clock.currentTime);
+                            viewer.scene.requestRender();
+                            viewer.render();
                             return viewer.scene.globe.tilesLoaded;
                         }
                     """)

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -137,6 +137,11 @@ const interpolatePosition = (
     start.z + (end.z - start.z) * ratio
   );
 
+const renderViewerFrame = (viewer: CesiumViewer) => {
+  viewer.scene.requestRender();
+  viewer.render();
+};
+
 /**
  * AccordionSection - Collapsible section component for control panel
  */
@@ -1181,8 +1186,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           );
         }
 
-        viewer.scene.requestRender();
-        viewer.scene.render(viewer.clock.currentTime);
+        renderViewerFrame(viewer);
       }
 
       let progress = 0;

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -2,11 +2,24 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { apiGet, apiPost, invalidateQueries, mockFlight, viewerOptions } =
-  vi.hoisted(() => ({
+const {
+  apiGet,
+  apiPost,
+  invalidateQueries,
+  mockFlight,
+  viewerInstances,
+  viewerOptions,
+} = vi.hoisted(() => ({
     apiGet: vi.fn(),
     apiPost: vi.fn(),
     invalidateQueries: vi.fn(),
+    viewerInstances: [] as {
+      render: ReturnType<typeof vi.fn>;
+      scene: {
+        requestRender: ReturnType<typeof vi.fn>;
+        render: ReturnType<typeof vi.fn>;
+      };
+    }[],
     viewerOptions: [] as unknown[],
     mockFlight: {
       gpx_file_path: 'sample.gpx',
@@ -82,9 +95,11 @@ vi.mock('cesium', () => {
     };
     shadows = false;
     terrainShadows = 0;
+    render = vi.fn();
 
     constructor(_container: Element, options: unknown) {
       viewerOptions.push(options);
+      viewerInstances.push(this);
     }
 
     isDestroyed() {
@@ -247,10 +262,13 @@ describe('FlightViewer3D video export mode', () => {
     apiGet.mockReset();
     apiPost.mockClear();
     invalidateQueries.mockClear();
+    viewerInstances.length = 0;
     viewerOptions.length = 0;
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
+    window._exportMode = undefined;
+    window._setExportFrame = undefined;
   });
 
   afterEach(() => {
@@ -276,6 +294,8 @@ describe('FlightViewer3D video export mode', () => {
         originalClientWidth
       );
     }
+    window._exportMode = undefined;
+    window._setExportFrame = undefined;
   });
 
   it('starts fast smooth export by default and shows its hint', async () => {
@@ -326,6 +346,23 @@ describe('FlightViewer3D video export mode', () => {
         selectionIndicator: false,
       });
     });
+  });
+
+  it('renders the full Cesium viewer after setting an export frame', async () => {
+    window._exportMode = 'manual_render';
+
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(window._setExportFrame).toBeTypeOf('function');
+    });
+
+    const viewer = viewerInstances[viewerInstances.length - 1];
+    const frameState = window._setExportFrame?.(1, 2);
+
+    expect(frameState).toMatchObject({ progress: 100, tilesLoaded: true });
+    expect(viewer.scene.requestRender).toHaveBeenCalled();
+    expect(viewer.render).toHaveBeenCalled();
   });
 
   it('starts max quality export after switching mode', async () => {


### PR DESCRIPTION
## Summary
- Use Cesium viewer-level rendering during export frames so entity updates are included in screenshots.
- Apply the same render path in the backend Playwright manual export loop.
- Add coverage for `_setExportFrame` triggering a full viewer render.

## Validation
- `NODE_ENV=test NX_DAEMON=false NX_NO_CLOUD=true NX_DISABLE_ANALYTICS=true /media/nas/usb2/developement/moi/dashboard-parapente/node_modules/.bin/vitest run --config vitest.config.ts FlightViewer3D.video-export.test.tsx --reporter=verbose`
- `/media/nas/usb2/developement/moi/dashboard-parapente/node_modules/.bin/oxlint -c .oxlintrc.json apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx`
- `python3 -m py_compile video_export_manual.py`

## Notes
- Backend pytest was not run locally because `pytest`/`uv` are unavailable in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated rendering mechanism for video export functionality.
  * Improved 3D viewer frame rendering approach.

* **Tests**
  * Enhanced test coverage for viewer rendering with expanded mocks and new test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->