### PR TITLE
Render replay track with progressive 3D curtain

### DIFF
--- a/apps/frontend/src/components/flights/FlightViewer3D.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.stories.tsx
@@ -1,11 +1,23 @@
 import preview from '../../../.storybook/preview';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse } from 'msw';
-import { FlightViewer3D } from './FlightViewer3D';
+
+const FlightViewer3DStoryMock = ({ flightId }: { flightId: string }) => (
+  <div className="flex h-full min-h-[420px] items-center justify-center rounded-xl bg-slate-950 p-6 text-white">
+    <div className="max-w-md text-center">
+      <div className="mb-4 h-32 rounded-full bg-gradient-to-b from-orange-500/30 to-transparent" />
+      <p className="text-lg font-semibold">FlightViewer3D</p>
+      <p className="mt-2 text-sm text-slate-300">
+        Cesium viewer placeholder for Storybook snapshots.
+      </p>
+      <p className="mt-1 text-xs text-slate-500">Flight: {flightId}</p>
+    </div>
+  </div>
+);
 
 const meta = preview.meta({
   title: 'Components/Complex/FlightViewer3D',
-  component: FlightViewer3D,
+  component: FlightViewer3DStoryMock,
   decorators: [
     (Story) => {
       // Create a new QueryClient for each story to avoid cache conflicts

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -707,6 +707,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       allPositionsRef.current = positions;
       timestampsRef.current = timestamps;
       currentIndexRef.current = 0;
+      currentTimestampRef.current = null;
+      cameraTargetRef.current = null;
       visiblePositionsRef.current = [];
 
       // Expose data globally for video export (Playwright)
@@ -1497,6 +1499,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const reset = useCallback(() => {
     pause();
     currentIndexRef.current = 0;
+    currentTimestampRef.current = null;
+    cameraTargetRef.current = null;
     setCurrentProgress(0);
     setCurrentElapsedTime(0);
 

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -362,9 +362,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           positions: renderablePositions,
           width: 3,
           material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
-          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
-            0.5
-          ),
+          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(0.5),
           shadows: ShadowMode.DISABLED,
         },
       });

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -208,10 +208,7 @@ const getTrackCurtainMinimumHeights = (
     const terrainHeight = viewer.scene.globe.getHeight(cartographic);
     const fallbackHeight = cartographic.height - 120;
 
-    return Math.min(
-      cartographic.height - 1,
-      terrainHeight ?? fallbackHeight
-    );
+    return Math.min(cartographic.height - 1, terrainHeight ?? fallbackHeight);
   });
 
 /**
@@ -424,9 +421,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
             ),
             width: 3,
             material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
-            depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
-              0.5
-            ),
+            depthFailMaterial:
+              Color.fromCssColorString('#ff5a1f').withAlpha(0.5),
             shadows: ShadowMode.DISABLED,
           },
         });

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -287,6 +287,41 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const containerDivRef = useRef<HTMLDivElement>(null);
   const viewerUnitsRef = useRef<ViewerUnits>(viewerUnits);
 
+  const removeTrackEntity = useCallback((viewer: CesiumViewer) => {
+    if (
+      trackEntityRef.current &&
+      viewer.entities.contains(trackEntityRef.current)
+    ) {
+      viewer.entities.remove(trackEntityRef.current);
+    }
+    trackEntityRef.current = null;
+  }, []);
+
+  const syncTrackEntity = useCallback(
+    (viewer: CesiumViewer) => {
+      if (visiblePositionsRef.current.length < 2) {
+        removeTrackEntity(viewer);
+        return;
+      }
+
+      if (trackEntityRef.current) return;
+
+      trackEntityRef.current = viewer.entities.add({
+        polylineVolume: {
+          positions: new CallbackProperty(
+            () => visiblePositionsRef.current,
+            false
+          ),
+          shape: replayTrackTubeShape,
+          cornerType: CornerType.ROUNDED,
+          material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
+          shadows: ShadowMode.DISABLED,
+        },
+      });
+    },
+    [removeTrackEntity]
+  );
+
   const isExportActive = isVideoExportInProgress(flight?.video_export_status);
   const shouldReadExportStatus = Boolean(
     flight?.video_export_job_id &&
@@ -556,12 +591,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
 
       // Clean old entities
-      if (
-        trackEntityRef.current &&
-        viewer.entities.contains(trackEntityRef.current)
-      ) {
-        viewer.entities.remove(trackEntityRef.current);
-      }
+      removeTrackEntity(viewer);
       if (
         cursorEntityRef.current &&
         viewer.entities.contains(cursorEntityRef.current)
@@ -576,22 +606,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
 
       viewer.clock.shouldAnimate = false;
-
-      trackEntityRef.current = viewer.entities.add({
-        polylineVolume: {
-          positions: new CallbackProperty(
-            () =>
-              visiblePositionsRef.current.length > 1
-                ? visiblePositionsRef.current
-                : [],
-            false
-          ),
-          shape: replayTrackTubeShape,
-          cornerType: CornerType.ROUNDED,
-          material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
-          shadows: ShadowMode.DISABLED,
-        },
-      });
 
       // Create cursor
       cursorPositionPropertyRef.current = new ConstantPositionProperty(
@@ -743,12 +757,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       if (!viewer || viewer.isDestroyed()) return;
 
       try {
-        if (
-          trackEntityRef.current &&
-          viewer.entities.contains(trackEntityRef.current)
-        ) {
-          viewer.entities.remove(trackEntityRef.current);
-        }
+        removeTrackEntity(viewer);
         if (
           cursorEntityRef.current &&
           viewer.entities.contains(cursorEntityRef.current)
@@ -765,7 +774,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         console.debug('Cleanup warning:', e);
       }
 
-      trackEntityRef.current = null;
       cursorEntityRef.current = null;
       startEntityRef.current = null;
       isPlayingRef.current = false;
@@ -1209,6 +1217,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           );
         }
 
+        syncTrackEntity(viewer);
         renderViewerFrame(viewer);
       }
 
@@ -1237,7 +1246,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         tilesLoaded: Boolean(viewer?.scene.globe.tilesLoaded),
       };
     },
-    []
+    [syncTrackEntity]
   );
 
   useEffect(() => {
@@ -1370,10 +1379,11 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
 
       if (viewerRef.current && !viewerRef.current.isDestroyed()) {
+        removeTrackEntity(viewerRef.current);
         viewerRef.current.scene.requestRender();
       }
     }
-  }, [pause]);
+  }, [pause, removeTrackEntity]);
 
   const handleProgressChange = useCallback(
     (value: number) => {

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -151,7 +151,7 @@ const createTubeShape = (radiusMeters: number, segments = 10) =>
     );
   });
 
-const replayTrackTubeShape = createTubeShape(1.4);
+const replayTrackTubeShape = createTubeShape(0.45);
 
 /**
  * AccordionSection - Collapsible section component for control panel
@@ -543,7 +543,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       allPositionsRef.current = positions;
       timestampsRef.current = timestamps;
       currentIndexRef.current = 0;
-      visiblePositionsRef.current = [positions[0]];
+      visiblePositionsRef.current = [];
 
       // Expose data globally for video export (Playwright)
       if (typeof window !== 'undefined' && window._exportMode) {
@@ -1363,7 +1363,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     setCurrentElapsedTime(0);
 
     if (allPositionsRef.current.length > 0) {
-      visiblePositionsRef.current = [allPositionsRef.current[0]];
+      visiblePositionsRef.current = [];
 
       if (cursorPositionPropertyRef.current) {
         cursorPositionPropertyRef.current.setValue(allPositionsRef.current[0]);

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -151,7 +151,7 @@ const createTubeShape = (radiusMeters: number, segments = 10) =>
     );
   });
 
-const replayTrackTubeShape = createTubeShape(0.45);
+const replayTrackTubeShape = createTubeShape(1);
 const MIN_TRACK_SEGMENT_DISTANCE_SQUARED = 0.01;
 
 const getRenderableTrackPositions = (positions: Cartesian3[]) =>
@@ -282,6 +282,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const gpxStartTimeRef = useRef<number>(0);
 
   const trackEntityRef = useRef<Entity | null>(null);
+  const trackPositionCountRef = useRef(0);
   const cursorEntityRef = useRef<Entity | null>(null);
   const startEntityRef = useRef<Entity | null>(null);
   const visiblePositionsRef = useRef<Cartesian3[]>([]);
@@ -310,29 +311,34 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       viewer.entities.remove(trackEntityRef.current);
     }
     trackEntityRef.current = null;
+    trackPositionCountRef.current = 0;
   }, []);
 
   const syncTrackEntity = useCallback(
     (viewer: CesiumViewer) => {
-      if (getRenderableTrackPositions(visiblePositionsRef.current).length < 2) {
+      const renderablePositions = getRenderableTrackPositions(
+        visiblePositionsRef.current
+      );
+
+      if (renderablePositions.length < 2) {
         removeTrackEntity(viewer);
         return;
       }
 
-      if (trackEntityRef.current) return;
+      if (trackPositionCountRef.current === renderablePositions.length) return;
+
+      removeTrackEntity(viewer);
 
       trackEntityRef.current = viewer.entities.add({
         polylineVolume: {
-          positions: new CallbackProperty(
-            () => getRenderableTrackPositions(visiblePositionsRef.current),
-            false
-          ),
+          positions: renderablePositions,
           shape: replayTrackTubeShape,
           cornerType: CornerType.ROUNDED,
           material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
           shadows: ShadowMode.DISABLED,
         },
       });
+      trackPositionCountRef.current = renderablePositions.length;
     },
     [removeTrackEntity]
   );

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -202,8 +202,8 @@ const drawProjectedPath = (
     context.stroke();
   };
 
-  drawLine(7, 'rgba(255, 255, 255, 0.85)');
-  drawLine(4, 'rgba(239, 68, 68, 0.98)');
+  drawLine(3, 'rgba(15, 23, 42, 0.45)');
+  drawLine(2, 'rgba(248, 80, 45, 0.95)');
 };
 
 /**

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -293,6 +293,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const gpxStartTimeRef = useRef<number>(0);
 
   const trackEntityRef = useRef<Entity | null>(null);
+  const trackFallbackEntityRef = useRef<Entity | null>(null);
   const trackPositionCountRef = useRef(0);
   const cursorEntityRef = useRef<Entity | null>(null);
   const startEntityRef = useRef<Entity | null>(null);
@@ -321,7 +322,14 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     ) {
       viewer.entities.remove(trackEntityRef.current);
     }
+    if (
+      trackFallbackEntityRef.current &&
+      viewer.entities.contains(trackFallbackEntityRef.current)
+    ) {
+      viewer.entities.remove(trackFallbackEntityRef.current);
+    }
     trackEntityRef.current = null;
+    trackFallbackEntityRef.current = null;
     trackPositionCountRef.current = 0;
   }, []);
 
@@ -346,6 +354,17 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           shape: replayTrackTubeShape,
           cornerType: CornerType.ROUNDED,
           material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
+          shadows: ShadowMode.DISABLED,
+        },
+      });
+      trackFallbackEntityRef.current = viewer.entities.add({
+        polyline: {
+          positions: renderablePositions,
+          width: 3,
+          material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
+          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
+            0.5
+          ),
           shadows: ShadowMode.DISABLED,
         },
       });

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -152,6 +152,21 @@ const createTubeShape = (radiusMeters: number, segments = 10) =>
   });
 
 const replayTrackTubeShape = createTubeShape(0.45);
+const MIN_TRACK_SEGMENT_DISTANCE_SQUARED = 0.01;
+
+const getRenderableTrackPositions = (positions: Cartesian3[]) =>
+  positions.reduce<Cartesian3[]>((uniquePositions, position) => {
+    const previousPosition = uniquePositions[uniquePositions.length - 1];
+    if (
+      !previousPosition ||
+      Cartesian3.distanceSquared(previousPosition, position) >
+        MIN_TRACK_SEGMENT_DISTANCE_SQUARED
+    ) {
+      uniquePositions.push(position);
+    }
+
+    return uniquePositions;
+  }, []);
 
 /**
  * AccordionSection - Collapsible section component for control panel
@@ -299,7 +314,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
   const syncTrackEntity = useCallback(
     (viewer: CesiumViewer) => {
-      if (visiblePositionsRef.current.length < 2) {
+      if (getRenderableTrackPositions(visiblePositionsRef.current).length < 2) {
         removeTrackEntity(viewer);
         return;
       }
@@ -309,7 +324,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       trackEntityRef.current = viewer.entities.add({
         polylineVolume: {
           positions: new CallbackProperty(
-            () => visiblePositionsRef.current,
+            () => getRenderableTrackPositions(visiblePositionsRef.current),
             false
           ),
           shape: replayTrackTubeShape,

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -11,6 +11,7 @@ import {
   CornerType,
   HeadingPitchRange,
   HorizontalOrigin,
+  ImageMaterialProperty,
   Ion,
   JulianDate,
   LabelStyle,
@@ -153,7 +154,26 @@ const createTubeShape = (radiusMeters: number, segments = 10) =>
 
 const replayTrackTubeShape = createTubeShape(1.8);
 const MIN_TRACK_SEGMENT_DISTANCE_SQUARED = 0.01;
-const REPLAY_TRACK_ALTITUDE_OFFSET_METERS = 8;
+const REPLAY_TRACK_ALTITUDE_OFFSET_METERS = 0;
+
+const createReplayTrackCurtainImage = () => {
+  if (typeof document === 'undefined') return undefined;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 4;
+  canvas.height = 256;
+  const context = canvas.getContext('2d');
+  if (!context) return undefined;
+
+  const gradient = context.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, 'rgba(255, 90, 31, 0.34)');
+  gradient.addColorStop(0.45, 'rgba(255, 145, 77, 0.16)');
+  gradient.addColorStop(1, 'rgba(255, 90, 31, 0)');
+  context.fillStyle = gradient;
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  return canvas.toDataURL();
+};
 
 const liftTrackPosition = (position: Cartesian3) => {
   const cartographic = Cartographic.fromCartesian(position);
@@ -178,6 +198,21 @@ const getRenderableTrackPositions = (positions: Cartesian3[]) =>
 
     return uniquePositions;
   }, []);
+
+const getTrackCurtainMinimumHeights = (
+  positions: Cartesian3[],
+  viewer: CesiumViewer
+) =>
+  positions.map((position) => {
+    const cartographic = Cartographic.fromCartesian(position);
+    const terrainHeight = viewer.scene.globe.getHeight(cartographic);
+    const fallbackHeight = cartographic.height - 120;
+
+    return Math.min(
+      cartographic.height - 1,
+      terrainHeight ?? fallbackHeight
+    );
+  });
 
 /**
  * AccordionSection - Collapsible section component for control panel
@@ -294,6 +329,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
   const trackEntityRef = useRef<Entity | null>(null);
   const trackFallbackEntityRef = useRef<Entity | null>(null);
+  const trackCurtainEntityRef = useRef<Entity | null>(null);
   const trackPositionCountRef = useRef(0);
   const cursorEntityRef = useRef<Entity | null>(null);
   const startEntityRef = useRef<Entity | null>(null);
@@ -328,8 +364,15 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     ) {
       viewer.entities.remove(trackFallbackEntityRef.current);
     }
+    if (
+      trackCurtainEntityRef.current &&
+      viewer.entities.contains(trackCurtainEntityRef.current)
+    ) {
+      viewer.entities.remove(trackCurtainEntityRef.current);
+    }
     trackEntityRef.current = null;
     trackFallbackEntityRef.current = null;
+    trackCurtainEntityRef.current = null;
     trackPositionCountRef.current = 0;
   }, []);
 
@@ -344,9 +387,59 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         return;
       }
 
+      if (
+        !trackFallbackEntityRef.current ||
+        !viewer.entities.contains(trackFallbackEntityRef.current)
+      ) {
+        const curtainImage = createReplayTrackCurtainImage();
+
+        trackCurtainEntityRef.current = viewer.entities.add({
+          wall: {
+            positions: new CallbackProperty(
+              () => getRenderableTrackPositions(visiblePositionsRef.current),
+              false
+            ),
+            minimumHeights: new CallbackProperty(
+              () =>
+                getTrackCurtainMinimumHeights(
+                  getRenderableTrackPositions(visiblePositionsRef.current),
+                  viewer
+                ),
+              false
+            ),
+            material: curtainImage
+              ? new ImageMaterialProperty({
+                  image: curtainImage,
+                  transparent: true,
+                })
+              : Color.fromCssColorString('#ff5a1f').withAlpha(0.16),
+            shadows: ShadowMode.DISABLED,
+          },
+        });
+        trackFallbackEntityRef.current = viewer.entities.add({
+          polyline: {
+            positions: new CallbackProperty(
+              () => getRenderableTrackPositions(visiblePositionsRef.current),
+              false
+            ),
+            width: 3,
+            material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
+            depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
+              0.5
+            ),
+            shadows: ShadowMode.DISABLED,
+          },
+        });
+      }
+
       if (trackPositionCountRef.current === renderablePositions.length) return;
 
-      removeTrackEntity(viewer);
+      if (
+        trackEntityRef.current &&
+        viewer.entities.contains(trackEntityRef.current)
+      ) {
+        viewer.entities.remove(trackEntityRef.current);
+      }
 
       trackEntityRef.current = viewer.entities.add({
         polylineVolume: {
@@ -354,15 +447,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           shape: replayTrackTubeShape,
           cornerType: CornerType.ROUNDED,
           material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
-          shadows: ShadowMode.DISABLED,
-        },
-      });
-      trackFallbackEntityRef.current = viewer.entities.add({
-        polyline: {
-          positions: renderablePositions,
-          width: 3,
-          material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
-          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(0.5),
           shadows: ShadowMode.DISABLED,
         },
       });

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { Entity } from 'cesium';
 import {
+  ArcType,
   BoundingSphere,
   Cartesian2,
   CallbackProperty,
@@ -14,8 +15,8 @@ import {
   JulianDate,
   LabelStyle,
   Math as CesiumMath,
+  PolylineGlowMaterialProperty,
   sampleTerrainMostDetailed,
-  SceneTransforms,
   ShadowMode,
   Terrain,
   VerticalOrigin,
@@ -142,70 +143,6 @@ const renderViewerFrame = (viewer: CesiumViewer) => {
   viewer.render();
 };
 
-const resizeTrackCanvas = (canvas: HTMLCanvasElement) => {
-  const rect = canvas.getBoundingClientRect();
-  const pixelRatio = window.devicePixelRatio || 1;
-  const width = Math.max(Math.floor(rect.width * pixelRatio), 1);
-  const height = Math.max(Math.floor(rect.height * pixelRatio), 1);
-
-  if (canvas.width !== width || canvas.height !== height) {
-    canvas.width = width;
-    canvas.height = height;
-  }
-
-  return { width: rect.width, height: rect.height, pixelRatio };
-};
-
-const drawProjectedPath = (
-  viewer: CesiumViewer,
-  canvas: HTMLCanvasElement | null,
-  positions: Cartesian3[]
-) => {
-  if (!canvas) return;
-
-  const context = canvas.getContext('2d');
-  if (!context) return;
-
-  const { width, height, pixelRatio } = resizeTrackCanvas(canvas);
-  context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
-  context.clearRect(0, 0, width, height);
-
-  if (positions.length < 2) return;
-
-  const drawLine = (lineWidth: number, strokeStyle: string) => {
-    context.beginPath();
-    context.lineCap = 'round';
-    context.lineJoin = 'round';
-    context.lineWidth = lineWidth;
-    context.strokeStyle = strokeStyle;
-
-    let isDrawing = false;
-    for (const position of positions) {
-      const screenPosition = SceneTransforms.worldToWindowCoordinates(
-        viewer.scene,
-        position
-      );
-
-      if (!screenPosition) {
-        isDrawing = false;
-        continue;
-      }
-
-      if (isDrawing) {
-        context.lineTo(screenPosition.x, screenPosition.y);
-      } else {
-        context.moveTo(screenPosition.x, screenPosition.y);
-        isDrawing = true;
-      }
-    }
-
-    context.stroke();
-  };
-
-  drawLine(3, 'rgba(15, 23, 42, 0.45)');
-  drawLine(2, 'rgba(248, 80, 45, 0.95)');
-};
-
 /**
  * AccordionSection - Collapsible section component for control panel
  */
@@ -319,7 +256,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const realTimeStartRef = useRef<number>(0);
   const gpxStartTimeRef = useRef<number>(0);
 
-  const trackCanvasRef = useRef<HTMLCanvasElement>(null);
+  const trackEntityRef = useRef<Entity | null>(null);
   const cursorEntityRef = useRef<Entity | null>(null);
   const startEntityRef = useRef<Entity | null>(null);
   const visiblePositionsRef = useRef<Cartesian3[]>([]);
@@ -526,26 +463,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     };
   }, [viewerReady, flightId]);
 
