### PR TITLE
fix(backend): show hourly best spots until sunset

### DIFF
--- a/apps/backend/best_spot.py
+++ b/apps/backend/best_spot.py
@@ -527,7 +527,7 @@ async def calculate_best_spot_from_db(db: Session, day_index: int = 0) -> dict[s
 
 
 async def calculate_hourly_best_spots_from_cache(
-    db: Session, day_index: int = 0, hours: int = 8
+    db: Session, day_index: int = 0, hours: int = 24
 ) -> dict[str, Any] | None:
     """Calculate the best flying spot for each upcoming flyable hour."""
     from para_index import calculate_hourly_para_index, get_hourly_verdict
@@ -686,7 +686,7 @@ async def get_best_spot_cached(db: Session, day_index: int = 0) -> dict[str, Any
 
 
 async def get_hourly_best_spots_cached(
-    db: Session, day_index: int = 0, hours: int = 8
+    db: Session, day_index: int = 0, hours: int = 24
 ) -> dict[str, Any] | None:
     """Get hourly best spots from cache or calculate if not cached."""
     start_hour = datetime.now().hour if day_index == 0 else 0

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -1367,7 +1367,7 @@ async def get_hourly_best_spots(
         le=6,
         description="Day index (0=today, 1=tomorrow, ..., 6=in 6 days)",
     ),
-    hours: int = Query(default=8, ge=1, le=24, description="Maximum number of hourly winners"),
+    hours: int = Query(default=24, ge=1, le=24, description="Maximum number of hourly winners"),
     db: Session = Depends(get_db),
 ):
     """Get the best flying spot for each upcoming flyable hour."""

--- a/apps/backend/tests/unit/test_best_spot.py
+++ b/apps/backend/tests/unit/test_best_spot.py
@@ -334,6 +334,45 @@ async def test_calculate_hourly_best_spots_from_cache_can_change_by_hour(
 
 
 @pytest.mark.asyncio
+async def test_calculate_hourly_best_spots_from_cache_today_runs_until_sunset(
+    db_session, arguel_site
+):
+    """Test today's hourly winners cover current hour through sunset by default."""
+    mock_forecast = {
+        "success": True,
+        "sunrise": "07:00",
+        "sunset": "19:00",
+        "consensus": [
+            {
+                "hour": hour,
+                "wind_speed": 12,
+                "wind_gust": 10,
+                "wind_direction": 270,
+                "precipitation": 0,
+                "temperature": 20,
+                "lifted_index": 0,
+            }
+            for hour in range(12, 21)
+        ],
+    }
+
+    with (
+        patch("best_spot.datetime") as mock_datetime,
+        patch(
+            "weather_pipeline.get_normalized_forecast",
+            new=AsyncMock(return_value=mock_forecast),
+        ),
+    ):
+        mock_datetime.now.return_value.hour = 14
+        result = await calculate_hourly_best_spots_from_cache(db_session, day_index=0)
+
+    assert result is not None
+    assert result["dayIndex"] == 0
+    assert result["startHour"] == 14
+    assert [spot["hour"] for spot in result["hours"]] == [14, 15, 16, 17, 18, 19]
+
+
+@pytest.mark.asyncio
 async def test_calculate_best_spot_from_cache_low_scores(db_session, arguel_site):
     """Test best spot with low scores adds warning"""
 


### PR DESCRIPTION
## Summary
- Extend hourly best spot defaults to return the full current-hour-to-sunset window.
- Align the hourly best spots endpoint default with the frontend request window.
- Add backend coverage for today's hourly results ending at sunset.

## Validation
- `python3 -m py_compile best_spot.py routes.py tests/unit/test_best_spot.py`
- `git diff --check`
- Backend pytest/Nx not run: this worktree has no `node_modules`, no `.venv`, and `pytest` is not installed in the current environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Extended hourly best spots results to display 24 hours of data by default instead of 8 hours, providing broader forecast coverage and recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->