### PR TITLE
refactor(design-system): group component styles into slots

### DIFF
--- a/libs/design-system/src/Lightbox.tsx
+++ b/libs/design-system/src/Lightbox.tsx
@@ -2,19 +2,25 @@ import { useState, useEffect } from 'react';
 import { Dialog, Modal, ModalOverlay, Button } from 'react-aria-components';
 import { tv } from 'tailwind-variants';
 
-const overlay = tv({
-  base: 'fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm',
-});
-
-const closeButton = tv({
-  base: 'absolute -top-3 -right-3 z-10 w-8 h-8 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full shadow-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-lg font-bold',
-});
-
-const navButton = tv({
-  base: 'w-8 h-8 flex items-center justify-center bg-white/90 dark:bg-gray-800/90 rounded-full shadow text-gray-700 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-700 transition-colors',
+const lightbox = tv({
+  slots: {
+    overlay:
+      'fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm',
+    root: 'relative max-w-[90vw] max-h-[90vh] flex flex-col items-center',
+    closeButton:
+      'absolute -top-3 -right-3 z-10 w-8 h-8 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full shadow-lg text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-lg font-bold',
+    image: 'max-w-[90vw] max-h-[80vh] object-contain rounded-lg shadow-2xl',
+    footer: 'mt-3 flex items-center gap-4',
+    navButton:
+      'w-8 h-8 flex items-center justify-center bg-white/90 dark:bg-gray-800/90 rounded-full shadow text-gray-700 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-700 transition-colors',
+    caption:
+      'text-sm text-white font-medium px-3 py-1 bg-black/40 rounded-full',
+  },
   variants: {
     disabled: {
-      true: 'opacity-30 cursor-default',
+      true: {
+        navButton: 'opacity-30 cursor-default',
+      },
     },
   },
 });
@@ -49,6 +55,7 @@ export function Lightbox({
   const hasPrev = index > 0;
   const hasNext = index < images.length - 1;
   const multi = images.length > 1;
+  const styles = lightbox();
 
   const goToPrev = () => {
     if (hasPrev) setIndex(index - 1);
@@ -74,19 +81,16 @@ export function Lightbox({
       onOpenChange={(open) => {
         if (!open) onClose();
       }}
-      className={overlay()}
+      className={styles.overlay()}
     >
       <Modal className="outline-none">
         <Dialog className="outline-none">
           {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-          <div
-            className="relative max-w-[90vw] max-h-[90vh] flex flex-col items-center"
-            onKeyDown={handleKeyDown}
-          >
+          <div className={styles.root()} onKeyDown={handleKeyDown}>
             <Button
               aria-label="Fermer"
               onPress={onClose}
-              className={closeButton()}
+              className={styles.closeButton()}
             >
               ✕
             </Button>
@@ -94,21 +98,21 @@ export function Lightbox({
             <img
               src={current.src}
               alt={current.alt}
-              className="max-w-[90vw] max-h-[80vh] object-contain rounded-lg shadow-2xl"
+              className={styles.image()}
             />
 
-            <div className="mt-3 flex items-center gap-4">
+            <div className={styles.footer()}>
               {multi && (
                 <Button
                   aria-label="Image précédente"
                   onPress={goToPrev}
                   isDisabled={!hasPrev}
-                  className={navButton({ disabled: !hasPrev })}
+                  className={lightbox({ disabled: !hasPrev }).navButton()}
                 >
                   ←
                 </Button>
               )}
-              <span className="text-sm text-white font-medium px-3 py-1 bg-black/40 rounded-full">
+              <span className={styles.caption()}>
                 {current.alt}
                 {multi && ` (${index + 1}/${images.length})`}
               </span>
@@ -117,7 +121,7 @@ export function Lightbox({
                   aria-label="Image suivante"
                   onPress={goToNext}
                   isDisabled={!hasNext}
-                  className={navButton({ disabled: !hasNext })}
+                  className={lightbox({ disabled: !hasNext }).navButton()}
                 >
                   →
                 </Button>

--- a/libs/design-system/src/components/DataList/DataList.tsx
+++ b/libs/design-system/src/components/DataList/DataList.tsx
@@ -9,24 +9,32 @@ import {
 import { useTranslation } from 'react-i18next';
 import { tv } from 'tailwind-variants';
 
-const sortButton = tv({
-  base: 'px-3 py-2 sm:px-2 sm:py-1 text-xs rounded-md font-medium transition-colors',
+const dataList = tv({
+  slots: {
+    sortButton:
+      'px-3 py-2 sm:px-2 sm:py-1 text-xs rounded-md font-medium transition-colors',
+    paginationButton:
+      'px-3 py-2.5 sm:py-1 text-sm rounded-md font-medium transition-colors',
+  },
   variants: {
     active: {
-      true: 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300',
-      false:
-        'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600',
+      true: {
+        sortButton:
+          'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-300',
+      },
+      false: {
+        sortButton:
+          'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600',
+      },
     },
-  },
-});
-
-const paginationButton = tv({
-  base: 'px-3 py-2.5 sm:py-1 text-sm rounded-md font-medium transition-colors',
-  variants: {
     disabled: {
-      true: 'text-gray-300 dark:text-gray-600 cursor-not-allowed',
-      false:
-        'text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer',
+      true: {
+        paginationButton: 'text-gray-300 dark:text-gray-600 cursor-not-allowed',
+      },
+      false: {
+        paginationButton:
+          'text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 cursor-pointer',
+      },
     },
   },
 });
@@ -87,7 +95,7 @@ export function DataList<TData>({
             return (
               <Button
                 key={col.id}
-                className={sortButton({ active: isActive })}
+                className={dataList({ active: isActive }).sortButton()}
                 aria-label={
                   currentSort
                     ? t(
@@ -161,9 +169,9 @@ export function DataList<TData>({
           <div className="flex gap-1">
             <Button
               aria-label={t('dataList.previousPage')}
-              className={paginationButton({
+              className={dataList({
                 disabled: !table.getCanPreviousPage(),
-              })}
+              }).paginationButton()}
               onPress={() => table.previousPage()}
               isDisabled={!table.getCanPreviousPage()}
             >
@@ -171,9 +179,9 @@ export function DataList<TData>({
             </Button>
             <Button
               aria-label={t('dataList.nextPage')}
-              className={paginationButton({
+              className={dataList({
                 disabled: !table.getCanNextPage(),
-              })}
+              }).paginationButton()}
               onPress={() => table.nextPage()}
               isDisabled={!table.getCanNextPage()}
             >

--- a/libs/design-system/src/components/DataTable/DataTable.tsx
+++ b/libs/design-system/src/components/DataTable/DataTable.tsx
@@ -2,22 +2,25 @@ import type { ReactNode } from 'react';
 import { flexRender, type Table } from '@tanstack/react-table';
 import { tv } from 'tailwind-variants';
 
-const headerCell = tv({
-  base: 'text-left py-2 px-2 font-semibold text-gray-700 dark:text-gray-300',
+const dataTable = tv({
+  slots: {
+    headerCell:
+      'text-left py-2 px-2 font-semibold text-gray-700 dark:text-gray-300',
+    row: 'border-b border-gray-100 dark:border-gray-700 transition-colors',
+  },
   variants: {
     sortable: {
-      true: 'cursor-pointer select-none hover:text-sky-600 dark:hover:text-sky-400 transition-colors',
-      false: '',
+      true: {
+        headerCell:
+          'cursor-pointer select-none hover:text-sky-600 dark:hover:text-sky-400 transition-colors',
+      },
+      false: {},
     },
-  },
-});
-
-const row = tv({
-  base: 'border-b border-gray-100 dark:border-gray-700 transition-colors',
-  variants: {
     hoverable: {
-      true: 'hover:bg-gray-50 dark:hover:bg-gray-700',
-      false: '',
+      true: {
+        row: 'hover:bg-gray-50 dark:hover:bg-gray-700',
+      },
+      false: {},
     },
   },
   defaultVariants: {
@@ -49,7 +52,7 @@ export function DataTable<TData>({ table, className }: DataTableProps<TData>) {
                     <th
                       key={header.id}
                       colSpan={header.colSpan}
-                      className={headerCell({ sortable: canSort })}
+                      className={dataTable({ sortable: canSort }).headerCell()}
                       onClick={
                         canSort
                           ? header.column.getToggleSortingHandler()
@@ -75,7 +78,10 @@ export function DataTable<TData>({ table, className }: DataTableProps<TData>) {
           </thead>
           <tbody>
             {table.getRowModel().rows.map((tableRow) => (
-              <tr key={tableRow.id} className={row({ hoverable: true })}>
+              <tr
+                key={tableRow.id}
+                className={dataTable({ hoverable: true }).row()}
+              >
                 {tableRow.getVisibleCells().map((cell) => (
                   <td key={cell.id} className="py-2 px-2">
                     {cell.column.columnDef.cell


### PR DESCRIPTION
## Summary
- Refactor `Lightbox` styles to use a single `tailwind-variants` slots definition.
- Apply the same slots pattern to `DataList` and `DataTable`, the other design-system components with multiple local `tv()` definitions.
- Keep public component APIs and usages unchanged.

## Validation
- `pnpm dlx oxlint -c .oxlintrc.json libs/design-system/src/Lightbox.tsx libs/design-system/src/components/DataTable/DataTable.tsx libs/design-system/src/components/DataList/DataList.tsx`
- `pnpm dlx oxfmt -c .oxfmtrc.json --check libs/design-system/src/Lightbox.tsx libs/design-system/src/components/DataTable/DataTable.tsx libs/design-system/src/components/DataList/DataList.tsx`

## Notes
- Full Nx validation was not run because `pnpm install --frozen-lockfile` in the worktree did not complete within the available timeout on the NAS workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the styling configuration architecture across Lightbox, DataList, and DataTable components in the design system library. These internal structural improvements enhance code organization, consistency, and maintainability for future development. All component functionality, behavior, interactions, visual appearance, and overall user experience remain completely unchanged, with no adjustments or migration steps required by users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->