### PR TITLE
feat(frontend): highlight selected flight card

### DIFF
--- a/apps/frontend/src/components/flights/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.stories.tsx
@@ -86,11 +86,15 @@ const mockFlights: Flight[] = [
 function FlightsTableWrapper({
   flights,
   selectionMode = false,
+  initialSelectedFlightId = null,
 }: {
   flights: Flight[];
   selectionMode?: boolean;
+  initialSelectedFlightId?: string | null;
 }) {
-  const [selectedFlightId, setSelectedFlightId] = useState<string | null>(null);
+  const [selectedFlightId, setSelectedFlightId] = useState<string | null>(
+    initialSelectedFlightId
+  );
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   return (
@@ -126,6 +130,16 @@ export const SelectionMode = meta.story({
   name: 'Selection Mode',
   render: () => (
     <FlightsTableWrapper flights={mockFlights} selectionMode={true} />
+  ),
+});
+
+export const ActiveFlight = meta.story({
+  name: 'Active Flight',
+  render: () => (
+    <FlightsTableWrapper
+      flights={mockFlights}
+      initialSelectedFlightId="flight-1"
+    />
   ),
 });
 

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -71,12 +71,18 @@ export function FlightsTable({
         }
       };
 
-      let color = 'border-gray-200 dark:border-gray-700 hover:border-sky-400';
+      let surface = 'bg-white dark:bg-gray-800';
+      let color =
+        'border-gray-200 dark:border-gray-700 hover:border-sky-400 hover:shadow-md';
 
       if (isSelected) {
-        color = 'border-sky-600 shadow-md bg-sky-50 dark:bg-sky-900/20';
+        surface = 'bg-sky-50 dark:bg-sky-900/25';
+        color =
+          'border-sky-600 dark:border-sky-400 shadow-md ring-2 ring-sky-500/20 dark:ring-sky-300/20';
       } else if (isActive) {
-        color = 'border-sky-600 shadow-md';
+        surface = 'bg-sky-50 dark:bg-sky-900/25';
+        color =
+          'border-sky-500 dark:border-sky-400 shadow-md ring-2 ring-sky-500/20 dark:ring-sky-300/20';
       }
 
       return (
@@ -85,9 +91,7 @@ export function FlightsTable({
           aria-selected={isActive || isSelected}
           tabIndex={0}
           data-testid={`flight-row-${flight.id}`}
-          className={`group relative bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm border-2 transition-all cursor-pointer ${
-            color
-          }`}
+          className={`group relative overflow-hidden rounded-lg p-3 shadow-sm border-2 transition-all duration-200 cursor-pointer ${surface} ${color}`}
           onClick={selectFlight}
           onKeyDown={(event) => {
             if (event.key === 'Enter' || event.key === ' ') {
@@ -96,6 +100,12 @@ export function FlightsTable({
             }
           }}
         >
+          {(isActive || isSelected) && (
+            <span
+              aria-hidden="true"
+              className="absolute inset-y-2 left-0 w-1 rounded-r-full bg-sky-500 dark:bg-sky-300"
+            />
+          )}
           {/* Bouton supprimer au survol */}
           {!selectionMode && (
             <Button


### PR DESCRIPTION
## Summary
- Add a stronger visual selected state for flight cards in the flights list.
- Add a Storybook `Active Flight` variant to preview the selected-card style.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` passed with existing warnings.
- `/home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json apps/frontend/src/components/flights/FlightsTable.tsx apps/frontend/src/components/flights/FlightsTable.stories.tsx` passed.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` failed before running tests due local Playwright/Vitest environment issues: missing `chromium_headless_shell` and `vitest` resolution from pnpm store.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` failed on existing unrelated TypeScript errors outside this change.