### PR TITLE
feat(frontend): expose GoPro overlay from dashboard

### DIFF
--- a/apps/frontend/src/pages/Dashboard.tsx
+++ b/apps/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery, useQueries } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { CalendarDays, CloudSun, MapPinned } from 'lucide-react';
+import { CalendarDays, CloudSun, MapPinned, Video } from 'lucide-react';
 import StatsPanel from '../components/dashboard/StatsPanel';
 import AllSitesConditions from '../components/dashboard/AllSitesConditions';
 import { BestSpotSuggestion } from '../components/weather/BestSpotSuggestion';
@@ -106,6 +106,13 @@ export default function Dashboard() {
               className="rounded-2xl bg-sky-600 px-4 py-2.5 text-sm font-bold text-white shadow-md shadow-sky-600/20 transition-colors hover:bg-sky-700"
             >
               {t('weather.viewForecast')}
+            </Button>
+            <Button
+              onClick={() => void navigate({ to: '/gopro-overlay' })}
+              className="inline-flex items-center gap-2 rounded-2xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white shadow-md shadow-slate-950/20 transition-colors hover:bg-slate-800 dark:bg-cyan-500 dark:text-slate-950 dark:hover:bg-cyan-400"
+            >
+              <Video className="h-4 w-4" aria-hidden="true" />
+              {t('header.goproOverlay')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add a direct dashboard CTA to the GoPro overlay page.
- Improve discoverability of the overlay entry point without changing the underlying route.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "GoPro overlay" button to the Dashboard, enabling quick access to the GoPro overlay feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/764)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->