### PR TITLE
feat(emagram): explain AI analysis in tooltip

### DIFF
--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -163,6 +163,7 @@ def _normalize_llm_analysis(
         "conseils_vol": raw_analysis.get("conseils_vol"),
         "alertes_securite": raw_analysis.get("alertes_securite", []),
         "details_analyse": raw_analysis.get("details_analyse"),
+        "explication_analyse": raw_analysis.get("explication_analyse"),
         "llm_provider": provider["provider"],
         "llm_model": raw_analysis.get("llm_model", provider["model"]),
         "llm_tokens_used": raw_analysis.get("llm_tokens_used"),
@@ -415,7 +416,7 @@ def save_emagram_analysis(
         sources_count=screenshot_result.get("sources_successful", 0),
         sources_agreement=analysis_result.get("sources_agreement"),
         sources_errors=json.dumps(sources_errors, ensure_ascii=False) if sources_errors else None,
-        ai_raw_response=analysis_result.get("raw_response"),
+        ai_raw_response=json.dumps(analysis_result, ensure_ascii=False),
         # Status
         analysis_status="completed",
     )

--- a/apps/backend/llm/gemini_analyzer.py
+++ b/apps/backend/llm/gemini_analyzer.py
@@ -174,7 +174,15 @@ Réponds UNIQUEMENT avec ce JSON (sans markdown):
   "score_volabilite": <0-100>,
   "conseils_vol": "<conseils courts MAX 50 mots>",
   "alertes_securite": [<liste ou []>],
-  "details_analyse": "<analyse courte MAX 100 mots>"
+  "details_analyse": "<analyse courte MAX 100 mots>",
+  "explication_analyse": {{
+    "resume": "<pourquoi ce score en 1 phrase>",
+    "indices": [
+      "<courbe/indice observe -> interpretation parapente>",
+      "<courbe/indice observe -> interpretation parapente>"
+    ],
+    "par_source": {{"<source si identifiable>": ["<observation -> consequence>"]}}
+  }}
 }}
 
 IMPORTANT: Réponds UNIQUEMENT le JSON complet, rien d'autre.
@@ -277,6 +285,8 @@ def _parse_gemini_response(response_text: str) -> dict:
         if not isinstance(analysis["alertes_securite"], list):
             analysis["alertes_securite"] = []
 
+        analysis.setdefault("explication_analyse", None)
+
         return analysis
 
     except json.JSONDecodeError as e:
@@ -292,6 +302,7 @@ def _parse_gemini_response(response_text: str) -> dict:
             "conseils_vol": "Analyse impossible - erreur de parsing Gemini",
             "alertes_securite": ["Erreur lors de l'analyse"],
             "details_analyse": f"Erreur de parsing JSON: {str(e)}\n\nRéponse brute: {response_text[:1000]}",
+            "explication_analyse": None,
         }
 
 
@@ -305,6 +316,7 @@ def _get_default_value(field: str):
         "conseils_vol": "",
         "alertes_securite": [],
         "details_analyse": "",
+        "explication_analyse": None,
     }
     return defaults.get(field, None)
 

--- a/apps/backend/llm/groq_analyzer.py
+++ b/apps/backend/llm/groq_analyzer.py
@@ -29,7 +29,15 @@ Réponds UNIQUEMENT en JSON valide avec cette structure exacte :
   "score_volabilite": <score 0-100>,
   "conseils_vol": "<conseils pratiques pour le pilote>",
   "alertes_securite": ["<alerte 1>", "<alerte 2>"],
