### PR TITLE
feat(frontend): improve settings page ux

### DIFF
--- a/apps/frontend/src/components/settings/WeatherSourceCard.tsx
+++ b/apps/frontend/src/components/settings/WeatherSourceCard.tsx
@@ -65,21 +65,43 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
         role="status"
         aria-label={`Statut de la source: ${statusLabels[source.status]}`}
       >
-        ● {statusLabels[source.status]}
+        {statusLabels[source.status]}
       </span>
     );
   };
 
-  // Scraper type icon
-  const getScraperIcon = () => {
+  const getScraperLabel = () => {
     switch (source.scraper_type) {
       case 'api':
-        return '🌐';
+        return 'API';
       case 'playwright':
-        return '🎭';
+        return 'Browser';
       case 'stealth':
-        return '🥷';
+        return 'Stealth';
     }
+  };
+
+  const getNotificationClassName = () => {
+    switch (notification?.type) {
+      case 'error':
+        return 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-700';
+      case 'success':
+        return 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200 border border-green-200 dark:border-green-700';
+      case 'warning':
+        return 'bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200 border border-yellow-200 dark:border-yellow-700';
+      default:
+        return '';
+    }
+  };
+
+  const getSuccessRateClassName = () => {
+    if (source.success_rate >= 95) {
+      return 'text-green-600 dark:text-green-400';
+    }
+    if (source.success_rate >= 80) {
+      return 'text-yellow-600 dark:text-yellow-400';
+    }
+    return 'text-red-600 dark:text-red-400';
   };
 
   const notificationTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
@@ -174,18 +196,27 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
       if (result.success) {
         setTestResult({
           success: true,
-          message: `✅ ${t('settings.weatherSources.testSuccess', { time: result.response_time_ms })}`,
+          message: t('settings.weatherSources.testSuccess', {
+            time: result.response_time_ms,
+          }),
         });
       } else {
         setTestResult({
           success: false,
-          message: `❌ ${t('settings.weatherSources.testFailure', { error: result.error || t('settings.weatherSources.unknownError') })}`,
+          message: t('settings.weatherSources.testFailure', {
+            error: result.error || t('settings.weatherSources.unknownError'),
+          }),
         });
       }
     } catch (error: unknown) {
       setTestResult({
         success: false,
-        message: `❌ ${t('settings.weatherSources.testError', { error: error instanceof Error ? error.message : t('settings.weatherSources.testFailed') })}`,
+        message: t('settings.weatherSources.testError', {
+          error:
+            error instanceof Error
+              ? error.message
+              : t('settings.weatherSources.testFailed'),
+        }),
       });
     } finally {
       setIsTesting(false);
@@ -224,13 +255,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
       {/* Notification */}
       {notification && (
         <div
-          className={`mb-3 p-3 rounded-lg text-sm font-medium ${
-            notification.type === 'error'
-              ? 'bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-700'
-              : notification.type === 'success'
-                ? 'bg-green-50 dark:bg-green-900/20 text-green-800 dark:text-green-200 border border-green-200 dark:border-green-700'
-                : 'bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200 border border-yellow-200 dark:border-yellow-700'
-          }`}
+          className={`mb-3 p-3 rounded-lg text-sm font-medium ${getNotificationClassName()}`}
           role="alert"
           aria-live="assertive"
           aria-atomic="true"
@@ -242,9 +267,9 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1">
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-2xl" aria-hidden="true">
-              {getScraperIcon()}
+          <div className="flex flex-wrap items-center gap-2 mb-1">
+            <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {getScraperLabel()}
             </span>
             <h3 className="text-lg font-bold text-gray-900 dark:text-white">
               {source.display_name}
@@ -291,7 +316,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
               className="text-sm font-medium text-gray-700 dark:text-gray-300"
               aria-hidden="true"
             >
-              🔑 {t('settings.weatherSources.apiKey')}
+              {t('settings.weatherSources.apiKey')}
             </span>
             {source.api_key_configured ? (
               <span
@@ -299,7 +324,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                 role="status"
                 aria-label={t('settings.weatherSources.apiKeyConfigured')}
               >
-                ✓ {t('settings.weatherSources.apiKeyConfigured')}
+                {t('settings.weatherSources.apiKeyConfigured')}
               </span>
             ) : (
               <span
@@ -307,7 +332,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                 role="status"
                 aria-label={t('settings.weatherSources.apiKeyMissing')}
               >
-                ✗ {t('settings.weatherSources.apiKeyMissing')}
+                {t('settings.weatherSources.apiKeyMissing')}
               </span>
             )}
           </div>
@@ -335,7 +360,9 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                     : t('settings.weatherSources.showApiKey')
                 }
               >
-                <span aria-hidden="true">{showApiKey ? '🙈' : '👁️'}</span>
+                {showApiKey
+                  ? t('settings.weatherSources.hideApiKey')
+                  : t('settings.weatherSources.showApiKey')}
               </Button>
               <Button
                 onPress={handleSaveApiKey}
@@ -343,7 +370,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                 className="px-3 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700 pressed:bg-green-800 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
                 aria-label={t('common.save')}
               >
-                <span aria-hidden="true">✓</span>
+                {t('common.save')}
               </Button>
               <Button
                 onPress={() => {
@@ -353,7 +380,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                 className="px-3 py-1 text-xs bg-gray-400 text-white rounded hover:bg-gray-500 pressed:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
                 aria-label={t('common.cancel')}
               >
-                <span aria-hidden="true">✗</span>
+                {t('common.cancel')}
               </Button>
             </div>
           ) : (
@@ -374,7 +401,6 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
               rel="noopener noreferrer"
               className="text-xs text-blue-600 dark:text-blue-400 hover:underline dark:hover:text-blue-300 mt-1 inline-block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 rounded"
             >
-              <span aria-hidden="true">📖 </span>
               {t('settings.weatherSources.documentation')}
             </Link>
           )}
@@ -395,13 +421,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
             {t('settings.weatherSources.successRate')}
           </div>
           <div
-            className={`text-lg font-bold ${
-              source.success_rate >= 95
-                ? 'text-green-600 dark:text-green-400'
-                : source.success_rate >= 80
-                  ? 'text-yellow-600 dark:text-yellow-400'
-                  : 'text-red-600 dark:text-red-400'
-            }`}
+            className={`text-lg font-bold ${getSuccessRateClassName()}`}
             aria-labelledby={`success-rate-label-${source.source_name}`}
             aria-live="polite"
           >
@@ -450,7 +470,6 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
       >
         {source.last_success_at && (
           <div role="status">
-            <span aria-hidden="true">✓ </span>
             <Trans
               i18nKey="settings.weatherSources.lastSuccessMessage"
               values={{ date: formatTimestamp(source.last_success_at) }}
@@ -459,7 +478,6 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
         )}
         {source.last_error_at && (
           <div className="text-red-600 dark:text-red-400" role="alert">
-            <span aria-hidden="true">✗ </span>
             <Trans
               i18nKey="settings.weatherSources.lastErrorMessage"
               values={{ date: formatTimestamp(source.last_error_at) }}
@@ -510,17 +528,11 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
             name: source.display_name,
           })}
         >
-          {isTesting ? (
-            <>
-              <span aria-hidden="true">⏳ </span>
-              <span>{t('settings.weatherSources.testing')}</span>
-            </>
-          ) : (
-            <>
-              <span aria-hidden="true">🔍 </span>
-              <span>{t('settings.weatherSources.test')}</span>
-            </>
-          )}
+          <span>
+            {isTesting
+              ? t('settings.weatherSources.testing')
+              : t('settings.weatherSources.test')}
+          </span>
         </Button>
 
         {onDelete &&
@@ -538,8 +550,7 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
                 name: source.display_name,
               })}
             >
