### PR TITLE
fix(frontend): move best spot below day selector

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -175,22 +175,6 @@ export default function WeatherPage() {
           }}
         />
 
-        <BestSpotSuggestion
-          bestSpot={bestSpot ?? null}
-          hourlyBestSpots={hourlyBestSpots?.hours ?? []}
-          hourlyStartHour={hourlyBestSpots?.startHour}
-          onSelectSite={(siteId) => {
-            setSelectedSearchTarget(null);
-            void navigate({
-              to: '/weather',
-              search: {
-                siteId,
-                day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
-              },
-            });
-          }}
-          selectedDayIndex={selectedDayIndex}
-        />
       </aside>
 
       <div className="min-w-0 space-y-3 sm:space-y-4">
@@ -301,19 +285,38 @@ export default function WeatherPage() {
 
         {/* 7-Day Forecast + Day Selector */}
         {!selectedSearchTarget && selectedSiteId && (
-          <Forecast7Day
-            spotId={selectedSiteId}
-            selectedDayIndex={selectedDayIndex}
-            onSelectDay={(day) =>
-              void navigate({
-                to: '/weather',
-                search: {
-                  ...weatherSearch,
-                  day: day > 0 ? day : undefined,
-                },
-              })
-            }
-          />
+          <>
+            <Forecast7Day
+              spotId={selectedSiteId}
+              selectedDayIndex={selectedDayIndex}
+              onSelectDay={(day) =>
+                void navigate({
+                  to: '/weather',
+                  search: {
+                    ...weatherSearch,
+                    day: day > 0 ? day : undefined,
+                  },
+                })
+              }
+            />
+
+            <BestSpotSuggestion
+              bestSpot={bestSpot ?? null}
+              hourlyBestSpots={hourlyBestSpots?.hours ?? []}
+              hourlyStartHour={hourlyBestSpots?.startHour}
+              onSelectSite={(siteId) => {
+                setSelectedSearchTarget(null);
+                void navigate({
+                  to: '/weather',
+                  search: {
+                    siteId,
+                    day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                  },
+                });
+              }}
+              selectedDayIndex={selectedDayIndex}
+            />
+          </>
         )}
 
         {/* Emagram Analysis (authenticated only) */}


### PR DESCRIPTION
## Summary
- Move the weather best spot recommendation from the sidebar into the main weather content.
- Display the best spot card immediately below the 7-day/day selector block.

## Validation
- `git diff --check`
- `pnpm nx lint frontend` could not be completed because `/` is full and the worktree dependency install on the NAS did not finish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the layout structure of the weather page to better group related forecast components together while preserving all navigation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->