-  "details_analyse": "<resume technique de l'analyse>"
+  "details_analyse": "<resume technique de l'analyse>",
+  "explication_analyse": {{
+    "resume": "<pourquoi ce score en 1 phrase>",
+    "indices": [
+      "<courbe/indice observe -> interpretation parapente>",
+      "<courbe/indice observe -> interpretation parapente>"
+    ],
+    "par_source": {{"<source si identifiable>": ["<observation -> consequence>"]}}
+  }}
 }}"""
 
 
@@ -118,6 +126,7 @@ def analyze_emagram_with_groq(
             result.setdefault("heures_volables", "11:00-17:00")
             result.setdefault("alertes_securite", [])
             result.setdefault("details_analyse", "Analyse par Groq Llama Vision")
+            result.setdefault("explication_analyse", None)
             usage = getattr(response, "usage", None)
             prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
             completion_tokens = getattr(usage, "completion_tokens", 0) or 0

--- a/apps/backend/llm/openrouter_analyzer.py
+++ b/apps/backend/llm/openrouter_analyzer.py
@@ -31,7 +31,15 @@ Réponds UNIQUEMENT en JSON valide avec cette structure exacte :
   "score_volabilite": <score 0-100>,
   "conseils_vol": "<conseils pratiques pour le pilote>",
   "alertes_securite": ["<alerte 1>", "<alerte 2>"],
-  "details_analyse": "<resume technique de l'analyse>"
+  "details_analyse": "<resume technique de l'analyse>",
+  "explication_analyse": {{
+    "resume": "<pourquoi ce score en 1 phrase>",
+    "indices": [
+      "<courbe/indice observe -> interpretation parapente>",
+      "<courbe/indice observe -> interpretation parapente>"
+    ],
+    "par_source": {{"<source si identifiable>": ["<observation -> consequence>"]}}
+  }}
 }}"""
 
 
@@ -174,5 +182,6 @@ def _parse_openrouter_response(response_text: str) -> dict[str, Any]:
     result["score_volabilite"] = max(0, min(100, int(result["score_volabilite"])))
     if not isinstance(result["alertes_securite"], list):
         result["alertes_securite"] = []
+    result.setdefault("explication_analyse", None)
 
     return result

