### PR TITLE
Improve infrastructure page UX

### DIFF
--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -93,7 +93,6 @@ describe('VideoExportJobsPanel', () => {
         can_cancel: false,
       }
     );
-    window.confirm = vi.fn(() => true);
   });
 
   it('shows active jobs with a stop action only when cancellable', () => {
@@ -111,6 +110,7 @@ describe('VideoExportJobsPanel', () => {
 
     render(<VideoExportJobsPanel />);
     fireEvent.click(screen.getByRole('button', { name: 'Stopper' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Stopper' }).at(-1)!);
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
@@ -128,6 +128,11 @@ describe('VideoExportJobsPanel', () => {
     render(<VideoExportJobsPanel />);
     fireEvent.click(
       screen.getByRole('button', { name: 'Nettoyer les temporaires' })
+    );
+    fireEvent.click(
+      screen
+        .getAllByRole('button', { name: 'Nettoyer les temporaires' })
+        .at(-1)!
     );
 
     await waitFor(() => expect(cleanupTempFiles).toHaveBeenCalled());

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@dashboard-parapente/design-system';
+import { Button, Modal } from '@dashboard-parapente/design-system';
 import {
   type VideoExportJob,
   useCancelVideoExportJob,
@@ -28,6 +29,12 @@ const statusClassNames: Record<string, string> = {
   processing: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300',
   queued:
     'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+};
+
+type PendingVideoConfirm = {
+  message: string;
+  confirmLabel: string;
+  onConfirm: () => Promise<void>;
 };
 
 function getJobPhase(job: VideoExportJob) {
@@ -76,6 +83,8 @@ function getDateLabel(job: VideoExportJob) {
 export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   const { t } = useTranslation();
   const toast = useToast();
+  const [pendingConfirm, setPendingConfirm] =
+    useState<PendingVideoConfirm | null>(null);
   const { data: jobs = [], isLoading, isError, refetch } = useVideoExportJobs();
   const cancelJob = useCancelVideoExportJob();
   const cleanupTempFiles = useCleanupVideoExportTempFiles();
@@ -83,66 +92,62 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
 
   const activeCount = jobs.filter((job) => job.can_cancel).length;
 
-  async function handleCancel(job: VideoExportJob) {
-    if (
-      !window.confirm(
-        t('videoJobs.confirmStop', 'Stopper cette génération vidéo ?')
-      )
-    ) {
-      return;
-    }
-
-    try {
-      await cancelJob.mutateAsync(job.job_id);
-      toast.success(t('videoJobs.stopSuccess', 'Génération stoppée'));
-    } catch {
-      toast.error(
-        t('videoJobs.stopError', 'Impossible de stopper la génération')
-      );
-    }
+  function handleCancel(job: VideoExportJob) {
+    setPendingConfirm({
+      message: t('videoJobs.confirmStop', 'Stopper cette génération vidéo ?'),
+      confirmLabel: t('videoJobs.stop', 'Stopper'),
+      onConfirm: async () => {
+        try {
+          await cancelJob.mutateAsync(job.job_id);
+          toast.success(t('videoJobs.stopSuccess', 'Génération stoppée'));
+        } catch {
+          toast.error(
+            t('videoJobs.stopError', 'Impossible de stopper la génération')
+          );
+        }
+      },
+    });
   }
 
-  async function handleCleanupTempFiles() {
-    if (
-      !window.confirm(
-        t(
-          'videoJobs.confirmCleanupTempFiles',
-          'Supprimer les fichiers temporaires des générations terminées, échouées ou annulées ?'
-        )
-      )
-    ) {
-      return;
-    }
+  function handleCleanupTempFiles() {
+    setPendingConfirm({
+      message: t(
+        'videoJobs.confirmCleanupTempFiles',
+        'Supprimer les fichiers temporaires des générations terminées, échouées ou annulées ?'
+      ),
+      confirmLabel: t('videoJobs.cleanupTempFiles', 'Nettoyer les temporaires'),
+      onConfirm: async () => {
+        try {
+          const result = await cleanupTempFiles.mutateAsync();
+          const deletedCount = result.files_deleted + result.dirs_deleted;
+          if (result.errors.length > 0) {
+            toast.error(
+              t(
+                'videoJobs.cleanupPartialError',
+                '{{count}} élément(s) supprimé(s), mais certains fichiers n’ont pas pu être supprimés',
+                { count: deletedCount }
+              )
+            );
+            return;
+          }
 
-    try {
-      const result = await cleanupTempFiles.mutateAsync();
-      const deletedCount = result.files_deleted + result.dirs_deleted;
-      if (result.errors.length > 0) {
-        toast.error(
-          t(
-            'videoJobs.cleanupPartialError',
-            '{{count}} élément(s) supprimé(s), mais certains fichiers n’ont pas pu être supprimés',
-            { count: deletedCount }
-          )
-        );
-        return;
-      }
-
-      toast.success(
-        t(
-          'videoJobs.cleanupSuccess',
-          '{{count}} élément(s) temporaire(s) supprimé(s)',
-          { count: deletedCount }
-        )
-      );
-    } catch {
-      toast.error(
-        t(
-          'videoJobs.cleanupError',
-          'Impossible de supprimer les fichiers temporaires'
-        )
-      );
-    }
+          toast.success(
+            t(
+              'videoJobs.cleanupSuccess',
+              '{{count}} élément(s) temporaire(s) supprimé(s)',
+              { count: deletedCount }
+            )
+          );
+        } catch {
+          toast.error(
+            t(
+              'videoJobs.cleanupError',
+              'Impossible de supprimer les fichiers temporaires'
+            )
+          );
+        }
+      },
+    });
   }
 
   return (
@@ -189,8 +194,13 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       )}
 
       {isLoading && (
-        <div className="p-4 text-sm text-gray-600 dark:text-gray-300">
-          {t('common.loading', 'Chargement...')}
+        <div
+          className="space-y-3 p-4"
+          aria-label={t('common.loading', 'Chargement...')}
+        >
+          <div className="h-4 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-2 w-full animate-pulse rounded-full bg-gray-100 dark:bg-gray-700" />
+          <div className="h-2 w-2/3 animate-pulse rounded-full bg-gray-100 dark:bg-gray-700" />
         </div>
       )}
 
@@ -284,6 +294,38 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
           })}
         </div>
       )}
+      <Modal
+        isOpen={pendingConfirm !== null}
+        onClose={() => setPendingConfirm(null)}
+        title={t('common.confirm', 'Confirmation')}
+        size="sm"
+        role="alertdialog"
+      >
+        {pendingConfirm && (
+          <div className="space-y-4">
+            <p className="text-sm text-gray-700 dark:text-gray-300">
+              {pendingConfirm.message}
+            </p>
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="secondary"
+                onPress={() => setPendingConfirm(null)}
+              >
+                {t('common.cancel', 'Annuler')}
+              </Button>
+              <Button
+                variant="danger"
+                onPress={() => {
+                  void pendingConfirm.onConfirm();
+                  setPendingConfirm(null);
+                }}
+              >
+                {pendingConfirm.confirmLabel}
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
     </section>
   );
 }

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useDeferredValue } from 'react';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useTranslation } from 'react-i18next';
 import { Checkbox, Input, TextField } from 'react-aria-components';
@@ -293,9 +293,17 @@ function StravaTokenSection() {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
-        {t('infrastructure.strava.title')}
-      </h3>
+      <div>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+          {t('infrastructure.strava.title')}
+        </h3>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          {t(
+            'infrastructure.strava.description',
+            'Surveille la validité du jeton et les derniers rafraîchissements.'
+          )}
+        </p>
+      </div>
 
       {/* Status card */}
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-wrap items-center gap-6">
@@ -362,6 +370,7 @@ function CacheSection() {
   const { t } = useTranslation();
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [searchFilter, setSearchFilter] = useState('');
+  const deferredSearchFilter = useDeferredValue(searchFilter);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(
@@ -375,9 +384,9 @@ function CacheSection() {
   const deleteMutation = useDeleteCacheKey();
 
   const filteredGroups = useMemo(() => {
-    if (!searchFilter) return overview.groups;
+    if (!deferredSearchFilter) return overview.groups;
 
-    const lower = searchFilter.toLowerCase();
+    const lower = deferredSearchFilter.toLowerCase();
     const result: typeof overview.groups = {};
     for (const [prefix, group] of Object.entries(overview.groups)) {
       const filteredKeys = group.keys.filter((k) => {
@@ -396,7 +405,7 @@ function CacheSection() {
       }
     }
     return result;
-  }, [overview, searchFilter, t]);
+  }, [overview, deferredSearchFilter, t]);
 
   const toggleGroup = (prefix: string) => {
     setExpandedGroups((prev) => {
@@ -435,9 +444,17 @@ function CacheSection() {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
-        {t('cache.title')}
-      </h3>
+      <div>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+          {t('cache.title')}
+        </h3>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          {t(
+            'cache.description',
+            'Inspecte les clés actives, leur TTL et les groupes les plus volumineux.'
+          )}
+        </p>
+      </div>
 
       {/* Stats bar */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -481,7 +498,7 @@ function CacheSection() {
           onChange={setAutoRefresh}
           className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 group"
         >
-          {({ isSelected }) => (
+          {({ isSelected }: { isSelected: boolean }) => (
             <>
               <div
                 className={`w-4 h-4 rounded border flex items-center justify-center transition-colors ${
@@ -669,23 +686,167 @@ function CacheSection() {
 // MAIN PAGE
 // =============================================================================
 
+function InfrastructureStatCard({
+  label,
+  value,
+  detail,
+  tone = 'sky',
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  tone?: 'sky' | 'green' | 'amber' | 'red' | 'gray';
+}) {
+  const toneClassNames = {
+    sky: 'border-sky-100 bg-sky-50 text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/40 dark:text-sky-300',
+    green:
+      'border-green-100 bg-green-50 text-green-700 dark:border-green-900/60 dark:bg-green-950/40 dark:text-green-300',
+    amber:
+      'border-amber-100 bg-amber-50 text-amber-700 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-300',
+    red: 'border-red-100 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300',
+    gray: 'border-gray-100 bg-gray-50 text-gray-700 dark:border-gray-700 dark:bg-gray-900/40 dark:text-gray-300',
+  };
+
+  return (
+    <div className={`rounded-xl border p-4 shadow-sm ${toneClassNames[tone]}`}>
+      <div className="text-xs font-medium uppercase tracking-wide opacity-80">
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-bold text-gray-900 dark:text-white">
+        {value}
+      </div>
+      <div className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+        {detail}
+      </div>
+    </div>
+  );
+}
+
+function InfrastructureOverview() {
+  const { t } = useTranslation();
+  const { data: stravaStatus, isLoading: stravaLoading } =
+    useStravaTokenStatus();
+  const { data: cacheOverview } = useCacheOverview();
+
+  const cacheGroups = Object.keys(cacheOverview.groups).length;
+  let stravaTone: 'gray' | 'green' | 'red' = 'red';
+  let stravaValue = t('infrastructure.strava.expired');
+
+  if (stravaLoading) {
+    stravaTone = 'gray';
+    stravaValue = t('common.loading', 'Chargement...');
+  } else if (stravaStatus?.valid) {
+    stravaTone = 'green';
+    stravaValue = t('infrastructure.strava.valid');
+  }
+
+  return (
+    <section className="rounded-2xl border border-sky-100 bg-white p-4 shadow-md dark:border-sky-900/60 dark:bg-gray-800">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-wide text-sky-700 dark:text-sky-300">
+            {t('infrastructure.overviewLabel', 'Monitoring')}
+          </p>
+          <h2 className="mt-1 text-2xl font-bold text-gray-900 dark:text-white">
+            {t('infrastructure.title')}
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm text-gray-600 dark:text-gray-400">
+          {t(
+            'infrastructure.subtitle',
+            'Vue opérationnelle des intégrations, exports vidéo et données cache.'
+          )}
+        </p>
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <InfrastructureStatCard
+          label={t('infrastructure.tabs.strava')}
+          value={stravaValue}
+          detail={
+            stravaStatus?.expires_at
+              ? t('infrastructure.strava.expiresAt') +
+                `: ${formatDate(stravaStatus.expires_at)}`
+              : t('infrastructure.strava.modeUnknown')
+          }
+          tone={stravaTone}
+        />
+        <InfrastructureStatCard
+          label={t('infrastructure.tabs.videoExports')}
+          value={t('infrastructure.videoExports.ready', 'File')}
+          detail={t(
+            'infrastructure.videoExports.description',
+            'Suivi des exports et nettoyage des fichiers temporaires.'
+          )}
+          tone="amber"
+        />
+        <InfrastructureStatCard
+          label={t('cache.totalKeys')}
+          value={String(cacheOverview.total_keys)}
+          detail={t('cache.groups') + `: ${String(cacheGroups)}`}
+          tone={cacheOverview.truncated ? 'amber' : 'sky'}
+        />
+        <InfrastructureStatCard
+          label={t('cache.memoryUsage')}
+          value={cacheOverview.memory_usage ?? '—'}
+          detail={
+            cacheOverview.truncated
+              ? t('cache.truncatedWarning')
+              : t('cache.noResolution')
+          }
+          tone={cacheOverview.truncated ? 'amber' : 'gray'}
+        />
+      </div>
+    </section>
+  );
+}
+
 export default function InfrastructurePage() {
   const { t } = useTranslation();
   const { toasts, removeToast } = useToastStore();
+  const { data: stravaStatus } = useStravaTokenStatus();
+  const { data: cacheOverview } = useCacheOverview();
 
   return (
     <div className="py-4 space-y-8">
       <ToastContainer toasts={toasts} onClose={removeToast} />
 
-      <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-100">
-        {t('infrastructure.title')}
-      </h2>
+      <InfrastructureOverview />
 
       <Tabs className="space-y-4">
         <TabList className="grid-cols-1 sm:grid-cols-3">
-          <Tab id="strava">{t('infrastructure.tabs.strava')}</Tab>
-          <Tab id="videoExports">{t('infrastructure.tabs.videoExports')}</Tab>
-          <Tab id="cache">{t('infrastructure.tabs.cache')}</Tab>
+          <Tab id="strava">
+            <span className="flex items-center justify-center gap-2">
+              {t('infrastructure.tabs.strava')}
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs ${
+                  stravaStatus?.valid
+                    ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                    : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                }`}
+              >
+                {stravaStatus?.valid
+                  ? t('infrastructure.strava.valid')
+                  : t('infrastructure.strava.expired')}
+              </span>
+            </span>
+          </Tab>
+          <Tab id="videoExports">
+            <span className="flex items-center justify-center gap-2">
+              {t('infrastructure.tabs.videoExports')}
+              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                {t('infrastructure.videoExports.ready', 'File')}
+              </span>
+            </span>
+          </Tab>
+          <Tab id="cache">
+            <span className="flex items-center justify-center gap-2">
+              {t('infrastructure.tabs.cache')}
+              <span className="rounded-full bg-sky-100 px-2 py-0.5 text-xs text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+                {String(cacheOverview.total_keys)}
+              </span>
+            </span>
+          </Tab>
         </TabList>
 
         <TabPanel id="strava" className="outline-none">

--- a/libs/design-system/src/components/Button/Button.tsx
+++ b/libs/design-system/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import { tv } from 'tailwind-variants';
 import { twMerge } from 'tailwind-merge';
 
 const buttonStyles = tv({
-  base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 disabled:pointer-events-none disabled:opacity-50',
+  base: 'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-lg font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
   variants: {
     tone: {
       primary:

--- a/libs/design-system/src/components/DataTable/DataTable.tsx
+++ b/libs/design-system/src/components/DataTable/DataTable.tsx
@@ -33,6 +33,22 @@ interface DataTableProps<TData> {
   className?: string;
 }
 
+function getAriaSort(
+  sorted: false | 'asc' | 'desc',
+  canSort: boolean
+): 'ascending' | 'descending' | 'none' | undefined {
+  if (sorted === 'asc') {
+    return 'ascending';
+  }
+  if (sorted === 'desc') {
+    return 'descending';
+  }
+  if (canSort) {
+    return 'none';
+  }
+  return undefined;
+}
+
 export function DataTable<TData>({ table, className }: DataTableProps<TData>) {
   return (
     <div className={className}>
@@ -47,29 +63,33 @@ export function DataTable<TData>({ table, className }: DataTableProps<TData>) {
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sorted = header.column.getIsSorted();
+                  const headerContent = flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  );
 
                   return (
                     <th
                       key={header.id}
                       colSpan={header.colSpan}
                       className={dataTable({ sortable: canSort }).headerCell()}
-                      onClick={
-                        canSort
-                          ? header.column.getToggleSortingHandler()
-                          : undefined
-                      }
+                      aria-sort={getAriaSort(sorted, canSort)}
                     >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
+                      {!header.isPlaceholder && canSort && (
+                        <button
+                          type="button"
+                          className="flex w-full cursor-pointer items-center gap-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                          onClick={header.column.getToggleSortingHandler()}
+                        >
+                          {headerContent}
+                          {sorted && (
+                            <span aria-hidden="true">
+                              {sorted === 'desc' ? '↓' : '↑'}
+                            </span>
                           )}
-                      {sorted && (
-                        <span className="ml-1">
-                          {sorted === 'desc' ? '↓' : '↑'}
-                        </span>
+                        </button>
                       )}
+                      {!header.isPlaceholder && !canSort && headerContent}
                     </th>
                   );
                 })}


### PR DESCRIPTION
## Summary
- Add an operational overview and status badges to the infrastructure page.
- Replace video export `window.confirm` prompts with design-system modals and add skeleton loading feedback.
- Improve shared table sorting accessibility and button cursor states.

## Validation
- `CI=true PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm nx lint frontend --skip-nx-cache` passed with existing warnings.
- `CI=true PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm nx lint design-system --skip-nx-cache` passed with existing warning.
- `pnpm nx build frontend` remains blocked by pre-existing TypeScript errors outside this change set.
- Targeted Vitest run remains blocked by the local pnpm store resolving `@testing-library/jest-dom` without `vitest`.