### PR TITLE
fix(deploy): quote nested Docker inspect formats

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -405,8 +405,8 @@ jobs:
                       return 0
                     fi
 
-                    existing_project=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project" }}' 2>/dev/null || true)
-                    existing_workdir=$(docker inspect "$existing_container_id" --format '{{ index .Config.Labels "com.docker.compose.project.working_dir" }}' 2>/dev/null || true)
+                    existing_project=$(docker inspect "$existing_container_id" --format "{{ index .Config.Labels \"com.docker.compose.project\" }}" 2>/dev/null || true)
+                    existing_workdir=$(docker inspect "$existing_container_id" --format "{{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}" 2>/dev/null || true)
                     current_workdir=$(pwd)
 
                     if [ "$existing_project" = "$COMPOSE_PROJECT_NAME" ] && [ "$existing_workdir" = "$current_workdir" ]; then


### PR DESCRIPTION
## Summary
- Fix shell quoting for Docker inspect templates inside the Portainer-volume deployment script.
- Preserve the orphan container cleanup from the previous deploy fix.

## Validation
- git diff --check
- python3 YAML parse for .github/workflows/deploy-portainer.yml