### PR TITLE
fix(deploy): remove orphaned backend container

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -220,7 +220,33 @@ jobs:
               fi
 
               compose_cmd build --pull backend
+              remove_conflicting_container parapente-backend
               BACKEND_DEPLOY_VERSION="$TARGET_VERSION" compose_cmd up -d --force-recreate --remove-orphans backend redis
+            }
+
+            remove_conflicting_container() {
+              container_name="$1"
+              existing_container_id=""
+
+              for container_id in $(docker ps -aq --filter "name=^/${container_name}$" 2>/dev/null || true); do
+                existing_container_id="$container_id"
+                break
+              done
+
+              if [ -z "$existing_container_id" ]; then
+                return 0
+              fi
+
+              existing_project=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project" }}' 2>/dev/null || true)
+              existing_workdir=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || true)
+              current_workdir=$(pwd)
+
+              if [ "$existing_project" = "$COMPOSE_PROJECT_NAME" ] && [ "$existing_workdir" = "$current_workdir" ]; then
+                return 0
+              fi
+
+              echo "Removing conflicting container $container_name ($existing_container_id) from previous deploy context"
+              docker rm -f "$existing_container_id"
             }
 
             set_portainer_volume() {
@@ -366,13 +392,40 @@ jobs:
                   cp -a "$stage_dir"/. "$work_dir"/
                   cd "$work_dir"
 
+                  remove_conflicting_container() {
+                    container_name="$1"
+                    existing_container_id=""
+
+                    for container_id in $(docker ps -aq --filter "name=^/${container_name}$" 2>/dev/null || true); do
+                      existing_container_id="$container_id"
+                      break
+                    done
+
+                    if [ -z "$existing_container_id" ]; then
+                      return 0
+                    fi
+
+                    existing_project=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project" }}' 2>/dev/null || true)
+                    existing_workdir=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || true)
+                    current_workdir=$(pwd)
+
+                    if [ "$existing_project" = "$COMPOSE_PROJECT_NAME" ] && [ "$existing_workdir" = "$current_workdir" ]; then
+                      return 0
+                    fi
+
+                    echo "Removing conflicting container $container_name ($existing_container_id) from previous deploy context"
+                    docker rm -f "$existing_container_id"
+                  }
+
                   if [ -f stack.env ]; then
                     if [ -n "$VITE_CESIUM_ION_TOKEN" ]; then export VITE_CESIUM_ION_TOKEN; fi
                     docker compose -p "$COMPOSE_PROJECT_NAME" --env-file stack.env build --pull backend
+                    remove_conflicting_container parapente-backend
                     BACKEND_DEPLOY_VERSION="$TARGET_VERSION" docker compose -p "$COMPOSE_PROJECT_NAME" --env-file stack.env up -d --force-recreate --remove-orphans backend redis
                   elif [ -f .env ]; then
                     if [ -n "$VITE_CESIUM_ION_TOKEN" ]; then export VITE_CESIUM_ION_TOKEN; fi
                     docker compose -p "$COMPOSE_PROJECT_NAME" --env-file .env build --pull backend
+                    remove_conflicting_container parapente-backend
                     BACKEND_DEPLOY_VERSION="$TARGET_VERSION" docker compose -p "$COMPOSE_PROJECT_NAME" --env-file .env up -d --force-recreate --remove-orphans backend redis
                   else
                     if [ -z "$VITE_CESIUM_ION_TOKEN" ]; then
@@ -381,6 +434,7 @@ jobs:
                     fi
                     export VITE_CESIUM_ION_TOKEN
                     docker compose -p "$COMPOSE_PROJECT_NAME" build --pull backend
+                    remove_conflicting_container parapente-backend
                     BACKEND_DEPLOY_VERSION="$TARGET_VERSION" docker compose -p "$COMPOSE_PROJECT_NAME" up -d --force-recreate --remove-orphans backend redis
                   fi
                 '


### PR DESCRIPTION
## Summary
- Remove a stale `parapente-backend` container when it belongs to a previous deploy context before running Docker Compose.
- Apply the cleanup to both host-path and Portainer-volume deployment paths.

## Validation
- git diff --check
- python3 YAML parse for .github/workflows/deploy-portainer.yml