### PR TITLE
fix(weather): use forecast timezone for hourly best spots

### DIFF
--- a/apps/backend/best_spot.py
+++ b/apps/backend/best_spot.py
@@ -10,6 +10,7 @@ This module provides functions to:
 import logging
 from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
@@ -17,6 +18,11 @@ from models import EmagramAnalysis as EmagramAnalysisModel
 from models import Site, WeatherForecast
 
 logger = logging.getLogger(__name__)
+FORECAST_TIME_ZONE = ZoneInfo("Europe/Paris")
+
+
+def _get_current_forecast_hour() -> int:
+    return datetime.now(FORECAST_TIME_ZONE).hour
 
 
 def _get_cache_functions():
@@ -541,7 +547,7 @@ async def calculate_hourly_best_spots_from_cache(
             logger.warning("No sites found in database")
             return None
 
-        start_hour = datetime.now().hour if day_index == 0 else 0
+        start_hour = _get_current_forecast_hour() if day_index == 0 else 0
         best_by_hour: dict[int, dict[str, Any]] = {}
 
         for site in sites:
@@ -689,7 +695,7 @@ async def get_hourly_best_spots_cached(
     db: Session, day_index: int = 0, hours: int = 24
 ) -> dict[str, Any] | None:
     """Get hourly best spots from cache or calculate if not cached."""
-    start_hour = datetime.now().hour if day_index == 0 else 0
+    start_hour = _get_current_forecast_hour() if day_index == 0 else 0
     cache_key = f"best_spot_hourly:day_{day_index}:start_{start_hour}:hours_{hours}"
     get_cached_func, set_cached_func, get_cache_ttl_func = _get_cache_functions()
 

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -23,6 +23,7 @@ pydantic-settings==2.14.0
 # Configuration Management
 # ============================================
 python-dotenv==1.2.2
+tzdata==2026.2
 
 # ============================================
 # Async File I/O

--- a/apps/backend/tests/unit/test_best_spot.py
+++ b/apps/backend/tests/unit/test_best_spot.py
@@ -23,6 +23,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from best_spot import (
+    FORECAST_TIME_ZONE,
+    _get_current_forecast_hour,
     calculate_angle_difference,
     calculate_best_spot_from_cache,
     calculate_best_spot_from_db,
@@ -48,6 +50,16 @@ def test_parse_wind_direction_valid():
     assert parse_wind_direction("W") == 270
     assert parse_wind_direction("NE") == 45
     assert parse_wind_direction("SW") == 225
+
+
+def test_get_current_forecast_hour_uses_forecast_timezone():
+    """Test current forecast hour follows the weather forecast timezone."""
+    with patch("best_spot.datetime") as mock_datetime:
+        mock_datetime.now.return_value.hour = 16
+
+        assert _get_current_forecast_hour() == 16
+
+    mock_datetime.now.assert_called_once_with(FORECAST_TIME_ZONE)
 
 
 def test_parse_wind_direction_case_insensitive():

--- a/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
+++ b/apps/frontend/src/hooks/weather/useBestSpotAPI.ts
@@ -20,6 +20,15 @@ import {
   type HourlyBestSpotsResult,
 } from '@dashboard-parapente/shared-types';
 
+const forecastHourFormatter = new Intl.DateTimeFormat('fr-FR', {
+  timeZone: 'Europe/Paris',
+  hour: 'numeric',
+  hourCycle: 'h23',
+});
+
+const getCurrentForecastHour = () =>
+  Number.parseInt(forecastHourFormatter.format(new Date()), 10);
+
 export const bestSpotQueryOptions = (dayIndex = 0) =>
   queryOptions<BestSpotResult>({
     queryKey: ['bestSpot', dayIndex],
@@ -35,7 +44,7 @@ export const bestSpotQueryOptions = (dayIndex = 0) =>
   });
 
 export const hourlyBestSpotsQueryOptions = (dayIndex = 0, hours = 24) => {
-  const currentHour = dayIndex === 0 ? new Date().getHours() : null;
+  const currentHour = dayIndex === 0 ? getCurrentForecastHour() : null;
 
   return queryOptions<HourlyBestSpotsResult>({
     queryKey: ['bestSpot', 'hourly', dayIndex, hours, currentHour],


### PR DESCRIPTION
## Summary
- Use the Europe/Paris forecast timezone when filtering and caching hourly best spots.
- Align the frontend React Query hourly cache key with the same forecast timezone.
- Add backend coverage for the forecast-hour helper.

## Tests
- `tests/unit/test_best_spot.py`: 37 passed
- `ruff` on modified backend files
- `black --check` on modified backend files
- `oxlint` on modified frontend hook
- `oxfmt --check` on modified frontend hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hourly forecast calculations to consistently use the Europe/Paris timezone, ensuring accurate hourly recommendations regardless of user location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->