### PR TITLE
fix(frontend): centralize tab selected styles

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -2,15 +2,14 @@ import type { ChangeEvent } from 'react';
 import { useState, useRef, lazy, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
+import { TextField, TextArea } from 'react-aria-components';
 import {
+  Button,
   Tab,
   TabList,
   TabPanel,
   Tabs,
-  TextField,
-  TextArea,
-} from 'react-aria-components';
-import { Button } from '@dashboard-parapente/design-system';
+} from '@dashboard-parapente/design-system';
 import {
   useUpdateFlight,
   useUploadGPXToFlight,
@@ -391,17 +390,11 @@ export function FlightDetails({
           onSelectionChange={(key) => setActiveTab(key as FlightDetailsTab)}
           className="space-y-4"
         >
-          <TabList className="grid grid-cols-2 gap-2 mb-4 bg-white dark:bg-gray-800 rounded-xl p-2 shadow-md">
-            <Tab
-              id="infos"
-              className="px-3 py-2 text-sm rounded-md transition-colors cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 selected:bg-sky-600 selected:text-white outline-none"
-            >
+          <TabList className="mb-4 grid-cols-2">
+            <Tab id="infos" className="rounded-md px-3 py-2 text-sm">
               {t('flights.infoTab')}
             </Tab>
-            <Tab
-              id="replay"
-              className="px-3 py-2 text-sm rounded-md transition-colors cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 selected:bg-sky-600 selected:text-white outline-none"
-            >
+            <Tab id="replay" className="rounded-md px-3 py-2 text-sm">
               {t('flights.replayTab')}
             </Tab>
           </TabList>

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -1,15 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useTranslation } from 'react-i18next';
-import {
-  Checkbox,
-  Input,
-  Tab,
-  TabList,
-  TabPanel,
-  Tabs,
-  TextField,
-} from 'react-aria-components';
+import { Checkbox, Input, TextField } from 'react-aria-components';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -21,6 +13,10 @@ import {
   Button,
   DataTable,
   Modal,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
   ToastContainer,
 } from '@dashboard-parapente/design-system';
 import {
@@ -43,9 +39,6 @@ interface PendingConfirm {
   message: string;
   onConfirm: () => void;
 }
-
-const infrastructureTabClassName =
-  'flex-1 px-4 py-2 rounded-lg font-medium transition-all cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 selected:bg-sky-600 selected:text-white selected:shadow-md outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800';
 
 function formatTtl(ttl: number): string {
   if (ttl < 0) return '—';
@@ -689,16 +682,10 @@ export default function InfrastructurePage() {
       </h2>
 
       <Tabs className="space-y-4">
-        <TabList className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-2 grid grid-cols-1 gap-2 sm:grid-cols-3">
-          <Tab id="strava" className={infrastructureTabClassName}>
-            {t('infrastructure.tabs.strava')}
-          </Tab>
-          <Tab id="videoExports" className={infrastructureTabClassName}>
-            {t('infrastructure.tabs.videoExports')}
-          </Tab>
-          <Tab id="cache" className={infrastructureTabClassName}>
-            {t('infrastructure.tabs.cache')}
-          </Tab>
+        <TabList className="grid-cols-1 sm:grid-cols-3">
+          <Tab id="strava">{t('infrastructure.tabs.strava')}</Tab>
+          <Tab id="videoExports">{t('infrastructure.tabs.videoExports')}</Tab>
+          <Tab id="cache">{t('infrastructure.tabs.cache')}</Tab>
         </TabList>
 
         <TabPanel id="strava" className="outline-none">

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1,8 +1,14 @@
 import { Suspense, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Switch, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
-import { Button } from '@dashboard-parapente/design-system';
+import { Switch } from 'react-aria-components';
+import {
+  Button,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from '@dashboard-parapente/design-system';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 import {
   useWeatherSources,
@@ -1121,13 +1127,9 @@ export default function Settings() {
         className="space-y-4"
       >
         {/* Tabs Navigation */}
-        <TabList className="bg-white dark:bg-gray-800 rounded-xl shadow-md mb-4 p-2 grid grid-cols-2 gap-2 sm:flex">
+        <TabList className="mb-4 grid-cols-2 sm:flex">
           {(['general', 'sites', 'weather', 'data'] as const).map((tabKey) => (
-            <Tab
-              key={tabKey}
-              id={tabKey}
-              className="flex-1 px-4 py-2 rounded-lg font-medium transition-all cursor-pointer bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 selected:bg-sky-600 selected:text-white selected:shadow-md outline-none"
-            >
+            <Tab key={tabKey} id={tabKey} className="flex-1">
               {tabKey === 'general' && `🎛️ ${t('settings.tabs.general')}`}
               {tabKey === 'sites' && `📍 ${t('settings.tabs.favoriteSites')}`}
               {tabKey === 'weather' &&

--- a/libs/design-system/src/Tabs.stories.tsx
+++ b/libs/design-system/src/Tabs.stories.tsx
@@ -1,0 +1,66 @@
+import preview from '../.storybook/preview';
+import { expect } from 'storybook/test';
+import { Tab, TabList, TabPanel, Tabs } from './Tabs';
+
+const meta = preview.meta({
+  title: 'Components/UI/Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Accessible tabs built on react-aria-components with a visible selected state and dark mode support.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+});
+
+export const Default = meta.story({
+  render: () => (
+    <div className="w-[min(36rem,calc(100vw-2rem))]">
+      <Tabs defaultSelectedKey="weather">
+        <TabList className="grid-cols-3">
+          <Tab id="general">General</Tab>
+          <Tab id="weather">Weather</Tab>
+          <Tab id="data">Data</Tab>
+        </TabList>
+        <TabPanel id="general" className="rounded-xl bg-white p-4 shadow-md">
+          General settings
+        </TabPanel>
+        <TabPanel id="weather" className="rounded-xl bg-white p-4 shadow-md">
+          Weather sources
+        </TabPanel>
+        <TabPanel id="data" className="rounded-xl bg-white p-4 shadow-md">
+          Data management
+        </TabPanel>
+      </Tabs>
+    </div>
+  ),
+});
+
+Default.test('shows selected tab state', async ({ canvas }) => {
+  await expect(canvas.getByRole('tab', { name: 'Weather' })).toHaveAttribute(
+    'data-selected'
+  );
+});
+
+export const Responsive = meta.story({
+  render: () => (
+    <div className="w-[min(36rem,calc(100vw-2rem))]">
+      <Tabs defaultSelectedKey="sites">
+        <TabList className="grid-cols-2 sm:flex">
+          <Tab id="general">General</Tab>
+          <Tab id="sites">Sites</Tab>
+          <Tab id="weather">Weather</Tab>
+          <Tab id="data">Data</Tab>
+        </TabList>
+        <TabPanel id="general">General settings</TabPanel>
+        <TabPanel id="sites">Favorite sites</TabPanel>
+        <TabPanel id="weather">Weather sources</TabPanel>
+        <TabPanel id="data">Data management</TabPanel>
+      </Tabs>
+    </div>
+  ),
+});

--- a/libs/design-system/src/Tabs.stories.tsx
+++ b/libs/design-system/src/Tabs.stories.tsx
@@ -41,8 +41,13 @@ export const Default = meta.story({
 });
 
 Default.test('shows selected tab state', async ({ canvas }) => {
-  await expect(canvas.getByRole('tab', { name: 'Weather' })).toHaveAttribute(
-    'data-selected'
+  const selectedTab = canvas.getByRole('tab', { name: 'Weather' });
+  const unselectedTab = canvas.getByRole('tab', { name: 'General' });
+
+  await expect(selectedTab).toHaveAttribute('data-selected');
+  await expect(unselectedTab).not.toHaveAttribute('data-selected');
+  expect(getComputedStyle(selectedTab).backgroundColor).not.toBe(
+    getComputedStyle(unselectedTab).backgroundColor
   );
 });
 

--- a/libs/design-system/src/Tabs.tsx
+++ b/libs/design-system/src/Tabs.tsx
@@ -1,0 +1,67 @@
+import {
+  composeRenderProps,
+  Tab as AriaTab,
+  TabList as AriaTabList,
+  TabPanel as AriaTabPanel,
+  Tabs as AriaTabs,
+} from 'react-aria-components';
+import type {
+  TabListProps,
+  TabPanelProps,
+  TabProps,
+  TabsProps,
+} from 'react-aria-components';
+import { twMerge } from 'tailwind-merge';
+
+export function Tabs({ className, ...props }: TabsProps) {
+  return (
+    <AriaTabs
+      {...props}
+      className={composeRenderProps(className, (className) =>
+        twMerge('space-y-4', className)
+      )}
+    />
+  );
+}
+
+export function TabList<T extends object>({
+  className,
+  ...props
+}: TabListProps<T>) {
+  return (
+    <AriaTabList
+      {...props}
+      className={composeRenderProps(className, (className) =>
+        twMerge(
+          'grid gap-2 rounded-xl bg-white p-2 shadow-md dark:bg-gray-800',
+          className
+        )
+      )}
+    />
+  );
+}
+
+export function Tab({ className, ...props }: TabProps) {
+  return (
+    <AriaTab
+      {...props}
+      className={composeRenderProps(className, (className) =>
+        twMerge(
+          'flex-1 cursor-pointer rounded-lg bg-gray-100 px-4 py-2 text-center font-medium text-gray-700 outline-none transition-all hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 data-[selected]:bg-sky-600 data-[selected]:text-white data-[selected]:shadow-md dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:focus-visible:ring-offset-gray-800',
+          className
+        )
+      )}
+    />
+  );
+}
+
+export function TabPanel({ className, ...props }: TabPanelProps) {
+  return (
+    <AriaTabPanel
+      {...props}
+      className={composeRenderProps(className, (className) =>
+        twMerge('outline-none', className)
+      )}
+    />
+  );
+}

--- a/libs/design-system/src/Tabs.tsx
+++ b/libs/design-system/src/Tabs.tsx
@@ -68,6 +68,3 @@ export function TabPanel({ className, ...props }: TabPanelProps) {
     />
   );
 }
-    />
-  );
-}

--- a/libs/design-system/src/Tabs.tsx
+++ b/libs/design-system/src/Tabs.tsx
@@ -60,8 +60,14 @@ export function TabPanel({ className, ...props }: TabPanelProps) {
     <AriaTabPanel
       {...props}
       className={composeRenderProps(className, (className) =>
-        twMerge('outline-none', className)
+        twMerge(
+          'outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800',
+          className
+        )
       )}
+    />
+  );
+}
     />
   );
 }

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -6,6 +6,7 @@ export { Modal } from './Modal';
 export { Toast, ToastContainer } from './Toast';
 export { Button } from './Button';
 export type { ButtonProps } from './Button';
+export { Tab, TabList, TabPanel, Tabs } from './Tabs';
 export { DatePicker } from './components/DatePicker/DatePicker';
 export { Select } from './Select';
 export type { SelectOption } from './Select';


### PR DESCRIPTION
## Summary
- Add shared `Tabs`, `TabList`, `Tab`, and `TabPanel` wrappers in the design system.
- Use React Aria `data-selected` state styling so active tabs are visibly highlighted.
- Migrate existing Settings, Infrastructure, and Flight Details tabs to the shared component.

## Validation
- `oxfmt --check` on changed files: passed
- `tsc --noEmit` for design-system: passed
- `oxlint` on changed files: 0 errors, existing warnings only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive grid-based tab layouts with enhanced mobile support

* **Refactor**
  * Consolidated tab components to design system library
  * Simplified tab styling for cleaner interface

* **Tests**
  * Added test coverage and documentation for tab components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->