### PR TITLE
fix(frontend): move best spot above site selector

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -66,21 +66,6 @@ export default function WeatherPage() {
       <div className="space-y-4">
         <CityWeatherSearch dayIndex={selectedDayIndex} />
 
-        {/* Site Selector */}
-        <SiteSelector
-          selectedSiteId={selectedSiteId}
-          onSelectSite={(siteId) =>
-            void navigate({
-              to: '/weather',
-              search: {
-                siteId,
-                day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
-              },
-            })
-          }
-          weatherData={weatherDataMap}
-        />
-
         {/* Best Spot for selected day */}
         <BestSpotSuggestion
           bestSpot={bestSpot ?? null}
@@ -96,6 +81,21 @@ export default function WeatherPage() {
             })
           }
           selectedDayIndex={selectedDayIndex}
+        />
+
+        {/* Site Selector */}
+        <SiteSelector
+          selectedSiteId={selectedSiteId}
+          onSelectSite={(siteId) =>
+            void navigate({
+              to: '/weather',
+              search: {
+                siteId,
+                day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+              },
+            })
+          }
+          weatherData={weatherDataMap}
         />
 
         {/* Current Conditions */}


### PR DESCRIPTION
## Summary
- Move the best spot suggestion above the site selector on the weather page.
- Keep the existing selection/navigation behavior unchanged.

## Validation
- Ran oxlint on `apps/frontend/src/pages/WeatherPage.tsx` with 0 errors and 1 existing max-dependencies warning.
- `pnpm install --frozen-lockfile` in the worktree timed out before full Nx validation could run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized spot recommendations on the weather page to help users discover ideal locations and destinations.

* **Updates**
  * Reorganized page layout with improved component positioning for better user interface experience and information flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->