### PR TITLE
chore(workflow): bootstrap worktree dependencies with subagents

### DIFF
--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -29,6 +29,7 @@ description: Workflow expert for the dashboard-parapente Nx monorepo. Use when i
 ## Worktrees
 - For branch/worktree start-of-work decisions, use the `implementation-worktree-strategy` skill.
 - This skill only defines repository commands, validation strategy, GitHub usage, and tooling preferences.
+- When a worktree is created, use the bootstrap subagent defined by `implementation-worktree-strategy` before relying on Nx commands.
 - Before opening a PR from a worktree, fetch the remote and update the worktree branch with the latest `origin/main`.
 - Do not create a PR from a stale worktree; resolve merge/rebase conflicts and rerun impacted checks first.
 
@@ -89,6 +90,8 @@ Run all lint targets:
 
 ## Validation Strategy
 - Prefer targeted lint/test commands during implementation.
+- For long or multi-command validation runs, prefer a validation subagent that runs commands from the active worktree and returns a concise pass/fail report.
+- Keep the main agent responsible for fixing failures and deciding whether extra validation is needed.
 - Prefer `nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e` for branch/PR validation.
 - Use `run-many -t test` only when affected detection is not appropriate or a full-repo check is explicitly needed.
 - Use `run-many -t lint` only when affected detection is not appropriate or a full-repo lint is explicitly needed.

--- a/.agents/skills/implementation-worktree-strategy/SKILL.md
+++ b/.agents/skills/implementation-worktree-strategy/SKILL.md
@@ -14,9 +14,26 @@ Before any implementation task:
 3. If on another branch, ask whether to create a worktree.
 4. If yes, update `main` and create the worktree from `main`.
 5. If no, stay on the current branch.
+6. When a worktree is created, immediately launch a bootstrap subagent for dependency readiness.
 
 Create worktrees in `.codenomad/worktree` with names starting with `wt-`.
 Whenever a worktree is created, immediately name the current AI session with the exact worktree name.
+
+## Worktree Bootstrap Subagent
+
+After creating a worktree, launch a `general` subagent immediately and let it run in parallel with the main implementation work.
+
+Subagent responsibility:
+
+- Work in the new worktree path.
+- Verify that local dependencies are usable before Nx commands run.
+- Check for `node_modules/.bin/nx` and representative required packages such as `typescript`.
+- Run `CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile` only when dependencies are missing or unusable.
+- Prefer the existing pnpm global virtual store when configured; do not run install just because the worktree is new.
+- Run a lightweight readiness command after install/check, for example `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx --version`.
+- Return a concise report with status, commands run, failures, and whether any files changed.
+
+The main agent remains responsible for interpreting blockers and making code changes. The bootstrap subagent must not edit source code or commit files.
 
 ## Rules
 
@@ -25,6 +42,7 @@ Whenever a worktree is created, immediately name the current AI session with the
 - Update `main`.
 - Create a worktree from `main`.
 - Name the current AI session with the exact worktree name.
+- Launch the worktree bootstrap subagent.
 - Continue implementation in that worktree.
 
 ### If current branch is not `main`
@@ -39,6 +57,7 @@ If yes:
 - Create a worktree from `main` in `.codenomad/worktree`.
 - Use a name like `wt-<task-label>`.
 - Name the current AI session with the exact worktree name.
+- Launch the worktree bootstrap subagent.
 - Continue there.
 
 If no:

--- a/.agents/skills/implementation-worktree-strategy/SKILL.md
+++ b/.agents/skills/implementation-worktree-strategy/SKILL.md
@@ -29,7 +29,7 @@ Subagent responsibility:
 - Verify that local dependencies are usable before Nx commands run.
 - Check for `node_modules/.bin/nx` and representative required packages such as `typescript`.
 - Run `CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile` only when dependencies are missing or unusable.
