### PR TITLE
feat(skills): add Storybook visual preview workflow

### DIFF
--- a/.agents/skills/storybook-visual-preview/SKILL.md
+++ b/.agents/skills/storybook-visual-preview/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: storybook-visual-preview
+description: Captures and exports Storybook screenshots for UI work in the dashboard-parapente Nx monorepo. Use when the user asks for a visual preview, screenshot, aperçu visuel, Storybook capture, responsive check, or wants to see a developed frontend feature.
+---
+
+# Storybook Visual Preview
+
+## Purpose
+
+Use this skill to produce a concrete visual preview of a Storybook story after frontend or design-system work.
+
+Important limitation: some chat/API clients do not render images read from tools, and some users do not have access to local workspace files. In that case, do not claim the screenshot is visible to the user. Report the limitation clearly and ask for, or use, an accessible delivery channel such as a PR comment, GitHub artifact, public/internal file hosting, or a client that supports image attachments.
+
+The workflow is:
+
+1. Run the relevant Storybook server.
+2. Capture one or more stories with Playwright.
+3. Export the generated PNG to a stable preview path.
+4. Try reading the PNG so clients that support inline images can display it.
+5. Always provide the PNG path and a Markdown image link for users with workspace access.
+6. If the user is chat-only, provide a short visual diagnosis and explain that a viewable image requires an attachment-capable client or upload target.
+7. Add a short visual assessment with any obvious issues.
+
+## Project Defaults
+
+- Frontend Storybook: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook frontend`, port `6006`.
+- Design system Storybook: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook design-system`, port `6007`.
+- Screenshot script: `.agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs`.
+- Default output directory: `.codenomad/storybook-previews` when the user should open the file, or `/tmp/opencode/storybook-visual-preview` for disposable captures.
+- Browser fallback: if Playwright browsers are missing, the script tries `/usr/bin/chromium`.
+
+If a worktree has no `node_modules`, follow `local-machine-stack` and run `CI=true /home/capic/.local/share/pnpm/pnpm install` before capturing.
+
+## Quick Start
+
+Start Storybook as a background process:
+
+```bash
+NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook frontend
+```
+
+Capture a story by id:
+
+```bash
+node .agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs \
+  --base-url http://localhost:6006 \
+  --story-id components-button--primary \
+  --output .codenomad/storybook-previews/button-primary.png
+```
+
+Then use the Read tool on the PNG path and include this fallback in the response:
+
+```md
+Preview: `.codenomad/storybook-previews/button-primary.png`
+
+![Storybook preview](.codenomad/storybook-previews/button-primary.png)
+```
+
+## Workflow
+
+- Determine the project from the changed files or user request: `frontend` or `design-system`.
+- If the user did not provide a story id, find relevant `*.stories.tsx` files and infer likely story ids from the title/name.
+- Start Storybook with `run_background_process`; do not block the main turn with a long-lived Bash command.
+- Wait until the server prints its local URL or the capture script can load the page.
+- Capture desktop first at `1440x1000` unless the user requested another viewport.
+- For responsive work, also capture mobile at `390x844`.
+- Prefer writing preview PNGs to `.codenomad/storybook-previews/<story-id>-<viewport>.png` so the user can open them from the workspace.
+- Read every generated PNG that should be shown to the user, but do not assume the chat client will render the image.
+- In the final response, always include the file path and a Markdown image link for every generated PNG.
+- Stop the background Storybook process when the preview is complete unless it was already running before the task.
+
+## Script Options
+
+- `--base-url`: Storybook root URL, for example `http://localhost:6006`.
+- `--story-id`: Storybook story id; builds `iframe.html?id=<story-id>` automatically.
+- `--url`: Full Storybook or iframe URL; use this when a user gives an exact URL.
+- `--output`: PNG destination path.
+- `--width`: viewport width, default `1440`.
+- `--height`: viewport height, default `1000`.
+- `--timeout`: load timeout in milliseconds, default `30000`.
+- `--full-page`: capture full page instead of viewport.
+
+## Reporting
+
+Keep the user-facing report concise:
+
+- Mention which story and viewport were captured.
+- Include the preview file path and Markdown image link.
+- If the image did not render inline, explicitly say the client may not support image attachments from tool output.
+- If the user has no workspace access, do not rely on local paths. Ask for an upload target or suggest creating a PR/check artifact if GitHub is available.
+- State obvious visual issues only if visible: clipped content, overlap, empty state, unreadable text, broken spacing, missing assets, horizontal scroll.
+- If capture fails, report the Storybook URL, command, and the first actionable error.
+
+## Chat-Only Users
+
+If the user cannot access the project/workspace and the chat client does not render tool images:
+
+- Be explicit: `I can capture the screenshot, but this client is not rendering image attachments and you cannot open local files, so I cannot directly show the PNG here.`
+- Give a visual text summary from the captured image.
+- Offer one concrete next step: upload to a destination the user can access, attach through a compatible client, or publish as a GitHub PR artifact/comment if allowed.
+- Do not paste large base64 image blobs into the conversation unless the user explicitly asks for that format.
+
+## Guardrails
+
+- Prefer `iframe.html?id=...` screenshots to avoid Storybook chrome unless the user asks for the full UI.
+- Do not expose secrets from query params, local storage, logs, or environment output.
+- Do not modify stories just to make a screenshot pass unless the user asked for a fix.
+- If the story depends on backend services and renders broken data, report that dependency instead of faking state.

