### PR TITLE
refactor(design-system): use aria progress bar in IconCard

### DIFF
--- a/libs/design-system/package.json
+++ b/libs/design-system/package.json
@@ -13,6 +13,7 @@
   "peerDependencies": {
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-aria-components": "catalog:",
     "tailwindcss": "catalog:"
   },
   "devDependencies": {

--- a/libs/design-system/src/components/IconCard/IconCard.tsx
+++ b/libs/design-system/src/components/IconCard/IconCard.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
 const iconCard = tv({
@@ -58,14 +59,22 @@ export function IconCard({
   return (
     <div className={styles.root()}>
       {!unlocked && progress !== undefined && (
-        <div
-          className={styles.progressOverlay()}
-          style={{
-            height: `${progress}%`,
-            bottom: 0,
-            top: 'auto',
-          }}
-        ></div>
+        <ProgressBar
+          aria-label={`Progression ${title}`}
+          className="absolute inset-0"
+          maxValue={100}
+          minValue={0}
+          value={progress}
+        >
+          <div
+            className={styles.progressOverlay()}
+            style={{
+              height: `${progress}%`,
+              bottom: 0,
+              top: 'auto',
+            }}
+          ></div>
+        </ProgressBar>
       )}
 
       {unlocked ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.6
+      react-aria-components:
+        specifier: 'catalog:'
+        version: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)


### PR DESCRIPTION
## Summary
- Replace IconCard's manual locked-state progress overlay with React Aria's ProgressBar semantics.
- Preserve the existing vertical gradient progress visualization.
- Declare react-aria-components as a design-system peer dependency and sync the lockfile.

## Validation
- pnpm dlx oxlint -c .oxlintrc.json libs/design-system/src/components/IconCard/IconCard.tsx
- pnpm dlx --package typescript --package react-aria-components --package react --package react-dom --package @types/react --package @types/react-dom --package tailwind-variants tsc --jsx react-jsx --moduleResolution bundler --module esnext --target es2022 --noEmit --skipLibCheck libs/design-system/src/components/IconCard/IconCard.tsx
- pnpm install --lockfile-only --frozen-lockfile --offline

## Notes
- Full Nx design-system targets were not run because node_modules installation in the NAS worktree repeatedly timed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated IconCard progress indicator with improved accessibility features and semantic markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->