-- Prefer the existing pnpm global virtual store when configured; do not run install just because the worktree is new.
+- Do not rely on pnpm's global virtual store; each worktree must have a workspace-local dependency layout usable by Nx and Knip.
 - Run a lightweight readiness command after install/check, for example `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx --version`.
 - Return a concise report with status, commands run, failures, and whether any files changed.
 

--- a/.agents/skills/local-machine-stack/SKILL.md
+++ b/.agents/skills/local-machine-stack/SKILL.md
@@ -18,8 +18,12 @@ Do not assume `pnpm`, `npm`, `npx`, `yarn`, or `corepack` are available in `PATH
 Before running Nx commands, verify local dependencies exist. If `node_modules/.bin/nx` or required packages such as `typescript` are missing, run:
 
 ```bash
-CI=true /home/capic/.local/share/pnpm/pnpm install
+CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile
 ```
+
+For new worktrees, prefer a bootstrap subagent to perform this dependency readiness check in parallel with implementation work. The subagent should only run install when dependencies are missing or unusable.
+
+This repository can use pnpm's global virtual store to make repeated installs across worktrees faster and reduce duplicated package linking. It improves the bootstrap path when the lockfile and pnpm store are already warm, but every worktree still needs a valid local `node_modules` layout before Nx commands run.
 
 ## Repository
 
@@ -106,3 +110,5 @@ Use a longer Bash timeout for full-repo tasks:
 Lint can produce many warnings while still succeeding. Treat the process exit code as authoritative for pass/fail.
 
 If a command creates temporary build artifacts such as `*.tsbuildinfo`, remove untracked generated artifacts unless they are intentionally part of the task.
+
+`enableGlobalVirtualStore` is expected to improve repeated worktree bootstraps by sharing virtual-store data globally. It does not eliminate all install work: pnpm may still need to create or refresh local project links and lifecycle-built artifacts.

--- a/.agents/skills/local-machine-stack/SKILL.md
+++ b/.agents/skills/local-machine-stack/SKILL.md
@@ -23,7 +23,7 @@ CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile
 
 For new worktrees, prefer a bootstrap subagent to perform this dependency readiness check in parallel with implementation work. The subagent should only run install when dependencies are missing or unusable.
 
-This repository can use pnpm's global virtual store to make repeated installs across worktrees faster and reduce duplicated package linking. It improves the bootstrap path when the lockfile and pnpm store are already warm, but every worktree still needs a valid local `node_modules` layout before Nx commands run.
+Do not enable pnpm's global virtual store in this repository. Nx and Knip expect dependency resolution from the workspace-local `node_modules` layout, and CI can fail when packages resolve through a global virtual store path.
 
 ## Repository
 
@@ -111,4 +111,4 @@ Lint can produce many warnings while still succeeding. Treat the process exit co
 
 If a command creates temporary build artifacts such as `*.tsbuildinfo`, remove untracked generated artifacts unless they are intentionally part of the task.
 
-`enableGlobalVirtualStore` is expected to improve repeated worktree bootstraps by sharing virtual-store data globally. It does not eliminate all install work: pnpm may still need to create or refresh local project links and lifecycle-built artifacts.
+Keep `enableGlobalVirtualStore: false` in `pnpm-workspace.yaml` so workspace tools resolve dependencies from local project links.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - 'apps/*'
   - 'libs/*'
 
-enableGlobalVirtualStore: false
+enableGlobalVirtualStore: true
 
 allowBuilds:
   core-js: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - 'apps/*'
   - 'libs/*'
 
-enableGlobalVirtualStore: true
+enableGlobalVirtualStore: false
 
 allowBuilds:
   core-js: true


### PR DESCRIPTION
## Summary
- Add a worktree bootstrap subagent step to verify dependency readiness before Nx commands.
- Prefer conditional `pnpm install --frozen-lockfile` instead of installing on every new worktree.
- Enable pnpm `enableGlobalVirtualStore` for faster repeated worktree bootstraps.

## Validation
- Husky pre-commit ran lint-staged and knip during commit.
- Verified `pnpm config get enableGlobalVirtualStore` returns `true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow documentation for worktree initialization and dependency management processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/636)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->