### PR TITLE
docs: rewrite dashboard workflow skill

### DIFF
--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -1,111 +1,99 @@
 ---
 name: dashboard-parapente-workflow
-description: Workflow expert for the dashboard-parapente Nx monorepo. Use when implementing, debugging, testing, reviewing, or modifying frontend/backend code in this repository, especially when choosing commands, project targets, validation steps, GitHub workflow, and repo-specific tooling.
+description: Guides implementation, debugging, review, validation, and GitHub workflow in the dashboard-parapente Nx monorepo. Use when modifying frontend/backend code, choosing Nx commands, validating impacted projects, handling GitHub PRs/issues, CodeRabbit comments, or applying repository-specific tooling rules.
 ---
 
 # Dashboard Parapente Workflow
 
-## Repository
+## Quick Start
 
-- Nx monorepo.
-- Frontend project: `frontend` under `apps/frontend`.
-- Backend project: `backend` under `apps/backend`.
-- Package manager executable: `/home/capic/.local/share/pnpm/pnpm`.
+Use this skill for repository workflow decisions, validation strategy, GitHub operations, and frontend/backend conventions.
 
-## Tool Usage
-- Prefer `Glob` to find files by path or extension.
-- Prefer `Grep` to search code content.
-- Use `Read` for specific files.
-- Use `apply_patch` for manual edits.
-- Avoid shell-based file editing.
-- Do not use destructive git commands.
+1. Read the closest applicable `AGENTS.md`.
+2. Inspect the current structure before editing.
+3. Keep changes minimal and scoped.
+4. Do not modify unrelated dirty files.
+5. Prefer affected Nx tasks for validation.
 
-## GitHub
-- Use `gh` for all GitHub interactions.
-- Use `gh` for issues, pull requests, checks, releases, comments, and GitHub API calls.
-- If the user provides a GitHub URL, inspect it with `gh`.
-- When handling CodeRabbit comments, delegate comment discovery, analysis, and triage to a subagent; the main agent does not need the full global context.
-- The CodeRabbit subagent should inspect only the relevant PR conversations/comments via `gh` and return a concise actionable report: requested changes, affected files/lines, priority, and conversations to reply to/close.
-- When fixing CodeRabbit CI review comments, REPLY to each resolved conversation and CLOSE it.
+Projects: `frontend` in `apps/frontend`, `backend` in `apps/backend`, `design-system` in `libs/design-system`, `shared-types` in `libs/shared-types`.
+
+Package manager:
+
+```bash
+/home/capic/.local/share/pnpm/pnpm
+```
+
+## Tooling
+
+- Use `Glob` for file discovery, `Grep` for code search, and `Read` for known files.
+- Use `apply_patch` for manual edits; avoid shell-based file editing.
+- Never use destructive git commands.
+- Load `local-machine-stack` for pnpm, dependency readiness, command timeouts, and machine-specific command details.
 
 ## Worktrees
-- For branch/worktree start-of-work decisions, use the `implementation-worktree-strategy` skill.
-- This skill only defines repository commands, validation strategy, GitHub usage, and tooling preferences.
-- When a worktree is created, use the `worktree-bootstrap` subagent defined by `implementation-worktree-strategy` before relying on Nx commands.
-- Before opening a PR from a worktree, fetch the remote and update the worktree branch with the latest `origin/main`.
-- Do not create a PR from a stale worktree; resolve merge/rebase conflicts and rerun impacted checks first.
 
-## Start Of Work
-- Read the closest applicable `AGENTS.md`.
-- Check current structure before editing.
-- Keep changes minimal and scoped.
-- Do not modify unrelated dirty files.
+Load `implementation-worktree-strategy` before implementation tasks: feature work, bug fixes, refactors, and code changes.
+
+When a worktree is created, work from the new worktree path, launch the `worktree-bootstrap` subagent immediately, and run impacted checks there before PR creation.
+
+Do not open a PR from a stale worktree. Fetch remote changes, update against `origin/main`, resolve conflicts, and rerun impacted checks first.
 
 ## Frontend
 
-Use when files are under `apps/frontend`.
+Applies to `apps/frontend/**`; follow `apps/frontend/AGENTS.md`.
 
-- Follow TanStack Router loader patterns.
+- Prefer TanStack Router loaders for route data.
 - Use React Query for server state.
