### PR TITLE
fix(frontend): contain weather mobile overflow

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -165,12 +165,12 @@ export const BestSpotSuggestion = ({
 
   return (
     <div
-      className={`bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm overflow-hidden ${className}`}
+      className={`min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className}`}
     >
       {/* Header with colored accent bar */}
       <div className={`h-1.5 ${scoreColor.bg}`} />
 
-      <div className="p-4">
+      <div className="min-w-0 p-4">
         {/* Top row: title + verdict badge */}
         <div className="flex items-center justify-between mb-3 gap-2">
           <div className="flex items-center gap-2">
@@ -187,8 +187,8 @@ export const BestSpotSuggestion = ({
         </div>
 
         {/* Site name + rating */}
-        <div className="flex items-center gap-2 mb-4">
-          <span className="text-xl font-bold text-gray-900 dark:text-white">
+        <div className="flex min-w-0 items-center gap-2 mb-4">
+          <span className="min-w-0 truncate text-xl font-bold text-gray-900 dark:text-white">
             {site.name}
           </span>
           {site.rating != null && site.rating > 0 && (
@@ -323,7 +323,7 @@ export const BestSpotSuggestion = ({
         </p>
 
         {hourlyBestSpots.length > 0 && (
-          <div className="mb-4 border-t border-gray-100 dark:border-gray-700 pt-3">
+          <div className="mb-4 min-w-0 border-t border-gray-100 pt-3 dark:border-gray-700">
             <div className="flex items-center justify-between gap-2 mb-2">
               <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 {t('weather.bestSpotTimeline')}
@@ -332,7 +332,7 @@ export const BestSpotSuggestion = ({
                 {t('weather.byHour')}
               </span>
             </div>
-            <div className="flex gap-2 overflow-x-auto pb-1">
+            <div className="flex max-w-full min-w-0 gap-2 overflow-x-auto overscroll-x-contain pb-1">
               {hourlyBestSpots.map((hourlySpot) => {
                 const hourlyScore = Math.min(
                   100,

--- a/apps/frontend/src/components/weather/Forecast7Day.tsx
+++ b/apps/frontend/src/components/weather/Forecast7Day.tsx
@@ -104,7 +104,7 @@ export default function Forecast7Day({
   }
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+    <div className="min-w-0 rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           {t('weather.forecast7Days')}
@@ -114,7 +114,7 @@ export default function Forecast7Day({
         </div>
       </div>
 
-      <div className="flex gap-3 overflow-x-auto pb-2 snap-x snap-mandatory scrollbar-thin sm:grid sm:grid-cols-2 sm:overflow-x-visible sm:pb-0 sm:snap-none md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
+      <div className="flex max-w-full min-w-0 snap-x snap-mandatory gap-3 overflow-x-auto overscroll-x-contain pb-2 scrollbar-thin sm:grid sm:grid-cols-2 sm:overflow-x-visible sm:pb-0 sm:snap-none md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
         {dailySummary.days.map((day, index) => {
           const isSelected = index === selectedDayIndex;
 

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -782,7 +782,7 @@ export default function HourlyForecast({
   };
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+    <div className="min-w-0 rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           Prévisions Horaires
@@ -793,7 +793,7 @@ export default function HourlyForecast({
         Glissez le tableau horizontalement pour voir toutes les mesures.
       </p>
 
-      <div className="overflow-x-auto overscroll-x-contain rounded-lg border border-gray-100 touch-pan-x dark:border-gray-700">
+      <div className="max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-lg border border-gray-100 dark:border-gray-700">
         <table className="w-full min-w-[800px] text-sm">
           <thead>
             <tr className="border-b-2 border-gray-200 dark:border-gray-600">

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -106,8 +106,8 @@ export default function WeatherPage() {
   };
 
   return (
-    <div className="grid gap-3 sm:gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
-      <aside className="space-y-3 sm:space-y-4 xl:sticky xl:top-4 xl:self-start">
+    <div className="grid w-full min-w-0 gap-3 sm:gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
+      <aside className="min-w-0 space-y-3 sm:space-y-4 xl:sticky xl:top-4 xl:self-start">
         <section className="rounded-2xl border border-sky-100 bg-white p-3 shadow-md dark:border-gray-700 dark:bg-gray-800 sm:p-4">
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>


### PR DESCRIPTION
## Summary
- Constrain the weather page grid and sidebar so mobile overflow stays inside local scroll containers.
- Add width constraints to the best-spot timeline, 7-day forecast carousel, and hourly forecast table.

## Validation
- `git diff --check`
- `pnpm nx lint frontend` could not run because `nx` was unavailable in the worktree after dependency install timed out on the NAS.