### PR TITLE
fix(backend): fallback to remote flight spots

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -382,7 +382,7 @@ async def get_nearby_flight_options(
     db: Session = Depends(get_db),
 ):
     """Return the selected city plus nearby takeoff and landing options."""
-    from spots import search_by_coordinates
+    from spots import search_by_coordinates, search_remote_by_coordinates
 
     takeoff_result = search_by_coordinates(db, lat, lon, radius_km, "takeoff")
     if "error" in takeoff_result:
@@ -391,6 +391,22 @@ async def get_nearby_flight_options(
     landing_result = search_by_coordinates(db, lat, lon, radius_km, "landing")
     if "error" in landing_result:
         raise HTTPException(status_code=404, detail=landing_result["error"])
+
+    if not takeoff_result["spots"]:
+        try:
+            takeoff_result = await asyncio.to_thread(
+                search_remote_by_coordinates, lat, lon, radius_km, "takeoff"
+            )
+        except Exception:
+            logger.exception("Remote takeoff search failed for %s,%s", lat, lon)
+
+    if not landing_result["spots"]:
+        try:
+            landing_result = await asyncio.to_thread(
+                search_remote_by_coordinates, lat, lon, radius_km, "landing"
+            )
+        except Exception:
+            logger.exception("Remote landing search failed for %s,%s", lat, lon)
 
     takeoffs = takeoff_result["spots"][:limit]
     landings = landing_result["spots"][:limit]

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -392,21 +392,34 @@ async def get_nearby_flight_options(
     if "error" in landing_result:
         raise HTTPException(status_code=404, detail=landing_result["error"])
 
-    if not takeoff_result["spots"]:
+    if not takeoff_result["spots"] or not landing_result["spots"]:
         try:
-            takeoff_result = await asyncio.to_thread(
-                search_remote_by_coordinates, lat, lon, radius_km, "takeoff"
+            remote_result = await asyncio.to_thread(
+                search_remote_by_coordinates, lat, lon, radius_km, None
             )
-        except Exception:
-            logger.exception("Remote takeoff search failed for %s,%s", lat, lon)
+            remote_spots = remote_result.get("spots", [])
 
-    if not landing_result["spots"]:
-        try:
-            landing_result = await asyncio.to_thread(
-                search_remote_by_coordinates, lat, lon, radius_km, "landing"
-            )
+            if not takeoff_result["spots"]:
+                takeoff_spots = [
+                    spot for spot in remote_spots if spot.get("type") in {"takeoff", "both"}
+                ]
+                takeoff_result = {
+                    **remote_result,
+                    "total": len(takeoff_spots),
+                    "spots": takeoff_spots,
+                }
+
+            if not landing_result["spots"]:
+                landing_spots = [
+                    spot for spot in remote_spots if spot.get("type") in {"landing", "both"}
+                ]
+                landing_result = {
+                    **remote_result,
+                    "total": len(landing_spots),
+                    "spots": landing_spots,
+                }
         except Exception:
-            logger.exception("Remote landing search failed for %s,%s", lat, lon)
+            logger.exception("Remote nearby search failed for %s,%s", lat, lon)
 
     takeoffs = takeoff_result["spots"][:limit]
     landings = landing_result["spots"][:limit]

--- a/apps/backend/spots/__init__.py
+++ b/apps/backend/spots/__init__.py
@@ -11,7 +11,13 @@ This module provides functionality to:
 from .data_fetcher import sync_to_database
 from .distance import calculate_bounding_box, haversine_distance
 from .geocoding import geocode_city, search_locations
-from .search import get_spot_by_id, get_sync_status, search_by_city, search_by_coordinates
+from .search import (
+    get_spot_by_id,
+    get_sync_status,
+    search_by_city,
+    search_by_coordinates,
+    search_remote_by_coordinates,
+)
 
 __all__ = [
     "haversine_distance",
@@ -20,6 +26,7 @@ __all__ = [
     "search_locations",
     "search_by_city",
     "search_by_coordinates",
+    "search_remote_by_coordinates",
     "get_spot_by_id",
     "get_sync_status",
     "sync_to_database",

--- a/apps/backend/spots/search.py
+++ b/apps/backend/spots/search.py
@@ -128,9 +128,15 @@ def search_remote_by_coordinates(
             continue
 
         try:
+            spot_id = spot["id"]
+            spot_name = spot["name"]
+            spot_kind = spot["type"]
             spot_lat = float(spot["latitude"])
             spot_lon = float(spot["longitude"])
         except (KeyError, TypeError, ValueError):
+            continue
+
+        if not spot_id or not spot_name or not spot_kind:
             continue
 
         distance = haversine_distance(lat, lon, spot_lat, spot_lon)
@@ -139,9 +145,9 @@ def search_remote_by_coordinates(
 
         results.append(
             {
-                "id": spot["id"],
-                "name": spot["name"],
-                "type": spot["type"],
+                "id": spot_id,
+                "name": spot_name,
+                "type": spot_kind,
                 "latitude": spot_lat,
                 "longitude": spot_lon,
                 "elevation_m": spot.get("elevation_m"),

--- a/apps/backend/spots/search.py
+++ b/apps/backend/spots/search.py
@@ -95,6 +95,80 @@ def search_by_coordinates(
     }
 
 
+def search_remote_by_coordinates(
+    lat: float, lon: float, radius_km: int = 50, spot_type: str | None = None
+) -> dict:
+    """
+    Search external spot sources directly without relying on the local database.
+
+    This is used as a fallback when the local ParaglidingSpot table has not been
+    synced yet, while preserving the same response shape as search_by_coordinates.
+    """
+    from .data_fetcher import (
+        fetch_openaip_data,
+        fetch_paraglidingspots_data,
+        merge_duplicate_spots,
+    )
+
+    logger.info(
+        "Searching remote spots at (%s, %s) within %skm, type=%s",
+        lat,
+        lon,
+        radius_km,
+        spot_type,
+    )
+
+    openaip_spots = fetch_openaip_data()
+    pgs_spots = fetch_paraglidingspots_data()
+    all_spots = merge_duplicate_spots(openaip_spots, pgs_spots)
+
+    results = []
+    for spot in all_spots:
+        if spot_type and spot.get("type") not in {spot_type, "both"}:
+            continue
+
+        try:
+            spot_lat = float(spot["latitude"])
+            spot_lon = float(spot["longitude"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        distance = haversine_distance(lat, lon, spot_lat, spot_lon)
+        if distance > radius_km:
+            continue
+
+        results.append(
+            {
+                "id": spot["id"],
+                "name": spot["name"],
+                "type": spot["type"],
+                "latitude": spot_lat,
+                "longitude": spot_lon,
+                "elevation_m": spot.get("elevation_m"),
+                "orientation": spot.get("orientation"),
+                "rating": spot.get("rating"),
+                "country": spot.get("country", "FR"),
+                "source": spot.get("source", "remote"),
+                "distance_km": distance,
+            }
+        )
+
+    results.sort(key=lambda x: x["distance_km"])
+
+    logger.info("✓ Found %s remote spots within %skm", len(results), radius_km)
+    return {
+        "query": {
+            "latitude": lat,
+            "longitude": lon,
+            "radius_km": radius_km,
+            "type": spot_type,
+            "source": "remote",
+        },
+        "total": len(results),
+        "spots": results,
+    }
+
+
 def search_by_city(
     db: Session,
     city_name: str,

--- a/apps/backend/tests/test_routes.py
+++ b/apps/backend/tests/test_routes.py
@@ -238,6 +238,67 @@ class TestLocationWeatherEndpoints:
         assert [spot["id"] for spot in data["takeoffs"]] == ["both-near", "takeoff-near"]
         assert [spot["id"] for spot in data["landings"]] == ["both-near", "landing-near"]
 
+    def test_nearby_flight_options_falls_back_to_remote_sources(self, client, monkeypatch):
+        def fake_search_remote_by_coordinates(lat, lon, radius_km=50, spot_type=None):
+            assert lat == 47.238
+            assert lon == 6.024
+            assert radius_km == 10
+            spots = {
+                "takeoff": [
+                    {
+                        "id": "openaip-takeoff",
+                        "name": "Déco distant",
+                        "type": "takeoff",
+                        "latitude": 47.24,
+                        "longitude": 6.03,
+                        "elevation_m": 450,
+                        "orientation": None,
+                        "rating": None,
+                        "country": "FR",
+                        "source": "openaip",
+                        "distance_km": 0.5,
+                    }
+                ],
+                "landing": [
+                    {
+                        "id": "pgs-landing",
+                        "name": "Atterro distant",
+                        "type": "landing",
+                        "latitude": 47.23,
+                        "longitude": 6.02,
+                        "elevation_m": None,
+                        "orientation": None,
+                        "rating": 4,
+                        "country": "FR",
+                        "source": "paraglidingspots",
+                        "distance_km": 0.8,
+                    }
+                ],
+            }
+            selected_spots = spots[spot_type]
+            return {
+                "query": {
+                    "latitude": lat,
+                    "longitude": lon,
+                    "radius_km": radius_km,
+                    "type": spot_type,
+                    "source": "remote",
+                },
+                "total": len(selected_spots),
+                "spots": selected_spots,
+            }
+
+        monkeypatch.setattr("spots.search_remote_by_coordinates", fake_search_remote_by_coordinates)
+
+        response = client.get(
+            "/api/locations/nearby-flight-options?lat=47.238&lon=6.024&name=Besançon&radius_km=10&limit=3"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [spot["id"] for spot in data["takeoffs"]] == ["openaip-takeoff"]
+        assert [spot["id"] for spot in data["landings"]] == ["pgs-landing"]
+
     def test_weather_by_coordinates(self, client, monkeypatch):
         async def fake_forecast(*args, **kwargs):
             return {

--- a/apps/backend/tests/test_routes.py
+++ b/apps/backend/tests/test_routes.py
@@ -239,43 +239,42 @@ class TestLocationWeatherEndpoints:
         assert [spot["id"] for spot in data["landings"]] == ["both-near", "landing-near"]
 
     def test_nearby_flight_options_falls_back_to_remote_sources(self, client, monkeypatch):
+        calls = []
+
         def fake_search_remote_by_coordinates(lat, lon, radius_km=50, spot_type=None):
             assert lat == 47.238
             assert lon == 6.024
             assert radius_km == 10
-            spots = {
-                "takeoff": [
-                    {
-                        "id": "openaip-takeoff",
-                        "name": "Déco distant",
-                        "type": "takeoff",
-                        "latitude": 47.24,
-                        "longitude": 6.03,
-                        "elevation_m": 450,
-                        "orientation": None,
-                        "rating": None,
-                        "country": "FR",
-                        "source": "openaip",
-                        "distance_km": 0.5,
-                    }
-                ],
-                "landing": [
-                    {
-                        "id": "pgs-landing",
-                        "name": "Atterro distant",
-                        "type": "landing",
-                        "latitude": 47.23,
-                        "longitude": 6.02,
-                        "elevation_m": None,
-                        "orientation": None,
-                        "rating": 4,
-                        "country": "FR",
-                        "source": "paraglidingspots",
-                        "distance_km": 0.8,
-                    }
-                ],
-            }
-            selected_spots = spots[spot_type]
+            assert spot_type is None
+            calls.append(spot_type)
+            spots = [
+                {
+                    "id": "openaip-takeoff",
+                    "name": "Déco distant",
+                    "type": "takeoff",
+                    "latitude": 47.24,
+                    "longitude": 6.03,
+                    "elevation_m": 450,
+                    "orientation": None,
+                    "rating": None,
+                    "country": "FR",
+                    "source": "openaip",
+                    "distance_km": 0.5,
+                },
+                {
+                    "id": "pgs-landing",
+                    "name": "Atterro distant",
+                    "type": "landing",
+                    "latitude": 47.23,
+                    "longitude": 6.02,
+                    "elevation_m": None,
+                    "orientation": None,
+                    "rating": 4,
+                    "country": "FR",
+                    "source": "paraglidingspots",
+                    "distance_km": 0.8,
+                },
+            ]
             return {
                 "query": {
                     "latitude": lat,
@@ -284,8 +283,8 @@ class TestLocationWeatherEndpoints:
                     "type": spot_type,
                     "source": "remote",
                 },
-                "total": len(selected_spots),
-                "spots": selected_spots,
+                "total": len(spots),
+                "spots": spots,
             }
 
         monkeypatch.setattr("spots.search_remote_by_coordinates", fake_search_remote_by_coordinates)
@@ -296,6 +295,7 @@ class TestLocationWeatherEndpoints:
 
         assert response.status_code == 200
         data = response.json()
+        assert calls == [None]
         assert [spot["id"] for spot in data["takeoffs"]] == ["openaip-takeoff"]
         assert [spot["id"] for spot in data["landings"]] == ["pgs-landing"]
 


### PR DESCRIPTION
## Summary
- Add remote fallback search for nearby takeoff and landing options when the local spots table is empty.
- Reuse existing OpenAIP and ParaglidingSpots fetchers so city weather search can still show flight options before a DB sync.
- Cover the fallback path with a backend route test.

## Validation
- `ruff check apps/backend/spots/search.py apps/backend/routes.py apps/backend/tests/test_routes.py --config apps/backend/pyproject.toml`
- `black --check --diff apps/backend/spots/search.py apps/backend/routes.py apps/backend/tests/test_routes.py`
- `python3 -m py_compile apps/backend/spots/search.py apps/backend/routes.py apps/backend/tests/test_routes.py`

## Notes
- `pytest` and `pnpm nx` were unavailable in this worktree because the required local dependencies are not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nearby flight options endpoint now automatically searches remote spot sources as a fallback when local results lack takeoff or landing options, improving coverage and search reliability.

* **Tests**
  * Added verification for fallback behavior to remote spot sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->