-- Avoid ad hoc fetching inside components when loader + query fits.
-- Keep Storybook stories focused.
-- Use CSF Factory.
+- Avoid ad hoc component fetching when loader plus query fits.
+- Keep Storybook stories focused and use CSF Factory.
 - Update `apps/frontend/chromatic.config.json` when stories are added or restructured.
 
-Prefer affected Nx tasks for validation:
+Frontend validation:
 
 ```bash
 NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test,build --parallel=5 --exclude=e2e
 ```
 
-Use direct project targets only for a narrow diagnostic rerun after an affected task identifies a specific failing project.
+Run frontend build when behavior, routing, bundling, or UI code changes.
 
 ## Backend
 
-Use when files are under `apps/backend`.
+Applies to `apps/backend/**`; follow `apps/backend/AGENTS.md`.
 
-- Python >= 3.12.
-- Add explicit typing on new functions.
+- Use Python `>=3.12` and explicit typing on new functions.
 - Keep routes, schemas, business logic, and data access separated.
-- Validate API input/output with Pydantic.
+- Validate API input and output with Pydantic.
+- Follow existing SQLAlchemy patterns.
 - Add pytest coverage for new business behavior or bug fixes.
 
-Prefer affected Nx tasks for validation:
+Backend validation:
 
 ```bash
 NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test --parallel=5 --exclude=e2e
 ```
 
-Use direct project targets only for a narrow diagnostic rerun after an affected task identifies a specific failing project.
+## Validation
 
-## Global Commands
-Run impacted tests:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e
-```
-
-Run impacted lint targets:
+Prefer this command for implementation and PR validation:
 
 ```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
+NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e
 ```
 
-## Validation Strategy
-- Prefer `nx affected` for Nx lint/test/build tasks during implementation and PR validation.
-- For long or multi-command validation runs, prefer a validation subagent that runs commands from the active worktree and returns a concise pass/fail report.
-- Keep the main agent responsible for fixing failures and deciding whether extra validation is needed.
-- Prefer `nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e` for branch/PR validation.
-- Use direct project commands such as `nx lint frontend` or `nx test backend` only as a follow-up diagnostic when an affected run has already identified a failing project, or when the user explicitly asks for a direct project target.
-- Use `run-many -t test` only when affected detection is not appropriate or a full-repo check is explicitly needed.
-- Use `run-many -t lint` only when affected detection is not appropriate or a full-repo lint is explicitly needed.
-- Use frontend build when frontend behavior, routing, bundling, or UI code changes.
-- Before creating or updating a PR, run all impacted checks from the active worktree and fix failures first.
-- For frontend PRs, run `nx affected -t lint,test,build --parallel=5 --exclude=e2e` from the worktree before opening the PR.
-- Do not create the PR if required checks cannot run locally because of the worktree environment; stop, report the blocker, and ask before proceeding.
+Use direct project targets only after an affected run identifies a failing project, or when explicitly requested. Use `run-many` only when affected detection is inappropriate or a full-repo check is required.
+
+For long validation runs, prefer a validation subagent that runs commands from the active worktree and returns a concise pass/fail report. The main agent fixes failures and decides whether more validation is needed.
+
+## GitHub And CodeRabbit
+
+Use `gh` for all GitHub interactions: issues, PRs, checks, releases, comments, API calls, and GitHub URLs.
+
+Before creating or updating a PR, check branch status, review commits and diff against the base branch, run impacted checks, and fix failures.
+
+For CodeRabbit comments, delegate discovery and triage to a subagent. It should inspect only relevant PR conversations through `gh` and return requested changes, affected files/lines, priority, and conversations to reply to or close. When fixed, reply to each resolved conversation and close it.
 
 ## Git
 - Do not commit unless explicitly requested.
-- If committing, use Conventional Commits.
+- Use Conventional Commits when committing.
 - Never commit secrets.
 - Never amend unless explicitly requested.


### PR DESCRIPTION
## Summary
- Rewrite the dashboard-parapente workflow skill with clearer trigger metadata.
- Condense repo workflow, validation, GitHub, CodeRabbit, and worktree guidance.
- Keep the skill under 100 lines while preserving repository-specific rules.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --base=origin/main --head=HEAD --parallel=5 --exclude=e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined dashboard-parapente-workflow skill guide with Quick Start checklist, explicit project mappings, and standardized package manager guidance.
  * Reorganized validation subsections with concrete commands for frontend and backend workflows.
  * Simplified GitHub, CodeRabbit, and Git workflow instructions for improved clarity.
  * Updated worktree procedures emphasizing consistency and best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/766)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->