### PR TITLE
fix: make production frontend build portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /workspace
 
 ARG VITE_CESIUM_ION_TOKEN
 ENV VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN}
+ENV NX_NO_CLOUD=true
 
 # Installer pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
@@ -22,7 +23,7 @@ COPY libs/design-system ./libs/design-system
 COPY apps/frontend ./apps/frontend
 
 # Installer toutes les dépendances (root + frontend)
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --config.enable-global-virtual-store=false
 
 # Build frontend avec Nx
 RUN pnpm exec nx build frontend --configuration=production

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -21,6 +21,7 @@ const {
     render: ReturnType<typeof vi.fn>;
     destroy: () => void;
     isDestroyed: () => boolean;
+    useDefaultRenderLoop: boolean;
     scene?: {
       requestRender: ReturnType<typeof vi.fn>;
       render: ReturnType<typeof vi.fn>;

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -110,7 +110,9 @@ describe('VideoExportJobsPanel', () => {
 
     render(<VideoExportJobsPanel />);
     fireEvent.click(screen.getByRole('button', { name: 'Stopper' }));
-    fireEvent.click(screen.getAllByRole('button', { name: 'Stopper' }).at(-1)!);
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Stopper' }).slice(-1)[0]!
+    );
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
@@ -132,7 +134,7 @@ describe('VideoExportJobsPanel', () => {
     fireEvent.click(
       screen
         .getAllByRole('button', { name: 'Nettoyer les temporaires' })
-        .at(-1)!
+        .slice(-1)[0]!
     );
 
     await waitFor(() => expect(cleanupTempFiles).toHaveBeenCalled());

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1558,7 +1558,7 @@ export default function Settings() {
       {/* Save Button */}
       <div className="mt-6 sticky bottom-4 z-10">
         <Button
-          onClick={saveSettings}
+          onClick={() => saveSettings()}
           className={`w-full px-6 py-4 rounded-xl font-bold text-lg shadow-lg transition-all ${
             saved
               ? 'bg-green-600 text-white'

--- a/apps/frontend/src/routes/flights.tsx
+++ b/apps/frontend/src/routes/flights.tsx
@@ -13,10 +13,11 @@ export const Route = createFileRoute('/flights')({
     siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
   }),
   beforeLoad: requireAuth,
-  loader: async ({ search }) => {
+  loaderDeps: ({ search }) => search,
+  loader: async ({ deps }) => {
     await Promise.all([
       queryClient.ensureQueryData(
-        flightsQueryOptions({ limit: 50, siteId: search.siteId })
+        flightsQueryOptions({ limit: 50, siteId: deps.siteId })
       ),
       queryClient.ensureQueryData(sitesQueryOptions()),
     ]);


### PR DESCRIPTION
## Summary
- Disable pnpm global virtual store only inside the Docker frontend build step so Nx can resolve build-time dev dependencies like `typescript`.
- Disable Nx Cloud inside the production Docker build to avoid deployments failing when Nx Cloud is unavailable.
- Fix TypeScript errors surfaced by the production frontend build.

## Validation
- `git diff --check -- Dockerfile apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx apps/frontend/src/pages/Settings.tsx apps/frontend/src/routes/flights.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `docker build --target frontend-builder --build-arg VITE_CESIUM_ION_TOKEN=test -t dashboard-parapente-frontend-builder-test .`

## Notes
- The repo-level `enableGlobalVirtualStore: true` remains unchanged for local installs.
- Local `nx build frontend` still depends on the existing machine-local pnpm layout; the production Docker build path is validated.