--- a/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.tsx
@@ -1,0 +1,74 @@
+import { Button, Tooltip, TooltipTrigger } from 'react-aria-components';
+import { parseAnalysisExplanation } from '../../types/emagram';
+import type { EmagramAnalysis } from '../../types/emagram';
+
+interface EmagramExplanationTooltipProps {
+  emagram: EmagramAnalysis;
+  compact?: boolean;
+}
+
+export function EmagramExplanationTooltip({
+  emagram,
+  compact = false,
+}: EmagramExplanationTooltipProps) {
+  const explanation = parseAnalysisExplanation(emagram.ai_raw_response);
+  if (!explanation) return null;
+
+  const sourceEntries = Object.entries(explanation.par_source);
+  const label = "Comment l'IA a analysé ?";
+
+  return (
+    <TooltipTrigger>
+      <Button
+        className={`inline-flex items-center gap-1 rounded-full border border-purple-200 bg-purple-50 text-purple-700 hover:bg-purple-100 dark:border-purple-700 dark:bg-purple-900/30 dark:text-purple-200 dark:hover:bg-purple-900/50 transition-colors cursor-pointer ${
+          compact ? 'px-2 py-1 text-[11px]' : 'px-3 py-1.5 text-xs'
+        }`}
+        aria-label={label}
+      >
+        <span aria-hidden="true">?</span>
+        {!compact && <span>{label}</span>}
+      </Button>
+      <Tooltip className="max-w-sm rounded-lg border border-purple-200 bg-white p-3 text-xs text-gray-700 shadow-xl dark:border-purple-700 dark:bg-gray-900 dark:text-gray-200">
+        <div className="space-y-2">
+          <div className="font-semibold text-purple-800 dark:text-purple-200">
+            {label}
+          </div>
+          {explanation.resume && <p>{explanation.resume}</p>}
+          {explanation.indices.length > 0 && (
+            <ul className="space-y-1 pl-4">
+              {explanation.indices.map((indice) => (
+                <li key={indice} className="list-disc">
+                  {indice}
+                </li>
+              ))}
+            </ul>
+          )}
+          {sourceEntries.length > 0 && (
+            <div className="space-y-1 border-t border-gray-100 pt-2 dark:border-gray-700">
+              {sourceEntries.map(([source, observations]) => (
+                <div key={source}>
+                  <div className="font-medium capitalize text-gray-800 dark:text-gray-100">
+                    {source.replace('-', ' ')}
+                  </div>
+                  <ul className="space-y-0.5 pl-4">
+                    {observations.map((observation) => (
+                      <li key={observation} className="list-disc">
+                        {observation}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="border-t border-gray-100 pt-2 text-[11px] text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            {emagram.llm_model ? `Modèle : ${emagram.llm_model}` : 'Analyse IA'}
+            {emagram.sources_agreement
+              ? ` • Consensus : ${emagram.sources_agreement}`
+              : ''}
+          </div>
+        </div>
+      </Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/apps/frontend/src/components/dashboard/EmagramWidget.chromatic.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.chromatic.stories.tsx
@@ -50,6 +50,16 @@ const meta = preview.meta({
             score_volabilite: 75,
             plafond_thermique_m: 2500,
             force_thermique_ms: 2.5,
+            ai_raw_response: JSON.stringify({
+              explication_analyse: {
+                resume:
+                  'Le score est bon car les thermiques sont nets, avec une vigilance sur le vent au-dessus du plafond utile.',
+                indices: [
+                  'Température et point de rosée se séparent en basses couches -> convection exploitable.',
+                  'Plafond vers 2500 m -> marge confortable au-dessus du relief.',
+                ],
+              },
+            }),
             analysis_status: 'completed',
             is_from_llm: true,
             has_thermal_data: true,

--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -57,6 +57,27 @@ const mockEmagramData = {
   alertes_securite: JSON.stringify([
     'Attention au vent en altitude au-dessus de 2000m',
   ]),
+  ai_raw_response: JSON.stringify({
+    details_analyse:
+      'Les courbes indiquent une convection exploitable avec un plafond correct.',
+    explication_analyse: {
+      resume:
+        'Le score est bon car les thermiques sont établis, mais le vent en altitude limite la marge.',
+      indices: [
+        'La courbe de température s’écarte progressivement du point de rosée, donc l’air devient assez instable pour déclencher des thermiques.',
+        'Le plafond estimé autour de 2500 m donne une marge correcte au-dessus du relief.',
+        'Le vent se renforce au-dessus de 2000 m, donc la dérive devient le principal point de vigilance.',
+      ],
+      par_source: {
+        'meteo-parapente': [
+          'La couche convective monte nettement en milieu de journée -> créneau favorable après 11h.',
+        ],
+        topmeteo: [
+          'Le profil confirme un plafond élevé -> bonnes transitions possibles.',
+        ],
+      },
+    },
+  }),
   is_from_llm: true,
   has_thermal_data: true,
   flyable_hours_formatted: '6h',
@@ -127,6 +148,9 @@ export const Default = meta.story({
 Default.test('displays emagram score and metrics', async ({ canvas }) => {
   await canvas.findByText(/75/);
   await expect(canvas.getByText(/Arguel/)).toBeInTheDocument();
+  await expect(
+    canvas.getByLabelText(/Comment l'IA a analysé/)
+  ).toBeInTheDocument();
 });
 
 /*Default.test('displays screenshot buttons', async ({ canvas }) => {

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -18,6 +18,7 @@ import {
 import { useState, useMemo, useEffect } from 'react';
 import { parseApiUtcDate } from '../../lib/date';
 import { Lightbox } from '@dashboard-parapente/design-system';
+import { EmagramExplanationTooltip } from './EmagramExplanationTooltip';
 import {
   Slider,
   SliderTrack,
@@ -474,18 +475,21 @@ export default function EmagramWidget({
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           🌡️ Analyse Thermique (Émagramme)
         </h2>
-        <Button
-          onPress={handleRefresh}
-          isDisabled={isRefreshing}
-          className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-          aria-label="Actualiser"
-        >
-          <span
-            className={`text-base ${isRefreshing ? 'animate-spin inline-block' : ''}`}
+        <div className="flex items-center gap-2">
+          <EmagramExplanationTooltip emagram={emagram} compact />
+          <Button
+            onPress={handleRefresh}
+            isDisabled={isRefreshing}
+            className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+            aria-label="Actualiser"
           >
-            🔄
-          </span>
-        </Button>
+            <span
+              className={`text-base ${isRefreshing ? 'animate-spin inline-block' : ''}`}
+            >
+              🔄
+            </span>
+          </Button>
+        </div>
       </div>
 
       {/* Hour Slider */}

--- a/apps/frontend/src/pages/ThermalAnalysis.stories.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.stories.tsx
@@ -43,6 +43,16 @@ const mockEmagramLatest = {
       message: 'Renforcement du vent en altitude > 2000m',
     },
   ]),
+  ai_raw_response: JSON.stringify({
+    explication_analyse: {
+      resume:
+        'Le score est moyen-bon : les thermiques existent, mais la couche exploitable reste modérée.',
+      indices: [
+        'La courbe température/point de rosée suggère une instabilité en basses couches -> déclenchement possible.',
+        'La base estimée vers 1600 m limite les marges au-dessus du relief.',
+      ],
+    },
+  }),
   raw_analysis: 'Detailed analysis...',
   source: 'open-meteo',
   created_at: '2026-03-24T08:00:00',

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -22,6 +22,7 @@ import { parseAlerts, getScoreColor } from '../types/emagram';
 import type { EmagramListItem } from '../types/emagram';
 import { DataTable, Button } from '@dashboard-parapente/design-system';
 import { parseApiUtcDate } from '../lib/date';
+import { EmagramExplanationTooltip } from '../components/dashboard/EmagramExplanationTooltip';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
 
@@ -205,9 +206,10 @@ export default function ThermalAnalysis() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
         {/* Left Column - Score & Metrics */}
         <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-          <h2 className="text-lg font-bold mb-4">
-            {t('thermal.scoreCardTitle')}
-          </h2>
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-lg font-bold">{t('thermal.scoreCardTitle')}</h2>
+            <EmagramExplanationTooltip emagram={latest} compact />
+          </div>
 
           {/* Score Gauge */}
           <div className="flex justify-center mb-6">

--- a/apps/frontend/src/types/emagram.ts
+++ b/apps/frontend/src/types/emagram.ts
@@ -99,6 +99,12 @@ export interface EmagramListItem {
   created_at: string;
 }
 
+export interface EmagramAnalysisExplanation {
+  resume: string | null;
+  indices: string[];
+  par_source: Record<string, string[]>;
+}
+
 // Parsed alerts (from JSON string)
 type SafetyAlert = string;
 
@@ -126,6 +132,62 @@ export function parseSourcesErrors(
   } catch {
     return {};
   }
+}
+
+export function parseAnalysisExplanation(
+  ai_raw_response: string | null | undefined
+): EmagramAnalysisExplanation | null {
+  if (!ai_raw_response) return null;
+
+  try {
+    const parsed = JSON.parse(ai_raw_response);
+    const rawExplanation =
+      parsed?.explication_analyse ?? parsed?.details_analyse;
+
+    if (!rawExplanation) return null;
+
+    if (typeof rawExplanation === 'string') {
+      return { resume: rawExplanation, indices: [], par_source: {} };
+    }
+
+    if (Array.isArray(rawExplanation)) {
+      return {
+        resume: null,
+        indices: rawExplanation.filter((item) => typeof item === 'string'),
+        par_source: {},
+      };
+    }
+
+    if (typeof rawExplanation === 'object') {
+      const sourceEntries = Object.entries(
+        rawExplanation.par_source ?? {}
+      ).reduce<Record<string, string[]>>((acc, [source, observations]) => {
+        if (Array.isArray(observations)) {
+          acc[source] = observations.filter((item) => typeof item === 'string');
+        } else if (typeof observations === 'string') {
+          acc[source] = [observations];
+        }
+        return acc;
+      }, {});
+
+      return {
+        resume:
+          typeof rawExplanation.resume === 'string'
+            ? rawExplanation.resume
+            : null,
+        indices: Array.isArray(rawExplanation.indices)
+          ? rawExplanation.indices.filter(
+              (item: unknown) => typeof item === 'string'
+            )
+          : [],
+        par_source: sourceEntries,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 // Score categories


### PR DESCRIPTION
## Summary
- Ask LLM emagram analyzers to return structured reasoning about curves, indices, and per-source observations.
- Persist the normalized AI explanation in `ai_raw_response` and parse it on the frontend.
- Add an accessible tooltip in the emagram widget and detailed thermal analysis page, with Storybook mocks updated.

## Validation
- `python3 -m py_compile apps/backend/emagram_multi_source.py apps/backend/llm/gemini_analyzer.py apps/backend/llm/groq_analyzer.py apps/backend/llm/openrouter_analyzer.py`
- Pre-commit `lint-staged` passed for changed frontend/backend files.
- `pnpm knip` failed on existing repository baseline/config issues unrelated to this PR: missing Storybook/Vite/Playwright modules in the temporary hook environment and many existing unused-file/dependency reports. Commit was created with `--no-verify` after explicit approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI analysis explanation tooltips to emagram displays. Users can now view a detailed explanation of the AI analysis, including a summary, key insights, and per-source analysis breakdowns via a tooltip in the dashboard and thermal analysis pages.

* **Chores**
  * Updated mock data fixtures to support new explanation content structure across story and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->