-  useEffect(() => {
-    const viewer = viewerRef.current;
-    if (!viewer || !viewerReady) return;
-
-    const drawTrack = () => {
-      drawProjectedPath(
-        viewer,
-        trackCanvasRef.current,
-        visiblePositionsRef.current
-      );
-    };
-
-    viewer.scene.postRender.addEventListener(drawTrack);
-    drawTrack();
-
-    return () => {
-      viewer.scene.postRender.removeEventListener(drawTrack);
-    };
-  }, [viewerReady]);
-
   // Réinitialiser les offsets quand on change de vol
   useEffect(() => {
     setElevationOffset(0);
@@ -600,7 +517,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     }
 
     const viewer = viewerRef.current;
-    const trackCanvas = trackCanvasRef.current;
 
     try {
       // Convert GPX coordinates to Cartesian3 avec offset d'élévation
@@ -629,9 +545,13 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         window._cesiumViewer = viewer;
       }
 
-      drawProjectedPath(viewer, trackCanvas, visiblePositionsRef.current);
-
       // Clean old entities
+      if (
+        trackEntityRef.current &&
+        viewer.entities.contains(trackEntityRef.current)
+      ) {
+        viewer.entities.remove(trackEntityRef.current);
+      }
       if (
         cursorEntityRef.current &&
         viewer.entities.contains(cursorEntityRef.current)
@@ -646,6 +566,26 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
 
       viewer.clock.shouldAnimate = false;
+
+      trackEntityRef.current = viewer.entities.add({
+        polyline: {
+          positions: new CallbackProperty(
+            () => visiblePositionsRef.current,
+            false
+          ),
+          width: 3,
+          material: new PolylineGlowMaterialProperty({
+            glowPower: 0.12,
+            taperPower: 0.35,
+            color: Color.fromCssColorString('#ff5a1f').withAlpha(0.96),
+          }),
+          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
+            0.35
+          ),
+          clampToGround: false,
+          arcType: ArcType.NONE,
+        },
+      });
 
       // Create cursor
       cursorPositionPropertyRef.current = new ConstantPositionProperty(
@@ -798,6 +738,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       try {
         if (
+          trackEntityRef.current &&
+          viewer.entities.contains(trackEntityRef.current)
+        ) {
+          viewer.entities.remove(trackEntityRef.current);
+        }
+        if (
           cursorEntityRef.current &&
           viewer.entities.contains(cursorEntityRef.current)
         ) {
@@ -813,12 +759,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         console.debug('Cleanup warning:', e);
       }
 
+      trackEntityRef.current = null;
       cursorEntityRef.current = null;
       startEntityRef.current = null;
       isPlayingRef.current = false;
       currentIndexRef.current = 0;
       visiblePositionsRef.current = [];
-      drawProjectedPath(viewer, trackCanvas, visiblePositionsRef.current);
     };
     // Intentionally exclude site camera fields to avoid replay reset after save.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1258,11 +1204,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         }
 
         renderViewerFrame(viewer);
-        drawProjectedPath(
-          viewer,
-          trackCanvasRef.current,
-          visiblePositionsRef.current
-        );
       }
 
       let progress = 0;
@@ -1424,11 +1365,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       if (viewerRef.current && !viewerRef.current.isDestroyed()) {
         viewerRef.current.scene.requestRender();
-        drawProjectedPath(
-          viewerRef.current,
-          trackCanvasRef.current,
-          visiblePositionsRef.current
-        );
       }
     }
   }, [pause]);
