### PR TITLE
fix(frontend): load searched spot weather by coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     name: main
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - name: 🏷️ Remove ready-to-merge label
@@ -178,26 +180,22 @@ jobs:
         run: exit 1
 
       - name: 📊 Upload frontend coverage
-        if: always()
+        if: always() && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage/apps/frontend/lcov.info
           flags: frontend
           name: frontend-coverage
         continue-on-error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: 📊 Upload backend coverage
-        if: always()
+        if: always() && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage/apps/backend/coverage.xml
           flags: backend
           name: backend-coverage
         continue-on-error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   e2e:
     name: E2E Tests

--- a/apps/frontend/src/components/weather/CityWeatherSearch.tsx
+++ b/apps/frontend/src/components/weather/CityWeatherSearch.tsx
@@ -11,7 +11,6 @@ import {
   useCoordinateWeather,
   useLocationSearch,
   useNearbyFlightOptions,
-  useSpotWeather,
 } from '../../hooks/weather/useCityWeather';
 import { useCreateSite } from '../../hooks/sites/useSites';
 import type { Site } from '../../types';
@@ -158,6 +157,12 @@ const getOptionName = (option: SelectedOption | null) => {
   return option.type === 'city' ? option.location.name : option.spot.name;
 };
 
+const getOptionLocation = (option: SelectedOption | null) => {
+  if (!option) return null;
+  if (option.type === 'city') return option.location;
+  return option.spot;
+};
+
 export default function CityWeatherSearch({
   dayIndex,
   selectedTarget,
@@ -193,14 +198,9 @@ export default function CityWeatherSearch({
     radiusKm,
     limit
   );
+  const selectedWeatherLocation = getOptionLocation(selectedOption);
   const coordinateWeather = useCoordinateWeather(
-    selectedOption?.type === 'city' ? selectedOption.location : null,
-    dayIndex
-  );
-  const spotWeather = useSpotWeather(
-    isSpotOption(selectedOption)
-      ? selectedOption.spot.id
-      : null,
+    selectedWeatherLocation,
     dayIndex
   );
 
@@ -220,9 +220,9 @@ export default function CityWeatherSearch({
     isWeatherLoading = coordinateWeather.isLoading;
     isWeatherError = coordinateWeather.isError;
   } else if (isSpotOption(selectedOption)) {
-    selectedWeather = spotWeather.data;
-    isWeatherLoading = spotWeather.isLoading;
-    isWeatherError = spotWeather.isError;
+    selectedWeather = coordinateWeather.data;
+    isWeatherLoading = coordinateWeather.isLoading;
+    isWeatherError = coordinateWeather.isError;
   }
 
   const handleSelectLocation = (location: LocationSuggestion) => {

--- a/apps/frontend/src/hooks/weather/useCityWeather.ts
+++ b/apps/frontend/src/hooks/weather/useCityWeather.ts
@@ -5,13 +5,11 @@ import {
   BackendWeatherResponseSchema,
   LocationSearchResponseSchema,
   NearbyFlightOptionsResponseSchema,
-  SpotWeatherResponseSchema,
 } from '@dashboard-parapente/shared-types';
 import type {
   BackendWeatherResponse,
   LocationSearchResponse,
   NearbyFlightOptionsResponse,
-  SpotWeatherResponse,
 } from '@dashboard-parapente/shared-types';
 
 export const useLocationSearch = (query: string, limit = 5) => {
@@ -97,23 +95,6 @@ export const useCoordinateWeather = (
       return BackendWeatherResponseSchema.parse(data);
     },
     enabled: !!location,
-    staleTime: getStaleTime(1000 * 60 * 30),
-  });
-};
-
-export const useSpotWeather = (spotId: string | null, dayIndex: number) => {
-  return useQuery<SpotWeatherResponse>({
-    queryKey: ['weather', 'external-spot', spotId, dayIndex],
-    queryFn: async () => {
-      if (!spotId) throw new Error('Spot ID is required');
-      const data = await api
-        .get(`spots/weather/${spotId}`, {
-          searchParams: { day_index: dayIndex },
-        })
-        .json();
-      return SpotWeatherResponseSchema.parse(data);
-    },
-    enabled: !!spotId,
     staleTime: getStaleTime(1000 * 60 * 30),
   });
 };

--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -517,11 +517,7 @@ const coordinatesWeatherHandler = http.get('*/api/weather/coordinates', () =>
   })
 );
 const spotWeatherHandler = http.get('*/api/spots/weather/:spotId', () =>
-  HttpResponse.json({
-    ...mockWeatherArguel,
-    spot_id: 'merged-takeoff-arguel',
-    spot_name: 'Arguel déco',
-  })
+  new HttpResponse(null, { status: 404 })
 );
 const bestSpotsHandler = http.get('*/api/spots/best', ({ request }) => {
   const dayIndex = Number(
@@ -725,6 +721,9 @@ WithCitySearch.test(
     await userEvent.click(searchedSpotButton);
     await canvas.findByText('Résultat de recherche sélectionné');
     await canvas.findByText('Météo sélectionnée');
+    expect(
+      canvas.queryByText(/Impossible de charger la météo/u)
+    ).not.toBeInTheDocument();
     await canvas.findByText('Prévisions Horaires');
 
     const addFavoriteButton = await canvas.findByRole('button', {

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -27,7 +27,6 @@ import {
 } from '../hooks/weather/useBestSpotAPI';
 import {
   useCoordinateWeather,
-  useSpotWeather,
 } from '../hooks/weather/useCityWeather';
 import { transformWeatherResponse } from '../hooks/weather/useWeather';
 
@@ -39,6 +38,12 @@ const isSpotSearchTarget = (
 const getSearchTargetName = (target: CityWeatherTarget | null) => {
   if (!target) return '';
   return target.type === 'city' ? target.location.name : target.spot.name;
+};
+
+const getSearchTargetLocation = (target: CityWeatherTarget | null) => {
+  if (!target) return null;
+  if (target.type === 'city') return target.location;
+  return target.spot;
 };
 
 const getSearchDayLabel = (
@@ -68,24 +73,14 @@ export default function WeatherPage() {
   const selectedSiteId =
     sites.find((site) => site.id === routeSiteId)?.id ?? sites[0]?.id ?? '';
   const selectedSearchTitle = getSearchTargetName(selectedSearchTarget);
+  const selectedSearchLocation = getSearchTargetLocation(selectedSearchTarget);
   const coordinateWeather = useCoordinateWeather(
-    selectedSearchTarget?.type === 'city'
-      ? selectedSearchTarget.location
-      : null,
+    selectedSearchLocation,
     selectedDayIndex
   );
-  const spotWeather = useSpotWeather(
-    isSpotSearchTarget(selectedSearchTarget)
-      ? selectedSearchTarget.spot.id
-      : null,
-    selectedDayIndex
-  );
-  const selectedSearchWeather =
-    selectedSearchTarget?.type === 'city'
-      ? coordinateWeather.data
-      : selectedSearchTarget
-        ? spotWeather.data
-        : undefined;
+  const selectedSearchWeather = selectedSearchTarget
+    ? coordinateWeather.data
+    : undefined;
   const selectedSearchWeatherData = useMemo(
     () =>
       selectedSearchWeather
@@ -94,17 +89,9 @@ export default function WeatherPage() {
     [selectedSearchWeather]
   );
   const isSearchWeatherLoading =
-    selectedSearchTarget?.type === 'city'
-      ? coordinateWeather.isLoading
-      : selectedSearchTarget
-        ? spotWeather.isLoading
-        : false;
+    selectedSearchTarget ? coordinateWeather.isLoading : false;
   const isSearchWeatherError =
-    selectedSearchTarget?.type === 'city'
-      ? coordinateWeather.isError
-      : selectedSearchTarget
-        ? spotWeather.isError
-        : false;
+    selectedSearchTarget ? coordinateWeather.isError : false;
 
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [weatherDataMap] = useState<Map<string, Record<string, unknown>>>(


### PR DESCRIPTION
## Summary
- Load weather for city-search takeoff and landing selections via coordinates instead of external spot IDs.
- Keep selected search detail and hourly forecast working when `/api/spots/weather/:id` cannot resolve a searched spot.
- Update the WeatherPage story to cover the 404 spot-weather fallback path.

## Validation
- `pnpm nx lint frontend` / `pnpm nx test frontend` could not run because the worktree had no installed `node_modules`.
- `pnpm install` was attempted twice but timed out on the workspace/NAS before completion.
- `pnpm dlx oxlint -c .oxlintrc.json apps/frontend/src/components/weather/CityWeatherSearch.tsx apps/frontend/src/pages/WeatherPage.tsx apps/frontend/src/pages/WeatherPage.stories.tsx` ran and reported pre-existing lint issues in these files unrelated to the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Weather retrieval is unified for city, takeoff, and landing searches, simplifying behavior and improving consistency.

* **Tests**
  * Story/test mocks adjusted to simulate missing spot weather and added checks to prevent an error message from appearing after selecting a search result.

* **Chores**
  * CI configuration updated for conditional coverage upload.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/622)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->