--- a/.agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs
+++ b/.agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import { access, mkdir } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const output = options.output
+  ? resolve(options.output)
+  : resolve('/tmp/opencode/storybook-visual-preview/storybook.png');
+
+const width = parsePositiveInt(options.width, 1440, 'width');
+const height = parsePositiveInt(options.height, 1000, 'height');
+const timeout = parsePositiveInt(options.timeout, 30_000, 'timeout');
+const targetUrl = buildTargetUrl(options);
+
+await mkdir(dirname(output), { recursive: true });
+
+const { chromium } = await importPlaywright();
+const browser = await launchBrowser(chromium);
+
+try {
+  const page = await browser.newPage({
+    viewport: { width, height },
+    deviceScaleFactor: 1,
+  });
+
+  page.setDefaultTimeout(timeout);
+  page.setDefaultNavigationTimeout(timeout);
+
+  await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout });
+  await page.waitForLoadState('networkidle', { timeout }).catch(() => undefined);
+  await page
+    .locator('#storybook-root, #storybook-docs, .sb-errordisplay')
+    .first()
+    .waitFor({ state: 'attached', timeout });
+  await page.screenshot({ path: output, fullPage: Boolean(options.fullPage) });
+
+  console.log(JSON.stringify({ output, url: targetUrl, width, height }, null, 2));
+} finally {
+  await browser.close();
+}
+
+function buildTargetUrl(parsedOptions) {
+  if (parsedOptions.url) {
+    return parsedOptions.url;
+  }
+
+  if (!parsedOptions.baseUrl || !parsedOptions.storyId) {
+    throw new Error('Provide either --url or both --base-url and --story-id.');
+  }
+
+  const baseUrl = parsedOptions.baseUrl.replace(/\/$/, '');
+  const url = new URL(`${baseUrl}/iframe.html`);
+  url.searchParams.set('id', parsedOptions.storyId);
+  url.searchParams.set('viewMode', 'story');
+  return url.toString();
+}
+
+function parseArgs(args) {
+  const parsed = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+      continue;
+    }
+
+    if (arg === '--full-page') {
+      parsed.fullPage = true;
+      continue;
+    }
+
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const key = toCamelCase(arg.slice(2));
+    const value = args[index + 1];
+
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    parsed[key] = value;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function parsePositiveInt(value, fallback, label) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`--${label} must be a positive integer.`);
+  }
+
+  return parsed;
+}
+
+function toCamelCase(value) {
+  return value.replace(/-([a-z])/g, (_, character) => character.toUpperCase());
+}
+
+async function importPlaywright() {
+  try {
+    return await import('playwright');
+  } catch (error) {
+    if (error?.code !== 'ERR_MODULE_NOT_FOUND') {
+      throw error;
+    }
+
+    try {
+      const requireFromCwd = createRequire(`${process.cwd()}/package.json`);
+      return requireFromCwd('playwright');
+    } catch {
+      // Fall through to a clearer setup error below.
+    }
+
+    throw new Error(
+      'Cannot load Playwright. Run `CI=true /home/capic/.local/share/pnpm/pnpm install` from this workspace, then retry.',
+    );
+  }
+}
+
+async function launchBrowser(chromium) {
+  const systemChromium = await getSystemChromiumPath();
+
+  try {
+    return await chromium.launch({
+      headless: true,
+      ...(systemChromium ? { executablePath: systemChromium } : {}),
+    });
+  } catch (error) {
+    if (systemChromium || !isMissingPlaywrightBrowserError(error)) {
+      throw error;
+    }
+
+    throw new Error(
+      'Cannot launch Chromium. Run `pnpm exec playwright install chromium` or install system Chromium, then retry.',
+    );
+  }
+}
+
+async function getSystemChromiumPath() {
+  const candidates = [process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE, '/usr/bin/chromium'].filter(Boolean);
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  return undefined;
+}
+
+function isMissingPlaywrightBrowserError(error) {
+  return String(error?.message ?? '').includes("Executable doesn't exist");
+}
+
+function printHelp() {
+  console.log(`Capture a Storybook story screenshot with Playwright.
+
+Usage:
+  node capture-storybook.mjs --base-url http://localhost:6006 --story-id components-button--primary --output /tmp/story.png
+  node capture-storybook.mjs --url http://localhost:6006/iframe.html?id=components-button--primary --output /tmp/story.png
+
+Options:
+  --base-url   Storybook root URL.
+  --story-id   Storybook story id. Used with --base-url.
+  --url        Full URL to capture.
+  --output     PNG output path.
+  --width      Viewport width. Default: 1440.
+  --height     Viewport height. Default: 1000.
+  --timeout    Timeout in milliseconds. Default: 30000.
+  --full-page  Capture the full page instead of the viewport.
+`);
+}

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,8 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignore": [
     "apps/e2e/**",
-    "apps/frontend/vitest.shims.d.ts"
+    "apps/frontend/vitest.shims.d.ts",
+    ".agents/skills/**/scripts/**"
   ],
   "ignoreBinaries": ["eslint", "apps/backend/.venv/bin/ruff", "apps/backend/.venv/bin/black"],
   "ignoreDependencies": ["chromatic"],


### PR DESCRIPTION
## Summary
- Add a `storybook-visual-preview` skill for capturing Storybook screenshots from frontend/design-system stories.
- Include a Playwright-based capture script with system Chromium fallback and chat-only reporting guidance.
- Document GitHub/download-link fallback when inline image rendering is unavailable.

## Validation
- `node --check .agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs`
- `node .agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs --help`
- Manual Storybook capture test against `design-system` story `components-ui-button--default`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated tooling for capturing Storybook component screenshots.
  * Updated development configuration to support new agent skills.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->