### PR TITLE
fix(backend): include both flight option types in nearby search

### DIFF
--- a/apps/backend/spots/search.py
+++ b/apps/backend/spots/search.py
@@ -54,9 +54,9 @@ def search_by_coordinates(
         ParaglidingSpot.longitude <= max_lon,
     )
 
-    # Apply type filter if specified
+    # A "both" spot can be used as either takeoff or landing.
     if spot_type:
-        query = query.filter(ParaglidingSpot.type == spot_type)
+        query = query.filter(ParaglidingSpot.type.in_([spot_type, "both"]))
 
     candidates = query.all()
 

--- a/apps/backend/tests/test_routes.py
+++ b/apps/backend/tests/test_routes.py
@@ -191,7 +191,7 @@ class TestLocationWeatherEndpoints:
         assert data["query"] == "Besan"
         assert data["locations"][0]["name"] == "Besançon"
 
-    def test_nearby_flight_options_split_takeoffs_and_landings(self, client, db_session):
+    def test_nearby_flight_options_split_takeoffs_landings_and_both(self, client, db_session):
         db_session.add_all(
             [
                 ParaglidingSpot(
@@ -214,6 +214,16 @@ class TestLocationWeatherEndpoints:
                     country="FR",
                     source="test",
                 ),
+                ParaglidingSpot(
+                    id="both-near",
+                    name="Site polyvalent proche",
+                    type="both",
+                    latitude=47.238,
+                    longitude=6.024,
+                    elevation_m=350,
+                    country="FR",
+                    source="test",
+                ),
             ]
         )
         db_session.commit()
@@ -225,8 +235,8 @@ class TestLocationWeatherEndpoints:
         assert response.status_code == 200
         data = response.json()
         assert data["city_option"]["name"] == "Besançon"
-        assert [spot["id"] for spot in data["takeoffs"]] == ["takeoff-near"]
-        assert [spot["id"] for spot in data["landings"]] == ["landing-near"]
+        assert [spot["id"] for spot in data["takeoffs"]] == ["both-near", "takeoff-near"]
+        assert [spot["id"] for spot in data["landings"]] == ["both-near", "landing-near"]
 
     def test_weather_by_coordinates(self, client, monkeypatch):
         async def fake_forecast(*args, **kwargs):


### PR DESCRIPTION
## Summary
- Include `both` paragliding spots when searching nearby takeoffs or landings.
- Cover the nearby flight options endpoint with a regression test for `both` spots.

## Validation
- `python3 -m ruff check . --output-format=github`
- `python3 -m black --check --diff .`
- `python3 -m py_compile apps/backend/spots/search.py apps/backend/tests/test_routes.py`

## Notes
- `pnpm nx test backend` could not run locally because Nx/dependencies were unavailable in the worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the nearby flight options search to return more comprehensive results when filtering by spot type, now including locations that serve multiple purposes alongside exact type matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->