-              <span aria-hidden="true">🗑️</span>
-              <span className="sr-only">{t('common.delete')}</span>
+              {t('common.delete')}
             </Button>
           )}
       </div>

--- a/apps/frontend/src/pages/Settings.chromatic.stories.tsx
+++ b/apps/frontend/src/pages/Settings.chromatic.stories.tsx
@@ -1,5 +1,6 @@
 import preview from '../../.storybook/preview.tsx';
 import { defaultHandlers } from './Settings.stories.tsx';
+import Settings from './Settings.tsx';
 
 const meta = preview.meta({
   title: 'Pages/Settings/Chromatic',
@@ -15,14 +16,8 @@ const meta = preview.meta({
 
 export const SettingsChromatic = meta.story({
   render: () => (
-    <div className="flex flex-col gap-2">
-      {/*   <FigureWrapper title={Default.composed.name}>
-        <Default.Component />
-      </FigureWrapper>
-*/}
-      {/* <FigureWrapper title={Loading.composed.name}>
-        <Loading.Component />
-      </FigureWrapper>*/}
+    <div className="mx-auto w-full max-w-5xl">
+      <Settings />
     </div>
   ),
 });

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -61,6 +61,73 @@ interface AppSettings {
 
 type SettingsTabKey = 'general' | 'sites' | 'weather' | 'data';
 
+type SettingsIconName =
+  | 'bell'
+  | 'database'
+  | 'globe'
+  | 'mapPin'
+  | 'ruler'
+  | 'settings'
+  | 'sliders'
+  | 'weather';
+
+function SettingsIcon({ name }: { name: SettingsIconName }) {
+  const paths: Record<SettingsIconName, React.ReactNode> = {
+    bell: (
+      <path d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 0 0-5-5.9V4a1 1 0 1 0-2 0v1.1A6 6 0 0 0 6 11v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 0 1-6 0" />
+    ),
+    database: (
+      <path d="M4 6c0-1.7 3.6-3 8-3s8 1.3 8 3-3.6 3-8 3-8-1.3-8-3Zm0 0v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
+    ),
+    globe: (
+      <path d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 0c2 0 3.5-4 3.5-9S14 3 12 3 8.5 7 8.5 12 10 21 12 21ZM3 12h18" />
+    ),
+    mapPin: (
+      <path d="M12 21s7-5.1 7-11a7 7 0 1 0-14 0c0 5.9 7 11 7 11Zm0-8a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+    ),
+    ruler: <path d="m4 17 13-13 3 3L7 20l-3-3Zm4-4 2 2m1-5 2 2m1-5 2 2" />,
+    settings: (
+      <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm7.4-2.5a7.8 7.8 0 0 0 0-2l2-1.5-2-3.5-2.4 1a8 8 0 0 0-1.7-1L15 3h-4l-.4 3a8 8 0 0 0-1.7 1l-2.4-1-2 3.5 2 1.5a7.8 7.8 0 0 0 0 2l-2 1.5 2 3.5 2.4-1a8 8 0 0 0 1.7 1l.4 3h4l.4-3a8 8 0 0 0 1.7-1l2.4 1 2-3.5-2-1.5Z" />
+    ),
+    sliders: (
+      <path d="M4 6h10m4 0h2M4 12h2m4 0h10M4 18h10m4 0h2M14 4v4M8 10v4m8 2v4" />
+    ),
+    weather: (
+      <path d="M17.5 18H8a5 5 0 1 1 1.2-9.9A6 6 0 0 1 20 11.7 3.5 3.5 0 0 1 17.5 18Z" />
+    ),
+  };
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="h-5 w-5 shrink-0"
+      aria-hidden="true"
+    >
+      {paths[name]}
+    </svg>
+  );
+}
+
+function SectionTitle({
+  icon,
+  children,
+}: {
+  icon: SettingsIconName;
+  children: React.ReactNode;
+}) {
+  return (
+    <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-gray-900 dark:text-white">
+      <SettingsIcon name={icon} />
+      {children}
+    </h2>
+  );
+}
+
 const DEFAULT_SETTINGS: AppSettings = {
   units: {
     distance: 'km',
@@ -90,9 +157,7 @@ function SitesTab({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-      <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-        📍 {t('settings.favorites.title')}
-      </h2>
+      <SectionTitle icon="mapPin">{t('settings.favorites.title')}</SectionTitle>
       {sites.length === 0 ? (
         <p className="text-gray-600 dark:text-gray-300 text-center py-8">
           {t('settings.favorites.noSites')}
@@ -114,8 +179,8 @@ function SitesTab({
                 </h3>
                 {site.latitude && site.longitude && site.elevation_m && (
                   <div className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-                    📍 {site.latitude.toFixed(4)}, {site.longitude.toFixed(4)} •
-                    ⛰️ {site.elevation_m}m
+                    {site.latitude.toFixed(4)}, {site.longitude.toFixed(4)} ·{' '}
+                    {site.elevation_m}m
                   </div>
                 )}
                 {site.description && (
@@ -126,6 +191,7 @@ function SitesTab({
               </div>
               <Button
                 onClick={() => toggleFavorite(site.id)}
+                aria-pressed={settings.favoriteSites.includes(site.id)}
                 className={`ml-4 px-4 py-2 rounded-lg font-medium transition-all ${
                   settings.favoriteSites.includes(site.id)
                     ? 'bg-sky-600 text-white hover:bg-sky-700'
@@ -133,15 +199,15 @@ function SitesTab({
                 }`}
               >
                 {settings.favoriteSites.includes(site.id)
-                  ? '⭐ ' + t('settings.favorites.favorite')
-                  : '☆ ' + t('settings.favorites.add')}
+                  ? t('settings.favorites.favorite')
+                  : t('settings.favorites.add')}
               </Button>
             </div>
           ))}
         </div>
       )}
       <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg text-sm text-blue-800 dark:text-blue-200">
-        💡 <strong>{t('settings.favorites.tip')}</strong>{' '}
+        <strong>{t('settings.favorites.tip')}</strong>{' '}
         {t('settings.favorites.tipText')}
       </div>
     </div>
@@ -194,7 +260,7 @@ function WeatherSourcesTab() {
   if (error) {
     return (
       <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4 text-red-800 dark:text-red-200">
-        ❌ {t('settings.weatherSources.loadError')}
+        {t('settings.weatherSources.loadError')}
       </div>
     );
   }
@@ -203,9 +269,10 @@ function WeatherSourcesTab() {
     <div className="space-y-4">
       {/* Header with stats */}
       <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-        <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-          🌦️ {t('settings.weatherSources.title')}
-        </h2>
+        <div className="mb-2 flex items-center gap-2 text-xl font-bold text-gray-900 dark:text-white">
+          <SettingsIcon name="weather" />
+          <h2>{t('settings.weatherSources.title')}</h2>
+        </div>
         <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
           {t('settings.weatherSources.description')}
         </p>
@@ -271,7 +338,7 @@ function WeatherSourcesTab() {
       {/* Info Box */}
       <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg p-4">
         <h3 className="font-semibold text-yellow-900 dark:text-yellow-100 mb-2">
-          ℹ️ {t('settings.weatherSources.aboutTitle')}
+          {t('settings.weatherSources.aboutTitle')}
         </h3>
         <ul className="text-sm text-yellow-800 dark:text-yellow-200 space-y-1">
           <li>
@@ -319,6 +386,14 @@ function PerformanceSection() {
     value: string
   ) => {
     updateBackend.mutate({ [key]: value });
+  };
+
+  const handleBackendNumberSetting = (
+    key: keyof BackendAppSettings,
+    value: string
+  ) => {
+    if (!value.trim() || Number.isNaN(Number(value))) return;
+    handleBackendSetting(key, value);
   };
 
   const currentCacheTtl = backendSettings?.cache_ttl_default ?? '3600';
@@ -588,6 +663,7 @@ function PerformanceSection() {
               <Button
                 key={opt.value}
                 onClick={() => setFreshnessLevel(opt.value as FreshnessLevel)}
+                aria-pressed={freshnessLevel === opt.value}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   freshnessLevel === opt.value
                     ? 'bg-sky-600 text-white shadow-md'
@@ -652,6 +728,7 @@ function PerformanceSection() {
               <Button
                 key={opt.value}
                 onClick={() => setHttpTimeout(opt.value as HttpTimeout)}
+                aria-pressed={httpTimeout === opt.value}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   httpTimeout === opt.value
                     ? 'bg-sky-600 text-white shadow-md'
@@ -709,6 +786,7 @@ function PerformanceSection() {
                 onClick={() =>
                   handleBackendSetting('cache_ttl_default', opt.value)
                 }
+                aria-pressed={currentCacheTtl === opt.value}
                 isDisabled={updateBackend.isPending}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   currentCacheTtl === opt.value
@@ -757,6 +835,7 @@ function PerformanceSection() {
                 onClick={() =>
                   handleBackendSetting('spotair_live_wind_radius_km', opt.value)
                 }
+                aria-pressed={currentSpotairRadius === opt.value}
                 isDisabled={updateBackend.isPending}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   currentSpotairRadius === opt.value
@@ -808,6 +887,7 @@ function PerformanceSection() {
                     opt.value
                   )
                 }
+                aria-pressed={currentSpotairCacheTtl === opt.value}
                 isDisabled={updateBackend.isPending}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   currentSpotairCacheTtl === opt.value
@@ -855,6 +935,7 @@ function PerformanceSection() {
                 onClick={() =>
                   handleBackendSetting('scheduler_interval_minutes', opt.value)
                 }
+                aria-pressed={currentSchedulerInterval === opt.value}
                 isDisabled={updateBackend.isPending}
                 className={`px-5 py-2 rounded-lg font-medium transition-all text-sm ${
                   currentSchedulerInterval === opt.value
@@ -904,7 +985,7 @@ function PerformanceSection() {
                         backendSettings?.[item.key] ?? item.defaultValue
                       }
                       onBlur={(event) =>
-                        handleBackendSetting(item.key, event.target.value)
+                        handleBackendNumberSetting(item.key, event.target.value)
                       }
                       className="px-3 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
                     />
@@ -948,8 +1029,8 @@ export default function Settings() {
   }, [i18n, settings.language]);
 
   // Save settings to localStorage
-  const saveSettings = () => {
-    localStorage.setItem('paragliding-settings', JSON.stringify(settings));
+  const saveSettings = (nextSettings = settings) => {
+    localStorage.setItem('paragliding-settings', JSON.stringify(nextSettings));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   };
@@ -999,7 +1080,7 @@ export default function Settings() {
         const imported = JSON.parse(e.target?.result as string);
         if (imported.settings) {
           setSettings(imported.settings);
-          saveSettings();
+          saveSettings(imported.settings as AppSettings);
         }
         if (imported.cacheSettings) {
           const { setFreshnessLevel, setAutoRefreshWeather, setHttpTimeout } =
@@ -1054,10 +1135,11 @@ export default function Settings() {
   };
 
   return (
-    <div>
+    <div className="pb-24">
       <div className="mb-4 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        <h1 className="text-xl font-bold text-gray-900 dark:text-white">
-          ⚙️ {t('settings.title')}
+        <h1 className="flex items-center gap-2 text-xl font-bold text-gray-900 dark:text-white">
+          <SettingsIcon name="settings" />
+          {t('settings.title')}
         </h1>
         <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
           {t('settings.subtitle')}
@@ -1073,11 +1155,30 @@ export default function Settings() {
         <TabList className="mb-4 grid-cols-2 sm:flex">
           {(['general', 'sites', 'weather', 'data'] as const).map((tabKey) => (
             <Tab key={tabKey} id={tabKey} className="flex-1">
-              {tabKey === 'general' && `🎛️ ${t('settings.tabs.general')}`}
-              {tabKey === 'sites' && `📍 ${t('settings.tabs.favoriteSites')}`}
-              {tabKey === 'weather' &&
-                `🌦️ ${t('settings.tabs.weatherSources')}`}
-              {tabKey === 'data' && `💾 ${t('settings.tabs.data')}`}
+              {tabKey === 'general' && (
+                <span className="inline-flex items-center justify-center gap-2">
+                  <SettingsIcon name="sliders" />
+                  {t('settings.tabs.general')}
+                </span>
+              )}
+              {tabKey === 'sites' && (
+                <span className="inline-flex items-center justify-center gap-2">
+                  <SettingsIcon name="mapPin" />
+                  {t('settings.tabs.favoriteSites')}
+                </span>
+              )}
+              {tabKey === 'weather' && (
+                <span className="inline-flex items-center justify-center gap-2">
+                  <SettingsIcon name="weather" />
+                  {t('settings.tabs.weatherSources')}
+                </span>
+              )}
+              {tabKey === 'data' && (
+                <span className="inline-flex items-center justify-center gap-2">
+                  <SettingsIcon name="database" />
+                  {t('settings.tabs.data')}
+                </span>
+              )}
             </Tab>
           ))}
         </TabList>
@@ -1088,9 +1189,9 @@ export default function Settings() {
           <TabPanel id="general" className="space-y-4 outline-none">
             {/* Units Section */}
             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                📏 {t('settings.units.title')}
-              </h2>
+              <SectionTitle icon="ruler">
+                {t('settings.units.title')}
+              </SectionTitle>
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -1104,6 +1205,7 @@ export default function Settings() {
                           units: { ...prev.units, distance: 'km' },
                         }))
                       }
+                      aria-pressed={settings.units.distance === 'km'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.distance === 'km'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1119,6 +1221,7 @@ export default function Settings() {
                           units: { ...prev.units, distance: 'miles' },
                         }))
                       }
+                      aria-pressed={settings.units.distance === 'miles'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.distance === 'miles'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1142,6 +1245,7 @@ export default function Settings() {
                           units: { ...prev.units, altitude: 'm' },
                         }))
                       }
+                      aria-pressed={settings.units.altitude === 'm'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.altitude === 'm'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1157,6 +1261,7 @@ export default function Settings() {
                           units: { ...prev.units, altitude: 'ft' },
                         }))
                       }
+                      aria-pressed={settings.units.altitude === 'ft'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.altitude === 'ft'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1180,6 +1285,7 @@ export default function Settings() {
                           units: { ...prev.units, speed: 'kmh' },
                         }))
                       }
+                      aria-pressed={settings.units.speed === 'kmh'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.speed === 'kmh'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1195,6 +1301,7 @@ export default function Settings() {
                           units: { ...prev.units, speed: 'mph' },
                         }))
                       }
+                      aria-pressed={settings.units.speed === 'mph'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.units.speed === 'mph'
                           ? 'bg-sky-600 text-white shadow-md'
@@ -1210,9 +1317,9 @@ export default function Settings() {
 
             {/* Language & Theme Section */}
             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                🌐 {t('settings.languageTheme.title')}
-              </h2>
+              <SectionTitle icon="globe">
+                {t('settings.languageTheme.title')}
+              </SectionTitle>
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -1223,25 +1330,27 @@ export default function Settings() {
                       onClick={() => {
                         setSettings((prev) => ({ ...prev, language: 'fr' }));
                       }}
+                      aria-pressed={settings.language === 'fr'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.language === 'fr'
                           ? 'bg-sky-600 text-white shadow-md'
                           : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
                       }`}
                     >
-                      🇫🇷 Français
+                      Français
                     </Button>
                     <Button
                       onClick={() => {
                         setSettings((prev) => ({ ...prev, language: 'en' }));
                       }}
+                      aria-pressed={settings.language === 'en'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
                         settings.language === 'en'
                           ? 'bg-sky-600 text-white shadow-md'
                           : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
                       }`}
                     >
-                      🇬🇧 English
+                      English
                     </Button>
                   </div>
                 </div>
@@ -1258,15 +1367,13 @@ export default function Settings() {
                           setThemePreference(theme as ThemePreference);
                           setSettings((prev) => ({ ...prev, theme }));
                         }}
+                        aria-pressed={themePreference === theme}
                         className={`px-6 py-2 rounded-lg font-medium transition-all ${
                           themePreference === theme
                             ? 'bg-sky-600 text-white shadow-md'
                             : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
                         }`}
                       >
-                        {theme === 'light' && '☀️ '}
-                        {theme === 'dark' && '🌙 '}
-                        {theme === 'auto' && '🔄 '}
                         {t(`settings.languageTheme.${theme}`)}
                       </Button>
                     ))}
@@ -1277,9 +1384,9 @@ export default function Settings() {
 
             {/* Notifications Section */}
             <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                🔔 {t('settings.notifications.title')}
-              </h2>
+              <SectionTitle icon="bell">
+                {t('settings.notifications.title')}
+              </SectionTitle>
               <div className="space-y-3">
                 <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
                   <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -1287,7 +1394,7 @@ export default function Settings() {
                   </span>
                   <Switch
                     isSelected={settings.notifications.weather}
-                    onChange={(isSelected) =>
+                    onChange={(isSelected: boolean) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
@@ -1311,7 +1418,7 @@ export default function Settings() {
                   </span>
                   <Switch
                     isSelected={settings.notifications.flights}
-                    onChange={(isSelected) =>
+                    onChange={(isSelected: boolean) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
@@ -1335,7 +1442,7 @@ export default function Settings() {
                   </span>
                   <Switch
                     isSelected={settings.notifications.alerts}
-                    onChange={(isSelected) =>
+                    onChange={(isSelected: boolean) =>
                       setSettings((prev) => ({
                         ...prev,
                         notifications: {
@@ -1388,19 +1495,17 @@ export default function Settings() {
             <div className="space-y-4">
               {/* Export/Import Section */}
               <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                  💾 {t('settings.data.backupTitle')}
-                </h2>
+                <SectionTitle icon="database">
+                  {t('settings.data.backupTitle')}
+                </SectionTitle>
                 <div className="space-y-3">
                   <Button
                     onClick={exportData}
                     className="w-full px-6 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition-all flex items-center justify-center gap-2"
                   >
-                    <span>📥</span>
                     {t('settings.data.export')}
                   </Button>
                   <label className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-all flex items-center justify-center gap-2 cursor-pointer">
-                    <span>📤</span>
                     {t('settings.data.import')}
                     <input
                       type="file"
@@ -1411,14 +1516,14 @@ export default function Settings() {
                   </label>
                 </div>
                 <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg text-sm text-yellow-800 dark:text-yellow-200">
-                  ⚠️ {t('settings.data.importWarning')}
+                  {t('settings.data.importWarning')}
                 </div>
               </div>
 
               {/* Clear Data Section */}
               <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
                 <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                  🗑️ {t('settings.data.resetTitle')}
+                  {t('settings.data.resetTitle')}
                 </h2>
                 <Button
                   onClick={clearData}
@@ -1427,18 +1532,18 @@ export default function Settings() {
                   {t('settings.data.resetAll')}
                 </Button>
                 <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200">
-                  ⚠️ {t('settings.data.resetWarning')}
+                  {t('settings.data.resetWarning')}
                 </div>
               </div>
 
               {/* User Profile Placeholder */}
               <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
                 <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                  👤 {t('settings.profile.title')}
+                  {t('settings.profile.title')}
                 </h2>
                 <div className="p-8 bg-gray-50 dark:bg-gray-900 rounded-lg text-center">
                   <p className="text-gray-600 dark:text-gray-300 mb-2">
-                    🚧 {t('settings.profile.wip')}
+                    {t('settings.profile.wip')}
                   </p>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
                     {t('settings.profile.wipDetails')}
@@ -1460,9 +1565,7 @@ export default function Settings() {
               : 'bg-sky-600 text-white hover:bg-sky-700 hover:shadow-xl'
           }`}
         >
-          {saved
-            ? '✅ ' + t('settings.saved')
-            : '💾 ' + t('settings.saveButton')}
+          {saved ? t('settings.saved') : t('settings.saveButton')}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace emoji-based settings UI affordances with consistent inline SVG/text treatments.
- Improve accessibility for settings option buttons with pressed states and safer numeric setting updates.
- Fix imported settings persistence and restore Chromatic coverage for the settings page.

## Validation
- `oxfmt --check apps/frontend/src/pages/Settings.tsx apps/frontend/src/components/settings/WeatherSourceCard.tsx apps/frontend/src/pages/Settings.chromatic.stories.tsx`
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`

## Notes
- `nx test frontend` is blocked locally by pnpm store resolution for `vitest` and a missing Playwright browser executable.
- `nx build frontend` is blocked by pre-existing TypeScript errors outside this change set.