### PR TITLE
ci: summarize deployment failures

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -746,6 +746,25 @@ jobs:
           echo "Verification step outcome: ${{ steps.verify_deploy.outcome }}"
           echo "Computed deployment version: ${{ steps.version.outputs.version }}"
 
+      - name: Summarize deployment failure
+        if: steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.outcome != 'success'
+        run: |
+          {
+            echo "## Production deployment failed"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Repository | ${{ github.repository }} |"
+            echo "| Branch | ${{ github.ref_name }} |"
+            echo "| Commit | ${{ github.sha }} |"
+            echo "| Deployment version | ${{ steps.version.outputs.version }} |"
+            echo "| SSH deployment | ${{ steps.trigger_deploy.conclusion }} |"
+            echo "| Version verification | ${{ steps.verify_deploy.outcome }} |"
+            echo "| Run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+            echo ""
+            echo "The deployment job is intentionally failed so GitHub sends the native Actions failure email notification."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fail job when deployment failed
         if: steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.outcome != 'success'
         run: |


### PR DESCRIPTION
## Summary
- Add a GitHub Actions job summary when production deployment fails.
- Keep the deployment job failing so native GitHub email notifications still trigger.
- Include branch, commit, deployment version, deployment status, verification status, and run URL in the failure summary.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-portainer.yml', encoding='utf-8')); print('workflow yaml ok')"`
- `git diff --check -- .github/workflows/deploy-portainer.yml`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e` (no affected Nx tasks)

## Notes
- `pnpm exec prettier --check .github/workflows/deploy-portainer.yml` could not run because `prettier` is not available as a pnpm exec binary in this workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow with improved failure notifications. The deployment process now generates a detailed summary when failures occur, including repository details, branch, commit information, deployment version, verification results, and Actions run URL. This provides better visibility into deployment issues and triggers GitHub's native failure email notifications for faster issue response.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/712)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->