### PR TITLE
fix(frontend): stop Cesium render loop on teardown

### DIFF
--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -139,11 +139,32 @@ const interpolatePosition = (
   );
 
 const getViewerScene = (viewer: CesiumViewer | null | undefined) => {
-  if (!viewer || viewer.isDestroyed() || !viewer.scene) {
+  try {
+    if (!viewer || viewer.isDestroyed()) {
+      return null;
+    }
+
+    return viewer.scene ?? null;
+  } catch {
     return null;
   }
+};
 
-  return viewer.scene;
+const destroyViewer = (viewer: CesiumViewer) => {
+  try {
+    viewer.useDefaultRenderLoop = false;
+    viewer.clock.shouldAnimate = false;
+  } catch {
+    // Cesium can invalidate internals while tearing down the WebGL context.
+  }
+
+  try {
+    if (!viewer.isDestroyed()) {
+      viewer.destroy();
+    }
+  } catch {
+    // Avoid surfacing late Cesium teardown errors during route transitions.
+  }
 };
 
 const renderViewerFrame = (viewer: CesiumViewer) => {
@@ -571,6 +592,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     let isMounted = true;
     let attemptCount = 0;
     const maxAttempts = 10;
+    let createViewerTimeout: ReturnType<typeof setTimeout> | null = null;
 
     const tryCreateViewer = () => {
       attemptCount++;
@@ -579,7 +601,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       if (!containerRef.current) {
         if (attemptCount < maxAttempts) {
-          setTimeout(tryCreateViewer, 100);
+          createViewerTimeout = setTimeout(tryCreateViewer, 100);
           return;
         }
         setViewerError('Container element not found after multiple attempts');
@@ -623,7 +645,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
         const scene = getViewerScene(viewer);
         if (!scene) {
-          viewer.destroy();
+          destroyViewer(viewer);
           setViewerError('Cesium scene could not be initialized');
           return;
         }
@@ -642,13 +664,17 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     };
 
     // Start trying to create viewer after a small delay
-    const initialTimeout = setTimeout(tryCreateViewer, 100);
+    createViewerTimeout = setTimeout(tryCreateViewer, 100);
 
     return () => {
       isMounted = false;
-      clearTimeout(initialTimeout);
-      if (viewerRef.current && !viewerRef.current.isDestroyed()) {
-        viewerRef.current.destroy();
+      if (createViewerTimeout) {
+        clearTimeout(createViewerTimeout);
+      }
+      const viewer = viewerRef.current;
+      viewerRef.current = null;
+      if (viewer) {
+        destroyViewer(viewer);
       }
       if (typeof window !== 'undefined') {
         window._setExportFrame = undefined;
@@ -656,7 +682,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         window._gpxData = undefined;
         window._cesiumViewer = undefined;
       }
-      viewerRef.current = null;
       if (isMountedRef.current) {
         setViewerReady(false);
       }

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -123,6 +123,7 @@ vi.mock('cesium', () => {
     };
     shadows = false;
     terrainShadows = 0;
+    useDefaultRenderLoop = true;
     render = vi.fn();
     destroyed = false;
 
@@ -455,6 +456,9 @@ describe('FlightViewer3D video export mode', () => {
 
     unmount();
 
+    expect(
+      viewerInstances[viewerInstances.length - 1]?.useDefaultRenderLoop
+    ).toBe(false);
     expect(window._setExportFrame).toBeUndefined();
     expect(window._getExportMetadata).toBeUndefined();
     expect(window._cesiumViewer).toBeUndefined();


### PR DESCRIPTION
## Summary
- Stop Cesium's default render loop before destroying the viewer to prevent late internal `scene` access during route/flight switches.
- Make scene access tolerant to Cesium teardown getters throwing after WebGL context invalidation.
- Track retry timers so delayed viewer creation cannot run after unmount.

## Validation
- NODE_OPTIONS=--preserve-symlinks NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightViewer3D.video-export.test.tsx
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NODE_OPTIONS=--preserve-symlinks NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened the 3D flight viewer component's reliability by implementing improved error handling and defensive safeguards throughout the initialization and teardown lifecycle, preventing potential crashes and unexpected behavior when the viewer is unmounted or removed from the page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/696)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->