### PR TITLE
fix(settings): wire local preferences to app behavior

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5847,7 +5847,11 @@ def get_app_settings(db: Session = Depends(get_db)):
 
 
 @router.put("/settings")
-async def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db)):
+def update_app_settings(
+    settings: dict[str, str],
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     """
     Update application settings.
     Body: {"key": "value", ...}
@@ -5999,13 +6003,10 @@ async def update_app_settings(settings: dict[str, str], db: Session = Depends(ge
         "ui_reason_",
     )
     if any(key.startswith(cache_sensitive_prefixes) for key in updated):
-        try:
-            from cache import delete_cached
+        from cache import delete_cached
 
-            await delete_cached("weather:*")
-            await delete_cached("best_spot:*")
-        except Exception as e:
-            logger.warning(f"Failed to invalidate weather caches after settings update: {e}")
+        background_tasks.add_task(delete_cached, "weather:*")
+        background_tasks.add_task(delete_cached, "best_spot:*")
 
     # If scheduler interval changed, reschedule dynamically
     scheduler_error = None

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5847,7 +5847,7 @@ def get_app_settings(db: Session = Depends(get_db)):
 
 
 @router.put("/settings")
-def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db)):
+async def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db)):
     """
     Update application settings.
     Body: {"key": "value", ...}
@@ -5991,6 +5991,21 @@ def update_app_settings(settings: dict[str, str], db: Session = Depends(get_db))
     for key, normalized_value in validated_updates.items():
         set_setting(db, key, normalized_value)
         updated[key] = normalized_value
+
+    cache_sensitive_prefixes = (
+        "cache_ttl_",
+        "spotair_live_wind_",
+        "para_",
+        "ui_reason_",
+    )
+    if any(key.startswith(cache_sensitive_prefixes) for key in updated):
+        try:
+            from cache import delete_cached
+
+            await delete_cached("weather:*")
+            await delete_cached("best_spot:*")
+        except Exception as e:
+            logger.warning(f"Failed to invalidate weather caches after settings update: {e}")
 
     # If scheduler interval changed, reschedule dynamically
     scheduler_error = None

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -4,7 +4,7 @@ API tests for /settings endpoints.
 Tests HTTP endpoints for reading and updating application settings.
 """
 
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import AsyncMock, patch
 
 import app_settings
 from models import AppSetting
@@ -113,7 +113,9 @@ class TestUpdateSettings:
             )
 
         assert response.status_code == 200
-        delete_cached.assert_has_awaits([call("weather:*"), call("best_spot:*")])
+        delete_cached.assert_any_await("weather:*")
+        delete_cached.assert_any_await("best_spot:*")
+        assert delete_cached.await_count == 2
 
     def test_non_cache_sensitive_settings_do_not_clear_weather_cache(self, client, db_session):
         """Scheduler-only changes should not evict weather response caches."""

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -4,7 +4,7 @@ API tests for /settings endpoints.
 Tests HTTP endpoints for reading and updating application settings.
 """
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, call, patch
 
 import app_settings
 from models import AppSetting
@@ -103,6 +103,32 @@ class TestUpdateSettings:
         assert response.status_code == 200
         data = response.json()
         assert len(data["updated"]) == 2
+
+    def test_cache_sensitive_settings_invalidate_weather_cache(self, client, db_session):
+        """Settings that affect displayed weather clear cached weather responses."""
+        with patch("cache.delete_cached", new_callable=AsyncMock) as delete_cached:
+            response = client.put(
+                f"{API_PREFIX}/settings",
+                json={"para_gust_high_max": "26"},
+            )
+
+        assert response.status_code == 200
+        delete_cached.assert_has_awaits([call("weather:*"), call("best_spot:*")])
+
+    def test_non_cache_sensitive_settings_do_not_clear_weather_cache(self, client, db_session):
+        """Scheduler-only changes should not evict weather response caches."""
+        with (
+            patch("cache.delete_cached", new_callable=AsyncMock) as delete_cached,
+            patch("scheduler.reschedule"),
+            patch("emagram_scheduler.emagram_scheduler.reschedule"),
+        ):
+            response = client.put(
+                f"{API_PREFIX}/settings",
+                json={"scheduler_interval_minutes": "15"},
+            )
+
+        assert response.status_code == 200
+        delete_cached.assert_not_awaited()
 
     def test_update_emagram_max_age_minutes(self, client, db_session):
         """Updates emagram freshness window setting."""

--- a/apps/frontend/src/components/dashboard/SiteSelector.tsx
+++ b/apps/frontend/src/components/dashboard/SiteSelector.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { createWeatherQueryFn } from '../../hooks/weather/useWeather';
 import type { Site } from '../../types';
 import { Button } from '@dashboard-parapente/design-system';
+import { useAppSettingsStore } from '../../stores/appSettingsStore';
 
 interface SiteSelectorProps {
   selectedSiteId: string;
@@ -84,19 +85,31 @@ export default function SiteSelector({
 }: SiteSelectorProps) {
   const { t } = useTranslation();
   const { data: sites, isLoading, error } = useSites();
+  const favoriteSiteIds = useAppSettingsStore(
+    (state) => state.settings.favoriteSites
+  );
   const queryClient = useQueryClient();
   const searchInputId = useId();
   const [isMobileSelectorOpen, setIsMobileSelectorOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const filteredSites = useMemo(() => {
+  const visibleSites = useMemo(() => {
     const availableSites = sites ?? [];
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return availableSites;
+    if (favoriteSiteIds.length === 0) return availableSites;
 
-    return availableSites.filter((site) =>
+    const favoriteSet = new Set(favoriteSiteIds);
+    const matchedFavorites = availableSites.filter((site) =>
+      favoriteSet.has(site.id)
+    );
+    return matchedFavorites.length > 0 ? matchedFavorites : availableSites;
+  }, [favoriteSiteIds, sites]);
+  const filteredSites = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return visibleSites;
+
+    return visibleSites.filter((site) =>
       getSiteSearchText(site).includes(query)
     );
-  }, [searchQuery, sites]);
+  }, [searchQuery, visibleSites]);
 
   // Prefetch site weather on hover (instant navigation)
   const handleMouseEnter = (siteId: string) => {
@@ -132,7 +145,7 @@ export default function SiteSelector({
   }
 
   // Group sites by base name
-  const siteGroups = groupSitesByBaseName(sites);
+  const siteGroups = groupSitesByBaseName(visibleSites);
   const selectedSite = sites.find((site) => site.id === selectedSiteId);
 
   const handleMobileSelect = (siteId: string) => {

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -18,6 +18,12 @@ import { useToast } from '../../hooks/useToast';
 import { api } from '../../lib/api';
 import type { Flight, FlightFormData, Site } from '../../types';
 import { FlightEditForm } from './FlightEditForm';
+import {
+  formatAltitudeMeters,
+  formatDistanceKm,
+  formatSpeedKmh,
+  useAppSettingsStore,
+} from '../../stores/appSettingsStore';
 
 const FlightViewer3D = lazy(() =>
   import('./FlightViewer3D').then((m) => ({
@@ -49,6 +55,7 @@ export function FlightDetails({
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
   const toast = useToast();
+  const units = useAppSettingsStore((state) => state.settings.units);
   const updateFlight = useUpdateFlight(flight.id);
   const uploadGPXMutation = useUploadGPXToFlight(flight.id);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -285,7 +292,7 @@ export function FlightDetails({
               <span className={labelClass}>{t('flights.distanceLabel')}</span>
               <span className={valueClass}>
                 {flight.distance_km != null
-                  ? `${flight.distance_km.toFixed(2)} km`
+                  ? formatDistanceKm(flight.distance_km, units.distance)
                   : 'N/A'}
               </span>
             </div>
@@ -296,7 +303,7 @@ export function FlightDetails({
               </span>
               <span className={valueClass}>
                 {flight.max_altitude_m != null
-                  ? `${flight.max_altitude_m} m`
+                  ? formatAltitudeMeters(flight.max_altitude_m, units.altitude)
                   : 'N/A'}
               </span>
             </div>
@@ -307,7 +314,10 @@ export function FlightDetails({
               </span>
               <span className={valueClass}>
                 {flight.elevation_gain_m != null
-                  ? `${flight.elevation_gain_m} m`
+                  ? formatAltitudeMeters(
+                      flight.elevation_gain_m,
+                      units.altitude
+                    )
                   : 'N/A'}
               </span>
             </div>
@@ -316,7 +326,7 @@ export function FlightDetails({
               <span className={labelClass}>{t('flights.maxSpeedLabel')}</span>
               <span className={valueClass}>
                 {flight.max_speed_kmh != null
-                  ? `${flight.max_speed_kmh.toFixed(2)} km/h`
+                  ? formatSpeedKmh(flight.max_speed_kmh, units.speed)
                   : 'N/A'}
               </span>
             </div>

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { Entity } from 'cesium';
 import {
   BoundingSphere,
@@ -54,10 +60,9 @@ import {
 } from '@dashboard-parapente/shared-types';
 import {
   computeCursorTelemetryLabel,
-  DEFAULT_VIEWER_UNITS,
-  getViewerUnitsFromStorage,
   type ViewerUnits,
 } from './flightViewerTelemetry';
+import { useAppSettingsStore } from '../../stores/appSettingsStore';
 
 const isVideoExportInProgress = (status?: string | null) =>
   Boolean(status && VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status));
@@ -333,10 +338,13 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const [videoExportMode, setVideoExportMode] =
     useState<VideoExportMode>('manual_fast');
   const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
-  const [viewerUnits, setViewerUnits] = useState<ViewerUnits>(() =>
-    typeof window === 'undefined'
-      ? DEFAULT_VIEWER_UNITS
-      : getViewerUnitsFromStorage(window.localStorage)
+  const appUnits = useAppSettingsStore((state) => state.settings.units);
+  const viewerUnits: ViewerUnits = useMemo(
+    () => ({
+      altitude: appUnits.altitude,
+      speed: appUnits.speed,
+    }),
+    [appUnits.altitude, appUnits.speed]
   );
 
   // Terrain rendering states
@@ -589,31 +597,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       });
     }
   }, [exportStatus?.internal_status, flightId, queryClient]);
-
-  useEffect(() => {
-    const refreshUnits = () => {
-      const nextUnits = getViewerUnitsFromStorage(window.localStorage);
-      setViewerUnits((previousUnits) => {
-        if (
-          previousUnits.altitude === nextUnits.altitude &&
-          previousUnits.speed === nextUnits.speed
-        ) {
-          return previousUnits;
-        }
-
-        return nextUnits;
-      });
-    };
-
-    refreshUnits();
-    window.addEventListener('storage', refreshUnits);
-    window.addEventListener('focus', refreshUnits);
-
-    return () => {
-      window.removeEventListener('storage', refreshUnits);
-      window.removeEventListener('focus', refreshUnits);
-    };
-  }, []);
 
   useEffect(() => {
     viewerUnitsRef.current = viewerUnits;

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -14,6 +14,11 @@ import {
 } from 'lucide-react';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
 import type { Flight } from '../../types';
+import {
+  formatAltitudeMeters,
+  formatDistanceKm,
+  useAppSettingsStore,
+} from '../../stores/appSettingsStore';
 
 interface FlightsTableProps {
   flights: Flight[];
@@ -36,6 +41,7 @@ export function FlightsTable({
   onRowSelectionChange,
 }: FlightsTableProps) {
   const { t, i18n } = useTranslation();
+  const units = useAppSettingsStore((state) => state.settings.units);
   const { table } = useFlightsTable({
     data: flights,
     selectionMode,
@@ -208,13 +214,17 @@ export function FlightsTable({
             {flight.distance_km && (
               <div className="flex items-center gap-1">
                 <Ruler className="h-3.5 w-3.5" aria-hidden="true" />
-                <span>{flight.distance_km.toFixed(1)} km</span>
+                <span>
+                  {formatDistanceKm(flight.distance_km, units.distance)}
+                </span>
               </div>
             )}
             {flight.max_altitude_m && (
               <div className="flex items-center gap-1">
                 <Mountain className="h-3.5 w-3.5" aria-hidden="true" />
-                <span>{flight.max_altitude_m} m</span>
+                <span>
+                  {formatAltitudeMeters(flight.max_altitude_m, units.altitude)}
+                </span>
               </div>
             )}
           </div>
@@ -231,7 +241,15 @@ export function FlightsTable({
         </div>
       );
     },
-    [selectionMode, selectedFlightId, onSelectFlight, onDeleteFlight, t, i18n]
+    [
+      selectionMode,
+      selectedFlightId,
+      onSelectFlight,
+      onDeleteFlight,
+      t,
+      i18n,
+      units,
+    ]
   );
 
   return (

--- a/apps/frontend/src/hooks/settings/useAppSettings.ts
+++ b/apps/frontend/src/hooks/settings/useAppSettings.ts
@@ -51,6 +51,10 @@ export function useUpdateAppSettings() {
       api.put('settings', { json: settings }).json(),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['app-settings'] });
+      void queryClient.invalidateQueries({ queryKey: ['weather'] });
+      void queryClient.invalidateQueries({ queryKey: ['bestSpot'] });
+      void queryClient.invalidateQueries({ queryKey: ['live-wind'] });
+      void queryClient.invalidateQueries({ queryKey: ['landings-weather'] });
     },
   });
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -222,6 +222,9 @@
   "settings": {
     "title": "Settings",
     "subtitle": "Configure your paragliding dashboard",
+    "description": "Preferences are applied immediately to the relevant pages and kept in this browser.",
+    "autoSave": "Auto-save",
+    "saved": "Applied",
     "tabs": {
       "general": "General",
       "favoriteSites": "Favorite Sites",
@@ -230,6 +233,7 @@
     },
     "units": {
       "title": "Units of Measurement",
+      "description": "Set the display used in flights, flight details and the 3D viewer.",
       "distance": "Distance",
       "kilometers": "Kilometers (km)",
       "miles": "Miles (mi)",
@@ -240,6 +244,7 @@
     },
     "languageTheme": {
       "title": "Language & Theme",
+      "description": "Adapt the interface to your language and display preference.",
       "language": "Language",
       "theme": "Theme",
       "light": "Light",
@@ -248,12 +253,17 @@
     },
     "notifications": {
       "title": "Notifications",
+      "description": "Stored preferences for future notifications. No external delivery is triggered here.",
       "weatherAlerts": "Weather alerts",
+      "weatherAlertsHelp": "Prepares alerts tied to weather conditions.",
       "newFlights": "New flights",
-      "customAlerts": "Custom alerts"
+      "newFlightsHelp": "Prepares notifications when new flights are imported.",
+      "customAlerts": "Custom alerts",
+      "customAlertsHelp": "Keeps your choice for future custom scenarios."
     },
     "favorites": {
       "title": "Manage your Favorite Sites",
+      "description": "{{count}} favorite site(s) used first in weather and selectors.",
       "noSites": "No sites available",
       "favorite": "Favorite",
       "add": "Add",
@@ -327,10 +337,12 @@
     },
     "data": {
       "backupTitle": "Backup & Restore",
+      "backupDescription": "Export or restore your local preferences and browser cache settings.",
       "export": "Export my settings",
       "import": "Import settings",
       "importWarning": "Importing will replace your current settings",
       "resetTitle": "Reset",
+      "resetDescription": "Return local preferences and browser cache to their default values.",
       "resetAll": "Reset all settings",
       "resetWarning": "This action is irreversible (unless you have exported a backup)",
       "importSuccess": "Settings imported successfully!",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -222,6 +222,9 @@
   "settings": {
     "title": "Paramètres",
     "subtitle": "Configuration de votre dashboard parapente",
+    "description": "Les préférences sont appliquées immédiatement aux pages concernées et conservées dans ce navigateur.",
+    "autoSave": "Auto-save",
+    "saved": "Appliqué",
     "tabs": {
       "general": "Général",
       "favoriteSites": "Sites Favoris",
@@ -230,6 +233,7 @@
     },
     "units": {
       "title": "Unités de Mesure",
+      "description": "Définissez l'affichage utilisé dans les vols, le détail et le viewer 3D.",
       "distance": "Distance",
       "kilometers": "Kilomètres (km)",
       "miles": "Miles (mi)",
@@ -240,6 +244,7 @@
     },
     "languageTheme": {
       "title": "Langue & Thème",
+      "description": "Adaptez l'interface à votre langue et à votre préférence d'affichage.",
       "language": "Langue",
       "theme": "Thème",
       "light": "Clair",
@@ -248,12 +253,17 @@
     },
     "notifications": {
       "title": "Notifications",
+      "description": "Préférences stockées pour les futures notifications. Aucun envoi externe n'est déclenché ici.",
       "weatherAlerts": "Alertes météo",
+      "weatherAlertsHelp": "Prépare les alertes liées aux conditions météo.",
       "newFlights": "Nouveaux vols",
-      "customAlerts": "Alertes personnalisées"
+      "newFlightsHelp": "Prépare les notifications lors de nouveaux vols importés.",
+      "customAlerts": "Alertes personnalisées",
+      "customAlertsHelp": "Conserve votre choix pour de futurs scénarios personnalisés."
     },
     "favorites": {
       "title": "Gérer vos Sites Favoris",
+      "description": "{{count}} site(s) favori(s) utilisés en priorité dans la météo et les sélecteurs.",
       "noSites": "Aucun site disponible",
       "favorite": "Favori",
       "add": "Ajouter",
@@ -327,10 +337,12 @@
     },
     "data": {
       "backupTitle": "Sauvegarde & Restauration",
+      "backupDescription": "Exportez ou restaurez vos préférences locales et vos réglages de cache navigateur.",
       "export": "Exporter mes paramètres",
       "import": "Importer des paramètres",
       "importWarning": "L'import remplacera vos paramètres actuels",
       "resetTitle": "Réinitialisation",
+      "resetDescription": "Revenez aux valeurs par défaut pour les préférences locales et le cache navigateur.",
       "resetAll": "Réinitialiser tous les paramètres",
       "resetWarning": "Cette action est irréversible (sauf si vous avez exporté une sauvegarde)",
       "importSuccess": "Paramètres importés avec succès !",

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -384,6 +384,8 @@ export const MobileFlowWithReplay = meta.story({
 MobileFlowWithReplay.test(
   'loads GPX data only when Replay tab is selected',
   async ({ canvas, userEvent, step }) => {
+    let requestsAfterOpeningFlight = 0;
+
     await step('has the flight list', async () => {
       const flightList = await canvas.findByRole('listbox', {
         name: i18n.t('flights.listAriaLabel'),
@@ -398,11 +400,11 @@ MobileFlowWithReplay.test(
           name: i18n.t('flights.backToList'),
         })
       ).toBeInTheDocument();
-      gpxRequestCount = 0;
+      requestsAfterOpeningFlight = gpxRequestCount;
     });
 
     await step('does not load GPX while Infos tab is active', () => {
-      expect(gpxRequestCount).toBe(0);
+      expect(gpxRequestCount).toBe(requestsAfterOpeningFlight);
     });
 
     await step('switches to Replay and shows loading state', async () => {
@@ -417,7 +419,7 @@ MobileFlowWithReplay.test(
 
     await step('triggers GPX loading once Replay is active', async () => {
       await waitFor(() => {
-        expect(gpxRequestCount).toBeGreaterThan(0);
+        expect(gpxRequestCount).toBeGreaterThan(requestsAfterOpeningFlight);
       });
     });
   }

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -228,15 +228,15 @@ export const Default = meta.story({
 Default.test(
   'Can cancel a simple flight deletion',
   async ({ canvas, userEvent, step }) => {
-    const flightList = await canvas.findByRole('grid', {
+    const flightList = await canvas.findByRole('listbox', {
       name: i18n.t('flights.listAriaLabel'),
     });
 
     await step('have flights', async () => {
       await waitFor(async () => {
-        await expect(within(flightList).getAllByRole('row')).toHaveLength(
-          mockFlights.length
-        );
+        await expect(
+          within(flightList).getAllByTestId(/^flight-row-/)
+        ).toHaveLength(mockFlights.length);
       });
     });
 
@@ -262,24 +262,24 @@ Default.test(
 
     await step('the flight is not deleted', async () => {
       await expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
-      await expect(within(flightList).getAllByRole('row')).toHaveLength(
-        mockFlights.length
-      );
+      await expect(
+        within(flightList).getAllByTestId(/^flight-row-/)
+      ).toHaveLength(mockFlights.length);
     });
   }
 );
 Default.test(
   'can delete a simple flight',
   async ({ canvas, userEvent, step }) => {
-    const flightList = await canvas.findByRole('grid', {
+    const flightList = await canvas.findByRole('listbox', {
       name: i18n.t('flights.listAriaLabel'),
     });
 
     await step('have flights', async () => {
       await waitFor(async () => {
-        await expect(within(flightList).getAllByRole('row')).toHaveLength(
-          mockFlights.length
-        );
+        await expect(
+          within(flightList).getAllByTestId(/^flight-row-/)
+        ).toHaveLength(mockFlights.length);
       });
     });
 
@@ -307,9 +307,9 @@ Default.test(
       await waitFor(async () => {
         await expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
 
-        await expect(within(flightList).getAllByRole('row')).toHaveLength(
-          mockFlights.length - 1
-        );
+        await expect(
+          within(flightList).getAllByTestId(/^flight-row-/)
+        ).toHaveLength(mockFlights.length - 1);
       });
     });
   }
@@ -327,7 +327,7 @@ MobileFlow.test(
   'opens a flight, switches tabs, and returns to list on mobile',
   async ({ canvas, userEvent, step }) => {
     await step('has the flight list', async () => {
-      const flightList = await canvas.findByRole('grid', {
+      const flightList = await canvas.findByRole('listbox', {
         name: i18n.t('flights.listAriaLabel'),
       });
       await expect(flightList).toBeInTheDocument();
@@ -357,7 +357,7 @@ MobileFlow.test(
         canvas.getByRole('button', { name: i18n.t('flights.backToList') })
       );
       await expect(
-        await canvas.findByRole('grid', {
+        await canvas.findByRole('listbox', {
           name: i18n.t('flights.listAriaLabel'),
         })
       ).toBeInTheDocument();
@@ -385,7 +385,7 @@ MobileFlowWithReplay.test(
   'loads GPX data only when Replay tab is selected',
   async ({ canvas, userEvent, step }) => {
     await step('has the flight list', async () => {
-      const flightList = await canvas.findByRole('grid', {
+      const flightList = await canvas.findByRole('listbox', {
         name: i18n.t('flights.listAriaLabel'),
       });
       await expect(flightList).toBeInTheDocument();

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -398,6 +398,7 @@ MobileFlowWithReplay.test(
           name: i18n.t('flights.backToList'),
         })
       ).toBeInTheDocument();
+      gpxRequestCount = 0;
     });
 
     await step('does not load GPX while Infos tab is active', () => {

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -985,29 +985,16 @@ export default function Settings() {
   const settings = useAppSettingsStore((state) => state.settings);
   const setSettings = useAppSettingsStore((state) => state.setSettings);
   const resetSettings = useAppSettingsStore((state) => state.resetSettings);
-  const [saved, setSaved] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTabKey>('general');
 
   useEffect(() => {
     void i18n.changeLanguage(settings.language);
   }, [i18n, settings.language]);
 
-  const showSaved = () => {
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
-
   const updateSettings = (
     updater: AppSettings | ((current: AppSettings) => AppSettings)
   ) => {
     setSettings(updater);
-    showSaved();
-  };
-
-  // Kept as a confirmation affordance now that settings are applied immediately.
-  const saveSettings = (nextSettings = settings) => {
-    setSettings(nextSettings);
-    showSaved();
   };
 
   // Toggle favorite site
@@ -1054,7 +1041,7 @@ export default function Settings() {
       try {
         const imported = JSON.parse(e.target?.result as string);
         if (imported.settings) {
-          saveSettings(imported.settings as AppSettings);
+          updateSettings(imported.settings as AppSettings);
         }
         if (imported.cacheSettings) {
           const { setFreshnessLevel, setAutoRefreshWeather, setHttpTimeout } =
@@ -1528,20 +1515,6 @@ export default function Settings() {
           </TabPanel>
         </div>
       </Tabs>
-
-      {/* Save Button */}
-      <div className="mt-6 sticky bottom-4 z-10">
-        <Button
-          onClick={() => saveSettings()}
-          className={`w-full px-6 py-4 rounded-xl font-bold text-lg shadow-lg transition-all ${
-            saved
-              ? 'bg-green-600 text-white'
-              : 'bg-sky-600 text-white hover:bg-sky-700 hover:shadow-xl'
-          }`}
-        >
-          {saved ? t('settings.saved') : t('settings.saveButton')}
-        </Button>
-      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -17,6 +17,11 @@ import {
 } from '../hooks/weather/useWeatherSources';
 import { WeatherSourceCard } from '../components/settings/WeatherSourceCard';
 import type { WeatherSource } from '../types/weatherSources';
+import {
+  DEFAULT_APP_SETTINGS,
+  useAppSettingsStore,
+  type AppSettings,
+} from '../stores/appSettingsStore';
 import { useThemeStore } from '../stores/themeStore';
 import type { ThemePreference } from '../stores/themeStore';
 import { useCacheSettingsStore } from '../stores/cacheSettingsStore';
@@ -40,23 +45,6 @@ interface ApiSite {
   is_active?: boolean;
   created_at?: string;
   updated_at?: string;
-}
-
-// Default settings structure
-interface AppSettings {
-  units: {
-    distance: 'km' | 'miles';
-    altitude: 'm' | 'ft';
-    speed: 'kmh' | 'mph';
-  };
-  language: 'fr' | 'en';
-  theme: 'light' | 'dark' | 'auto';
-  notifications: {
-    weather: boolean;
-    flights: boolean;
-    alerts: boolean;
-  };
-  favoriteSites: string[];
 }
 
 type SettingsTabKey = 'general' | 'sites' | 'weather' | 'data';
@@ -127,22 +115,6 @@ function SectionTitle({
     </h2>
   );
 }
-
-const DEFAULT_SETTINGS: AppSettings = {
-  units: {
-    distance: 'km',
-    altitude: 'm',
-    speed: 'kmh',
-  },
-  language: 'fr',
-  theme: 'light',
-  notifications: {
-    weather: true,
-    flights: true,
-    alerts: true,
-  },
-  favoriteSites: [],
-};
 
 // Sites Favorites Tab Component
 function SitesTab({
@@ -1010,17 +982,9 @@ export default function Settings() {
   const { t, i18n } = useTranslation();
   const { preference: themePreference, setPreference: setThemePreference } =
     useThemeStore();
-  const [settings, setSettings] = useState<AppSettings>(() => {
-    const stored = localStorage.getItem('paragliding-settings');
-    if (stored) {
-      try {
-        return JSON.parse(stored) as AppSettings;
-      } catch {
-        // Invalid JSON in localStorage, keep defaults
-      }
-    }
-    return DEFAULT_SETTINGS;
-  });
+  const settings = useAppSettingsStore((state) => state.settings);
+  const setSettings = useAppSettingsStore((state) => state.setSettings);
+  const resetSettings = useAppSettingsStore((state) => state.resetSettings);
   const [saved, setSaved] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTabKey>('general');
 
@@ -1028,16 +992,27 @@ export default function Settings() {
     void i18n.changeLanguage(settings.language);
   }, [i18n, settings.language]);
 
-  // Save settings to localStorage
-  const saveSettings = (nextSettings = settings) => {
-    localStorage.setItem('paragliding-settings', JSON.stringify(nextSettings));
+  const showSaved = () => {
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   };
 
+  const updateSettings = (
+    updater: AppSettings | ((current: AppSettings) => AppSettings)
+  ) => {
+    setSettings(updater);
+    showSaved();
+  };
+
+  // Kept as a confirmation affordance now that settings are applied immediately.
+  const saveSettings = (nextSettings = settings) => {
+    setSettings(nextSettings);
+    showSaved();
+  };
+
   // Toggle favorite site
   const toggleFavorite = (siteId: string) => {
-    setSettings((prev) => ({
+    updateSettings((prev) => ({
       ...prev,
       favoriteSites: prev.favoriteSites.includes(siteId)
         ? prev.favoriteSites.filter((id) => id !== siteId)
@@ -1079,7 +1054,6 @@ export default function Settings() {
       try {
         const imported = JSON.parse(e.target?.result as string);
         if (imported.settings) {
-          setSettings(imported.settings);
           saveSettings(imported.settings as AppSettings);
         }
         if (imported.cacheSettings) {
@@ -1122,14 +1096,14 @@ export default function Settings() {
   // Clear all data
   const clearData = () => {
     if (window.confirm(t('settings.data.resetConfirm'))) {
-      setSettings(DEFAULT_SETTINGS);
-      localStorage.removeItem('paragliding-settings');
+      resetSettings();
       // Reset cache settings to defaults
       const { setFreshnessLevel, setAutoRefreshWeather, setHttpTimeout } =
         useCacheSettingsStore.getState();
       setFreshnessLevel('normal');
       setAutoRefreshWeather(true);
       setHttpTimeout(30000);
+      setThemePreference(DEFAULT_APP_SETTINGS.theme);
       alert(t('settings.data.resetSuccess'));
     }
   };
@@ -1200,7 +1174,7 @@ export default function Settings() {
                   <div className="flex flex-wrap gap-2 sm:gap-4">
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, distance: 'km' },
                         }))
@@ -1216,7 +1190,7 @@ export default function Settings() {
                     </Button>
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, distance: 'miles' },
                         }))
@@ -1240,7 +1214,7 @@ export default function Settings() {
                   <div className="flex flex-wrap gap-2 sm:gap-4">
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, altitude: 'm' },
                         }))
@@ -1256,7 +1230,7 @@ export default function Settings() {
                     </Button>
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, altitude: 'ft' },
                         }))
@@ -1280,7 +1254,7 @@ export default function Settings() {
                   <div className="flex flex-wrap gap-2 sm:gap-4">
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, speed: 'kmh' },
                         }))
@@ -1296,7 +1270,7 @@ export default function Settings() {
                     </Button>
                     <Button
                       onClick={() =>
-                        setSettings((prev) => ({
+                        updateSettings((prev) => ({
                           ...prev,
                           units: { ...prev.units, speed: 'mph' },
                         }))
@@ -1328,7 +1302,7 @@ export default function Settings() {
                   <div className="flex flex-wrap gap-2 sm:gap-4">
                     <Button
                       onClick={() => {
-                        setSettings((prev) => ({ ...prev, language: 'fr' }));
+                        updateSettings((prev) => ({ ...prev, language: 'fr' }));
                       }}
                       aria-pressed={settings.language === 'fr'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
@@ -1341,7 +1315,7 @@ export default function Settings() {
                     </Button>
                     <Button
                       onClick={() => {
-                        setSettings((prev) => ({ ...prev, language: 'en' }));
+                        updateSettings((prev) => ({ ...prev, language: 'en' }));
                       }}
                       aria-pressed={settings.language === 'en'}
                       className={`px-6 py-2 rounded-lg font-medium transition-all ${
@@ -1365,7 +1339,7 @@ export default function Settings() {
                         key={theme}
                         onClick={() => {
                           setThemePreference(theme as ThemePreference);
-                          setSettings((prev) => ({ ...prev, theme }));
+                          updateSettings((prev) => ({ ...prev, theme }));
                         }}
                         aria-pressed={themePreference === theme}
                         className={`px-6 py-2 rounded-lg font-medium transition-all ${
@@ -1395,7 +1369,7 @@ export default function Settings() {
                   <Switch
                     isSelected={settings.notifications.weather}
                     onChange={(isSelected: boolean) =>
-                      setSettings((prev) => ({
+                      updateSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,
@@ -1419,7 +1393,7 @@ export default function Settings() {
                   <Switch
                     isSelected={settings.notifications.flights}
                     onChange={(isSelected: boolean) =>
-                      setSettings((prev) => ({
+                      updateSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,
@@ -1443,7 +1417,7 @@ export default function Settings() {
                   <Switch
                     isSelected={settings.notifications.alerts}
                     onChange={(isSelected: boolean) =>
-                      setSettings((prev) => ({
+                      updateSettings((prev) => ({
                         ...prev,
                         notifications: {
                           ...prev.notifications,

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -51,6 +51,7 @@ type SettingsTabKey = 'general' | 'sites' | 'weather' | 'data';
 
 type SettingsIconName =
   | 'bell'
+  | 'check'
   | 'database'
   | 'globe'
   | 'mapPin'
@@ -64,6 +65,7 @@ function SettingsIcon({ name }: { name: SettingsIconName }) {
     bell: (
       <path d="M15 17h5l-1.4-1.4A2 2 0 0 1 18 14.2V11a6 6 0 0 0-5-5.9V4a1 1 0 1 0-2 0v1.1A6 6 0 0 0 6 11v3.2c0 .5-.2 1-.6 1.4L4 17h5m6 0a3 3 0 0 1-6 0" />
     ),
+    check: <path d="m5 12 4 4L19 6" />,
     database: (
       <path d="M4 6c0-1.7 3.6-3 8-3s8 1.3 8 3-3.6 3-8 3-8-1.3-8-3Zm0 0v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
     ),
@@ -101,18 +103,53 @@ function SettingsIcon({ name }: { name: SettingsIconName }) {
   );
 }
 
-function SectionTitle({
+function SettingsCard({
   icon,
+  title,
+  description,
   children,
 }: {
   icon: SettingsIconName;
+  title: React.ReactNode;
+  description?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
-    <h2 className="mb-4 flex items-center gap-2 text-lg font-bold text-gray-900 dark:text-white">
-      <SettingsIcon name={icon} />
+    <section className="rounded-2xl border border-sky-100 bg-white p-5 shadow-md shadow-sky-100/50 dark:border-gray-700 dark:bg-gray-800 dark:shadow-black/20 sm:p-6">
+      <div className="mb-5 flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
+          <SettingsIcon name={icon} />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-lg font-bold text-gray-950 dark:text-white">
+            {title}
+          </h2>
+          {description && (
+            <p className="mt-1 text-sm leading-5 text-gray-600 dark:text-gray-300">
+              {description}
+            </p>
+          )}
+        </div>
+      </div>
       {children}
-    </h2>
+    </section>
+  );
+}
+
+function SavedStatus({ isVisible }: { isVisible: boolean }) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-bold transition-opacity duration-200 ${
+        isVisible
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700 opacity-100 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-300'
+          : 'border-sky-200 bg-white/80 text-sky-700 opacity-70 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-300'
+      }`}
+    >
+      <SettingsIcon name={isVisible ? 'check' : 'settings'} />
+      <span>{isVisible ? t('settings.saved') : t('settings.autoSave')}</span>
+    </div>
   );
 }
 
@@ -126,10 +163,16 @@ function SitesTab({
 }) {
   const { t } = useTranslation();
   const { data: sites } = useSuspenseQuery(sitesQueryOptions());
+  const favoriteCount = settings.favoriteSites.length;
 
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-      <SectionTitle icon="mapPin">{t('settings.favorites.title')}</SectionTitle>
+    <SettingsCard
+      icon="mapPin"
+      title={t('settings.favorites.title')}
+      description={t('settings.favorites.description', {
+        count: favoriteCount,
+      })}
+    >
       {sites.length === 0 ? (
         <p className="text-gray-600 dark:text-gray-300 text-center py-8">
           {t('settings.favorites.noSites')}
@@ -139,10 +182,10 @@ function SitesTab({
           {(sites as unknown as ApiSite[]).map((site: ApiSite) => (
             <div
               key={site.id}
-              className={`flex items-center justify-between p-4 rounded-lg border-2 transition-all ${
+              className={`flex flex-col gap-3 rounded-xl border p-4 transition-colors sm:flex-row sm:items-center sm:justify-between ${
                 settings.favoriteSites.includes(site.id)
-                  ? 'border-sky-600 bg-sky-50 dark:bg-sky-900/20'
-                  : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:border-gray-300 dark:hover:border-gray-600'
+                  ? 'border-sky-300 bg-sky-50 dark:border-sky-700 dark:bg-sky-900/20'
+                  : 'border-gray-200 bg-gray-50 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600'
               }`}
             >
               <div className="flex-1">
@@ -164,7 +207,7 @@ function SitesTab({
               <Button
                 onClick={() => toggleFavorite(site.id)}
                 aria-pressed={settings.favoriteSites.includes(site.id)}
-                className={`ml-4 px-4 py-2 rounded-lg font-medium transition-all ${
+                className={`px-4 py-2 rounded-lg font-medium transition-colors sm:ml-4 ${
                   settings.favoriteSites.includes(site.id)
                     ? 'bg-sky-600 text-white hover:bg-sky-700'
                     : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
@@ -178,11 +221,11 @@ function SitesTab({
           ))}
         </div>
       )}
-      <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg text-sm text-blue-800 dark:text-blue-200">
+      <div className="mt-4 rounded-xl border border-sky-100 bg-sky-50 p-3 text-sm text-sky-800 dark:border-sky-800 dark:bg-sky-900/20 dark:text-sky-200">
         <strong>{t('settings.favorites.tip')}</strong>{' '}
         {t('settings.favorites.tipText')}
       </div>
-    </div>
+    </SettingsCard>
   );
 }
 
@@ -985,16 +1028,23 @@ export default function Settings() {
   const settings = useAppSettingsStore((state) => state.settings);
   const setSettings = useAppSettingsStore((state) => state.setSettings);
   const resetSettings = useAppSettingsStore((state) => state.resetSettings);
+  const [saved, setSaved] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTabKey>('general');
 
   useEffect(() => {
     void i18n.changeLanguage(settings.language);
   }, [i18n, settings.language]);
 
+  const showSaved = () => {
+    setSaved(true);
+    window.setTimeout(() => setSaved(false), 1800);
+  };
+
   const updateSettings = (
     updater: AppSettings | ((current: AppSettings) => AppSettings)
   ) => {
     setSettings(updater);
+    showSaved();
   };
 
   // Toggle favorite site
@@ -1096,16 +1146,24 @@ export default function Settings() {
   };
 
   return (
-    <div className="pb-24">
-      <div className="mb-4 bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
-        <h1 className="flex items-center gap-2 text-xl font-bold text-gray-900 dark:text-white">
-          <SettingsIcon name="settings" />
-          {t('settings.title')}
-        </h1>
-        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
-          {t('settings.subtitle')}
-        </p>
-      </div>
+    <div className="space-y-4 pb-8">
+      <section className="overflow-hidden rounded-3xl border border-sky-100 bg-gradient-to-br from-white via-sky-50/70 to-blue-50 p-5 shadow-lg shadow-sky-100/70 dark:border-slate-700/80 dark:from-slate-950 dark:via-slate-900 dark:to-sky-950/50 dark:shadow-black/30 sm:p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700 shadow-sm dark:border-sky-800/80 dark:bg-sky-950/50 dark:text-sky-300">
+              <SettingsIcon name="settings" />
+              {t('settings.title')}
+            </div>
+            <h1 className="text-2xl font-black tracking-tight text-slate-950 dark:text-white sm:text-3xl">
+              {t('settings.subtitle')}
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {t('settings.description')}
+            </p>
+          </div>
+          <SavedStatus isVisible={saved} />
+        </div>
+      </section>
 
       <Tabs
         selectedKey={activeTab}
@@ -1149,10 +1207,11 @@ export default function Settings() {
           {/* GENERAL TAB */}
           <TabPanel id="general" className="space-y-4 outline-none">
             {/* Units Section */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <SectionTitle icon="ruler">
-                {t('settings.units.title')}
-              </SectionTitle>
+            <SettingsCard
+              icon="ruler"
+              title={t('settings.units.title')}
+              description={t('settings.units.description')}
+            >
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -1274,13 +1333,14 @@ export default function Settings() {
                   </div>
                 </div>
               </div>
-            </div>
+            </SettingsCard>
 
             {/* Language & Theme Section */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <SectionTitle icon="globe">
-                {t('settings.languageTheme.title')}
-              </SectionTitle>
+            <SettingsCard
+              icon="globe"
+              title={t('settings.languageTheme.title')}
+              description={t('settings.languageTheme.description')}
+            >
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -1341,19 +1401,26 @@ export default function Settings() {
                   </div>
                 </div>
               </div>
-            </div>
+            </SettingsCard>
 
             {/* Notifications Section */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-              <SectionTitle icon="bell">
-                {t('settings.notifications.title')}
-              </SectionTitle>
+            <SettingsCard
+              icon="bell"
+              title={t('settings.notifications.title')}
+              description={t('settings.notifications.description')}
+            >
               <div className="space-y-3">
-                <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    {t('settings.notifications.weatherAlerts')}
+                <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {t('settings.notifications.weatherAlerts')}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                      {t('settings.notifications.weatherAlertsHelp')}
+                    </span>
                   </span>
                   <Switch
+                    aria-label={t('settings.notifications.weatherAlerts')}
                     isSelected={settings.notifications.weather}
                     onChange={(isSelected: boolean) =>
                       updateSettings((prev) => ({
@@ -1372,12 +1439,18 @@ export default function Settings() {
                       </div>
                     </div>
                   </Switch>
-                </label>
-                <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    {t('settings.notifications.newFlights')}
+                </div>
+                <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {t('settings.notifications.newFlights')}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                      {t('settings.notifications.newFlightsHelp')}
+                    </span>
                   </span>
                   <Switch
+                    aria-label={t('settings.notifications.newFlights')}
                     isSelected={settings.notifications.flights}
                     onChange={(isSelected: boolean) =>
                       updateSettings((prev) => ({
@@ -1396,12 +1469,18 @@ export default function Settings() {
                       </div>
                     </div>
                   </Switch>
-                </label>
-                <label className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all cursor-pointer">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    {t('settings.notifications.customAlerts')}
+                </div>
+                <div className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                  <span>
+                    <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {t('settings.notifications.customAlerts')}
+                    </span>
+                    <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+                      {t('settings.notifications.customAlertsHelp')}
+                    </span>
                   </span>
                   <Switch
+                    aria-label={t('settings.notifications.customAlerts')}
                     isSelected={settings.notifications.alerts}
                     onChange={(isSelected: boolean) =>
                       updateSettings((prev) => ({
@@ -1420,9 +1499,9 @@ export default function Settings() {
                       </div>
                     </div>
                   </Switch>
-                </label>
+                </div>
               </div>
-            </div>
+            </SettingsCard>
 
             {/* Performance Section */}
             <PerformanceSection />
@@ -1455,10 +1534,11 @@ export default function Settings() {
           <TabPanel id="data" className="outline-none">
             <div className="space-y-4">
               {/* Export/Import Section */}
-              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-                <SectionTitle icon="database">
-                  {t('settings.data.backupTitle')}
-                </SectionTitle>
+              <SettingsCard
+                icon="database"
+                title={t('settings.data.backupTitle')}
+                description={t('settings.data.backupDescription')}
+              >
                 <div className="space-y-3">
                   <Button
                     onClick={exportData}
@@ -1479,13 +1559,14 @@ export default function Settings() {
                 <div className="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 rounded-lg text-sm text-yellow-800 dark:text-yellow-200">
                   {t('settings.data.importWarning')}
                 </div>
-              </div>
+              </SettingsCard>
 
               {/* Clear Data Section */}
-              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                  {t('settings.data.resetTitle')}
-                </h2>
+              <SettingsCard
+                icon="settings"
+                title={t('settings.data.resetTitle')}
+                description={t('settings.data.resetDescription')}
+              >
                 <Button
                   onClick={clearData}
                   className="w-full px-6 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-all"
@@ -1495,13 +1576,10 @@ export default function Settings() {
                 <div className="mt-4 p-3 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-800 dark:text-red-200">
                   {t('settings.data.resetWarning')}
                 </div>
-              </div>
+              </SettingsCard>
 
               {/* User Profile Placeholder */}
-              <div className="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md">
-                <h2 className="text-lg font-bold text-gray-900 dark:text-white mb-4">
-                  {t('settings.profile.title')}
-                </h2>
+              <SettingsCard icon="bell" title={t('settings.profile.title')}>
                 <div className="p-8 bg-gray-50 dark:bg-gray-900 rounded-lg text-center">
                   <p className="text-gray-600 dark:text-gray-300 mb-2">
                     {t('settings.profile.wip')}
@@ -1510,7 +1588,7 @@ export default function Settings() {
                     {t('settings.profile.wipDetails')}
                   </p>
                 </div>
-              </div>
+              </SettingsCard>
             </div>
           </TabPanel>
         </div>

--- a/apps/frontend/src/pages/Sites.stories.tsx
+++ b/apps/frontend/src/pages/Sites.stories.tsx
@@ -116,26 +116,28 @@ export const Default = meta.story({
 
 Default.test('filters by landing type', async ({ canvas, userEvent }) => {
   await waitForElementToBeRemoved(canvas.getByText(/Loading.*/i));
-  await expect(canvas.getAllByRole('row')).toHaveLength(3);
+  const siteList = canvas.getByRole('listbox', { name: 'Liste des sites' });
+  await expect(within(siteList).getAllByRole('option')).toHaveLength(3);
 
   const typeSelect = await canvas.findByDisplayValue('Tous les types');
   await userEvent.selectOptions(typeSelect, 'landing');
 
-  await expect(canvas.getAllByRole('row')).toHaveLength(1);
+  await expect(within(siteList).getAllByRole('option')).toHaveLength(1);
   await expect(
-    within(canvas.getByRole('row')).getByRole('heading')
+    within(within(siteList).getByRole('option')).getByRole('heading')
   ).toHaveTextContent("Plaine d'Arguel");
 });
 Default.test('filters by name', async ({ canvas, userEvent }) => {
   await waitForElementToBeRemoved(canvas.getByText(/Loading.*/i));
-  await expect(canvas.getAllByRole('row')).toHaveLength(3);
+  const siteList = canvas.getByRole('listbox', { name: 'Liste des sites' });
+  await expect(within(siteList).getAllByRole('option')).toHaveLength(3);
   await userEvent.type(
     await canvas.findByPlaceholderText('Rechercher par nom, code ou région...'),
     'cha'
   );
-  await expect(canvas.getAllByRole('row')).toHaveLength(1);
+  await expect(within(siteList).getAllByRole('option')).toHaveLength(1);
   await expect(
-    within(canvas.getByRole('row')).getByRole('heading')
+    within(within(siteList).getByRole('option')).getByRole('heading')
   ).toHaveTextContent('Chalais');
 });
 Default.test(
@@ -172,7 +174,7 @@ Default.test(
         await expect(screen.queryByRole('dialog')).toBeNull();
       });
       await expect(
-        await canvas.findByRole('row', { name: 'Mont Poupet' })
+        await canvas.findByRole('option', { name: 'Mont Poupet' })
       ).toBeInTheDocument();
     });
   }
@@ -185,7 +187,7 @@ Default.test(
     });
     await step('Update a site', async () => {
       await userEvent.click(
-        within(await canvas.findByRole('row', { name: 'Arguel' })).getByRole(
+        within(await canvas.findByRole('option', { name: 'Arguel' })).getByRole(
           'button',
           { name: /.*Éditer/ }
         )
@@ -210,7 +212,7 @@ Default.test(
         await expect(screen.queryByRole('dialog')).toBeNull();
       });
       await expect(
-        await canvas.findByRole('row', { name: 'Arguel updated' })
+        await canvas.findByRole('option', { name: 'Arguel updated' })
       ).toBeInTheDocument();
     });
   }
@@ -223,7 +225,7 @@ Default.test(
     });
     await step('Delete a site', async () => {
       await userEvent.click(
-        within(await canvas.findByRole('row', { name: 'Arguel' })).getByRole(
+        within(await canvas.findByRole('option', { name: 'Arguel' })).getByRole(
           'button',
           { name: 'Supprimer le site' }
         )
@@ -241,7 +243,7 @@ Default.test(
       });
       await waitFor(async () => {
         await expect(
-          canvas.queryByRole('row', { name: 'Arguel' })
+          canvas.queryByRole('option', { name: 'Arguel' })
         ).not.toBeInTheDocument();
       });
     });

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -25,10 +25,9 @@ import {
   useBestSpotAPI,
   useHourlyBestSpotsAPI,
 } from '../hooks/weather/useBestSpotAPI';
-import {
-  useCoordinateWeather,
-} from '../hooks/weather/useCityWeather';
+import { useCoordinateWeather } from '../hooks/weather/useCityWeather';
 import { transformWeatherResponse } from '../hooks/weather/useWeather';
+import { useAppSettingsStore } from '../stores/appSettingsStore';
 
 const isSpotSearchTarget = (
   target: CityWeatherTarget | null
@@ -46,10 +45,7 @@ const getSearchTargetLocation = (target: CityWeatherTarget | null) => {
   return target.spot;
 };
 
-const getSearchDayLabel = (
-  day: number,
-  t: (key: string) => string
-) => {
+const getSearchDayLabel = (day: number, t: (key: string) => string) => {
   if (day === 0) return t('common.today');
   if (day === 1) return t('common.tomorrow');
   return `J+${day}`;
@@ -61,6 +57,9 @@ export default function WeatherPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { data: sites } = useSuspenseQuery(sitesQueryOptions());
+  const favoriteSiteIds = useAppSettingsStore(
+    (state) => state.settings.favoriteSites
+  );
   const search = useSearch({ from: '/weather' });
   const routeSiteId = search ? search.siteId : '';
   const selectedDayIndex = search.day ?? 0;
@@ -68,10 +67,19 @@ export default function WeatherPage() {
   const { data: hourlyBestSpots } = useHourlyBestSpotsAPI(selectedDayIndex);
   const [selectedSearchTarget, setSelectedSearchTarget] =
     useState<CityWeatherTarget | null>(null);
-  const [selectionTab, setSelectionTab] =
-    useState<SelectionTab>('favorites');
+  const [selectionTab, setSelectionTab] = useState<SelectionTab>('favorites');
+  const favoriteSites = useMemo(() => {
+    if (favoriteSiteIds.length === 0) return sites;
+
+    const favoriteSet = new Set(favoriteSiteIds);
+    const matchedFavorites = sites.filter((site) => favoriteSet.has(site.id));
+    return matchedFavorites.length > 0 ? matchedFavorites : sites;
+  }, [favoriteSiteIds, sites]);
   const selectedSiteId =
-    sites.find((site) => site.id === routeSiteId)?.id ?? sites[0]?.id ?? '';
+    sites.find((site) => site.id === routeSiteId)?.id ??
+    favoriteSites[0]?.id ??
+    sites[0]?.id ??
+    '';
   const selectedSearchTitle = getSearchTargetName(selectedSearchTarget);
   const selectedSearchLocation = getSearchTargetLocation(selectedSearchTarget);
   const coordinateWeather = useCoordinateWeather(
@@ -88,10 +96,12 @@ export default function WeatherPage() {
         : undefined,
     [selectedSearchWeather]
   );
-  const isSearchWeatherLoading =
-    selectedSearchTarget ? coordinateWeather.isLoading : false;
-  const isSearchWeatherError =
-    selectedSearchTarget ? coordinateWeather.isError : false;
+  const isSearchWeatherLoading = selectedSearchTarget
+    ? coordinateWeather.isLoading
+    : false;
+  const isSearchWeatherError = selectedSearchTarget
+    ? coordinateWeather.isError
+    : false;
 
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const [weatherDataMap] = useState<Map<string, Record<string, unknown>>>(

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -75,8 +75,9 @@ export default function WeatherPage() {
     const matchedFavorites = sites.filter((site) => favoriteSet.has(site.id));
     return matchedFavorites.length > 0 ? matchedFavorites : sites;
   }, [favoriteSiteIds, sites]);
+  const routeSiteExists = sites.some((site) => site.id === routeSiteId);
   const selectedSiteId =
-    sites.find((site) => site.id === routeSiteId)?.id ??
+    (routeSiteExists ? routeSiteId : undefined) ??
     favoriteSites[0]?.id ??
     sites[0]?.id ??
     '';

--- a/apps/frontend/src/stores/appSettingsStore.test.ts
+++ b/apps/frontend/src/stores/appSettingsStore.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  APP_SETTINGS_STORAGE_KEY,
+  DEFAULT_APP_SETTINGS,
+  formatAltitudeMeters,
+  formatDistanceKm,
+  formatSpeedKmh,
+  readAppSettings,
+  useAppSettingsStore,
+} from './appSettingsStore';
+
+describe('appSettingsStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAppSettingsStore.setState({ settings: DEFAULT_APP_SETTINGS });
+  });
+
+  it('persists settings using the existing localStorage shape', () => {
+    useAppSettingsStore.getState().setSettings((settings) => ({
+      ...settings,
+      units: { ...settings.units, distance: 'miles' },
+      favoriteSites: ['arguel'],
+    }));
+
+    const stored = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored ?? '{}')).toMatchObject({
+      units: { distance: 'miles' },
+      favoriteSites: ['arguel'],
+    });
+  });
+
+  it('normalizes malformed persisted values', () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        units: { distance: 'bad', altitude: 'ft', speed: 'mph' },
+        language: 'en',
+        notifications: { weather: false, flights: 'bad' },
+        favoriteSites: ['arguel', 123],
+      })
+    );
+
+    expect(readAppSettings()).toMatchObject({
+      units: { distance: 'km', altitude: 'ft', speed: 'mph' },
+      language: 'en',
+      notifications: { weather: false, flights: true, alerts: true },
+      favoriteSites: ['arguel'],
+    });
+  });
+
+  it('formats configured units', () => {
+    expect(formatDistanceKm(10, 'miles')).toBe('6.2 mi');
+    expect(formatAltitudeMeters(100, 'ft')).toBe('328 ft');
+    expect(formatSpeedKmh(100, 'mph')).toBe('62.1 mph');
+  });
+});

--- a/apps/frontend/src/stores/appSettingsStore.ts
+++ b/apps/frontend/src/stores/appSettingsStore.ts
@@ -1,0 +1,156 @@
+import { create } from 'zustand';
+
+export type DistanceUnit = 'km' | 'miles';
+export type AltitudeUnit = 'm' | 'ft';
+export type SpeedUnit = 'kmh' | 'mph';
+export type ThemePreferenceSetting = 'light' | 'dark' | 'auto';
+
+export interface AppSettings {
+  units: {
+    distance: DistanceUnit;
+    altitude: AltitudeUnit;
+    speed: SpeedUnit;
+  };
+  language: 'fr' | 'en';
+  theme: ThemePreferenceSetting;
+  notifications: {
+    weather: boolean;
+    flights: boolean;
+    alerts: boolean;
+  };
+  favoriteSites: string[];
+}
+
+export const APP_SETTINGS_STORAGE_KEY = 'paragliding-settings';
+
+export const DEFAULT_APP_SETTINGS: AppSettings = {
+  units: {
+    distance: 'km',
+    altitude: 'm',
+    speed: 'kmh',
+  },
+  language: 'fr',
+  theme: 'light',
+  notifications: {
+    weather: true,
+    flights: true,
+    alerts: true,
+  },
+  favoriteSites: [],
+};
+
+type AppSettingsStore = {
+  settings: AppSettings;
+  setSettings: (
+    updater: AppSettings | ((settings: AppSettings) => AppSettings)
+  ) => void;
+  resetSettings: () => void;
+};
+
+function getStorage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.localStorage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeSettings(value: unknown): AppSettings {
+  if (!isRecord(value)) return DEFAULT_APP_SETTINGS;
+
+  const units = isRecord(value.units) ? value.units : {};
+  const notifications = isRecord(value.notifications)
+    ? value.notifications
+    : {};
+
+  return {
+    units: {
+      distance: units.distance === 'miles' ? 'miles' : 'km',
+      altitude: units.altitude === 'ft' ? 'ft' : 'm',
+      speed: units.speed === 'mph' ? 'mph' : 'kmh',
+    },
+    language: value.language === 'en' ? 'en' : 'fr',
+    theme:
+      value.theme === 'dark' || value.theme === 'auto' ? value.theme : 'light',
+    notifications: {
+      weather:
+        typeof notifications.weather === 'boolean'
+          ? notifications.weather
+          : DEFAULT_APP_SETTINGS.notifications.weather,
+      flights:
+        typeof notifications.flights === 'boolean'
+          ? notifications.flights
+          : DEFAULT_APP_SETTINGS.notifications.flights,
+      alerts:
+        typeof notifications.alerts === 'boolean'
+          ? notifications.alerts
+          : DEFAULT_APP_SETTINGS.notifications.alerts,
+    },
+    favoriteSites: Array.isArray(value.favoriteSites)
+      ? value.favoriteSites.filter(
+          (siteId): siteId is string => typeof siteId === 'string'
+        )
+      : [],
+  };
+}
+
+export function readAppSettings(
+  storage: Pick<Storage, 'getItem'> | null = getStorage()
+): AppSettings {
+  if (!storage) return DEFAULT_APP_SETTINGS;
+
+  try {
+    return normalizeSettings(
+      JSON.parse(storage.getItem(APP_SETTINGS_STORAGE_KEY) ?? 'null')
+    );
+  } catch {
+    return DEFAULT_APP_SETTINGS;
+  }
+}
+
+function writeAppSettings(settings: AppSettings) {
+  getStorage()?.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+}
+
+export function formatDistanceKm(valueKm: number, unit: DistanceUnit): string {
+  if (unit === 'miles') {
+    return `${(valueKm * 0.621371).toFixed(1)} mi`;
+  }
+
+  return `${valueKm.toFixed(1)} km`;
+}
+
+export function formatAltitudeMeters(
+  valueMeters: number,
+  unit: AltitudeUnit
+): string {
+  if (unit === 'ft') {
+    return `${Math.round(valueMeters * 3.28084)} ft`;
+  }
+
+  return `${Math.round(valueMeters)} m`;
+}
+
+export function formatSpeedKmh(valueKmh: number, unit: SpeedUnit): string {
+  if (unit === 'mph') {
+    return `${(valueKmh * 0.621371).toFixed(1)} mph`;
+  }
+
+  return `${valueKmh.toFixed(1)} km/h`;
+}
+
+export const useAppSettingsStore = create<AppSettingsStore>((set) => ({
+  settings: readAppSettings(),
+  setSettings: (updater) =>
+    set((state) => {
+      const nextSettings =
+        typeof updater === 'function' ? updater(state.settings) : updater;
+      const normalizedSettings = normalizeSettings(nextSettings);
+      writeAppSettings(normalizedSettings);
+      return { settings: normalizedSettings };
+    }),
+  resetSettings: () => {
+    getStorage()?.removeItem(APP_SETTINGS_STORAGE_KEY);
+    set({ settings: DEFAULT_APP_SETTINGS });
+  },
+}));


### PR DESCRIPTION
## Summary
- Persist local settings through a shared store and apply units/favorites across settings, weather, flight list, flight details, and 3D viewer.
- Invalidate frontend weather-related queries and backend weather/best-spot caches when cache-sensitive settings change.
- Update affected Storybook interactions to match current DataList accessibility roles and stabilize GPX replay assertions.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Favorite sites are prioritized in site selection.
  * Central app settings store with persistence, unit/theme controls, and formatting helpers.

* **Improvements**
  * Units consistently applied across flight views and 3D viewer.
  * Settings UI now updates store immediately with transient saved status; import/reset flows updated.
  * Weather/best-spot caches are invalidated (background) when cache-sensitive settings change; client queries are refreshed.

* **Tests**
  * Added tests for settings persistence and cache-invalidation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/747)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->