### PR TITLE
fix(frontend): use flight path params on flights page

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -57,6 +57,7 @@ export function FlightDetails({
   const [editingNotes, setEditingNotes] = useState(false);
   const [notesText, setNotesText] = useState(flight.notes ?? '');
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
+  const [hasOpenedReplay, setHasOpenedReplay] = useState(false);
   const [isDownloadingGpx, setIsDownloadingGpx] = useState(false);
 
   const hasGpx = Boolean(flight.gpx_file_path);
@@ -74,6 +75,7 @@ export function FlightDetails({
 
   useEffect(() => {
     setActiveTab('infos');
+    setHasOpenedReplay(false);
     setEditingMode(false);
     setEditingNotes(false);
     setNotesText(flight.notes ?? '');
@@ -414,7 +416,13 @@ export function FlightDetails({
 
         <Tabs
           selectedKey={activeTab}
-          onSelectionChange={(key) => setActiveTab(key as FlightDetailsTab)}
+          onSelectionChange={(key) => {
+            const tab = key as FlightDetailsTab;
+            setActiveTab(tab);
+            if (tab === 'replay') {
+              setHasOpenedReplay(true);
+            }
+          }}
           className="space-y-4"
         >
           <TabList className="mb-4 grid-cols-2">
@@ -430,7 +438,7 @@ export function FlightDetails({
             {infoCard}
           </TabPanel>
           <TabPanel id="replay" className="outline-none">
-            {replayCard}
+            {hasOpenedReplay ? replayCard : null}
           </TabPanel>
         </Tabs>
       </div>

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -41,8 +41,13 @@ const flightsRouteConfig = {
       path: '/flights',
       element: 'story' as const,
       validateSearch: (search: Record<string, unknown>) => ({
-        flightId:
-          typeof search.flightId === 'string' ? search.flightId : undefined,
+        siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
+      }),
+    },
+    {
+      path: '/flights/$flightId',
+      element: 'story' as const,
+      validateSearch: (search: Record<string, unknown>) => ({
         siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
       }),
     },
@@ -326,6 +331,7 @@ MobileFlow.test(
         name: i18n.t('flights.listAriaLabel'),
       });
       await expect(flightList).toBeInTheDocument();
+      gpxRequestCount = 0;
     });
 
     await step('opens a flight in mobile detail mode', async () => {

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -4,7 +4,7 @@ import { flightsQueryOptions } from '../hooks/flights/useFlights';
 import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import type { Flight, Site } from '../types';
 import type { RowSelectionState } from '@tanstack/react-table';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { Input, TextField } from 'react-aria-components';
 import {
   CheckSquare,
@@ -32,15 +32,16 @@ import { useIsMobile } from '../hooks/useIsMobile';
 
 export default function FlightHistory() {
   const { t } = useTranslation();
-  const navigate = useNavigate({ from: '/flights' });
-  const search = useSearch({ from: '/flights' });
+  const navigate = useNavigate();
+  const params = useParams({ strict: false });
+  const search = useSearch({ strict: false }) as { siteId?: string };
   const { data: flights } = useSuspenseQuery(
     flightsQueryOptions({ limit: 50, siteId: search.siteId })
   );
 
   const isMobile = useIsMobile();
 
-  const selectedFlightId = search.flightId ?? null;
+  const selectedFlightId = params.flightId ?? null;
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [selectionMode, setSelectionMode] = useState(false);
   const [flightToDelete, setFlightToDelete] = useState<Flight | null>(null);
@@ -81,11 +82,18 @@ export default function FlightHistory() {
 
   const setSelectedFlightId = useCallback(
     (flightId: string | undefined) => {
+      if (flightId) {
+        void navigate({
+          to: '/flights/$flightId',
+          params: { flightId },
+          search: { siteId: search.siteId },
+        });
+        return;
+      }
+
       void navigate({
-        search: {
-          flightId,
-          siteId: search.siteId,
-        },
+        to: '/flights',
+        search: { siteId: search.siteId },
       });
     },
     [navigate, search.siteId]

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as ExportViewerRouteImport } from './routes/export-viewer'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ViewerFlightIdRouteImport } from './routes/viewer.$flightId'
+import { Route as FlightsFlightIdRouteImport } from './routes/flights.$flightId'
 
 const WeatherRoute = WeatherRouteImport.update({
   id: '/weather',
@@ -80,31 +81,40 @@ const ViewerFlightIdRoute = ViewerFlightIdRouteImport.update({
 } as any).lazy(() =>
   import('./routes/viewer.$flightId.lazy').then((d) => d.Route),
 )
+const FlightsFlightIdRoute = FlightsFlightIdRouteImport.update({
+  id: '/$flightId',
+  path: '/$flightId',
+  getParentRoute: () => FlightsRoute,
+} as any).lazy(() =>
+  import('./routes/flights.$flightId.lazy').then((d) => d.Route),
+)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
-  '/flights': typeof FlightsRoute
+  '/flights': typeof FlightsRouteWithChildren
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
+  '/flights/$flightId': typeof FlightsFlightIdRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
-  '/flights': typeof FlightsRoute
+  '/flights': typeof FlightsRouteWithChildren
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
+  '/flights/$flightId': typeof FlightsFlightIdRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRoutesById {
@@ -112,13 +122,14 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/analytics': typeof AnalyticsRoute
   '/export-viewer': typeof ExportViewerRoute
-  '/flights': typeof FlightsRoute
+  '/flights': typeof FlightsRouteWithChildren
   '/infrastructure': typeof InfrastructureRoute
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
+  '/flights/$flightId': typeof FlightsFlightIdRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRouteTypes {
@@ -134,6 +145,7 @@ export interface FileRouteTypes {
     | '/sites'
     | '/thermal'
     | '/weather'
+    | '/flights/$flightId'
     | '/viewer/$flightId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -147,6 +159,7 @@ export interface FileRouteTypes {
     | '/sites'
     | '/thermal'
     | '/weather'
+    | '/flights/$flightId'
     | '/viewer/$flightId'
   id:
     | '__root__'
@@ -160,6 +173,7 @@ export interface FileRouteTypes {
     | '/sites'
     | '/thermal'
     | '/weather'
+    | '/flights/$flightId'
     | '/viewer/$flightId'
   fileRoutesById: FileRoutesById
 }
@@ -167,7 +181,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AnalyticsRoute: typeof AnalyticsRoute
   ExportViewerRoute: typeof ExportViewerRoute
-  FlightsRoute: typeof FlightsRoute
+  FlightsRoute: typeof FlightsRouteWithChildren
   InfrastructureRoute: typeof InfrastructureRoute
   LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
@@ -256,14 +270,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ViewerFlightIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/flights/$flightId': {
+      id: '/flights/$flightId'
+      path: '/$flightId'
+      fullPath: '/flights/$flightId'
+      preLoaderRoute: typeof FlightsFlightIdRouteImport
+      parentRoute: typeof FlightsRoute
+    }
   }
 }
+
+interface FlightsRouteChildren {
+  FlightsFlightIdRoute: typeof FlightsFlightIdRoute
+}
+
+const FlightsRouteChildren: FlightsRouteChildren = {
+  FlightsFlightIdRoute: FlightsFlightIdRoute,
+}
+
+const FlightsRouteWithChildren =
+  FlightsRoute._addFileChildren(FlightsRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRoute,
   ExportViewerRoute: ExportViewerRoute,
-  FlightsRoute: FlightsRoute,
+  FlightsRoute: FlightsRouteWithChildren,
   InfrastructureRoute: InfrastructureRoute,
   LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,

--- a/apps/frontend/src/routes/flights.$flightId.lazy.tsx
+++ b/apps/frontend/src/routes/flights.$flightId.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import FlightHistory from '../pages/FlightHistory';
+
+export const Route = createLazyFileRoute('/flights/$flightId')({
+  component: FlightHistory,
+});

--- a/apps/frontend/src/routes/flights.$flightId.tsx
+++ b/apps/frontend/src/routes/flights.$flightId.tsx
@@ -8,7 +8,7 @@ type FlightsSearch = {
   siteId?: string;
 };
 
-export const Route = createFileRoute('/flights')({
+export const Route = createFileRoute('/flights/$flightId')({
   validateSearch: (search: Record<string, unknown>): FlightsSearch => ({
     siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
   }),


### PR DESCRIPTION
## Summary
- Move selected-flight navigation from `?flightId=` to `/flights/:flightId`.
- Keep `siteId` in the query string and preserve list/detail navigation.
- Avoid loading the Replay viewer before the replay tab is opened on mobile.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- src/pages/FlightHistory.stories.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` (fails in Storybook interaction tests; FlightHistory stories intermittently cannot find the flights grid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the replay viewer to load on-demand, improving responsiveness when navigating between flights.

* **Improvements**
  * Enhanced flight navigation and state management for a smoother user experience when viewing flight details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->