### PR TITLE
fix(frontend): refresh hourly best spots over time

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -22,6 +22,7 @@ type HourlyBestSpot = BestSpotResult & { hour: number };
 interface BestSpotSuggestionProps {
   bestSpot: BestSpotResult | null;
   hourlyBestSpots?: HourlyBestSpot[];
+  hourlyStartHour?: number;
   onSelectSite: (siteId: string) => void;
   selectedDayIndex?: number;
   className?: string;
@@ -107,6 +108,7 @@ function getVerdict(paraIndex: number, verdict?: string) {
 export const BestSpotSuggestion = ({
   bestSpot,
   hourlyBestSpots = [],
+  hourlyStartHour,
   onSelectSite,
   selectedDayIndex = 0,
   className = '',
@@ -161,7 +163,6 @@ export const BestSpotSuggestion = ({
   const localizedReason = reason.replace(/Para-Index/g, t('weather.paraIndex'));
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
-  const nowHour = new Date().getHours();
 
   return (
     <div
@@ -350,7 +351,7 @@ export const BestSpotSuggestion = ({
                   hourlySpot.verdict ?? undefined
                 );
                 const hourLabel =
-                  selectedDayIndex === 0 && hourlySpot.hour === nowHour
+                  selectedDayIndex === 0 && hourlySpot.hour === hourlyStartHour
                     ? t('common.now')
                     : `${hourlySpot.hour}h`;
                 const roundedWindSpeed =

--- a/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
+++ b/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
@@ -34,9 +34,11 @@ export const bestSpotQueryOptions = (dayIndex = 0) =>
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
   });
 
-export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 24) =>
-  queryOptions<HourlyBestSpotsResult>({
-    queryKey: ['bestSpot', 'hourly', dayIndex, hours],
+export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 24) => {
+  const currentHour = dayIndex === 0 ? new Date().getHours() : null;
+
+  return queryOptions<HourlyBestSpotsResult>({
+    queryKey: ['bestSpot', 'hourly', dayIndex, hours, currentHour],
     queryFn: async () => {
       const params = new URLSearchParams({
         day_index: dayIndex.toString(),
@@ -46,10 +48,13 @@ export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 24) =>
       return HourlyBestSpotsResultSchema.parse(response);
     },
     staleTime: getStaleTime(1000 * 60 * 30),
+    refetchInterval: dayIndex === 0 ? 60_000 : false,
+    refetchOnWindowFocus: dayIndex === 0 ? 'always' : false,
     gcTime: 1000 * 60 * 60 * 2,
     retry: 2,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
   });
+};
 
 /**
  * Hook to fetch the best spot for a specific day

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -72,6 +72,7 @@ export default function Dashboard() {
         <BestSpotSuggestion
           bestSpot={bestSpot ?? null}
           hourlyBestSpots={hourlyBestSpots?.hours ?? []}
+          hourlyStartHour={hourlyBestSpots?.startHour}
           onSelectSite={(siteId) =>
             void navigate({ to: '/weather', search: { siteId } })
           }

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -82,6 +82,7 @@ export default function WeatherPage() {
         <BestSpotSuggestion
           bestSpot={bestSpot ?? null}
           hourlyBestSpots={hourlyBestSpots?.hours ?? []}
+          hourlyStartHour={hourlyBestSpots?.startHour}
           onSelectSite={(siteId) =>
             void navigate({
               to: '/weather',


### PR DESCRIPTION
## Summary
- Refresh today hourly best spot recommendations every minute and on window focus.
- Include the current hour in the React Query key so hourly cache entries advance over time.
- Label "now" from the API `startHour` instead of the component render time.

## Validation
- `NX_NO_CLOUD=true pnpm nx lint frontend` passed with 0 errors and existing warnings.
- `oxfmt --check` passed on modified files.
- `oxlint` passed on modified files with existing warnings.
- `NX_NO_CLOUD=true pnpm nx test frontend` could not complete in this worktree because dependencies/browser tooling were incomplete (`lucide-react` unresolved from the available node_modules and Playwright browser missing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced hourly spot suggestion accuracy—the "now" timeline label is now correctly determined by the current hour when viewing today's forecast.
  * Added smart data polling—today's forecast updates automatically while future days remain cached for optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->