### PR TITLE
feat(frontend): refresh dashboard home UI

### DIFF
--- a/apps/frontend/src/components/common/Header.test.tsx
+++ b/apps/frontend/src/components/common/Header.test.tsx
@@ -158,7 +158,7 @@ describe('Header theme controls', () => {
     fireEvent.click(desktopButton);
 
     const darkOption = screen.getByRole('button', {
-      name: '🌙 Dark',
+      name: 'Dark',
     });
     fireEvent.click(darkOption);
 
@@ -177,7 +177,7 @@ describe('Header theme controls', () => {
     fireEvent.click(mobileButton);
 
     const autoOption = screen.getByRole('button', {
-      name: '🔄 Auto',
+      name: 'Auto',
     });
     fireEvent.click(autoOption);
 
@@ -189,8 +189,6 @@ describe('Header theme controls', () => {
 
     render(<Header />);
 
-    expect(
-      screen.queryByRole('link', { name: 'Exports' })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Exports' })).toBeNull();
   });
 });

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -12,6 +12,7 @@ import {
   ModalOverlay,
   Popover,
 } from 'react-aria-components';
+import { MonitorCog, Moon, Sun } from 'lucide-react';
 import { Button } from '@dashboard-parapente/design-system';
 import { useAuthStore } from '../../stores/authStore';
 import { useThemeStore, type ThemePreference } from '../../stores/themeStore';
@@ -22,10 +23,10 @@ const linkClass =
 const drawerLinkClass =
   'block py-3 px-4 min-h-11 rounded-md text-gray-700 dark:text-gray-200 text-base transition-all hover:bg-gray-100 dark:hover:bg-gray-700 [&.active]:bg-sky-600 [&.active]:text-white';
 
-const themeIcons: Record<ThemePreference, string> = {
-  light: '☀️',
-  dark: '🌙',
-  auto: '🔄',
+const themeIcons = {
+  light: Sun,
+  dark: Moon,
+  auto: MonitorCog,
 };
 
 const themeOptions: ThemePreference[] = ['light', 'dark', 'auto'];
@@ -94,15 +95,13 @@ export default function Header() {
     setThemePreference(next);
   }
 
-  const themeLabel = `${themeIcons[themePreference]} ${t(
-    `settings.languageTheme.${themePreference}`
-  )}`;
+  const ActiveThemeIcon = themeIcons[themePreference];
   const themeTooltip = `${t('settings.languageTheme.theme')} : ${t(
     `settings.languageTheme.${themePreference}`
   )}`;
 
   return (
-    <header className="bg-white dark:bg-gray-800 rounded-xl p-4 mb-4 shadow-lg flex justify-between items-center gap-2.5">
+    <header className="mb-4 flex items-center justify-between gap-2.5 rounded-2xl border border-slate-200 bg-white/95 p-4 shadow-lg shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/25">
       <h1 className="text-2xl sm:text-xl text-sky-600 dark:text-sky-400 font-semibold min-w-0 sm:min-w-[200px] m-0 truncate">
         {t('header.title')}
       </h1>
@@ -112,17 +111,19 @@ export default function Header() {
         {navLinks(linkClass)}
         <MenuTrigger>
           <AriaButton
-            className="px-3 py-1.5 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-100 text-sm font-medium transition-all hover:bg-gray-300 dark:hover:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-100 text-sm font-medium transition-all hover:bg-gray-300 dark:hover:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
             aria-label={`${t('settings.languageTheme.theme')} : ${t(
               `settings.languageTheme.${themePreference}`
             )}`}
           >
-            {themeLabel}
+            <ActiveThemeIcon className="h-4 w-4" aria-hidden="true" />
+            {t(`settings.languageTheme.${themePreference}`)}
           </AriaButton>
           <Popover className="z-40 mt-2 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin">
             <Menu className="outline-none">
               {themeOptions.map((theme) => {
                 const isActive = theme === themePreference;
+                const ThemeIcon = themeIcons[theme];
                 return (
                   <MenuItem
                     key={theme}
@@ -133,8 +134,9 @@ export default function Header() {
                         : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
                     }`}
                   >
-                    <span>
-                      {themeIcons[theme]} {t(`settings.languageTheme.${theme}`)}
+                    <span className="flex items-center gap-2">
+                      <ThemeIcon className="h-4 w-4" aria-hidden="true" />
+                      {t(`settings.languageTheme.${theme}`)}
                     </span>
                     {isActive && <span aria-hidden="true">✓</span>}
                   </MenuItem>
@@ -173,13 +175,14 @@ export default function Header() {
               aria-hidden="true"
               className="text-lg leading-none inline-block"
             >
-              {themeIcons[themePreference]}
+              <ActiveThemeIcon className="h-5 w-5" aria-hidden="true" />
             </span>
           </AriaButton>
           <Popover className="z-40 mt-2 w-44 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-1 theme-menu-popin">
             <Menu className="outline-none">
               {themeOptions.map((theme) => {
                 const isActive = theme === themePreference;
+                const ThemeIcon = themeIcons[theme];
                 return (
                   <MenuItem
                     key={theme}
@@ -190,8 +193,9 @@ export default function Header() {
                         : 'text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'
                     }`}
                   >
-                    <span>
-                      {themeIcons[theme]} {t(`settings.languageTheme.${theme}`)}
+                    <span className="flex items-center gap-2">
+                      <ThemeIcon className="h-4 w-4" aria-hidden="true" />
+                      {t(`settings.languageTheme.${theme}`)}
                     </span>
                     {isActive && <span aria-hidden="true">✓</span>}
                   </MenuItem>
@@ -225,7 +229,7 @@ export default function Header() {
           >
             <Modal className="fixed top-0 left-0 h-full w-64 bg-white dark:bg-gray-800 shadow-xl outline-none animate-[slide-in_0.2s_ease-out]">
               <Dialog className="h-full flex flex-col outline-none">
-                {({ close }) => (
+                {({ close }: { close: () => void }) => (
                   <>
                     <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
                       <span className="text-lg font-semibold text-gray-800 dark:text-gray-100">

--- a/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
+++ b/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
+import { Cloud, Thermometer, Wind } from 'lucide-react';
 import { WindIndicator } from '../common/WindIndicator';
 import CacheTimestamp from '../common/CacheTimestamp';
 import type { WeatherData } from '../../types';
@@ -8,20 +9,20 @@ import type { Site } from '@dashboard-parapente/shared-types';
 const getVerdictClass = (verdict: string): string => {
   const v = verdict.toLowerCase();
   if (v === 'bon')
-    return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200';
+    return 'bg-emerald-100 dark:bg-emerald-900/35 text-emerald-800 dark:text-emerald-200 ring-emerald-200 dark:ring-emerald-800';
   if (v === 'moyen')
-    return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200';
+    return 'bg-amber-100 dark:bg-amber-900/35 text-amber-800 dark:text-amber-200 ring-amber-200 dark:ring-amber-800';
   if (v === 'limite')
-    return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200';
-  return 'bg-red-100 dark:bg-red-900/30 text-red-900 dark:text-red-100';
+    return 'bg-orange-100 dark:bg-orange-900/35 text-orange-800 dark:text-orange-200 ring-orange-200 dark:ring-orange-800';
+  return 'bg-red-100 dark:bg-red-900/35 text-red-900 dark:text-red-100 ring-red-200 dark:ring-red-800';
 };
 
-const getVerdictEmoji = (verdict: string): string => {
+const getVerdictDotClass = (verdict: string): string => {
   const v = verdict.toLowerCase();
-  if (v === 'bon') return '🟢';
-  if (v === 'moyen') return '🟡';
-  if (v === 'limite') return '🟠';
-  return '🔴';
+  if (v === 'bon') return 'bg-emerald-500';
+  if (v === 'moyen') return 'bg-amber-500';
+  if (v === 'limite') return 'bg-orange-500';
+  return 'bg-red-500';
 };
 
 export interface SiteWeatherEntry {
@@ -52,22 +53,22 @@ function SiteConditionCard({
     <button
       type="button"
       onClick={handleClick}
-      className="w-full text-left bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border border-gray-200 dark:border-gray-700 hover:border-sky-400 dark:hover:border-sky-500 hover:shadow-lg transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
+      className="w-full cursor-pointer rounded-2xl border border-slate-200 bg-white/90 p-4 text-left shadow-md shadow-slate-200/50 transition-colors hover:border-sky-300 hover:bg-white dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20 dark:hover:border-sky-700 dark:hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
     >
       {/* Site name + orientation */}
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-bold text-gray-900 dark:text-white truncate">
+        <h3 className="text-sm font-black text-slate-950 dark:text-white truncate">
           {site.name}
         </h3>
         {site.orientation && (
-          <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 font-medium ml-2 shrink-0">
+          <span className="ml-2 shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-bold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
             {site.orientation}
           </span>
         )}
       </div>
 
       {isLoading && (
-        <div className="py-4 text-center text-gray-400 dark:text-gray-400 text-sm">
+        <div className="py-4 text-center text-sm text-slate-500 dark:text-slate-400">
           {t('common.loading')}
         </div>
       )}
@@ -82,31 +83,41 @@ function SiteConditionCard({
         <>
           {/* Score + verdict */}
           <div className="flex items-center gap-2 mb-3">
-            <span className="text-2xl font-bold text-sky-600 dark:text-sky-400">
-              {weather.score != null ? weather.score : weather.para_index}
+            <span className="text-3xl font-black tracking-tight text-sky-600 dark:text-sky-400">
+              {weather.score ?? weather.para_index}
             </span>
-            <span className="text-sm text-gray-400 dark:text-gray-400">
+            <span className="text-sm font-semibold text-slate-400 dark:text-slate-500">
               /100
             </span>
             <span
-              className={`ml-auto px-2 py-0.5 rounded-full text-xs font-semibold ${getVerdictClass(weather.verdict)}`}
+              className={`ml-auto inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-bold ring-1 ${getVerdictClass(weather.verdict)}`}
             >
-              {getVerdictEmoji(weather.verdict)} {weather.verdict.toUpperCase()}
+              <span
+                className={`h-2 w-2 rounded-full ${getVerdictDotClass(weather.verdict)}`}
+                aria-hidden="true"
+              />
+              {weather.verdict.toUpperCase()}
             </span>
           </div>
 
           {/* Metrics */}
           <div className="space-y-1.5 text-sm">
             <div className="flex justify-between">
-              <span className="text-gray-500 dark:text-gray-400">🌡️</span>
-              <span className="font-medium text-gray-900 dark:text-white">
+              <Thermometer
+                className="h-4 w-4 text-slate-500 dark:text-slate-400"
+                aria-hidden="true"
+              />
+              <span className="font-bold text-slate-950 dark:text-white">
                 {weather.temperature}°C
               </span>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-gray-500 dark:text-gray-400">💨</span>
+              <Wind
+                className="h-4 w-4 text-slate-500 dark:text-slate-400"
+                aria-hidden="true"
+              />
               <div className="flex items-center gap-2">
-                <span className="font-medium text-gray-900 dark:text-white">
+                <span className="font-bold text-slate-950 dark:text-white">
                   {weather.wind_speed} km/h
                 </span>
                 {site.orientation && (
@@ -122,8 +133,11 @@ function SiteConditionCard({
             </div>
             {weather.conditions && (
               <div className="flex justify-between">
-                <span className="text-gray-500 dark:text-gray-400">☁️</span>
-                <span className="font-medium text-gray-900 dark:text-white truncate ml-2">
+                <Cloud
+                  className="h-4 w-4 shrink-0 text-slate-500 dark:text-slate-400"
+                  aria-hidden="true"
+                />
+                <span className="ml-2 truncate font-bold text-slate-950 dark:text-white">
                   {weather.conditions}
                 </span>
               </div>
@@ -131,7 +145,7 @@ function SiteConditionCard({
           </div>
 
           {/* Cache timestamp */}
-          <div className="mt-3 pt-2 border-t border-gray-100 dark:border-gray-700">
+          <div className="mt-3 border-t border-slate-100 pt-2 dark:border-slate-700">
             <CacheTimestamp cachedAt={weather.cached_at} />
           </div>
         </>
@@ -149,7 +163,11 @@ export default function AllSitesConditions({
 
   return (
     <div>
-      <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
+      <h2 className="mb-3 flex items-center gap-2 text-sm font-bold text-slate-700 dark:text-slate-200">
+        <Cloud
+          className="h-4 w-4 text-sky-600 dark:text-sky-400"
+          aria-hidden="true"
+        />
         {t(
           'dashboard.allSitesConditions',
           'Conditions actuelles — tous les sites'

--- a/apps/frontend/src/components/dashboard/StatsPanel.tsx
+++ b/apps/frontend/src/components/dashboard/StatsPanel.tsx
@@ -1,5 +1,55 @@
 import { useTranslation } from 'react-i18next';
+import {
+  CalendarDays,
+  Clock3,
+  Compass,
+  MapPin,
+  Ruler,
+  Timer,
+  Trophy,
+  Waves,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { useFlightStats } from '../../hooks/flights/useFlights';
+
+const iconClass = 'h-5 w-5';
+
+interface StatCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  tone: 'sky' | 'emerald' | 'amber' | 'violet';
+}
+
+const toneClasses: Record<StatCardProps['tone'], string> = {
+  sky: 'bg-sky-100 text-sky-700 ring-sky-200 dark:bg-sky-900/40 dark:text-sky-300 dark:ring-sky-800/70',
+  emerald:
+    'bg-emerald-100 text-emerald-700 ring-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-300 dark:ring-emerald-800/70',
+  amber:
+    'bg-amber-100 text-amber-700 ring-amber-200 dark:bg-amber-900/40 dark:text-amber-300 dark:ring-amber-800/70',
+  violet:
+    'bg-violet-100 text-violet-700 ring-violet-200 dark:bg-violet-900/40 dark:text-violet-300 dark:ring-violet-800/70',
+};
+
+function StatCard({ icon: Icon, label, value, tone }: StatCardProps) {
+  return (
+    <div className="group flex min-w-0 items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/90 p-3 transition-colors hover:border-sky-300 hover:bg-white dark:border-slate-700 dark:bg-slate-950/45 dark:hover:border-sky-700 dark:hover:bg-slate-900/80">
+      <div
+        className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ring-1 ${toneClasses[tone]}`}
+      >
+        <Icon className={iconClass} aria-hidden="true" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-lg font-black leading-tight text-slate-950 dark:text-white">
+          {value}
+        </div>
+        <div className="mt-0.5 truncate text-xs font-semibold text-slate-600 dark:text-slate-300">
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function StatsPanel() {
   const { t, i18n } = useTranslation();
@@ -7,11 +57,15 @@ export default function StatsPanel() {
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
-          📊 {t('stats.title')}
+      <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-md shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-bold text-slate-700 dark:text-slate-200">
+          <Waves
+            className="h-4 w-4 text-sky-600 dark:text-sky-400"
+            aria-hidden="true"
+          />
+          {t('stats.title')}
         </h2>
-        <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
+        <div className="py-5 text-center text-sm text-slate-500 dark:text-slate-400">
           {t('common.loading')}
         </div>
       </div>
@@ -20,9 +74,13 @@ export default function StatsPanel() {
 
   if (error || !stats) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
-          📊 {t('stats.title')}
+      <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-md shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
+        <h2 className="mb-3 flex items-center gap-2 text-sm font-bold text-slate-700 dark:text-slate-200">
+          <Waves
+            className="h-4 w-4 text-sky-600 dark:text-sky-400"
+            aria-hidden="true"
+          />
+          {t('stats.title')}
         </h2>
         <div className="py-5 text-center text-red-500 dark:text-red-400 text-sm">
           {t('common.dataUnavailable')}
@@ -47,118 +105,79 @@ export default function StatsPanel() {
       ? (stats.total_hours / stats.total_flights).toFixed(1)
       : '0.0';
 
+  const cards: StatCardProps[] = [
+    {
+      icon: Compass,
+      label: t('stats.totalFlights'),
+      value: stats.total_flights,
+      tone: 'sky',
+    },
+    {
+      icon: Timer,
+      label: t('stats.totalTime'),
+      value: formatDuration(stats.total_hours),
+      tone: 'emerald',
+    },
+    {
+      icon: Ruler,
+      label: t('stats.totalDistance'),
+      value: `${stats.total_distance_km.toFixed(1)} km`,
+      tone: 'violet',
+    },
+    {
+      icon: Clock3,
+      label: t('stats.avgDuration'),
+      value: formatDuration(stats.avg_duration_minutes / 60),
+      tone: 'amber',
+    },
+    {
+      icon: MapPin,
+      label: t('stats.avgDistance'),
+      value: `${avgDistancePerFlight} km`,
+      tone: 'sky',
+    },
+    {
+      icon: Waves,
+      label: t('stats.avgTime'),
+      value: `${avgHoursPerFlight}h`,
+      tone: 'emerald',
+    },
+    {
+      icon: Trophy,
+      label: t('stats.favoriteSite'),
+      value: stats.favorite_spot || 'N/A',
+      tone: 'amber',
+    },
+    {
+      icon: CalendarDays,
+      label: t('stats.lastFlight'),
+      value: stats.last_flight_date
+        ? new Date(stats.last_flight_date).toLocaleDateString(
+            i18n.language.startsWith('en') ? 'en-US' : 'fr-FR',
+            {
+              day: '2-digit',
+              month: '2-digit',
+            }
+          )
+        : 'N/A',
+      tone: 'violet',
+    },
+  ];
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex-1 flex flex-col">
-      <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
-        📊 {t('stats.title')}
+    <div className="flex flex-1 flex-col rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-md shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
+      <h2 className="mb-3 flex items-center gap-2 text-sm font-bold text-slate-700 dark:text-slate-200">
+        <Waves
+          className="h-4 w-4 text-sky-600 dark:text-sky-400"
+          aria-hidden="true"
+        />
+        {t('stats.title')}
       </h2>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2.5 md:gap-3 flex-1">
-        {/* Row 1 */}
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">🪂</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {stats.total_flights}
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.totalFlights')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">⏱️</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {formatDuration(stats.total_hours)}
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.totalTime')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">📏</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {stats.total_distance_km.toFixed(1)} km
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.totalDistance')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">⌀</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {formatDuration(stats.avg_duration_minutes / 60)}
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.avgDuration')}
-            </div>
-          </div>
-        </div>
-
-        {/* Row 2 */}
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">📍</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {avgDistancePerFlight} km
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.avgDistance')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">🕐</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {avgHoursPerFlight}h
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.avgTime')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">⭐</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {stats.favorite_spot || 'N/A'}
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.favoriteSite')}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2.5 p-2.5 bg-gray-50 dark:bg-gray-900 rounded-md border-2 border-gray-200 dark:border-gray-600 transition-all hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100">
-          <div className="text-2xl leading-none shrink-0">📅</div>
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold text-gray-900 dark:text-white leading-tight truncate">
-              {stats.last_flight_date
-                ? new Date(stats.last_flight_date).toLocaleDateString(
-                    i18n.language.startsWith('en') ? 'en-US' : 'fr-FR',
-                    {
-                      day: '2-digit',
-                      month: '2-digit',
-                    }
-                  )
-                : 'N/A'}
-            </div>
-            <div className="text-[10px] text-gray-600 dark:text-gray-300 font-medium mt-0.5">
-              {t('stats.lastFlight')}
-            </div>
-          </div>
-        </div>
+        {cards.map((card) => (
+          <StatCard key={card.label} {...card} />
+        ))}
       </div>
     </div>
   );

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -9,7 +9,17 @@
 
 import { useTranslation } from 'react-i18next';
 import { format, addDays } from 'date-fns';
+import type { Locale } from 'date-fns';
 import { fr } from 'date-fns/locale';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Cloud,
+  Target,
+  Wind,
+  XCircle,
+} from 'lucide-react';
 import CacheTimestamp from '../common/CacheTimestamp';
 import { enUS } from 'date-fns/locale';
 import { WindIndicator } from '../common/WindIndicator';
@@ -104,6 +114,61 @@ function getVerdict(paraIndex: number, verdict?: string) {
   };
 }
 
+function getDateLabel(
+  selectedDayIndex: number,
+  selectedDate: Date,
+  dateFnsLocale: Locale,
+  t: (key: string) => string
+) {
+  if (selectedDayIndex === 0) return t('common.today').toLowerCase();
+  if (selectedDayIndex === 1) return t('common.tomorrow').toLowerCase();
+  return format(selectedDate, 'EEEE d MMMM', { locale: dateFnsLocale });
+}
+
+function getWindFavorabilityIcon(windFavorability: string) {
+  if (windFavorability === 'good') {
+    return (
+      <CheckCircle2
+        className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (windFavorability === 'moderate') {
+    return (
+      <AlertTriangle
+        className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <XCircle
+      className="h-5 w-5 shrink-0 text-red-600 dark:text-red-400"
+      aria-hidden="true"
+    />
+  );
+}
+
+function getWindFavorabilityTextClass(windFavorability: string) {
+  if (windFavorability === 'good')
+    return 'text-emerald-600 dark:text-emerald-400';
+  if (windFavorability === 'moderate')
+    return 'text-amber-600 dark:text-amber-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+function getWindFavorabilityLabel(
+  windFavorability: string,
+  t: (key: string) => string
+) {
+  if (windFavorability === 'good') return t('weather.favorabilityGood');
+  if (windFavorability === 'moderate') return t('weather.favorabilityModerate');
+  return t('weather.favorabilityPoor');
+}
+
 export const BestSpotSuggestion = ({
   bestSpot,
   hourlyBestSpots = [],
@@ -117,24 +182,26 @@ export const BestSpotSuggestion = ({
   // Calculate the date label based on selectedDayIndex
   const selectedDate = addDays(new Date(), selectedDayIndex);
   const dateFnsLocale = i18n.language === 'en' ? enUS : fr;
-  const dateLabel =
-    selectedDayIndex === 0
-      ? t('common.today').toLowerCase()
-      : selectedDayIndex === 1
-        ? t('common.tomorrow').toLowerCase()
-        : format(selectedDate, 'EEEE d MMMM', { locale: dateFnsLocale });
+  const dateLabel = getDateLabel(
+    selectedDayIndex,
+    selectedDate,
+    dateFnsLocale,
+    t
+  );
 
   // Show loading state if no data available
   if (!bestSpot || !bestSpot.site) {
     return (
-      <div className="bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-700 rounded-lg p-4 shadow-sm">
+      <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-md shadow-slate-200/50 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
         <div className="flex items-center gap-3">
-          <div className="text-3xl">🎯</div>
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+            <Target className="h-6 w-6" aria-hidden="true" />
+          </div>
           <div>
-            <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            <h3 className="text-sm font-semibold text-slate-600 dark:text-slate-300">
               {t('weather.bestSpotFor', { date: dateLabel })}
             </h3>
-            <div className="text-lg text-gray-500 dark:text-gray-400 mt-1">
+            <div className="mt-1 text-lg font-bold text-slate-500 dark:text-slate-400">
               {t('weather.calculating')}
             </div>
           </div>
@@ -157,7 +224,7 @@ export const BestSpotSuggestion = ({
   } = bestSpot;
   const adjustedScore = Math.min(
     100,
-    Math.max(0, score != null ? Math.round(score) : paraIndex)
+    Math.max(0, Math.round(score ?? paraIndex))
   );
   const localizedReason = reason.replace(/Para-Index/g, t('weather.paraIndex'));
   const scoreColor = getScoreColor(adjustedScore);
@@ -165,22 +232,24 @@ export const BestSpotSuggestion = ({
 
   return (
     <div
-      className={`min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className}`}
+      className={`min-w-0 max-w-full overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-lg shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/25 ${className}`}
     >
       {/* Header with colored accent bar */}
       <div className={`h-1.5 ${scoreColor.bg}`} />
 
-      <div className="min-w-0 p-4">
+      <div className="min-w-0 p-4 md:p-5">
         {/* Top row: title + verdict badge */}
         <div className="flex items-center justify-between mb-3 gap-2">
-          <div className="flex items-center gap-2">
-            <span className="text-2xl">🎯</span>
-            <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+              <Target className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <h3 className="truncate text-sm font-bold text-slate-600 dark:text-slate-300">
               {t('weather.bestSpotFor', { date: dateLabel })}
             </h3>
           </div>
           <span
-            className={`px-2.5 py-0.5 rounded-full text-xs font-bold ${verdictInfo.className}`}
+            className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-black ${verdictInfo.className}`}
           >
             {verdictInfo.label}
           </span>
@@ -188,7 +257,7 @@ export const BestSpotSuggestion = ({
 
         {/* Site name + rating */}
         <div className="flex min-w-0 items-center gap-2 mb-4">
-          <span className="min-w-0 truncate text-xl font-bold text-gray-900 dark:text-white">
+          <span className="min-w-0 truncate text-2xl font-black tracking-tight text-slate-950 dark:text-white">
             {site.name}
           </span>
           {site.rating != null && site.rating > 0 && (
@@ -198,7 +267,7 @@ export const BestSpotSuggestion = ({
             </span>
           )}
           {site.orientation && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 font-medium">
+            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-bold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
               {site.orientation}
             </span>
           )}
@@ -207,24 +276,24 @@ export const BestSpotSuggestion = ({
         {/* Score gauge */}
         <div className="mb-4">
           <div className="flex items-end justify-between mb-1.5">
-            <span className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            <span className="text-sm font-bold text-slate-600 dark:text-slate-300">
               {t('weather.score')}
             </span>
             <span className={`text-2xl font-bold ${scoreColor.text}`}>
               {adjustedScore}
-              <span className="text-sm font-normal text-gray-400 dark:text-gray-400">
+              <span className="text-sm font-semibold text-slate-400 dark:text-slate-500">
                 /100
               </span>
             </span>
           </div>
-          <div className="w-full h-2.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+          <div className="h-3 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
             <div
               className={`h-full rounded-full ${scoreColor.bg} transition-all duration-500`}
               style={{ width: `${adjustedScore}%` }}
             />
           </div>
           {score != null && score !== paraIndex && (
-            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            <div className="mt-1 text-xs font-medium text-slate-500 dark:text-slate-400">
               {t('weather.paraIndex')} {paraIndex}/100
             </div>
           )}
@@ -233,7 +302,7 @@ export const BestSpotSuggestion = ({
         {/* Metrics grid */}
         <div className="grid grid-cols-2 gap-3 mb-4">
           {/* Wind */}
-          <div className="bg-gray-50 dark:bg-gray-750 dark:bg-gray-900/30 rounded-lg p-2.5">
+          <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
             {windDirection && windSpeed != null ? (
               <WindIndicator
                 windDirection={windDirection}
@@ -242,22 +311,25 @@ export const BestSpotSuggestion = ({
                 size="sm"
               />
             ) : (
-              <div className="flex items-center gap-2 text-sm text-gray-400 dark:text-gray-400">
-                <span>💨</span>
+              <div className="flex items-center gap-2 text-sm text-slate-400 dark:text-slate-400">
+                <Wind className="h-4 w-4" aria-hidden="true" />
                 <span>—</span>
               </div>
             )}
           </div>
 
           {/* Flyable slot */}
-          <div className="bg-gray-50 dark:bg-gray-900/30 rounded-lg p-2.5">
+          <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
             <div className="flex items-center gap-2">
-              <span className="text-lg">🕐</span>
+              <Clock3
+                className="h-5 w-5 shrink-0 text-sky-600 dark:text-sky-400"
+                aria-hidden="true"
+              />
               <div className="flex flex-col">
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
                   {t('weather.flyableSlot')}
                 </span>
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
+                <span className="text-sm font-black text-slate-950 dark:text-white">
                   {flyableSlot || '—'}
                 </span>
               </div>
@@ -266,14 +338,17 @@ export const BestSpotSuggestion = ({
 
           {/* Thermal ceiling */}
           {thermalCeiling != null && (
-            <div className="bg-gray-50 dark:bg-gray-900/30 rounded-lg p-2.5">
+            <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
               <div className="flex items-center gap-2">
-                <span className="text-lg">☁️</span>
+                <Cloud
+                  className="h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400"
+                  aria-hidden="true"
+                />
                 <div className="flex flex-col">
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                  <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
                     {t('weather.thermalCeiling')}
                   </span>
-                  <span className="text-sm font-bold text-orange-600 dark:text-orange-400">
+                  <span className="text-sm font-black text-orange-600 dark:text-orange-400">
                     {thermalCeiling}m
                   </span>
                 </div>
@@ -283,33 +358,17 @@ export const BestSpotSuggestion = ({
 
           {/* Wind favorability badge */}
           {windFavorability && (
-            <div className="bg-gray-50 dark:bg-gray-900/30 rounded-lg p-2.5">
+            <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
               <div className="flex items-center gap-2">
-                <span className="text-lg">
-                  {windFavorability === 'good'
-                    ? '✅'
-                    : windFavorability === 'moderate'
-                      ? '⚠️'
-                      : '❌'}
-                </span>
+                {getWindFavorabilityIcon(windFavorability)}
                 <div className="flex flex-col">
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
+                  <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
                     {t('weather.windOrientation')}
                   </span>
                   <span
-                    className={`text-sm font-bold ${
-                      windFavorability === 'good'
-                        ? 'text-emerald-600 dark:text-emerald-400'
-                        : windFavorability === 'moderate'
-                          ? 'text-amber-600 dark:text-amber-400'
-                          : 'text-red-600 dark:text-red-400'
-                    }`}
+                    className={`text-sm font-black ${getWindFavorabilityTextClass(windFavorability)}`}
                   >
-                    {windFavorability === 'good'
-                      ? t('weather.favorabilityGood')
-                      : windFavorability === 'moderate'
-                        ? t('weather.favorabilityModerate')
-                        : t('weather.favorabilityPoor')}
+                    {getWindFavorabilityLabel(windFavorability, t)}
                   </span>
                 </div>
               </div>
@@ -318,17 +377,17 @@ export const BestSpotSuggestion = ({
         </div>
 
         {/* Reason text */}
-        <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 leading-relaxed">
+        <p className="mb-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
           {localizedReason}
         </p>
 
         {hourlyBestSpots.length > 0 && (
-          <div className="mb-4 min-w-0 border-t border-gray-100 pt-3 dark:border-gray-700">
+          <div className="mb-4 min-w-0 border-t border-slate-100 pt-3 dark:border-slate-700">
             <div className="flex items-center justify-between gap-2 mb-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              <span className="text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 {t('weather.bestSpotTimeline')}
               </span>
-              <span className="text-xs text-gray-400 dark:text-gray-500">
+              <span className="text-xs font-medium text-slate-400 dark:text-slate-500">
                 {t('weather.byHour')}
               </span>
             </div>
@@ -338,9 +397,7 @@ export const BestSpotSuggestion = ({
                   100,
                   Math.max(
                     0,
-                    hourlySpot.score != null
-                      ? Math.round(hourlySpot.score)
-                      : hourlySpot.paraIndex
+                    Math.round(hourlySpot.score ?? hourlySpot.paraIndex)
                   )
                 );
                 const hourlyScoreColor = getScoreColor(hourlyScore);
@@ -353,7 +410,7 @@ export const BestSpotSuggestion = ({
                     ? t('common.now')
                     : `${hourlySpot.hour}h`;
                 const roundedWindSpeed =
-                  hourlySpot.windSpeed != null
+                  typeof hourlySpot.windSpeed === 'number'
                     ? Math.round(hourlySpot.windSpeed)
                     : null;
                 const windLabel =
@@ -372,10 +429,10 @@ export const BestSpotSuggestion = ({
                         onSelectSite(hourlySpot.site.id);
                       }
                     }}
-                    className="min-w-[176px] flex-col items-stretch justify-start gap-0 whitespace-normal rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-left shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900/50 dark:hover:bg-gray-900"
+                    className="min-w-[176px] cursor-pointer flex-col items-stretch justify-start gap-0 whitespace-normal rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-950/60 dark:hover:border-sky-800 dark:hover:bg-slate-950"
                   >
                     <div className="flex items-start justify-between gap-3">
-                      <span className="text-sm font-extrabold text-gray-900 dark:text-white">
+                      <span className="text-sm font-extrabold text-slate-950 dark:text-white">
                         {hourLabel}
                       </span>
                       <div className="text-right">
@@ -384,18 +441,18 @@ export const BestSpotSuggestion = ({
                         >
                           {hourlyScore}
                         </span>
-                        <span className="text-[10px] font-semibold text-gray-400 dark:text-gray-500">
+                        <span className="text-[10px] font-semibold text-slate-400 dark:text-slate-500">
                           /100
                         </span>
                       </div>
                     </div>
-                    <div className="mt-2 h-1.5 rounded-full bg-gray-100 dark:bg-gray-700">
+                    <div className="mt-2 h-1.5 rounded-full bg-slate-100 dark:bg-slate-800">
                       <div
                         className={`h-full rounded-full ${hourlyScoreColor.bg}`}
                         style={{ width: `${hourlyScore}%` }}
                       />
                     </div>
-                    <div className="mt-2 truncate text-base font-bold text-gray-900 dark:text-gray-50">
+                    <div className="mt-2 truncate text-base font-black text-slate-950 dark:text-gray-50">
                       {hourlySpot.site?.name ?? '—'}
                     </div>
                     <div className="mt-2 flex items-center justify-between gap-2">
@@ -405,12 +462,12 @@ export const BestSpotSuggestion = ({
                         {hourlyVerdict.label}
                       </span>
                       {orientationLabel && (
-                        <span className="truncate text-xs font-semibold text-gray-500 dark:text-gray-400">
+                        <span className="truncate text-xs font-semibold text-slate-500 dark:text-slate-400">
                           {orientationLabel}
                         </span>
                       )}
                     </div>
-                    <div className="mt-2 text-xs font-medium text-gray-600 dark:text-gray-300">
+                    <div className="mt-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
                       {windLabel}
                     </div>
                   </Button>
@@ -424,7 +481,7 @@ export const BestSpotSuggestion = ({
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
           <Button
             onClick={() => onSelectSite(site.id)}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors"
+            className="cursor-pointer rounded-xl bg-sky-600 px-4 py-2 text-sm font-bold text-white shadow-sm shadow-sky-600/20 transition-colors hover:bg-sky-700"
           >
             {t('weather.viewForecast')}
           </Button>
@@ -450,18 +507,19 @@ export function BestSpotSuggestionCompact({
   }
 
   const { site, paraIndex, score, windDirection, windSpeed } = bestSpot;
-  const adjustedScore = score != null ? Math.round(score) : paraIndex;
+  const adjustedScore = Math.round(score ?? paraIndex);
   const scoreColor = getScoreColor(adjustedScore);
 
   return (
     <Button
       onClick={() => onSelectSite(site.id)}
-      className={`w-full text-left p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors overflow-hidden ${className}`}
+      className={`w-full overflow-hidden rounded-xl border border-slate-200 bg-white p-3 text-left transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800 ${className}`}
     >
       <div className={`h-1 ${scoreColor.bg} -mt-3 -mx-3 mb-2`} />
       <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
-          🎯 {t('weather.recommended')}
+        <span className="inline-flex items-center gap-1.5 text-xs font-medium text-blue-600 dark:text-blue-400">
+          <Target className="h-3.5 w-3.5" aria-hidden="true" />
+          {t('weather.recommended')}
         </span>
         {windDirection && windSpeed != null && (
           <WindIndicator

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -181,7 +181,7 @@ export const BestSpotSuggestion = ({
 
   // Calculate the date label based on selectedDayIndex
   const selectedDate = addDays(new Date(), selectedDayIndex);
-  const dateFnsLocale = i18n.language === 'en' ? enUS : fr;
+  const dateFnsLocale = i18n.language.startsWith('en') ? enUS : fr;
   const dateLabel = getDateLabel(
     selectedDayIndex,
     selectedDate,
@@ -507,7 +507,10 @@ export function BestSpotSuggestionCompact({
   }
 
   const { site, paraIndex, score, windDirection, windSpeed } = bestSpot;
-  const adjustedScore = Math.round(score ?? paraIndex);
+  const adjustedScore = Math.min(
+    100,
+    Math.max(0, Math.round(score ?? paraIndex))
+  );
   const scoreColor = getScoreColor(adjustedScore);
 
   return (

--- a/apps/frontend/src/pages/Dashboard.chromatic.stories.tsx
+++ b/apps/frontend/src/pages/Dashboard.chromatic.stories.tsx
@@ -1,7 +1,7 @@
 import { FigureWrapper } from '../../.storybook/FigureWrapper.tsx';
 import preview from '../../.storybook/preview.tsx';
 import { http, HttpResponse } from 'msw';
-import { Default, Loading, Error } from './Dashboard.stories.tsx';
+import { Default, Loading, Empty, Error } from './Dashboard.stories.tsx';
 
 const mockSites = {
   sites: [
@@ -134,6 +134,9 @@ export const DashboardChromatic = meta.story({
       </FigureWrapper>
       <FigureWrapper title={Loading.composed.name}>
         <Loading.Component />
+      </FigureWrapper>
+      <FigureWrapper title={Empty.composed.name}>
+        <Empty.Component />
       </FigureWrapper>
       <FigureWrapper title={Error.composed.name}>
         <Error.Component />

--- a/apps/frontend/src/pages/Dashboard.stories.tsx
+++ b/apps/frontend/src/pages/Dashboard.stories.tsx
@@ -258,6 +258,18 @@ export const Loading = meta.story({
   },
 });
 
+export const Empty = meta.story({
+  name: 'Empty',
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/spots', () => HttpResponse.json({ sites: [] })),
+        ...defaultHandlers.slice(1),
+      ],
+    },
+  },
+});
+
 export const Error = meta.story({
   name: 'Error',
   parameters: {

--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery, useQueries } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
+import { CalendarDays, CloudSun, MapPinned } from 'lucide-react';
 import StatsPanel from '../components/dashboard/StatsPanel';
 import AllSitesConditions from '../components/dashboard/AllSitesConditions';
 import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
@@ -16,11 +17,19 @@ import type { WeatherData } from '../types';
 import type { SiteWeatherEntry } from '../components/dashboard/AllSitesConditions';
 
 export default function Dashboard() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { data: sites } = useSuspenseQuery(sitesQueryOptions());
   const { data: bestSpot } = useBestSpotAPI(0);
   const { data: hourlyBestSpots } = useHourlyBestSpotsAPI(0);
+  const todayLabel = new Intl.DateTimeFormat(
+    i18n.language.startsWith('en') ? 'en-US' : 'fr-FR',
+    {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+    }
+  ).format(new Date());
 
   // Fetch current weather for all sites (day 0), auto-refresh every hour
   const weatherQueries = useQueries({
@@ -44,7 +53,10 @@ export default function Dashboard() {
   if (sites.length === 0) {
     return (
       <div className="py-8">
-        <div className="bg-white dark:bg-gray-800 rounded-xl p-8 shadow-md text-center max-w-md mx-auto">
+        <div className="mx-auto max-w-md rounded-2xl border border-slate-200 bg-white/90 p-8 text-center shadow-lg shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+            <MapPinned className="h-6 w-6" aria-hidden="true" />
+          </div>
           <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-3">
             {t('dashboard.noSites')}
           </h2>
@@ -63,12 +75,45 @@ export default function Dashboard() {
   }
 
   return (
-    <div>
+    <div className="space-y-5">
+      <section className="overflow-hidden rounded-3xl border border-sky-100 bg-gradient-to-br from-white via-sky-50/70 to-blue-50 p-5 shadow-lg shadow-sky-100/70 dark:border-slate-700/80 dark:from-slate-950 dark:via-slate-900 dark:to-sky-950/50 dark:shadow-black/30 md:p-6">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div className="min-w-0">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700 shadow-sm dark:border-sky-800/80 dark:bg-sky-950/50 dark:text-sky-300">
+              <CloudSun className="h-4 w-4" aria-hidden="true" />
+              {t('header.dashboard')}
+            </div>
+            <h2 className="text-2xl font-black tracking-tight text-slate-950 dark:text-white sm:text-3xl">
+              {t('dashboard.homeTitle', 'Vue météo et vols du jour')}
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {t(
+                'dashboard.homeDescription',
+                'Suivez rapidement les sites exploitables, les meilleurs créneaux et vos indicateurs de vol.'
+              )}
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white/85 px-3.5 py-2 text-sm font-semibold text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-900/75 dark:text-slate-200">
+              <CalendarDays
+                className="h-4 w-4 text-sky-600 dark:text-sky-400"
+                aria-hidden="true"
+              />
+              <span className="capitalize">{todayLabel}</span>
+            </div>
+            <Button
+              onClick={() => void navigate({ to: '/weather' })}
+              className="rounded-2xl bg-sky-600 px-4 py-2.5 text-sm font-bold text-white shadow-md shadow-sky-600/20 transition-colors hover:bg-sky-700"
+            >
+              {t('weather.viewForecast')}
+            </Button>
+          </div>
+        </div>
+      </section>
+
       <div className="space-y-4">
-        {/* 1. Stats Panel */}
         <StatsPanel />
 
-        {/* 2. Best Spot (Today) */}
         <BestSpotSuggestion
           bestSpot={bestSpot ?? null}
           hourlyBestSpots={hourlyBestSpots?.hours ?? []}
@@ -79,7 +124,6 @@ export default function Dashboard() {
           selectedDayIndex={0}
         />
 
-        {/* 3. Current Conditions - All Sites (auto-refresh hourly) */}
         <AllSitesConditions entries={siteWeatherEntries} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Refresh the `/` dashboard with a contextual hero, stronger light/dark surfaces, and clearer CTA hierarchy.
- Replace visible emoji UI markers with Lucide icons across the home dashboard and theme selector.
- Add an Empty dashboard story and include it in the Chromatic dashboard set.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` passed with existing warnings.
- Direct touched-file `oxlint` + `oxfmt` checks passed.
- `git diff --check` passed.
- `nx test frontend` blocked by local worktree environment: `vitest` resolution from pnpm global store and missing Playwright browser.
- `nx build frontend` blocked by pre-existing TypeScript errors outside the touched files; with `NODE_PATH=$PWD/node_modules`, no build errors referenced the files changed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added top dashboard header with weather information and navigation to weather section.
  * Added empty state view for dashboard when no sites are available.

* **Style**
  * Replaced emoji indicators with iconography throughout the dashboard.
  * Enhanced visual styling of stats cards, weather conditions, and theme selector.
  * Improved dashboard layout and typography consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/668)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->