### PR TITLE
feat(frontend): improve weather page ux

### DIFF
--- a/apps/frontend/src/components/common/WindIndicator.stories.tsx
+++ b/apps/frontend/src/components/common/WindIndicator.stories.tsx
@@ -1,5 +1,9 @@
 import preview from '../../../.storybook/preview';
-import { WindIndicator, WindIndicatorCompact } from './WindIndicator';
+import {
+  WindIndicator,
+  WindIndicatorCompact,
+  type WindIndicatorProps,
+} from './WindIndicator';
 
 const meta = preview.meta({
   title: 'Components/WindIndicator',
@@ -9,7 +13,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'Wind indicator component that shows visual feedback (🟢/🟡/🔴) based on wind favorability for a specific takeoff orientation.',
+          'Wind indicator component that shows visual feedback based on wind favorability for a specific takeoff orientation.',
       },
     },
   },
@@ -55,6 +59,7 @@ export const Perfect = meta.story({
     windSpeed: 15,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -69,6 +74,7 @@ export const Good = meta.story({
     windSpeed: 12,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -83,6 +89,7 @@ export const Acceptable = meta.story({
     windSpeed: 10,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -97,6 +104,7 @@ export const Unfavorable = meta.story({
     windSpeed: 20,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -111,6 +119,7 @@ export const TooStrong = meta.story({
     windSpeed: 35,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -125,6 +134,7 @@ export const TooWeak = meta.story({
     windSpeed: 3,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
@@ -139,11 +149,12 @@ export const NoData = meta.story({
     windSpeed: undefined,
     showLabel: true,
     size: 'md',
+    className: '',
   },
 });
 
 /**
- * Without label: Only showing the emoji indicator
+ * Without label: Only showing the icon indicator
  */
 export const WithoutLabel = meta.story({
   name: 'Without Label',
@@ -153,6 +164,7 @@ export const WithoutLabel = meta.story({
     windSpeed: 15,
     showLabel: false,
     size: 'md',
+    className: '',
   },
 });
 
@@ -167,6 +179,7 @@ export const SmallSize = meta.story({
     windSpeed: 12,
     showLabel: true,
     size: 'sm',
+    className: '',
   },
 });
 
@@ -181,6 +194,7 @@ export const LargeSize = meta.story({
     windSpeed: 15,
     showLabel: true,
     size: 'lg',
+    className: '',
   },
 });
 
@@ -239,21 +253,24 @@ export const AllStates = meta.story({
 });
 
 /**
- * Compact version showing only emoji with tooltip
+ * Compact version showing only an icon with tooltip
  */
 export const Compact = meta.story({
   name: 'Compact Version',
-  render: (args) => <WindIndicatorCompact {...args} />,
+  render: (args) => <WindIndicatorCompact {...(args as WindIndicatorProps)} />,
   args: {
     windDirection: 'N',
     siteOrientation: 'N',
     windSpeed: 15,
+    showLabel: false,
+    size: 'md',
+    className: '',
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Compact version showing only emoji with tooltip (hover to see details)',
+          'Compact version showing only an icon with tooltip (hover to see details)',
       },
     },
   },

--- a/apps/frontend/src/components/common/WindIndicator.tsx
+++ b/apps/frontend/src/components/common/WindIndicator.tsx
@@ -1,19 +1,19 @@
 /**
  * WindIndicator Component
  *
- * Shows a visual indicator (🟢/🟡/🔴) based on wind favorability
+ * Shows a visual indicator based on wind favorability
  * for a specific takeoff orientation.
  */
 
 import { useTranslation } from 'react-i18next';
+import { AlertTriangle, CheckCircle2, CircleHelp, XCircle } from 'lucide-react';
 import {
   getWindFavorability,
-  getWindFavorabilityEmoji,
   getWindFavorabilityLabel,
   getWindFavorabilityColor,
 } from '../../utils/windMatcher';
 
-interface WindIndicatorProps {
+export interface WindIndicatorProps {
   windDirection?: string;
   siteOrientation?: string;
   windSpeed?: number;
@@ -21,6 +21,13 @@ interface WindIndicatorProps {
   size?: 'sm' | 'md' | 'lg';
   className?: string;
 }
+
+const getWindFavorabilityIcon = (favorability: string) => {
+  if (favorability === 'good') return CheckCircle2;
+  if (favorability === 'moderate') return AlertTriangle;
+  if (favorability === 'bad') return XCircle;
+  return CircleHelp;
+};
 
 export function WindIndicator({
   windDirection,
@@ -36,9 +43,9 @@ export function WindIndicator({
     siteOrientation,
     windSpeed
   );
-  const emoji = getWindFavorabilityEmoji(favorability);
   const label = getWindFavorabilityLabel(favorability, i18n.language);
   const colorClass = getWindFavorabilityColor(favorability);
+  const Icon = getWindFavorabilityIcon(favorability);
 
   // Size classes
   const sizeClasses = {
@@ -53,7 +60,10 @@ export function WindIndicator({
       <div
         className={`flex items-center gap-2 ${sizeClasses[size]} ${className}`}
       >
-        <span className="text-gray-400 dark:text-gray-400">⚪</span>
+        <CircleHelp
+          className="h-5 w-5 shrink-0 text-gray-400 dark:text-gray-400"
+          aria-hidden="true"
+        />
         {showLabel && (
           <span className="text-gray-400 dark:text-gray-400">
             {t('weather.windUnavailable')}
@@ -67,7 +77,7 @@ export function WindIndicator({
     <div
       className={`flex items-center gap-2 ${sizeClasses[size]} ${className}`}
     >
-      <span className="text-xl">{emoji}</span>
+      <Icon className={`h-5 w-5 shrink-0 ${colorClass}`} aria-hidden="true" />
       {showLabel && (
         <div className="flex flex-col">
           <span className={`font-medium ${colorClass}`}>{label}</span>
@@ -83,7 +93,7 @@ export function WindIndicator({
 }
 
 /**
- * Compact version showing only emoji with tooltip
+ * Compact version showing only an icon with tooltip
  */
 export function WindIndicatorCompact({
   windDirection,
@@ -97,8 +107,9 @@ export function WindIndicatorCompact({
     siteOrientation,
     windSpeed
   );
-  const emoji = getWindFavorabilityEmoji(favorability);
   const label = getWindFavorabilityLabel(favorability, i18n.language);
+  const colorClass = getWindFavorabilityColor(favorability);
+  const Icon = getWindFavorabilityIcon(favorability);
 
   const tooltipText =
     windDirection && windSpeed != null
@@ -107,11 +118,11 @@ export function WindIndicatorCompact({
 
   return (
     <span
-      className={`text-xl cursor-help ${className}`}
+      className={`inline-flex cursor-help ${className}`}
       title={tooltipText}
       aria-label={tooltipText}
     >
-      {emoji}
+      <Icon className={`h-5 w-5 ${colorClass}`} aria-hidden="true" />
     </span>
   );
 }

--- a/apps/frontend/src/components/dashboard/SiteSelector.tsx
+++ b/apps/frontend/src/components/dashboard/SiteSelector.tsx
@@ -247,7 +247,7 @@ export default function SiteSelector({
                   ${
                     isActive
                       ? 'border-sky-600 bg-gradient-to-br from-sky-600 to-sky-800 text-white'
-                      : 'border-gray-200 bg-white dark:bg-gray-700 dark:border-gray-600 hover:border-sky-600 hover:-translate-y-0.5 hover:shadow-md hover:shadow-sky-100'
+                      : 'border-gray-200 bg-white dark:bg-gray-700 dark:border-gray-600 hover:border-sky-600 hover:shadow-md hover:shadow-sky-100'
                   }
                 `}
                 onClick={() => onSelectSite(site.id)}

--- a/apps/frontend/src/components/weather/CityWeatherSearch.tsx
+++ b/apps/frontend/src/components/weather/CityWeatherSearch.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useId, useState } from 'react';
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useEffect,
+  useId,
+  useState,
+} from 'react';
 import { Input, Label, TextField } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
 import type {
@@ -126,7 +132,7 @@ function OptionButton({
       type="button"
       onClick={onSelect}
       aria-pressed={isSelected}
-      className={`rounded-xl border p-3 text-left transition-all ${
+      className={`cursor-pointer rounded-xl border p-3 text-left transition-colors ${
         isSelected
           ? 'border-sky-500 bg-sky-50 ring-2 ring-sky-200 dark:border-sky-400 dark:bg-sky-950/40 dark:ring-sky-900'
           : 'border-gray-200 bg-white hover:border-sky-300 hover:bg-sky-50/60 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-sky-700 dark:hover:bg-sky-950/20'
@@ -263,6 +269,12 @@ export default function CityWeatherSearch({
     ? createdSpotIds.has(selectedSpot.id) ||
       favoriteSites.some(isSameFavoriteSite)
     : false;
+  let favoriteButtonLabel = 'Ajouter aux favoris';
+  if (isSelectedSpotFavorite) {
+    favoriteButtonLabel = 'Déjà dans les favoris';
+  } else if (createSite.isPending) {
+    favoriteButtonLabel = 'Ajout...';
+  }
 
   const handleCreateFavorite = async () => {
     if (!selectedSpot) return;
@@ -335,241 +347,251 @@ export default function CityWeatherSearch({
       </div>
 
       <div className={`${isExpanded ? 'block' : 'hidden'} sm:block`}>
-      <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
-        <TextField className="relative flex flex-col gap-1">
-          <Label className="text-sm font-medium text-gray-700 dark:text-gray-200">
-            Ville
-          </Label>
-          <Input
-            value={query}
-            onChange={(event) => {
-              setQuery(event.target.value);
-              setSelectedLocation(null);
-              setSelectedOption(null);
-              onSelectTarget(null);
-            }}
-            onKeyDown={(event) => {
-              if (!isSuggestionsOpen || !suggestions.length) return;
-              if (event.key === 'ArrowDown') {
-                event.preventDefault();
-                setActiveSuggestionIndex((index) =>
-                  Math.min(index + 1, suggestions.length - 1)
-                );
-              } else if (event.key === 'ArrowUp') {
-                event.preventDefault();
-                setActiveSuggestionIndex((index) => Math.max(index - 1, 0));
-              } else if (event.key === 'Enter') {
-                event.preventDefault();
-                handleSelectLocation(suggestions[activeSuggestionIndex]);
-              }
-            }}
-            role="combobox"
-            aria-expanded={isSuggestionsOpen}
-            aria-haspopup="listbox"
-            aria-autocomplete="list"
-            aria-controls={listboxId}
-            aria-activedescendant={activeSuggestionId}
-            placeholder="Ex: Besançon, Annecy, Grenoble..."
-            className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 outline-none focus:ring-2 focus:ring-sky-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          />
-          {isSuggestionsOpen && (
-            <div
-              id={listboxId}
-              role="listbox"
-              className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900"
-            >
-              {locationSearch.isLoading ? (
-                <div className="p-3 text-sm text-gray-600 dark:text-gray-300">
-                  Recherche des villes...
-                </div>
-              ) : suggestions.length ? (
-                suggestions.map((location, index) => (
-                  <button
-                    id={`${listboxId}-${location.id}`}
-                    key={location.id}
-                    type="button"
-                    role="option"
-                    aria-selected={index === activeSuggestionIndex}
-                    onMouseEnter={() => setActiveSuggestionIndex(index)}
-                    onClick={() => handleSelectLocation(location)}
-                    className={`block w-full border-b border-gray-100 px-3 py-2 text-left last:border-b-0 dark:border-gray-800 ${
-                      index === activeSuggestionIndex
-                        ? 'bg-sky-100 dark:bg-sky-950/60'
-                        : 'hover:bg-sky-50 dark:hover:bg-sky-950/40'
-                    }`}
-                  >
-                    <span className="block font-medium text-gray-950 dark:text-white">
-                      {location.name}
-                    </span>
-                    <span className="block text-xs text-gray-500 dark:text-gray-400">
-                      {location.display_name}
-                    </span>
-                  </button>
-                ))
-              ) : (
-                <div className="p-3 text-sm text-gray-600 dark:text-gray-300">
-                  Aucune ville trouvée.
-                </div>
-              )}
-            </div>
-          )}
-        </TextField>
-
-        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
-          Rayon
-          <select
-            value={radiusKm}
-            onChange={(event) => setRadiusKm(Number(event.target.value))}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            {radiusChoices.map((radius) => (
-              <option key={radius} value={radius}>
-                {radius} km
-              </option>
-            ))}
-          </select>
-        </label>
-
-        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
-          Résultats
-          <select
-            value={limit}
-            onChange={(event) => setLimit(Number(event.target.value))}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          >
-            {limitChoices.map((choice) => (
-              <option key={choice} value={choice}>
-                {choice}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-
-      {selectedLocation && (
-        <div className="mt-5 space-y-4">
-          <div className="flex flex-col gap-2 rounded-xl bg-gray-50 p-3 dark:bg-gray-900/60 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="font-semibold text-gray-950 dark:text-white">
-                {selectedLocation.name}
-              </div>
-              <div className="text-sm text-gray-600 dark:text-gray-300">
-                {selectedLocation.display_name}
-              </div>
-            </div>
-            <Button
-              onPress={() => handleSelectLocation(selectedLocation)}
-              className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
-            >
-              Météo ville
-            </Button>
-          </div>
-
-          {nearbyOptions.isError ? (
-            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
-              Impossible de charger les décollages et atterrissages proches.
-            </div>
-          ) : nearbyOptions.isLoading ? (
-            <div className="rounded-xl border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300">
-              Recherche des décollages et atterrissages proches...
-            </div>
-          ) : (
-            <div className="grid gap-4 lg:grid-cols-2">
-              <div>
-                <h3 className="mb-2 font-semibold text-gray-950 dark:text-white">
-                  Décollages proches
-                </h3>
-                <div className="grid gap-2">
-                  {nearbyOptions.data?.takeoffs.length ? (
-                    nearbyOptions.data.takeoffs.map((spot) => (
-                      <OptionButton
-                        key={spot.id}
-                        label={spot.name}
-                        description={spotDescription(spot)}
-                        isSelected={
-                          selectedOption?.type === 'takeoff' &&
-                          selectedOption.spot.id === spot.id
-                        }
-                        onSelect={() => handleSelectSpot('takeoff', spot)}
-                      />
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Aucun décollage dans ce rayon.
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <h3 className="mb-2 font-semibold text-gray-950 dark:text-white">
-                  Atterrissages proches
-                </h3>
-                <div className="grid gap-2">
-                  {nearbyOptions.data?.landings.length ? (
-                    nearbyOptions.data.landings.map((spot) => (
-                      <OptionButton
-                        key={spot.id}
-                        label={spot.name}
-                        description={spotDescription(spot)}
-                        isSelected={
-                          selectedOption?.type === 'landing' &&
-                          selectedOption.spot.id === spot.id
-                        }
-                        onSelect={() => handleSelectSpot('landing', spot)}
-                      />
-                    ))
-                  ) : (
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Aucun atterrissage dans ce rayon.
-                    </p>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {weatherTitle && isWeatherError ? (
-            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
-              Impossible de charger la météo pour {weatherTitle}.
-            </div>
-          ) : weatherTitle ? (
-            <div className="space-y-3">
-              <WeatherSummaryCard
-                title={weatherTitle}
-                weather={selectedWeather}
-                isLoading={isWeatherLoading}
-              />
-              {selectedSpot && (
-                <div className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-sm text-gray-600 dark:text-gray-300">
-                      Enregistrer ce site dans vos favoris météo pour le retrouver
-                      directement dans la page.
-                    </p>
-                    <Button
-                      onPress={() => void handleCreateFavorite()}
-                      isDisabled={createSite.isPending || isSelectedSpotFavorite}
-                      className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {isSelectedSpotFavorite
-                        ? 'Déjà dans les favoris'
-                        : createSite.isPending
-                          ? 'Ajout...'
-                          : 'Ajouter aux favoris'}
-                    </Button>
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
+          <TextField className="relative flex flex-col gap-1">
+            <Label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Ville
+            </Label>
+            <Input
+              value={query}
+              onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                setQuery(event.target.value);
+                setSelectedLocation(null);
+                setSelectedOption(null);
+                onSelectTarget(null);
+              }}
+              onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+                if (!isSuggestionsOpen || !suggestions.length) return;
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault();
+                  setActiveSuggestionIndex((index) =>
+                    Math.min(index + 1, suggestions.length - 1)
+                  );
+                } else if (event.key === 'ArrowUp') {
+                  event.preventDefault();
+                  setActiveSuggestionIndex((index) => Math.max(index - 1, 0));
+                } else if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleSelectLocation(suggestions[activeSuggestionIndex]);
+                }
+              }}
+              role="combobox"
+              aria-expanded={isSuggestionsOpen}
+              aria-haspopup="listbox"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-activedescendant={activeSuggestionId}
+              placeholder="Ex: Besançon, Annecy, Grenoble..."
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 outline-none focus:ring-2 focus:ring-sky-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            />
+            {isSuggestionsOpen && (
+              <div
+                id={listboxId}
+                role="listbox"
+                className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900"
+              >
+                {locationSearch.isLoading ? (
+                  <div className="p-3 text-sm text-gray-600 dark:text-gray-300">
+                    Recherche des villes...
                   </div>
-                  {favoriteError && (
-                    <p className="mt-2 text-sm text-red-600 dark:text-red-300">
-                      {favoriteError}
-                    </p>
-                  )}
-                </div>
-              )}
-            </div>
-          ) : null}
+                ) : suggestions.length ? (
+                  suggestions.map((location, index) => (
+                    <button
+                      id={`${listboxId}-${location.id}`}
+                      key={location.id}
+                      type="button"
+                      role="option"
+                      aria-selected={index === activeSuggestionIndex}
+                      onMouseEnter={() => setActiveSuggestionIndex(index)}
+                      onClick={() => handleSelectLocation(location)}
+                      className={`block w-full border-b border-gray-100 px-3 py-2 text-left last:border-b-0 dark:border-gray-800 ${
+                        index === activeSuggestionIndex
+                          ? 'bg-sky-100 dark:bg-sky-950/60'
+                          : 'hover:bg-sky-50 dark:hover:bg-sky-950/40'
+                      }`}
+                    >
+                      <span className="block font-medium text-gray-950 dark:text-white">
+                        {location.name}
+                      </span>
+                      <span className="block text-xs text-gray-500 dark:text-gray-400">
+                        {location.display_name}
+                      </span>
+                    </button>
+                  ))
+                ) : (
+                  <div className="p-3 text-sm text-gray-600 dark:text-gray-300">
+                    Aucune ville trouvée.
+                  </div>
+                )}
+              </div>
+            )}
+          </TextField>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+            Rayon
+            <select
+              value={radiusKm}
+              onChange={(event) => setRadiusKm(Number(event.target.value))}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            >
+              {radiusChoices.map((radius) => (
+                <option key={radius} value={radius}>
+                  {radius} km
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+            Résultats
+            <select
+              value={limit}
+              onChange={(event) => setLimit(Number(event.target.value))}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            >
+              {limitChoices.map((choice) => (
+                <option key={choice} value={choice}>
+                  {choice}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
-      )}
+
+        {selectedLocation && (
+          <div className="mt-5 space-y-4">
+            <div className="flex flex-col gap-2 rounded-xl bg-gray-50 p-3 dark:bg-gray-900/60 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="font-semibold text-gray-950 dark:text-white">
+                  {selectedLocation.name}
+                </div>
+                <div className="text-sm text-gray-600 dark:text-gray-300">
+                  {selectedLocation.display_name}
+                </div>
+              </div>
+              <Button
+                onPress={() => handleSelectLocation(selectedLocation)}
+                className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
+              >
+                Météo ville
+              </Button>
+            </div>
+
+            {nearbyOptions.isError ? (
+              <div
+                className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+                role="alert"
+              >
+                Impossible de charger les décollages et atterrissages proches.
+              </div>
+            ) : nearbyOptions.isLoading ? (
+              <div
+                className="rounded-xl border border-gray-200 p-4 text-sm text-gray-600 dark:border-gray-700 dark:text-gray-300"
+                aria-live="polite"
+              >
+                Recherche des décollages et atterrissages proches...
+              </div>
+            ) : (
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div>
+                  <h3 className="mb-2 font-semibold text-gray-950 dark:text-white">
+                    Décollages proches
+                  </h3>
+                  <div className="grid gap-2">
+                    {nearbyOptions.data?.takeoffs.length ? (
+                      nearbyOptions.data.takeoffs.map((spot) => (
+                        <OptionButton
+                          key={spot.id}
+                          label={spot.name}
+                          description={spotDescription(spot)}
+                          isSelected={
+                            selectedOption?.type === 'takeoff' &&
+                            selectedOption.spot.id === spot.id
+                          }
+                          onSelect={() => handleSelectSpot('takeoff', spot)}
+                        />
+                      ))
+                    ) : (
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Aucun décollage dans ce rayon.
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div>
+                  <h3 className="mb-2 font-semibold text-gray-950 dark:text-white">
+                    Atterrissages proches
+                  </h3>
+                  <div className="grid gap-2">
+                    {nearbyOptions.data?.landings.length ? (
+                      nearbyOptions.data.landings.map((spot) => (
+                        <OptionButton
+                          key={spot.id}
+                          label={spot.name}
+                          description={spotDescription(spot)}
+                          isSelected={
+                            selectedOption?.type === 'landing' &&
+                            selectedOption.spot.id === spot.id
+                          }
+                          onSelect={() => handleSelectSpot('landing', spot)}
+                        />
+                      ))
+                    ) : (
+                      <p className="text-sm text-gray-500 dark:text-gray-400">
+                        Aucun atterrissage dans ce rayon.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {weatherTitle && isWeatherError ? (
+              <div
+                className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+                role="alert"
+              >
+                Impossible de charger la météo pour {weatherTitle}.
+              </div>
+            ) : weatherTitle ? (
+              <div className="space-y-3">
+                <WeatherSummaryCard
+                  title={weatherTitle}
+                  weather={selectedWeather}
+                  isLoading={isWeatherLoading}
+                />
+                {selectedSpot && (
+                  <div className="rounded-xl border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="text-sm text-gray-600 dark:text-gray-300">
+                        Enregistrer ce site dans vos favoris météo pour le
+                        retrouver directement dans la page.
+                      </p>
+                      <Button
+                        onPress={() => void handleCreateFavorite()}
+                        isDisabled={
+                          createSite.isPending || isSelectedSpotFavorite
+                        }
+                        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {favoriteButtonLabel}
+                      </Button>
+                    </div>
+                    {favoriteError && (
+                      <p
+                        className="mt-2 text-sm text-red-600 dark:text-red-300"
+                        role="alert"
+                      >
+                        {favoriteError}
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/frontend/src/components/weather/CurrentConditions.tsx
+++ b/apps/frontend/src/components/weather/CurrentConditions.tsx
@@ -4,6 +4,8 @@ import { useSite } from '../../hooks/sites/useSites';
 import { WindIndicator } from '../common/WindIndicator';
 import CacheTimestamp from '../common/CacheTimestamp';
 import type { WeatherData } from '../../types';
+import { Cloud, Thermometer, Wind, Zap } from 'lucide-react';
+import { getVerdictVisual, weatherCardClassName } from './weatherUi';
 
 interface CurrentConditionsProps {
   spotId?: string;
@@ -13,25 +15,6 @@ interface CurrentConditionsProps {
   isLoading?: boolean;
   isError?: boolean;
 }
-
-const getVerdictClass = (verdict: string): string => {
-  const v = verdict.toLowerCase();
-  if (v === 'bon')
-    return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200';
-  if (v === 'moyen')
-    return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200';
-  if (v === 'limite')
-    return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200';
-  return 'bg-red-100 dark:bg-red-900/30 text-red-900 dark:text-red-100';
-};
-
-const getVerdictEmoji = (verdict: string): string => {
-  const v = verdict.toLowerCase();
-  if (v === 'bon') return '🟢';
-  if (v === 'moyen') return '🟡';
-  if (v === 'limite') return '🟠';
-  return '🔴';
-};
 
 export default function CurrentConditions({
   spotId,
@@ -52,10 +35,11 @@ export default function CurrentConditions({
   const isLoading = isOverrideLoading ?? isFetchedLoading;
   const hasError = isOverrideError ?? !!error;
   const orientation = siteOrientation ?? site?.orientation;
+  const cardClassName = `${weatherCardClassName} border-l-4 border-l-sky-600 p-4`;
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600">
+      <div className={cardClassName} aria-live="polite">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
           {t('weather.currentConditions')}
         </h2>
@@ -68,7 +52,7 @@ export default function CurrentConditions({
 
   if (hasError || !weather) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600">
+      <div className={cardClassName} role="alert">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
           {t('weather.currentConditions')}
         </h2>
@@ -79,8 +63,11 @@ export default function CurrentConditions({
     );
   }
 
+  const verdictVisual = getVerdictVisual(weather.verdict);
+  const VerdictIcon = verdictVisual.Icon;
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600 flex-1 flex flex-col">
+    <div className={`${cardClassName} flex flex-1 flex-col`}>
       <div className="mb-3.5">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           {t('weather.currentConditionsFor', { name: weather.spot_name })}
@@ -92,9 +79,10 @@ export default function CurrentConditions({
           {weather.score != null ? weather.score : weather.para_index}/100
         </div>
         <div
-          className={`px-3.5 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap ${getVerdictClass(weather.verdict)}`}
+          className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap ${verdictVisual.badgeClassName}`}
         >
-          {getVerdictEmoji(weather.verdict)} {weather.verdict.toUpperCase()}
+          <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          {weather.verdict.toUpperCase()}
         </div>
       </div>
       {weather.score != null && weather.score !== weather.para_index && (
@@ -105,16 +93,18 @@ export default function CurrentConditions({
 
       <div className="flex flex-col gap-2">
         <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-          <span className="text-gray-600 dark:text-gray-300 font-medium">
-            🌡️ {t('common.temperature')}
+          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
+            <Thermometer className="h-4 w-4 text-red-500" aria-hidden="true" />
+            {t('common.temperature')}
           </span>
           <span className="font-semibold text-gray-900 dark:text-white text-right">
             {weather.temperature}°C
           </span>
         </div>
         <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-          <span className="text-gray-600 dark:text-gray-300 font-medium">
-            💨 {t('common.wind')}
+          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
+            <Wind className="h-4 w-4 text-sky-500" aria-hidden="true" />
+            {t('common.wind')}
           </span>
           <div className="flex flex-col items-end gap-1">
             <span className="font-semibold text-gray-900 dark:text-white text-right">
@@ -135,8 +125,9 @@ export default function CurrentConditions({
         </div>
         {weather.wind_gusts && (
           <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-            <span className="text-gray-600 dark:text-gray-300 font-medium">
-              🌪️ {t('common.gusts')}
+            <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
+              <Zap className="h-4 w-4 text-orange-500" aria-hidden="true" />
+              {t('common.gusts')}
             </span>
             <span className="font-semibold text-gray-900 dark:text-white text-right">
               {weather.wind_gusts} km/h
@@ -144,8 +135,9 @@ export default function CurrentConditions({
           </div>
         )}
         <div className="flex justify-between text-sm py-1.5">
-          <span className="text-gray-600 dark:text-gray-300 font-medium">
-            ☁️ {t('common.conditions')}
+          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
+            <Cloud className="h-4 w-4 text-slate-500" aria-hidden="true" />
+            {t('common.conditions')}
           </span>
           <span className="font-semibold text-gray-900 dark:text-white text-right">
             {weather.conditions}

--- a/apps/frontend/src/components/weather/Forecast7Day.tsx
+++ b/apps/frontend/src/components/weather/Forecast7Day.tsx
@@ -7,31 +7,14 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import CacheTimestamp from '../common/CacheTimestamp';
 import { Button } from '@dashboard-parapente/design-system';
+import { Wind } from 'lucide-react';
+import { getVerdictVisual, weatherCardClassName } from './weatherUi';
 
 interface Forecast7DayProps {
   spotId: string;
   selectedDayIndex?: number;
   onSelectDay?: (index: number) => void;
 }
-
-const getVerdictClass = (verdict: string): string => {
-  const v = verdict.toLowerCase();
-  if (v === 'bon')
-    return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200';
-  if (v === 'moyen')
-    return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200';
-  if (v === 'limite')
-    return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200';
-  return 'bg-red-100 dark:bg-red-900/30 text-red-900 dark:text-red-100';
-};
-
-const getVerdictEmoji = (verdict: string): string => {
-  const v = verdict.toLowerCase();
-  if (v === 'bon') return '🟢';
-  if (v === 'moyen') return '🟡';
-  if (v === 'limite') return '🟠';
-  return '🔴';
-};
 
 export default function Forecast7Day({
   spotId,
@@ -79,7 +62,7 @@ export default function Forecast7Day({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+      <div className={`${weatherCardClassName} p-4`} aria-live="polite">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
           {t('weather.forecast7Days')}
         </h2>
@@ -92,7 +75,7 @@ export default function Forecast7Day({
 
   if (error || !dailySummary || !dailySummary.days) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+      <div className={`${weatherCardClassName} p-4`} role="alert">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
           {t('weather.forecast7Days')}
         </h2>
@@ -104,7 +87,7 @@ export default function Forecast7Day({
   }
 
   return (
-    <div className="min-w-0 rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
+    <div className={`${weatherCardClassName} min-w-0 p-4`}>
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           {t('weather.forecast7Days')}
@@ -117,13 +100,15 @@ export default function Forecast7Day({
       <div className="flex max-w-full min-w-0 snap-x snap-mandatory gap-3 overflow-x-auto overscroll-x-contain pb-2 scrollbar-thin sm:grid sm:grid-cols-2 sm:overflow-x-visible sm:pb-0 sm:snap-none md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7">
         {dailySummary.days.map((day, index) => {
           const isSelected = index === selectedDayIndex;
+          const verdictVisual = getVerdictVisual(day.verdict);
+          const VerdictIcon = verdictVisual.Icon;
 
           return (
             <Button
               key={index}
               onClick={() => onSelectDay?.(index)}
               onMouseEnter={() => handleMouseEnter(index)}
-              className={`min-w-[150px] flex-shrink-0 snap-start sm:min-w-0 sm:flex-shrink bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border-2 transition-all hover:border-sky-600 hover:-translate-y-1 hover:shadow-md cursor-pointer relative min-h-[150px] ${
+              className={`min-w-[150px] flex-shrink-0 snap-start sm:min-w-0 sm:flex-shrink bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border-2 transition-colors hover:border-sky-600 hover:shadow-md cursor-pointer relative min-h-[150px] ${
                 isSelected
                   ? 'border-sky-600 shadow-lg bg-sky-50 dark:bg-sky-900/20 ring-2 ring-sky-200 dark:ring-sky-700'
                   : 'border-gray-200 dark:border-gray-700'
@@ -141,16 +126,20 @@ export default function Forecast7Day({
                     {day.score != null ? day.score : day.para_index}
                   </span>
                   <span
-                    className={`text-xl ${getVerdictClass(day.verdict)} px-1.5 py-0.5 rounded-full`}
+                    className={`inline-flex items-center justify-center rounded-full px-1.5 py-0.5 ${verdictVisual.badgeClassName}`}
                   >
-                    {getVerdictEmoji(day.verdict)}
+                    <VerdictIcon className="h-4 w-4" aria-hidden="true" />
                   </span>
                 </div>
                 <div className="text-sm text-gray-700 dark:text-gray-300 font-medium text-center">
                   {day.temp_min}° - {day.temp_max}°
                 </div>
-                <div className="text-xs text-gray-600 dark:text-gray-300 text-center">
-                  💨 {Math.round(day.wind_avg)} km/h
+                <div className="inline-flex items-center justify-center gap-1 text-xs text-gray-600 dark:text-gray-300 text-center">
+                  <Wind
+                    className="h-3.5 w-3.5 text-sky-500"
+                    aria-hidden="true"
+                  />
+                  {Math.round(day.wind_avg)} km/h
                 </div>
                 <div className="text-xs text-gray-500 dark:text-gray-400 text-center leading-tight min-h-8 break-words">
                   {day.verdict}

--- a/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
@@ -139,7 +139,7 @@ describe('HourlyForecast tooltip behavior', () => {
       screen.getByRole('button', { name: 'Para-Index 10:00' })
     );
 
-    expect(screen.getByText('📊 Para-Index - 10:00')).toBeTruthy();
+    expect(screen.getByText('Para-Index - 10:00')).toBeTruthy();
     expect(screen.getByText(/Metriques utilisees/i)).toBeTruthy();
   });
 

--- a/apps/frontend/src/components/weather/HourlyForecast.test.ts
+++ b/apps/frontend/src/components/weather/HourlyForecast.test.ts
@@ -51,6 +51,6 @@ describe('getFlyabilityDisplay', () => {
     );
 
     expect(display.text).toBe('BON');
-    expect(display.emoji).toBe('🟢');
+    expect(display.Icon).toBeTypeOf('function');
   });
 });

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -18,6 +18,7 @@ import { useWeather } from '../../hooks/weather/useWeather';
 import type { HourlyForecastItem, WeatherData } from '../../types';
 import CacheTimestamp from '../common/CacheTimestamp';
 import WindArrow from './WindArrow';
+import { getVerdictVisual, weatherCardClassName } from './weatherUi';
 
 interface HourlyForecastProps {
   spotId?: string;
@@ -112,30 +113,27 @@ const getSourceUrl = (sourceKey: string): string | null => {
 };
 
 /**
- * Get flyability display with emoji, verdict and reason
- * Format: "🟢 BON" or "🟡 MOYEN — Vent faible" or "🔴 MAUVAIS — Vent insuffisant"
+ * Get flyability display with verdict and reason.
  */
 export const getFlyabilityDisplay = (
   hour: HourlyForecastItem,
   thresholds: UiThresholds
-): { emoji: string; text: string; color: string } => {
+): {
+  text: string;
+  color: string;
+  Icon: ReturnType<typeof getVerdictVisual>['Icon'];
+} => {
   const verdict = hour.verdict?.toLowerCase();
   const verdictUpper = verdict?.toUpperCase() || 'MOYEN';
-
-  // Emoji and color based on verdict
-  let emoji = '🟡';
-  let color = 'text-yellow-700 dark:text-yellow-300';
+  const visual = getVerdictVisual(verdict || 'moyen');
+  let color = visual.textClassName;
 
   if (verdict === 'bon') {
-    emoji = '🟢';
-    color = 'text-green-700 dark:text-green-300';
-    return { emoji, text: 'BON', color };
+    return { text: 'BON', color, Icon: visual.Icon };
   } else if (verdict === 'mauvais') {
-    emoji = '🔴';
-    color = 'text-red-700 dark:text-red-300';
+    color = visual.textClassName;
   } else if (verdict === 'limite') {
-    emoji = '🟠';
-    color = 'text-orange-700 dark:text-orange-300';
+    color = visual.textClassName;
   }
 
   // Determine the reason when not BON
@@ -176,21 +174,15 @@ export const getFlyabilityDisplay = (
   }
 
   return {
-    emoji,
     text: `${verdictUpper} — ${reason}`,
     color,
+    Icon: visual.Icon,
   };
 };
 
 const getVerdictClass = (verdict: string): string => {
   const v = verdict.toLowerCase();
-  if (v === 'bon')
-    return 'bg-green-50 dark:bg-green-900/20 hover:bg-green-100 dark:hover:bg-green-900/30';
-  if (v === 'moyen')
-    return 'bg-yellow-50 dark:bg-yellow-900/20 hover:bg-yellow-100 dark:hover:bg-yellow-900/30';
-  if (v === 'limite')
-    return 'bg-orange-50 dark:bg-orange-900/20 hover:bg-orange-100 dark:hover:bg-orange-900/30';
-  return 'bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30';
+  return getVerdictVisual(v).softClassName;
 };
 
 const formatWindDirectionFromDegrees = (deg: number | null): string => {
@@ -265,7 +257,7 @@ const ParaIndexTooltip = ({
     <div className="bg-white dark:bg-gray-800 border-2 border-sky-500 rounded-lg shadow-xl p-4 text-sm max-w-[320px]">
       <div className="font-bold mb-3 text-sky-700 dark:text-sky-400 pr-8">
         <span>
-          📊 {label} - {hour}
+          {label} - {hour}
         </span>
       </div>
       <div className="space-y-2 text-gray-700 dark:text-gray-300">
@@ -627,7 +619,7 @@ export default function HourlyForecast({
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+      <div className={`${weatherCardClassName} p-4`} aria-live="polite">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
           Prévisions Horaires
         </h2>
@@ -640,7 +632,7 @@ export default function HourlyForecast({
 
   if (hasError || !weather || !weather.hourly_forecast) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
+      <div className={`${weatherCardClassName} p-4`} role="alert">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
           Prévisions Horaires
         </h2>
@@ -698,7 +690,7 @@ export default function HourlyForecast({
             consensus={data.temperature}
             unit="°C"
             fieldName="temperature"
-            label="🌡️ Température"
+            label="Température"
             color="#dc2626"
           />
         );
@@ -711,7 +703,7 @@ export default function HourlyForecast({
             consensus={data.wind_speed}
             unit="km/h"
             fieldName="wind_speed"
-            label="💨 Vent"
+            label="Vent"
             color="#2563eb"
           />
         );
@@ -724,7 +716,7 @@ export default function HourlyForecast({
             consensus={data.wind_gust ?? null}
             unit="km/h"
             fieldName="wind_gust"
-            label="💨 Rafales"
+            label="Rafales"
             color="#dc2626"
           />
         );
@@ -741,7 +733,7 @@ export default function HourlyForecast({
             )}
             unit=""
             fieldName="wind_direction"
-            label="🧭 Direction"
+            label="Direction"
             color="#7c3aed"
           />
         );
@@ -754,7 +746,7 @@ export default function HourlyForecast({
             consensus={data.precipitation}
             unit="mm"
             fieldName="precipitation"
-            label="🌧️ Précipitations"
+            label="Précipitations"
             color="#0891b2"
           />
         );
@@ -771,7 +763,7 @@ export default function HourlyForecast({
             }
             unit="%"
             fieldName="cloud_cover"
-            label="☁️ Couverture nuageuse"
+            label="Couverture nuageuse"
             color="#64748b"
           />
         );
@@ -782,18 +774,128 @@ export default function HourlyForecast({
   };
 
   return (
-    <div className="min-w-0 rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
+    <div className={`${weatherCardClassName} min-w-0 p-4`}>
       <div className="flex items-center justify-between mb-3">
         <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
           Prévisions Horaires
         </h2>
         <CacheTimestamp cachedAt={weather.cached_at} />
       </div>
-      <p className="mb-2 text-xs font-medium text-gray-500 dark:text-gray-400 sm:hidden">
-        Glissez le tableau horizontalement pour voir toutes les mesures.
-      </p>
+      <div className="grid gap-3 md:hidden">
+        {flyingHours.length > 0 ? (
+          flyingHours.map((hour, index) => {
+            const cloudCover =
+              hour.cloud_cover ??
+              hour.sources?.['open-meteo']?.cloud_cover ??
+              hour.sources?.['weatherapi']?.cloud_cover ??
+              null;
+            const gustValue =
+              hour.wind_gust ??
+              hour.sources?.['open-meteo']?.wind_gust ??
+              hour.sources?.['weatherapi']?.wind_gust ??
+              null;
+            const display = getFlyabilityDisplay(hour, uiThresholds);
+            const FlyabilityIcon = display.Icon;
 
-      <div className="max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-lg border border-gray-100 dark:border-gray-700">
+            return (
+              <article
+                key={index}
+                className={`rounded-xl border border-slate-200 p-3 dark:border-slate-700 ${getVerdictClass(hour.verdict)}`}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="inline-flex items-center gap-1.5 text-sm font-black text-slate-950 dark:text-white">
+                      <Clock
+                        className="h-4 w-4 text-slate-500"
+                        aria-hidden="true"
+                      />
+                      {hour.hour}
+                    </div>
+                    <div
+                      className={`mt-1 inline-flex items-center gap-1.5 text-sm font-bold ${display.color}`}
+                    >
+                      <FlyabilityIcon className="h-4 w-4" aria-hidden="true" />
+                      {display.text}
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-2xl font-black text-sky-600 dark:text-sky-400">
+                      {hour.para_index}
+                    </div>
+                    <div className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      /100
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <Wind
+                        className="h-3.5 w-3.5 text-sky-500"
+                        aria-hidden="true"
+                      />
+                      Vent
+                    </span>
+                    <div className="font-bold text-slate-950 dark:text-white">
+                      {hour.wind}
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <Zap
+                        className="h-3.5 w-3.5 text-orange-500"
+                        aria-hidden="true"
+                      />
+                      Rafales
+                    </span>
+                    <div className="font-bold text-slate-950 dark:text-white">
+                      {gustValue !== null && gustValue !== undefined
+                        ? `${gustValue.toFixed(1)} km/h`
+                        : '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <CloudRain
+                        className="h-3.5 w-3.5 text-cyan-500"
+                        aria-hidden="true"
+                      />
+                      Pluie
+                    </span>
+                    <div className="font-bold text-slate-950 dark:text-white">
+                      {hour.precipitation !== null &&
+                      hour.precipitation !== undefined
+                        ? `${hour.precipitation.toFixed(1)} mm`
+                        : '—'}
+                    </div>
+                  </div>
+                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <Cloud
+                        className="h-3.5 w-3.5 text-slate-500"
+                        aria-hidden="true"
+                      />
+                      Nuages
+                    </span>
+                    <div className="font-bold text-slate-950 dark:text-white">
+                      {cloudCover !== null && cloudCover !== undefined
+                        ? `${Math.round(cloudCover)}%`
+                        : '—'}
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })
+        ) : (
+          <div className="rounded-xl border border-slate-200 py-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+            Aucune donnée horaire disponible
+          </div>
+        )}
+      </div>
+
+      <div className="hidden max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-lg border border-gray-100 dark:border-gray-700 md:block">
         <table className="w-full min-w-[800px] text-sm">
           <thead>
             <tr className="border-b-2 border-gray-200 dark:border-gray-600">
@@ -1010,14 +1112,21 @@ export default function HourlyForecast({
                           hour,
                           uiThresholds
                         );
+                        const FlyabilityIcon = display.Icon;
                         return (
                           <TooltipTrigger delay={150} closeDelay={100}>
                             <Button
                               aria-label={`Verdict ${hour.hour}`}
                               className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-emerald-50 dark:hover:bg-emerald-900/20 transition-colors"
                             >
-                              <span className={`font-medium ${display.color}`}>
-                                {display.emoji} {display.text}
+                              <span
+                                className={`inline-flex items-center justify-center gap-1 font-medium ${display.color}`}
+                              >
+                                <FlyabilityIcon
+                                  className="h-4 w-4"
+                                  aria-hidden="true"
+                                />
+                                {display.text}
                               </span>
                             </Button>
                             <Tooltip offset={8} className="z-50">

--- a/apps/frontend/src/components/weather/LiveWindCard.tsx
+++ b/apps/frontend/src/components/weather/LiveWindCard.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import { useLiveWind } from '../../hooks/weather/useLiveWind';
 import type { LiveWindStation } from '../../types';
+import { Thermometer, Wind } from 'lucide-react';
+import { weatherCardClassName } from './weatherUi';
 
 interface LiveWindCardProps {
   siteId: string;
@@ -72,8 +74,8 @@ const StationRow = ({
         </span>
       </div>
 
-      <div className="text-sm text-gray-900 dark:text-white font-medium">
-        💨{' '}
+      <div className="inline-flex items-center gap-1.5 text-sm text-gray-900 dark:text-white font-medium">
+        <Wind className="h-4 w-4 text-sky-500" aria-hidden="true" />
         {formatStationWind(
           station,
           t('weather.windUnavailable'),
@@ -85,7 +87,13 @@ const StationRow = ({
           ? t('weather.liveWindAgeMinutes', { count: station.age_minutes })
           : t('weather.liveWindNoRecent')}
         {station.temperature_c !== null && (
-          <span>• 🌡️ {station.temperature_c}°C</span>
+          <span className="inline-flex items-center gap-1">
+            <Thermometer
+              className="h-3.5 w-3.5 text-red-500"
+              aria-hidden="true"
+            />
+            {station.temperature_c}°C
+          </span>
         )}
         {station.source_url && (
           <a
@@ -108,7 +116,10 @@ export default function LiveWindCard({ siteId }: LiveWindCardProps) {
 
   if (isLoading) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600">
+      <div
+        className={`${weatherCardClassName} border-l-4 border-l-sky-600 p-4`}
+        aria-live="polite"
+      >
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
           {t('weather.liveWindTitle')}
         </h2>
@@ -121,7 +132,10 @@ export default function LiveWindCard({ siteId }: LiveWindCardProps) {
 
   if (error) {
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600">
+      <div
+        className={`${weatherCardClassName} border-l-4 border-l-sky-600 p-4`}
+        role="alert"
+      >
         <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
           {t('weather.liveWindTitle')}
         </h2>
@@ -139,7 +153,9 @@ export default function LiveWindCard({ siteId }: LiveWindCardProps) {
   const additionalStations = stations.slice(1);
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-sky-600 flex-1 flex flex-col gap-3">
+    <div
+      className={`${weatherCardClassName} flex flex-1 flex-col gap-3 border-l-4 border-l-sky-600 p-4`}
+    >
       <div>
         <div>
           <h2 className="text-sm text-gray-700 dark:text-gray-300 font-semibold">

--- a/apps/frontend/src/components/weather/WeatherMultiLanding.tsx
+++ b/apps/frontend/src/components/weather/WeatherMultiLanding.tsx
@@ -3,29 +3,12 @@ import {
   useLandingAssociations,
   useLandingWeather,
 } from '../../hooks/sites/useLandingAssociations';
+import { getVerdictVisual, weatherCardClassName } from './weatherUi';
 
 interface WeatherMultiLandingProps {
   spotId: string;
   dayIndex: number;
 }
-
-const getVerdictColor = (verdict: string): string => {
-  const v = verdict?.toLowerCase();
-  if (v === 'bon') return 'border-green-500 bg-green-50 dark:bg-green-900/20';
-  if (v === 'moyen')
-    return 'border-yellow-500 bg-yellow-50 dark:bg-yellow-900/20';
-  if (v === 'limite')
-    return 'border-orange-500 bg-orange-50 dark:bg-orange-900/20';
-  return 'border-red-500 bg-red-50 dark:bg-red-900/20';
-};
-
-const getVerdictEmoji = (verdict: string): string => {
-  const v = verdict?.toLowerCase();
-  if (v === 'bon') return '🟢';
-  if (v === 'moyen') return '🟡';
-  if (v === 'limite') return '🟠';
-  return '🔴';
-};
 
 export default function WeatherMultiLanding({
   spotId,
@@ -39,7 +22,9 @@ export default function WeatherMultiLanding({
   if (!associations || associations.length === 0) return null;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-indigo-500">
+    <div
+      className={`${weatherCardClassName} border-l-4 border-l-indigo-500 p-4`}
+    >
       <div className="mb-3">
         <h2 className="text-sm text-gray-600 dark:text-gray-400 font-semibold">
           {t('weather.landings')}
@@ -47,7 +32,10 @@ export default function WeatherMultiLanding({
       </div>
 
       {isLoading ? (
-        <div className="py-3 text-center text-gray-500 dark:text-gray-400 text-sm">
+        <div
+          className="py-3 text-center text-gray-500 dark:text-gray-400 text-sm"
+          aria-live="polite"
+        >
           {t('weather.loadingLandings')}
         </div>
       ) : !weatherData || weatherData.length === 0 ? (
@@ -60,6 +48,8 @@ export default function WeatherMultiLanding({
             const weather = entry.weather;
             const hasError = !!weather.error;
             const verdict = weather.verdict || '';
+            const verdictVisual = getVerdictVisual(verdict);
+            const VerdictIcon = verdictVisual.Icon;
 
             return (
               <div
@@ -67,7 +57,7 @@ export default function WeatherMultiLanding({
                 className={`rounded-lg border-l-4 p-3 ${
                   hasError
                     ? 'border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700'
-                    : getVerdictColor(verdict)
+                    : verdictVisual.borderSoftClassName
                 } ${entry.is_primary ? 'ring-2 ring-indigo-400 ring-offset-1 dark:ring-offset-gray-800' : ''}`}
               >
                 <div className="flex items-center justify-between mb-2">
@@ -80,14 +70,18 @@ export default function WeatherMultiLanding({
                 </div>
 
                 {hasError ? (
-                  <p className="text-xs text-red-500 dark:text-red-400">
+                  <p
+                    className="text-xs text-red-500 dark:text-red-400"
+                    role="alert"
+                  >
                     {weather.error}
                   </p>
                 ) : (
                   <div className="flex items-center gap-3">
-                    <span className="text-lg" title={verdict}>
-                      {getVerdictEmoji(verdict)}
-                    </span>
+                    <VerdictIcon
+                      className={`h-5 w-5 shrink-0 ${verdictVisual.textClassName}`}
+                      aria-hidden="true"
+                    />
                     <div>
                       <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
                         {verdict}

--- a/apps/frontend/src/components/weather/weatherUi.tsx
+++ b/apps/frontend/src/components/weather/weatherUi.tsx
@@ -1,0 +1,76 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CircleAlert,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react';
+
+type VerdictTone = 'good' | 'medium' | 'limit' | 'bad';
+
+type VerdictVisual = {
+  tone: VerdictTone;
+  Icon: LucideIcon;
+  badgeClassName: string;
+  softClassName: string;
+  borderSoftClassName: string;
+  textClassName: string;
+};
+
+const verdictVisuals: Record<VerdictTone, VerdictVisual> = {
+  good: {
+    tone: 'good',
+    Icon: CheckCircle2,
+    badgeClassName:
+      'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200',
+    softClassName:
+      'bg-emerald-50 dark:bg-emerald-900/20 hover:bg-emerald-100 dark:hover:bg-emerald-900/30',
+    borderSoftClassName:
+      'border-emerald-500 bg-emerald-50 dark:bg-emerald-900/20',
+    textClassName: 'text-emerald-700 dark:text-emerald-300',
+  },
+  medium: {
+    tone: 'medium',
+    Icon: CircleAlert,
+    badgeClassName:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+    softClassName:
+      'bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/30',
+    borderSoftClassName: 'border-amber-500 bg-amber-50 dark:bg-amber-900/20',
+    textClassName: 'text-amber-700 dark:text-amber-300',
+  },
+  limit: {
+    tone: 'limit',
+    Icon: AlertTriangle,
+    badgeClassName:
+      'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-200',
+    softClassName:
+      'bg-orange-50 dark:bg-orange-900/20 hover:bg-orange-100 dark:hover:bg-orange-900/30',
+    borderSoftClassName: 'border-orange-500 bg-orange-50 dark:bg-orange-900/20',
+    textClassName: 'text-orange-700 dark:text-orange-300',
+  },
+  bad: {
+    tone: 'bad',
+    Icon: XCircle,
+    badgeClassName:
+      'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-100',
+    softClassName:
+      'bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/30',
+    borderSoftClassName: 'border-red-500 bg-red-50 dark:bg-red-900/20',
+    textClassName: 'text-red-700 dark:text-red-300',
+  },
+};
+
+export const weatherCardClassName =
+  'rounded-2xl border border-slate-200 bg-white/95 shadow-md shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/20';
+
+export const getVerdictVisual = (verdict: string): VerdictVisual => {
+  const normalized = verdict.toLowerCase();
+
+  if (normalized === 'bon' || normalized === 'excellent')
+    return verdictVisuals.good;
+  if (normalized === 'moyen') return verdictVisuals.medium;
+  if (normalized === 'limite') return verdictVisuals.limit;
+
+  return verdictVisuals.bad;
+};

--- a/apps/frontend/src/utils/windMatcher.ts
+++ b/apps/frontend/src/utils/windMatcher.ts
@@ -135,24 +135,6 @@ export function getWindFavorabilityLabel(
 }
 
 /**
- * Get emoji indicator for wind favorability
- */
-export function getWindFavorabilityEmoji(
-  favorability: WindFavorability
-): string {
-  switch (favorability) {
-    case 'good':
-      return '🟢';
-    case 'moderate':
-      return '🟡';
-    case 'bad':
-      return '🔴';
-    default:
-      return '⚪';
-  }
-}
-
-/**
  * Get Tailwind color class for wind favorability
  */
 export function getWindFavorabilityColor(


### PR DESCRIPTION
## Summary
- Replace weather UI emojis with Lucide icons and shared verdict visuals.
- Improve weather card styling, loading/error accessibility, and mobile hourly forecast layout.
- Update affected WindIndicator stories and HourlyForecast tests.

## Validation
- `git diff --check` passed.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` passed with existing warnings.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` failed before running tests because the worktree environment cannot resolve `vitest` from `@testing-library/jest-dom`, and Playwright Chromium is not installed locally.
- `NODE_PATH="$PWD/node_modules" NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` failed on existing TypeScript issues outside the weather UI changes.