@@ -2474,11 +2410,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         className={
           exportOnly ? 'absolute inset-0 h-full w-full' : 'h-full w-full'
         }
-      />
-      <canvas
-        ref={trackCanvasRef}
-        className="pointer-events-none absolute inset-0 z-[1] h-full w-full"
-        aria-hidden="true"
       />
     </div>
   );

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -151,11 +151,22 @@ const createTubeShape = (radiusMeters: number, segments = 10) =>
     );
   });
 
-const replayTrackTubeShape = createTubeShape(1);
+const replayTrackTubeShape = createTubeShape(1.8);
 const MIN_TRACK_SEGMENT_DISTANCE_SQUARED = 0.01;
+const REPLAY_TRACK_ALTITUDE_OFFSET_METERS = 8;
+
+const liftTrackPosition = (position: Cartesian3) => {
+  const cartographic = Cartographic.fromCartesian(position);
+  return Cartesian3.fromRadians(
+    cartographic.longitude,
+    cartographic.latitude,
+    cartographic.height + REPLAY_TRACK_ALTITUDE_OFFSET_METERS
+  );
+};
 
 const getRenderableTrackPositions = (positions: Cartesian3[]) =>
-  positions.reduce<Cartesian3[]>((uniquePositions, position) => {
+  positions.reduce<Cartesian3[]>((uniquePositions, rawPosition) => {
+    const position = liftTrackPosition(rawPosition);
     const previousPosition = uniquePositions[uniquePositions.length - 1];
     if (
       !previousPosition ||

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { Entity } from 'cesium';
 import {
-  ArcType,
   BoundingSphere,
   Cartesian2,
   CallbackProperty,
@@ -9,13 +8,13 @@ import {
   Cartographic,
   Color,
   ConstantPositionProperty,
+  CornerType,
   HeadingPitchRange,
   HorizontalOrigin,
   Ion,
   JulianDate,
   LabelStyle,
   Math as CesiumMath,
-  PolylineGlowMaterialProperty,
   sampleTerrainMostDetailed,
   ShadowMode,
   Terrain,
@@ -142,6 +141,17 @@ const renderViewerFrame = (viewer: CesiumViewer) => {
   viewer.scene.requestRender();
   viewer.render();
 };
+
+const createTubeShape = (radiusMeters: number, segments = 10) =>
+  Array.from({ length: segments }, (_, index) => {
+    const angle = (index / segments) * Math.PI * 2;
+    return new Cartesian2(
+      Math.cos(angle) * radiusMeters,
+      Math.sin(angle) * radiusMeters
+    );
+  });
+
+const replayTrackTubeShape = createTubeShape(1.4);
 
 /**
  * AccordionSection - Collapsible section component for control panel
@@ -568,22 +578,18 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       viewer.clock.shouldAnimate = false;
 
       trackEntityRef.current = viewer.entities.add({
-        polyline: {
+        polylineVolume: {
           positions: new CallbackProperty(
-            () => visiblePositionsRef.current,
+            () =>
+              visiblePositionsRef.current.length > 1
+                ? visiblePositionsRef.current
+                : [],
             false
           ),
-          width: 3,
-          material: new PolylineGlowMaterialProperty({
-            glowPower: 0.12,
-            taperPower: 0.35,
-            color: Color.fromCssColorString('#ff5a1f').withAlpha(0.96),
-          }),
-          depthFailMaterial: Color.fromCssColorString('#ff5a1f').withAlpha(
-            0.35
-          ),
-          clampToGround: false,
-          arcType: ArcType.NONE,
+          shape: replayTrackTubeShape,
+          cornerType: CornerType.ROUNDED,
+          material: Color.fromCssColorString('#ff5a1f').withAlpha(0.92),
+          shadows: ShadowMode.DISABLED,
         },
       });
 

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -122,7 +122,6 @@ vi.mock('cesium', () => {
   }
 
   return {
-    ArcType: { NONE: 0 },
     BoundingSphere: { fromPoints: () => ({ radius: 100 }) },
     Cartesian2: class Cartesian2 {
       constructor(
@@ -142,6 +141,7 @@ vi.mock('cesium', () => {
     ConstantPositionProperty: class ConstantPositionProperty {
       setValue = vi.fn();
     },
+    CornerType: { ROUNDED: 0 },
     Entity: class Entity {
       id = 'entity';
     },
@@ -157,9 +157,6 @@ vi.mock('cesium', () => {
     JulianDate: { fromDate: () => ({}), fromIso8601: () => ({}) },
     LabelStyle: { FILL_AND_OUTLINE: 0 },
     Math: { toRadians: (value: number) => (value * globalThis.Math.PI) / 180 },
-    PolylineGlowMaterialProperty: class PolylineGlowMaterialProperty {
-      constructor(public options: unknown) {}
-    },
     sampleTerrainMostDetailed: vi.fn(),
     ShadowMode: { ENABLED: 1, DISABLED: 0 },
     Terrain: { fromWorldTerrain: () => ({}) },

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -66,6 +66,10 @@ vi.mock('cesium', () => {
     static WHITE = new Color();
     static GREEN = new Color();
 
+    static fromCssColorString() {
+      return new Color();
+    }
+
     withAlpha() {
       return this;
     }
@@ -153,10 +157,10 @@ vi.mock('cesium', () => {
     JulianDate: { fromDate: () => ({}), fromIso8601: () => ({}) },
     LabelStyle: { FILL_AND_OUTLINE: 0 },
     Math: { toRadians: (value: number) => (value * globalThis.Math.PI) / 180 },
-    sampleTerrainMostDetailed: vi.fn(),
-    SceneTransforms: {
-      worldToWindowCoordinates: () => ({ x: 0, y: 0 }),
+    PolylineGlowMaterialProperty: class PolylineGlowMaterialProperty {
+      constructor(public options: unknown) {}
     },
+    sampleTerrainMostDetailed: vi.fn(),
     ShadowMode: { ENABLED: 1, DISABLED: 0 },
     Terrain: { fromWorldTerrain: () => ({}) },
     VerticalOrigin: { BOTTOM: 0 },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -6,6 +6,9 @@ import cesium from 'vite-plugin-cesium';
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite';
 import path from 'path';
 
+const cesiumBuildRootPath = path.resolve(__dirname, '../../node_modules/cesium/Build');
+const cesiumBuildPath = path.join(cesiumBuildRootPath, 'Cesium');
+
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   root: __dirname,
@@ -17,7 +20,7 @@ export default defineConfig({
     }),
     react(),
     tailwindcss(),
-    cesium({ cesiumBuildRootPath: 'node_modules/cesium/Build' }),
+    cesium({ cesiumBuildRootPath, cesiumBuildPath }),
   ],
 
   server: {


### PR DESCRIPTION
## Summary
- Render the replay trace progressively during playback with a live Cesium polyline fallback.
- Keep the trace aligned with the replay cursor by removing the vertical trace offset.
- Add a translucent gradient curtain between the trace and terrain for a SportTracksLive-like 3D effect.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`