### PR TITLE
Improve sites page UX

### DIFF
--- a/apps/frontend/src/components/sites/EditSiteModal.tsx
+++ b/apps/frontend/src/components/sites/EditSiteModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TextField, Label, Input } from 'react-aria-components';
 import { Button } from '@dashboard-parapente/design-system';
+import { Camera, Loader2, Save } from 'lucide-react';
 import type {
   Site,
   SiteUpdate,
@@ -113,7 +114,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
   const parseNumericFields = () => {
     const lat = parseFloat(latitudeRaw) || 0;
     const lon = parseFloat(longitudeRaw) || 0;
-    const elev = parseInt(elevationRaw) || 0;
+    const elev = parseInt(elevationRaw, 10) || 0;
     setFormData((prev) => ({
       ...prev,
       latitude: lat,
@@ -180,8 +181,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         });
       }
       onClose();
-    } catch (error) {
-      console.error('Failed to save site:', error);
+    } catch {
       alert(t('editSite.saveError'));
     } finally {
       setIsSaving(false);
@@ -202,7 +202,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         <TextField
           isRequired
           value={formData.name}
-          onChange={(v) => setFormData({ ...formData, name: v })}
+          onChange={(v: string) => setFormData({ ...formData, name: v })}
           className="flex flex-col gap-1"
         >
           <Label className={labelClass}>{t('editSite.siteName')} *</Label>
@@ -217,7 +217,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         {/* Code */}
         <TextField
           value={formData.code}
-          onChange={(v) => setFormData({ ...formData, code: v })}
+          onChange={(v: string) => setFormData({ ...formData, code: v })}
           isDisabled={!!site}
           className="flex flex-col gap-1"
         >
@@ -278,7 +278,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         </div>
 
         {/* GPS Coordinates */}
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <TextField
             isRequired
             value={latitudeRaw}
@@ -320,10 +320,10 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         </div>
 
         {/* Region & Country */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <TextField
             value={formData.region}
-            onChange={(v) => setFormData({ ...formData, region: v })}
+            onChange={(v: string) => setFormData({ ...formData, region: v })}
             className="flex flex-col gap-1"
           >
             <Label className={labelClass}>{t('editSite.region')}</Label>
@@ -379,7 +379,11 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
         {/* Camera Settings */}
         <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded border border-blue-200 dark:border-blue-700">
           <h4 className="text-sm font-semibold mb-3 dark:text-gray-200">
-            📷 {t('editSite.camera3D')}
+            <Camera
+              className="mr-1.5 inline h-4 w-4 align-[-2px]"
+              aria-hidden="true"
+            />
+            {t('editSite.camera3D')}
           </h4>
 
           <div className="mb-3">
@@ -395,7 +399,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
               onChange={(e) =>
                 setFormData({
                   ...formData,
-                  camera_angle: parseInt(e.target.value),
+                  camera_angle: parseInt(e.target.value, 10),
                 })
               }
               className="w-full"
@@ -421,7 +425,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
               onChange={(e) =>
                 setFormData({
                   ...formData,
-                  camera_distance: parseInt(e.target.value),
+                  camera_distance: parseInt(e.target.value, 10),
                 })
               }
               className="w-full"
@@ -445,7 +449,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
               onChange={(e) =>
                 setFormData({
                   ...formData,
-                  camera_close_zoom_percent: parseInt(e.target.value),
+                  camera_close_zoom_percent: parseInt(e.target.value, 10),
                 })
               }
               className="w-full"
@@ -469,7 +473,7 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
               onChange={(e) =>
                 setFormData({
                   ...formData,
-                  camera_transition_percent: parseInt(e.target.value),
+                  camera_transition_percent: parseInt(e.target.value, 10),
                 })
               }
               className="w-full"
@@ -516,12 +520,15 @@ export const EditSiteModal: React.FC<EditSiteModalProps> = ({
           </Button>
           <Button
             type="submit"
-            className="flex-1 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 cursor-pointer"
+            className="inline-flex flex-1 items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 cursor-pointer transition-colors"
             isDisabled={isSaving}
           >
-            {isSaving
-              ? `⏳ ${t('editSite.saving')}`
-              : `💾 ${t('editSite.saveButton')}`}
+            {isSaving ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Save className="h-4 w-4" aria-hidden="true" />
+            )}
+            {isSaving ? t('editSite.saving') : t('editSite.saveButton')}
           </Button>
         </div>
       </form>

--- a/apps/frontend/src/components/sites/SiteCard.tsx
+++ b/apps/frontend/src/components/sites/SiteCard.tsx
@@ -2,6 +2,15 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Site } from '@dashboard-parapente/shared-types';
 import { Button } from '@dashboard-parapente/design-system';
+import {
+  Compass,
+  List,
+  Map,
+  MapPin,
+  Pencil,
+  Plane,
+  Trash2,
+} from 'lucide-react';
 
 interface SiteCardProps {
   site: Site;
@@ -48,7 +57,7 @@ export const SiteCard: React.FC<SiteCardProps> = ({
   const typeBadge = getTypeBadge();
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow h-full flex flex-col">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow duration-200 h-full flex flex-col">
       {/* Header */}
       <div className="flex items-start justify-between mb-3">
         <div className="flex-1">
@@ -72,8 +81,11 @@ export const SiteCard: React.FC<SiteCardProps> = ({
       <div className="space-y-2 mb-4 flex-1">
         {/* GPS Coordinates */}
         {site.latitude && site.longitude && (
-          <div className="text-sm">
-            <span className="text-gray-600 dark:text-gray-300">📍 </span>
+          <div className="flex items-center gap-2 text-sm">
+            <MapPin
+              className="h-4 w-4 shrink-0 text-gray-600 dark:text-gray-300"
+              aria-hidden="true"
+            />
             <span className="text-gray-800 dark:text-gray-100">
               {site.latitude.toFixed(4)}°N, {site.longitude.toFixed(4)}°E
             </span>
@@ -87,8 +99,11 @@ export const SiteCard: React.FC<SiteCardProps> = ({
 
         {/* Orientation */}
         {site.orientation && (
-          <div className="text-sm">
-            <span className="text-gray-600 dark:text-gray-300">🧭 </span>
+          <div className="flex items-center gap-2 text-sm">
+            <Compass
+              className="h-4 w-4 shrink-0 text-gray-600 dark:text-gray-300"
+              aria-hidden="true"
+            />
             <span className="text-gray-800 dark:text-gray-100">
               {t('sites.orientation')} {site.orientation}
             </span>
@@ -97,8 +112,11 @@ export const SiteCard: React.FC<SiteCardProps> = ({
 
         {/* Region */}
         {site.region && (
-          <div className="text-sm">
-            <span className="text-gray-600 dark:text-gray-300">🗺️ </span>
+          <div className="flex items-center gap-2 text-sm">
+            <Map
+              className="h-4 w-4 shrink-0 text-gray-600 dark:text-gray-300"
+              aria-hidden="true"
+            />
             <span className="text-gray-800 dark:text-gray-100">
               {site.region}
             </span>
@@ -106,8 +124,11 @@ export const SiteCard: React.FC<SiteCardProps> = ({
         )}
 
         {/* Flight count */}
-        <div className="text-sm">
-          <span className="text-gray-600 dark:text-gray-300">✈️ </span>
+        <div className="flex items-center gap-2 text-sm">
+          <Plane
+            className="h-4 w-4 shrink-0 text-gray-600 dark:text-gray-300"
+            aria-hidden="true"
+          />
           <span className="text-gray-800 dark:text-gray-100">
             {flightCount} {t('common.flight', { count: flightCount })}
           </span>
@@ -127,25 +148,27 @@ export const SiteCard: React.FC<SiteCardProps> = ({
       <div className="flex flex-col sm:flex-row gap-2 pt-3 border-t dark:border-gray-700">
         <Button
           onClick={() => onEdit(site)}
-          className="flex-1 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer transition-colors"
           title={t('sites.editSite')}
         >
-          ✏️ {t('common.edit')}
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+          {t('common.edit')}
         </Button>
         <Button
           onClick={() => onViewFlights(site)}
-          className="flex-1 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-gray-600 text-white rounded hover:bg-gray-700"
+          className="inline-flex flex-1 items-center justify-center gap-1.5 px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-gray-600 text-white rounded hover:bg-gray-700 cursor-pointer transition-colors"
           title={t('sites.viewFlights')}
         >
-          📋 {t('header.flights')}
+          <List className="h-4 w-4" aria-hidden="true" />
+          {t('header.flights')}
         </Button>
         <Button
           onClick={() => onDelete(site)}
-          className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700"
+          className="inline-flex items-center justify-center px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-red-600 text-white rounded hover:bg-red-700 cursor-pointer transition-colors"
           title={t('sites.deleteSite')}
           aria-label={t('sites.deleteSite')}
         >
-          <span aria-hidden="true">🗑️</span>
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
     </div>

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -192,7 +192,9 @@
   "sites": {
     "management": "Site Management",
     "newSite": "New site",
+    "searchLabel": "Search",
     "searchPlaceholder": "Search by name, code or region...",
+    "typeFilterLabel": "Site type",
     "allTypes": "All types",
     "takeoffOnly": "Takeoff only",
     "landingOnly": "Landing only",
@@ -203,6 +205,8 @@
     "adjustFilters": "Try adjusting your search filters",
     "createFirstSite": "Create your first site",
     "deleteSiteConfirm": "Delete site \"{{name}}\"?\n\nThis action is irreversible.",
+    "deleteSiteTitle": "Delete this site?",
+    "deleteSiteDescription": "Site \"{{name}}\" will be permanently deleted. This action is irreversible.",
     "siteDeleted": "Site \"{{name}}\" deleted successfully",
     "deleteError": "Error deleting site",
     "sitesLoadError": "Error loading sites",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -192,7 +192,9 @@
   "sites": {
     "management": "Gestion des Sites",
     "newSite": "Nouveau site",
+    "searchLabel": "Rechercher",
     "searchPlaceholder": "Rechercher par nom, code ou région...",
+    "typeFilterLabel": "Type de site",
     "allTypes": "Tous les types",
     "takeoffOnly": "Décollage uniquement",
     "landingOnly": "Atterrissage uniquement",
@@ -203,6 +205,8 @@
     "adjustFilters": "Essayez de modifier vos filtres de recherche",
     "createFirstSite": "Créer votre premier site",
     "deleteSiteConfirm": "Supprimer le site \"{{name}}\" ?\n\nCette action est irréversible.",
+    "deleteSiteTitle": "Supprimer ce site ?",
+    "deleteSiteDescription": "Le site \"{{name}}\" sera supprimé définitivement. Cette action est irréversible.",
     "siteDeleted": "Site \"{{name}}\" supprimé avec succès",
     "deleteError": "Erreur lors de la suppression",
     "sitesLoadError": "Erreur lors du chargement des sites",

--- a/apps/frontend/src/pages/Sites.tsx
+++ b/apps/frontend/src/pages/Sites.tsx
@@ -1,8 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useDeferredValue, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
-import { Input, TextField } from 'react-aria-components';
-import { Button } from '@dashboard-parapente/design-system';
+import { Input, Label, TextField } from 'react-aria-components';
+import { Button, DataList, Modal } from '@dashboard-parapente/design-system';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   useReactTable,
@@ -12,13 +12,11 @@ import {
   type SortingState,
   type Row,
 } from '@tanstack/react-table';
-import { sitesQueryOptions } from '../hooks/sites/useSites';
+import { sitesQueryOptions, useCreateSite } from '../hooks/sites/useSites';
 import { useUpdateSite, useDeleteSite } from '../hooks/sites/useSiteMutations';
-import { useCreateSite } from '../hooks/sites/useSites';
 import type { Site } from '@dashboard-parapente/shared-types';
 import { SiteCard } from '../components/sites/SiteCard';
 import { EditSiteModal } from '../components/sites/EditSiteModal';
-import { DataList, Modal } from '@dashboard-parapente/design-system';
 
 const columnHelper = createColumnHelper<Site>();
 
@@ -58,6 +56,7 @@ export const Sites: React.FC = () => {
 
   // Filters & search
   const [searchQuery, setSearchQuery] = useState('');
+  const deferredSearchQuery = useDeferredValue(searchQuery);
   const [typeFilter, setTypeFilter] = useState<
     'all' | 'takeoff' | 'landing' | 'both'
   >('all');
@@ -73,19 +72,28 @@ export const Sites: React.FC = () => {
 
   // Filter logic (search + type filter only, sorting handled by TanStack)
   const filteredSites = useMemo(() => {
+    const normalizedSearch = deferredSearchQuery.trim().toLowerCase();
+
     return sites.filter((site) => {
       const matchesSearch =
-        searchQuery === '' ||
-        site.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        site.code?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        site.region?.toLowerCase().includes(searchQuery.toLowerCase());
+        normalizedSearch === '' ||
+        site.name.toLowerCase().includes(normalizedSearch) ||
+        site.code?.toLowerCase().includes(normalizedSearch) ||
+        site.region?.toLowerCase().includes(normalizedSearch);
 
       const matchesType =
         typeFilter === 'all' || site.usage_type === typeFilter;
 
       return matchesSearch && matchesType;
     });
-  }, [sites, searchQuery, typeFilter]);
+  }, [sites, deferredSearchQuery, typeFilter]);
+
+  const hasActiveFilters = searchQuery.trim() !== '' || typeFilter !== 'all';
+
+  const handleResetFilters = () => {
+    setSearchQuery('');
+    setTypeFilter('all');
+  };
 
   const table = useReactTable({
     data: filteredSites,
@@ -131,8 +139,8 @@ export const Sites: React.FC = () => {
     try {
       await deleteSite.mutateAsync(siteToDelete.id);
       setSiteToDelete(null);
-    } catch (error: unknown) {
-      console.error('Failed to delete site:', error);
+    } catch {
+      // Keep the confirmation open so the user can retry.
     }
   };
 
@@ -148,7 +156,7 @@ export const Sites: React.FC = () => {
     return (
       <SiteCard
         site={site}
-        flightCount={0}
+        flightCount={site.flight_count}
         onEdit={handleEdit}
         onDelete={handleDelete}
         onViewFlights={handleViewFlights}
@@ -163,42 +171,60 @@ export const Sites: React.FC = () => {
         <h1 className="text-3xl font-bold">{t('sites.management')}</h1>
         <Button
           onPress={handleOpenCreateModal}
-          className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer"
+          className="inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer transition-colors"
         >
-          ➕ {t('sites.newSite')}
+          {t('sites.newSite')}
         </Button>
       </div>
 
       {/* Filters Bar */}
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 mb-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-[1fr_220px_auto] gap-4 md:items-end">
           {/* Search */}
           <TextField
             value={searchQuery}
             onChange={setSearchQuery}
-            aria-label={t('sites.searchPlaceholder')}
+            className="flex flex-col gap-1"
           >
-            <Input
-              placeholder={t('sites.searchPlaceholder')}
-              className="px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 outline-none focus:ring-2 focus:ring-blue-500 w-full"
-            />
+            <Label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              {t('sites.searchLabel')}
+            </Label>
+            <div className="relative">
+              <Input
+                placeholder={t('sites.searchPlaceholder')}
+                className="w-full rounded border border-gray-300 bg-white px-3 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+              />
+            </div>
           </TextField>
 
           {/* Type Filter */}
-          <select
-            value={typeFilter}
-            onChange={(e) =>
-              setTypeFilter(
-                e.target.value as 'all' | 'takeoff' | 'landing' | 'both'
-              )
-            }
-            className="px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100"
+          <label className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              {t('sites.typeFilterLabel')}
+            </span>
+            <select
+              value={typeFilter}
+              onChange={(e) =>
+                setTypeFilter(
+                  e.target.value as 'all' | 'takeoff' | 'landing' | 'both'
+                )
+              }
+              className="rounded border border-gray-300 bg-white px-3 py-2 text-gray-900 outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            >
+              <option value="all">{t('sites.allTypes')}</option>
+              <option value="takeoff">{t('sites.takeoffOnly')}</option>
+              <option value="landing">{t('sites.landingOnly')}</option>
+              <option value="both">{t('sites.both')}</option>
+            </select>
+          </label>
+
+          <Button
+            onPress={handleResetFilters}
+            isDisabled={!hasActiveFilters}
+            className="inline-flex items-center justify-center gap-2 rounded border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
           >
-            <option value="all">{t('sites.allTypes')}</option>
-            <option value="takeoff">{t('sites.takeoffOnly')}</option>
-            <option value="landing">{t('sites.landingOnly')}</option>
-            <option value="both">{t('sites.both')}</option>
-          </select>
+            {t('filters.reset')}
+          </Button>
         </div>
       </div>
 
@@ -219,14 +245,28 @@ export const Sites: React.FC = () => {
         getTextValue={(row) => row.original.name}
       />
 
+      {filteredSites.length === 0 && hasActiveFilters && (
+        <div className="mt-4 text-center">
+          <p className="mb-3 text-sm text-gray-600 dark:text-gray-300">
+            {t('sites.adjustFilters')}
+          </p>
+          <Button
+            onPress={handleResetFilters}
+            className="inline-flex w-full sm:w-auto items-center justify-center gap-2 rounded border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-100 cursor-pointer transition-colors dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            {t('filters.reset')}
+          </Button>
+        </div>
+      )}
+
       {/* Create button when no sites and no filters */}
       {filteredSites.length === 0 && !searchQuery && typeFilter === 'all' && (
         <div className="text-center mt-4">
           <Button
             onPress={handleOpenCreateModal}
-            className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="inline-flex w-full sm:w-auto items-center justify-center gap-2 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 cursor-pointer transition-colors"
           >
-            ➕ {t('sites.createFirstSite')}
+            {t('sites.createFirstSite')}
           </Button>
         </div>
       )}
@@ -248,23 +288,26 @@ export const Sites: React.FC = () => {
         role="alertdialog"
         isOpen={!!siteToDelete}
         onClose={() => setSiteToDelete(null)}
-        title={t('sites.deleteSiteConfirm', { name: siteToDelete?.name })}
+        title={t('sites.deleteSiteTitle')}
         size="sm"
       >
-        <div className="flex flex-col sm:flex-row gap-3 pt-2">
+        <p className="text-sm text-gray-700 dark:text-gray-300">
+          {t('sites.deleteSiteDescription', { name: siteToDelete?.name })}
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 pt-4">
           <Button
             onPress={() => setSiteToDelete(null)}
             isDisabled={deleteSite.isPending}
-            className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 rounded hover:bg-gray-300 dark:hover:bg-gray-500 cursor-pointer disabled:opacity-50"
+            className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 rounded hover:bg-gray-300 dark:hover:bg-gray-500 cursor-pointer disabled:opacity-50 transition-colors"
           >
             {t('common.cancel')}
           </Button>
           <Button
             onPress={handleConfirmDelete}
             isDisabled={deleteSite.isPending}
-            className="flex-1 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 cursor-pointer disabled:opacity-50"
+            className="inline-flex flex-1 items-center justify-center gap-2 px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 cursor-pointer disabled:opacity-50 transition-colors"
           >
-            {deleteSite.isPending ? '⏳ ...' : t('common.delete', 'Supprimer')}
+            {deleteSite.isPending ? '...' : t('common.delete', 'Supprimer')}
           </Button>
         </div>
       </Modal>


### PR DESCRIPTION
## Summary
- Replace emoji UI markers on site cards and the edit modal with consistent Lucide SVG icons.
- Improve site filtering UX with visible labels, deferred search, reset actions, and a clearer filtered empty state.
- Display real site flight counts and make delete confirmation copy clearer.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` passed with existing warnings.
- `git diff --check` passed.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` blocked locally by unresolved `vitest` from pnpm store and missing Playwright browser.
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` blocked locally by `Cannot find module 'typescript'` from the worktree dependency layout.