### PR TITLE
docs: use smallest OpenAI model for bootstrap subagent

### DIFF
--- a/.agents/skills/implementation-worktree-strategy/SKILL.md
+++ b/.agents/skills/implementation-worktree-strategy/SKILL.md
@@ -21,7 +21,7 @@ Whenever a worktree is created, immediately name the current AI session with the
 
 ## Worktree Bootstrap Subagent
 
-After creating a worktree, launch a `general` subagent immediately and let it run in parallel with the main implementation work.
+After creating a worktree, launch a `general` subagent immediately with the smallest available OpenAI model and let it run in parallel with the main implementation work.
 
 Subagent responsibility:
 


### PR DESCRIPTION
## Summary
- Require the worktree bootstrap subagent to use the smallest available OpenAI model.
- Keep the existing bootstrap workflow unchanged otherwise.

## Validation
- Husky pre-commit ran lint-staged and knip during commit.
- No Nx checks run because this only updates skill documentation.