### PR TITLE
refactor(design-system): group IconCard styles into slots

### DIFF
--- a/libs/design-system/src/IconCard.tsx
+++ b/libs/design-system/src/IconCard.tsx
@@ -1,41 +1,29 @@
 import { tv } from 'tailwind-variants';
 
 const iconCard = tv({
-  base: 'flex flex-col items-center p-3 border-2 rounded-lg relative overflow-hidden',
-  variants: {
-    unlocked: {
-      true: 'bg-gradient-to-br from-sky-50 to-blue-50 dark:from-sky-900/20 dark:to-blue-900/20 border-sky-300 dark:border-sky-600 hover:shadow-md transition-shadow',
-      false: 'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700',
-    },
+  slots: {
+    root: 'flex flex-col items-center p-3 border-2 rounded-lg relative overflow-hidden',
+    icon: 'text-3xl mb-1',
+    title: 'text-xs font-semibold text-center',
+    description: 'text-xs text-center mt-1',
+    progress: 'text-xs text-sky-600 dark:text-sky-400 font-medium mt-1',
+    progressOverlay:
+      'absolute inset-0 bg-gradient-to-t from-sky-100 dark:from-sky-900/30 to-transparent opacity-50',
+    lockedContent: 'relative z-10 flex flex-col items-center',
   },
-});
-
-const iconStyle = tv({
-  base: 'text-3xl mb-1',
   variants: {
     unlocked: {
-      true: '',
-      false: 'opacity-40 grayscale',
-    },
-  },
-});
-
-const titleStyle = tv({
-  base: 'text-xs font-semibold text-center',
-  variants: {
-    unlocked: {
-      true: 'text-gray-800 dark:text-gray-100',
-      false: 'text-gray-500 dark:text-gray-400',
-    },
-  },
-});
-
-const descriptionStyle = tv({
-  base: 'text-xs text-center mt-1',
-  variants: {
-    unlocked: {
-      true: 'text-gray-600 dark:text-gray-300',
-      false: 'text-gray-400 dark:text-gray-500',
+      true: {
+        root: 'bg-gradient-to-br from-sky-50 to-blue-50 dark:from-sky-900/20 dark:to-blue-900/20 border-sky-300 dark:border-sky-600 hover:shadow-md transition-shadow',
+        title: 'text-gray-800 dark:text-gray-100',
+        description: 'text-gray-600 dark:text-gray-300',
+      },
+      false: {
+        root: 'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700',
+        icon: 'opacity-40 grayscale',
+        title: 'text-gray-500 dark:text-gray-400',
+        description: 'text-gray-400 dark:text-gray-500',
+      },
     },
   },
 });
@@ -55,24 +43,23 @@ export function IconCard({
   unlocked,
   progress,
 }: IconCardProps) {
+  const styles = iconCard({ unlocked });
   const content = (
     <>
-      <span className={iconStyle({ unlocked })}>{icon}</span>
-      <span className={titleStyle({ unlocked })}>{title}</span>
-      <span className={descriptionStyle({ unlocked })}>{description}</span>
+      <span className={styles.icon()}>{icon}</span>
+      <span className={styles.title()}>{title}</span>
+      <span className={styles.description()}>{description}</span>
       {!unlocked && progress !== undefined && progress > 0 && (
-        <span className="text-xs text-sky-600 dark:text-sky-400 font-medium mt-1">
-          {Math.round(progress)}%
-        </span>
+        <span className={styles.progress()}>{Math.round(progress)}%</span>
       )}
     </>
   );
 
   return (
-    <div className={iconCard({ unlocked })}>
+    <div className={styles.root()}>
       {!unlocked && progress !== undefined && (
         <div
-          className="absolute inset-0 bg-gradient-to-t from-sky-100 dark:from-sky-900/30 to-transparent opacity-50"
+          className={styles.progressOverlay()}
           style={{
             height: `${progress}%`,
             bottom: 0,
@@ -81,7 +68,11 @@ export function IconCard({
         ></div>
       )}
 
-      {unlocked ? content : <div className="relative z-10 flex flex-col items-center">{content}</div>}
+      {unlocked ? (
+        content
+      ) : (
+        <div className={styles.lockedContent()}>{content}</div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refactor IconCard styling to use a single tailwind-variants definition with slots.
- Preserve existing locked/unlocked visual states and progress rendering.

## Validation
- `oxfmt --check libs/design-system/src/IconCard.tsx`
- `nx lint design-system` passes with existing warnings outside IconCard
- `nx type-check design-system` still fails on pre-existing implicit any errors in Lightbox, DataList, and DatePicker