### PR TITLE
feat(flights): launch GoPro overlay from flight details

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -253,10 +253,6 @@ async def create_gopro_overlay_job(
 ) -> dict[str, Any]:
     job_id = str(uuid.uuid4())
     job_upload_dir = _upload_dir() / job_id
-    output_name = _safe_filename(output_filename, f"gopro-overlay-{job_id}.mp4")
-    if Path(output_name).suffix.lower() != ".mp4":
-        output_name = f"{Path(output_name).stem}.mp4"
-
     try:
         video_path = await save_uploaded_file(
             video_file,
@@ -276,21 +272,70 @@ async def create_gopro_overlay_job(
                 _VIDEO_EXTENSIONS,
             )
 
-        width, height = probe_video_resolution(video_path)
-        selected_layout = _find_layout(layout_id) if layout_id else _nearest_layout(width, height)
-        if not selected_layout:
-            raise ValueError("Unknown layout")
-        source_layout_path = _layout_path(selected_layout)
-        if not source_layout_path.exists():
-            raise ValueError(f"Layout file not found: {source_layout_path}")
-        layout_path = _prepare_layout_file(
-            source_layout_path,
-            job_upload_dir / source_layout_path.name,
-            has_pip=pip_path is not None,
+        return _create_gopro_overlay_job_from_paths(
+            job_id=job_id,
+            video_path=video_path,
+            gpx_path=gpx_path,
+            pip_path=pip_path,
+            layout_id=layout_id,
+            output_filename=output_filename,
+            work_dir=job_upload_dir,
         )
     except Exception:
         shutil.rmtree(job_upload_dir, ignore_errors=True)
         raise
+
+
+def create_gopro_overlay_job_from_paths(
+    video_path: Path,
+    gpx_path: Path,
+    pip_path: Path | None,
+    layout_id: str | None,
+    output_filename: str | None,
+) -> dict[str, Any]:
+    job_id = str(uuid.uuid4())
+    work_dir = _upload_dir() / job_id
+    work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        return _create_gopro_overlay_job_from_paths(
+            job_id=job_id,
+            video_path=video_path,
+            gpx_path=gpx_path,
+            pip_path=pip_path,
+            layout_id=layout_id,
+            output_filename=output_filename,
+            work_dir=work_dir,
+        )
+    except Exception:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
+
+
+def _create_gopro_overlay_job_from_paths(
+    job_id: str,
+    video_path: Path,
+    gpx_path: Path,
+    pip_path: Path | None,
+    layout_id: str | None,
+    output_filename: str | None,
+    work_dir: Path,
+) -> dict[str, Any]:
+    output_name = _safe_filename(output_filename, f"gopro-overlay-{job_id}.mp4")
+    if Path(output_name).suffix.lower() != ".mp4":
+        output_name = f"{Path(output_name).stem}.mp4"
+
+    width, height = probe_video_resolution(video_path)
+    selected_layout = _find_layout(layout_id) if layout_id else _nearest_layout(width, height)
+    if not selected_layout:
+        raise ValueError("Unknown layout")
+    source_layout_path = _layout_path(selected_layout)
+    if not source_layout_path.exists():
+        raise ValueError(f"Layout file not found: {source_layout_path}")
+    layout_path = _prepare_layout_file(
+        source_layout_path,
+        work_dir / source_layout_path.name,
+        has_pip=pip_path is not None,
+    )
 
     output_path = _output_dir() / job_id / output_name
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -120,6 +120,20 @@ def _safe_filename(filename: str | None, fallback: str) -> str:
     return cleaned or fallback
 
 
+def _validate_file_extension(path: Path, allowed_extensions: set[str]) -> None:
+    suffix = path.suffix.lower()
+    if suffix not in allowed_extensions:
+        allowed = ", ".join(sorted(allowed_extensions))
+        raise ValueError(f"Unsupported file extension '{suffix}'. Expected one of: {allowed}")
+
+
+def _copy_job_input(source: Path, destination: Path, allowed_extensions: set[str]) -> Path:
+    _validate_file_extension(source, allowed_extensions)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return destination
+
+
 def _update_job(job_id: str, **changes: Any) -> dict[str, Any]:
     with _LOCK:
         job = _JOBS[job_id]
@@ -232,10 +246,7 @@ async def save_uploaded_file(
     destination: Path,
     allowed_extensions: set[str],
 ) -> Path:
-    suffix = Path(upload.filename or "").suffix.lower()
-    if suffix not in allowed_extensions:
-        allowed = ", ".join(sorted(allowed_extensions))
-        raise ValueError(f"Unsupported file extension '{suffix}'. Expected one of: {allowed}")
+    _validate_file_extension(Path(upload.filename or ""), allowed_extensions)
 
     destination.parent.mkdir(parents=True, exist_ok=True)
     with destination.open("wb") as output:
@@ -293,6 +304,11 @@ def create_gopro_overlay_job_from_paths(
     layout_id: str | None,
     output_filename: str | None,
 ) -> dict[str, Any]:
+    _validate_file_extension(video_path, _VIDEO_EXTENSIONS)
+    _validate_file_extension(gpx_path, _GPX_EXTENSIONS)
+    if pip_path:
+        _validate_file_extension(pip_path, _VIDEO_EXTENSIONS)
+
     job_id = str(uuid.uuid4())
     work_dir = _upload_dir() / job_id
     work_dir.mkdir(parents=True, exist_ok=True)
@@ -305,6 +321,7 @@ def create_gopro_overlay_job_from_paths(
             layout_id=layout_id,
             output_filename=output_filename,
             work_dir=work_dir,
+            pin_inputs=True,
         )
     except Exception:
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -319,10 +336,29 @@ def _create_gopro_overlay_job_from_paths(
     layout_id: str | None,
     output_filename: str | None,
     work_dir: Path,
+    pin_inputs: bool = False,
 ) -> dict[str, Any]:
     output_name = _safe_filename(output_filename, f"gopro-overlay-{job_id}.mp4")
     if Path(output_name).suffix.lower() != ".mp4":
         output_name = f"{Path(output_name).stem}.mp4"
+
+    if pin_inputs:
+        video_path = _copy_job_input(
+            video_path,
+            work_dir / f"input{video_path.suffix.lower()}",
+            _VIDEO_EXTENSIONS,
+        )
+        gpx_path = _copy_job_input(
+            gpx_path,
+            work_dir / f"track{gpx_path.suffix.lower()}",
+            _GPX_EXTENSIONS,
+        )
+        if pip_path:
+            pip_path = _copy_job_input(
+                pip_path,
+                work_dir / f"pip{pip_path.suffix.lower()}",
+                _VIDEO_EXTENSIONS,
+            )
 
     width, height = probe_video_resolution(video_path)
     selected_layout = _find_layout(layout_id) if layout_id else _nearest_layout(width, height)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -35,6 +35,7 @@ from flight_backfill import calculate_and_persist_missing_max_speed
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import check_gopro_overlay_dependencies
 from gopro_overlay_export import create_gopro_overlay_job
+from gopro_overlay_export import create_gopro_overlay_job_from_paths
 from gopro_overlay_export import get_gopro_overlay_job
 from gopro_overlay_export import gopro_overlay_output_path
 from gopro_overlay_export import list_gopro_overlay_layouts
@@ -148,6 +149,16 @@ def _mark_flight_export_processing(db: Session, flight: Flight, job_id: str):
     flight.video_file_path = None
     db.commit()
     db.refresh(flight)
+
+
+def _resolve_flight_file_path(file_path: str | None) -> Path | None:
+    if not file_path:
+        return None
+
+    path = Path(file_path)
+    if path.is_absolute() or path.exists():
+        return path
+    return Path(__file__).parent / path
 
 
 def _resolve_export_status(job_id: str) -> dict[str, Any] | None:
@@ -4517,6 +4528,50 @@ def list_flight_exports(flight_id: str, db: Session = Depends(get_db)):
 def get_gopro_overlay_dependencies() -> GoproOverlayDependencies:
     """Return availability of the external GoPro overlay toolchain."""
     return check_gopro_overlay_dependencies()
+
+
+@router.post(
+    "/flights/{flight_id}/gopro-overlay",
+    response_model=GoproOverlayJob,
+)
+def create_flight_gopro_overlay_job(
+    flight_id: str,
+    db: Session = Depends(get_db),
+) -> GoproOverlayJob:
+    """Create a GoPro overlay render job from a flight's existing video and GPX."""
+    dependencies = check_gopro_overlay_dependencies()
+    missing = [name for name, available in dependencies.items() if not available]
+    if missing:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Missing GoPro overlay dependencies: {', '.join(missing)}",
+        )
+
+    flight = db.query(Flight).filter(Flight.id == flight_id).first()
+    if not flight:
+        raise HTTPException(status_code=404, detail="Flight not found")
+
+    gpx_path = _resolve_flight_file_path(flight.gpx_file_path)
+    if not gpx_path or not gpx_path.exists():
+        raise HTTPException(status_code=400, detail="Flight has no GPX file")
+
+    video_path = _resolve_flight_file_path(flight.video_file_path)
+    if not video_path or not video_path.exists():
+        raise HTTPException(status_code=400, detail="Flight has no video file")
+
+    title = flight.title or flight.name or flight.id
+    output_filename = f"{title}-overlay.mp4"
+
+    try:
+        return create_gopro_overlay_job_from_paths(
+            video_path=video_path,
+            gpx_path=gpx_path,
+            pip_path=None,
+            layout_id=None,
+            output_filename=output_filename,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -9,9 +9,11 @@ from starlette.datastructures import UploadFile
 
 import config
 import gopro_overlay_export
+import routes
 from gopro_overlay_export import _prepare_layout_file
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job
+from gopro_overlay_export import create_gopro_overlay_job_from_paths
 
 API_PREFIX = "/api"
 
@@ -146,6 +148,51 @@ def test_create_flight_gopro_overlay_job_requires_existing_video(
     assert response.json()["detail"] == "Flight has no video file"
 
 
+def test_create_flight_gopro_overlay_job_resolves_relative_paths(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    backend_root = tmp_path / "backend"
+    video_path = backend_root / "db" / "videos" / "flight.mp4"
+    gpx_path = backend_root / "db" / "gpx" / "flight.gpx"
+    video_path.parent.mkdir(parents=True)
+    gpx_path.parent.mkdir(parents=True)
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    sample_flight.video_file_path = "db/videos/flight.mp4"
+    sample_flight.gpx_file_path = "db/gpx/flight.gpx"
+    db_session.commit()
+
+    expected = {
+        "job_id": "job-flight-gopro-relative",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "flight-overlay.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(routes, "__file__", str(backend_root / "routes.py"))
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 200
+    assert create_job.call_args.kwargs["video_path"] == video_path
+    assert create_job.call_args.kwargs["gpx_path"] == gpx_path
+
+
 def test_download_gopro_overlay_rejects_unfinished_job(client: TestClient):
     with patch(
         "routes.get_gopro_overlay_job",
@@ -234,6 +281,59 @@ async def test_create_gopro_overlay_job_uses_job_unique_output_paths(tmp_path, m
     assert Path(first["output_path"]).parent.name == first["job_id"]
     assert Path(second["output_path"]).parent.name == second["job_id"]
     assert thread.call_count == 2
+
+
+def test_create_gopro_overlay_job_from_paths_rejects_unsupported_input_before_workdir(
+    tmp_path,
+    monkeypatch,
+):
+    upload_dir = tmp_path / "uploads"
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_OUTPUT_DIR", str(tmp_path / "outputs"))
+
+    with pytest.raises(ValueError, match="Unsupported file extension '.avi'"):
+        create_gopro_overlay_job_from_paths(
+            video_path=tmp_path / "flight.avi",
+            gpx_path=tmp_path / "flight.gpx",
+            pip_path=None,
+            layout_id="parapente-1080",
+            output_filename="overlay.mp4",
+        )
+
+    assert not upload_dir.exists()
+
+
+def test_create_gopro_overlay_job_from_paths_copies_inputs_into_job_dir(
+    tmp_path,
+    monkeypatch,
+):
+    upload_dir = tmp_path / "uploads"
+    output_dir = tmp_path / "outputs"
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_UPLOAD_DIR", str(upload_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_OUTPUT_DIR", str(output_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+
+    with patch("gopro_overlay_export.threading.Thread"):
+        job = create_gopro_overlay_job_from_paths(
+            video_path=video_path,
+            gpx_path=gpx_path,
+            pip_path=None,
+            layout_id="parapente-1080",
+            output_filename="overlay.mp4",
+        )
+
+    assert Path(job["video_path"]).parent == upload_dir / job["job_id"]
+    assert Path(job["gpx_path"]).parent == upload_dir / job["job_id"]
+    assert Path(job["video_path"]).read_bytes() == b"video"
+    assert Path(job["gpx_path"]).read_text() == "<gpx />"
 
 
 def test_cancelled_queued_job_does_not_start_process():

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -81,6 +81,71 @@ def test_create_gopro_overlay_job_passes_uploaded_files(client: TestClient):
     assert create_job.call_args.kwargs["pip_file"] is not None
 
 
+def test_create_flight_gopro_overlay_job_uses_flight_files(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+):
+    video_path = tmp_path / "flight.mp4"
+    gpx_path = tmp_path / "flight.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    sample_flight.video_file_path = str(video_path)
+    sample_flight.gpx_file_path = str(gpx_path)
+    sample_flight.title = "Arguel test"
+    db_session.commit()
+
+    expected = {
+        "job_id": "job-flight-gopro",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "Arguel_test-overlay.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 200
+    assert response.json()["job_id"] == "job-flight-gopro"
+    assert create_job.call_args.kwargs["video_path"] == video_path
+    assert create_job.call_args.kwargs["gpx_path"] == gpx_path
+    assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
+
+
+def test_create_flight_gopro_overlay_job_requires_existing_video(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+):
+    gpx_path = tmp_path / "flight.gpx"
+    gpx_path.write_text("<gpx />")
+    sample_flight.gpx_file_path = str(gpx_path)
+    sample_flight.video_file_path = str(tmp_path / "missing.mp4")
+    db_session.commit()
+
+    with patch(
+        "routes.check_gopro_overlay_dependencies",
+        return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Flight has no video file"
+
+
 def test_download_gopro_overlay_rejects_unfinished_job(client: TestClient):
     with patch(
         "routes.get_gopro_overlay_job",

--- a/apps/frontend/src/components/common/Header.tsx
+++ b/apps/frontend/src/components/common/Header.tsx
@@ -66,13 +66,6 @@ export default function Header() {
           <Link to="/sites" className={linkClassName} onClick={onNavigate}>
             {t('header.sites')}
           </Link>
-          <Link
-            to="/gopro-overlay"
-            className={linkClassName}
-            onClick={onNavigate}
-          >
-            {t('header.goproOverlay')}
-          </Link>
           <Link to="/settings" className={linkClassName} onClick={onNavigate}>
             {t('header.settings')}
           </Link>

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -67,6 +67,7 @@ export function FlightDetails({
   const cancelGoproOverlayJob = useCancelGoproOverlayJob();
   const resetGoproOverlayJob = createGoproOverlayJob.reset;
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const activeFlightIdRef = useRef(flight.id);
 
   const [editingMode, setEditingMode] = useState(false);
   const [editingNotes, setEditingNotes] = useState(false);
@@ -98,14 +99,18 @@ export function FlightDetails({
     })();
 
   useEffect(() => {
+    activeFlightIdRef.current = flight.id;
     setActiveTab('infos');
     setHasOpenedReplay(false);
     setEditingMode(false);
     setEditingNotes(false);
-    setNotesText(flight.notes ?? '');
     setGoproOverlayJobId(null);
     resetGoproOverlayJob();
-  }, [flight.id, flight.notes, resetGoproOverlayJob]);
+  }, [flight.id, resetGoproOverlayJob]);
+
+  useEffect(() => {
+    setNotesText(flight.notes ?? '');
+  }, [flight.notes]);
 
   const handleSubmitEdit = async (values: FlightFormData) => {
     await updateFlight.mutateAsync(values);
@@ -177,9 +182,11 @@ export function FlightDetails({
 
   const handleStartGoproOverlay = async () => {
     if (!hasGpx || !hasVideo || isGoproOverlayRunning) return;
+    const requestedFlightId = flight.id;
 
     try {
       const job = await createGoproOverlayJob.mutateAsync();
+      if (activeFlightIdRef.current !== requestedFlightId) return;
       setGoproOverlayJobId(job.job_id);
       toast.success(t('flights.goproOverlayStarted'));
     } catch {

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -14,6 +14,11 @@ import {
   useUpdateFlight,
   useUploadGPXToFlight,
 } from '../../hooks/flights/useFlights';
+import {
+  useCancelGoproOverlayJob,
+  useCreateFlightGoproOverlayJob,
+  useGoproOverlayJobStream,
+} from '../../hooks/gopro/useGoproOverlay';
 import { useToast } from '../../hooks/useToast';
 import { api } from '../../lib/api';
 import type { Flight, FlightFormData, Site } from '../../types';
@@ -58,6 +63,9 @@ export function FlightDetails({
   const units = useAppSettingsStore((state) => state.settings.units);
   const updateFlight = useUpdateFlight(flight.id);
   const uploadGPXMutation = useUploadGPXToFlight(flight.id);
+  const createGoproOverlayJob = useCreateFlightGoproOverlayJob(flight.id);
+  const cancelGoproOverlayJob = useCancelGoproOverlayJob();
+  const resetGoproOverlayJob = createGoproOverlayJob.reset;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [editingMode, setEditingMode] = useState(false);
@@ -66,9 +74,18 @@ export function FlightDetails({
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
   const [hasOpenedReplay, setHasOpenedReplay] = useState(false);
   const [isDownloadingGpx, setIsDownloadingGpx] = useState(false);
+  const [goproOverlayJobId, setGoproOverlayJobId] = useState<string | null>(
+    null
+  );
 
   const hasGpx = Boolean(flight.gpx_file_path);
   const hasVideo = Boolean(flight.video_file_path);
+  const { job: streamedGoproOverlayJob } =
+    useGoproOverlayJobStream(goproOverlayJobId);
+  const goproOverlayJob = streamedGoproOverlayJob ?? createGoproOverlayJob.data;
+  const isGoproOverlayRunning =
+    goproOverlayJob?.status === 'queued' ||
+    goproOverlayJob?.status === 'running';
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
     normalizedTitle ||
@@ -86,7 +103,9 @@ export function FlightDetails({
     setEditingMode(false);
     setEditingNotes(false);
     setNotesText(flight.notes ?? '');
-  }, [flight.id, flight.notes]);
+    setGoproOverlayJobId(null);
+    resetGoproOverlayJob();
+  }, [flight.id, flight.notes, resetGoproOverlayJob]);
 
   const handleSubmitEdit = async (values: FlightFormData) => {
     await updateFlight.mutateAsync(values);
@@ -156,6 +175,68 @@ export function FlightDetails({
     }
   };
 
+  const handleStartGoproOverlay = async () => {
+    if (!hasGpx || !hasVideo || isGoproOverlayRunning) return;
+
+    try {
+      const job = await createGoproOverlayJob.mutateAsync();
+      setGoproOverlayJobId(job.job_id);
+      toast.success(t('flights.goproOverlayStarted'));
+    } catch {
+      toast.error(t('flights.goproOverlayStartError'));
+    }
+  };
+
+  const handleCancelGoproOverlay = async () => {
+    if (!goproOverlayJob) return;
+
+    try {
+      await cancelGoproOverlayJob.mutateAsync(goproOverlayJob.job_id);
+      toast.success(t('flights.goproOverlayCancelled'));
+    } catch {
+      toast.error(t('flights.goproOverlayCancelError'));
+    }
+  };
+
+  const handleDownloadGoproOverlay = async () => {
+    if (!goproOverlayJob || goproOverlayJob.status !== 'completed') return;
+
+    try {
+      const blob = await api
+        .get(`gopro-overlays/jobs/${goproOverlayJob.job_id}/download`, {
+          timeout: false,
+        })
+        .blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = goproOverlayJob.output_filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error(t('flights.goproOverlayDownloadError'));
+    }
+  };
+
+  let goproOverlayAction = handleStartGoproOverlay;
+  let goproOverlayLabel = t('flights.goproOverlayGenerate');
+  if (goproOverlayJob?.status === 'completed') {
+    goproOverlayAction = handleDownloadGoproOverlay;
+    goproOverlayLabel = t('flights.goproOverlayDownload');
+  } else if (isGoproOverlayRunning) {
+    goproOverlayAction = handleCancelGoproOverlay;
+    goproOverlayLabel = t('flights.goproOverlayCancel');
+  } else if (createGoproOverlayJob.isPending) {
+    goproOverlayLabel = t('flights.goproOverlayStarting');
+  }
+
+  let goproOverlayTitle = t('flights.goproOverlayGenerateTitle');
+  if (!hasGpx) {
+    goproOverlayTitle = t('flights.goproOverlayNeedsGpx');
+  } else if (!hasVideo) {
+    goproOverlayTitle = t('flights.goproOverlayNeedsVideo');
+  }
+
   const infoCard = (
     <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md">
       {editingMode ? (
@@ -191,6 +272,19 @@ export function FlightDetails({
                     : t('flights.downloadGpx')}
                 </Button>
               )}
+              <Button
+                className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-slate-900 text-white rounded-md hover:bg-slate-800 transition-all disabled:cursor-not-allowed disabled:bg-gray-400 dark:bg-cyan-700 dark:hover:bg-cyan-600"
+                onPress={goproOverlayAction}
+                isDisabled={
+                  createGoproOverlayJob.isPending ||
+                  cancelGoproOverlayJob.isPending ||
+                  (!hasGpx && !goproOverlayJob) ||
+                  (!hasVideo && !goproOverlayJob)
+                }
+                title={goproOverlayTitle}
+              >
+                {goproOverlayLabel}
+              </Button>
               <Button
                 className={`px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm rounded-md transition-all ${
                   flight.gpx_file_path
@@ -228,6 +322,44 @@ export function FlightDetails({
                 <span className="inline-flex items-center rounded-full bg-indigo-100 px-2.5 py-1 text-xs font-semibold text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-200">
                   {t('flights.videoBadge')}
                 </span>
+              )}
+            </div>
+          )}
+
+          {goproOverlayJob && (
+            <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    {t('flights.goproOverlayJobTitle')}
+                  </p>
+                  <p className="text-xs text-slate-600 dark:text-slate-300">
+                    {goproOverlayJob.layout_label} ·{' '}
+                    {goproOverlayJob.output_filename}
+                  </p>
+                </div>
+                <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 shadow-sm dark:bg-slate-800 dark:text-slate-200">
+                  {t(`flights.goproOverlayStatus.${goproOverlayJob.status}`)}
+                </span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                <div
+                  className="h-full rounded-full bg-cyan-500 transition-all duration-300"
+                  style={{
+                    width: `${Math.max(
+                      0,
+                      Math.min(goproOverlayJob.progress, 100)
+                    )}%`,
+                  }}
+                />
+              </div>
+              <p className="mt-2 text-xs text-slate-700 dark:text-slate-200">
+                {goproOverlayJob.message}
+              </p>
+              {goproOverlayJob.error && (
+                <pre className="mt-2 max-h-36 overflow-auto rounded bg-red-950 p-2 text-xs text-red-50">
+                  {goproOverlayJob.error}
+                </pre>
               )}
             </div>
           )}

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -68,6 +68,16 @@ export function useCreateGoproOverlayJob() {
   });
 }
 
+export function useCreateFlightGoproOverlayJob(flightId: string) {
+  return useMutation({
+    mutationFn: async () => {
+      return await api
+        .post(`flights/${flightId}/gopro-overlay`, { timeout: false })
+        .json<GoproOverlayJob>();
+    },
+  });
+}
+
 export function useCancelGoproOverlayJob() {
   return useMutation({
     mutationFn: async (jobId: string) => {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -423,7 +423,9 @@
         "help": "Controls how sensitive the score and time slots are to atmospheric instability.",
         "fields": {
           "para_li_stable_min": { "label": "Stable above" },
-          "para_li_slightly_unstable_min": { "label": "Slightly unstable above" },
+          "para_li_slightly_unstable_min": {
+            "label": "Slightly unstable above"
+          },
           "para_li_very_unstable_max": { "label": "Very unstable below" }
         }
       },
@@ -449,9 +451,13 @@
         "help": "Adjusts the textual reasons shown in the flyability column (frontend only).",
         "fields": {
           "ui_reason_wind_moderate_min": { "label": "UI: moderate wind min" },
-          "ui_reason_wind_very_strong_min": { "label": "UI: very strong wind min" },
+          "ui_reason_wind_very_strong_min": {
+            "label": "UI: very strong wind min"
+          },
           "ui_reason_gust_high_min": { "label": "UI: high gusts min" },
-          "ui_reason_cloud_very_cloudy_min": { "label": "UI: very cloudy min (%)" }
+          "ui_reason_cloud_very_cloudy_min": {
+            "label": "UI: very cloudy min (%)"
+          }
         }
       }
     },
@@ -606,6 +612,26 @@
     "noNotes": "No notes for this flight",
     "gpxBadge": "GPX available",
     "videoBadge": "Video available",
+    "goproOverlayGenerate": "Generate GoPro overlay",
+    "goproOverlayStarting": "Starting...",
+    "goproOverlayCancel": "Cancel overlay",
+    "goproOverlayDownload": "Download overlay",
+    "goproOverlayGenerateTitle": "Generate a GoPro overlay video for this flight",
+    "goproOverlayNeedsGpx": "Add a GPX to this flight before generating the overlay",
+    "goproOverlayNeedsVideo": "Generate the flight video before adding the overlay",
+    "goproOverlayStarted": "GoPro overlay generation started",
+    "goproOverlayStartError": "Unable to start GoPro overlay",
+    "goproOverlayCancelled": "GoPro overlay generation cancelled",
+    "goproOverlayCancelError": "Unable to cancel GoPro overlay",
+    "goproOverlayDownloadError": "Unable to download GoPro overlay",
+    "goproOverlayJobTitle": "Flight GoPro overlay",
+    "goproOverlayStatus": {
+      "queued": "Queued",
+      "running": "Running",
+      "completed": "Completed",
+      "failed": "Error",
+      "cancelled": "Cancelled"
+    },
     "loading3dViewer": "Loading 3D viewer...",
     "flightOf": "Flight on {{date}}",
     "selectFlightHint": "Select a flight to view details and 3D trajectory",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -461,7 +461,7 @@
         }
       }
     },
-    "saved": "Settings saved!",
+    "saveSuccess": "Settings saved!",
     "saveButton": "Save changes"
   },
   "analytics": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -465,7 +465,7 @@
         }
       }
     },
-    "saved": "Paramètres sauvegardés !",
+    "saveSuccess": "Paramètres sauvegardés !",
     "saveButton": "Sauvegarder les modifications"
   },
   "analytics": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -423,8 +423,12 @@
         "help": "Contrôle la sensibilité à l'instabilité atmosphérique dans le score et les créneaux.",
         "fields": {
           "para_li_stable_min": { "label": "Stable au-dessus de" },
-          "para_li_slightly_unstable_min": { "label": "Légèrement instable au-dessus de" },
-          "para_li_very_unstable_max": { "label": "Très instable en dessous de" }
+          "para_li_slightly_unstable_min": {
+            "label": "Légèrement instable au-dessus de"
+          },
+          "para_li_very_unstable_max": {
+            "label": "Très instable en dessous de"
+          }
         }
       },
       "temperature": {
@@ -449,9 +453,15 @@
         "help": "Ajuste les raisons textuelles affichées dans la colonne Volabilité (frontend uniquement).",
         "fields": {
           "ui_reason_wind_moderate_min": { "label": "UI : vent modéré min" },
-          "ui_reason_wind_very_strong_min": { "label": "UI : vent très fort min" },
-          "ui_reason_gust_high_min": { "label": "UI : rafales importantes min" },
-          "ui_reason_cloud_very_cloudy_min": { "label": "UI : très nuageux min (%)" }
+          "ui_reason_wind_very_strong_min": {
+            "label": "UI : vent très fort min"
+          },
+          "ui_reason_gust_high_min": {
+            "label": "UI : rafales importantes min"
+          },
+          "ui_reason_cloud_very_cloudy_min": {
+            "label": "UI : très nuageux min (%)"
+          }
         }
       }
     },
@@ -606,6 +616,26 @@
     "noNotes": "Aucune note pour ce vol",
     "gpxBadge": "GPX disponible",
     "videoBadge": "Vidéo disponible",
+    "goproOverlayGenerate": "Générer overlay GoPro",
+    "goproOverlayStarting": "Lancement...",
+    "goproOverlayCancel": "Annuler overlay",
+    "goproOverlayDownload": "Télécharger overlay",
+    "goproOverlayGenerateTitle": "Générer une vidéo avec overlay GoPro pour ce vol",
+    "goproOverlayNeedsGpx": "Ajoutez un GPX à ce vol pour générer l'overlay",
+    "goproOverlayNeedsVideo": "Générez d'abord la vidéo du vol pour ajouter l'overlay",
+    "goproOverlayStarted": "Génération overlay GoPro lancée",
+    "goproOverlayStartError": "Impossible de lancer l'overlay GoPro",
+    "goproOverlayCancelled": "Génération overlay GoPro annulée",
+    "goproOverlayCancelError": "Impossible d'annuler l'overlay GoPro",
+    "goproOverlayDownloadError": "Impossible de télécharger l'overlay GoPro",
+    "goproOverlayJobTitle": "Overlay GoPro du vol",
+    "goproOverlayStatus": {
+      "queued": "En attente",
+      "running": "En cours",
+      "completed": "Terminé",
+      "failed": "Erreur",
+      "cancelled": "Annulé"
+    },
     "loading3dViewer": "Chargement du viewer 3D...",
     "flightOf": "Vol du {{date}}",
     "selectFlightHint": "Sélectionnez un vol pour visualiser les détails et la trajectoire 3D",


### PR DESCRIPTION
## Summary
- Remove GoPro overlay from the main navigation.
- Add a flight-level GoPro overlay action backed by existing flight GPX/video files.
- Show overlay job progress, cancel, and download actions in flight details.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `PATH=/tmp/opencode/dashboard-venv/bin:$PATH NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `PATH=/tmp/opencode/dashboard-venv/bin:$PATH NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate GoPro overlays from flight pages using existing video/GPX files; create/cancel/download overlay jobs with real-time status.

* **UI/Navigation**
  * Overlay action integrated into Flight Details; authenticated menu reordered (sites moved into nav).

* **Bug Fixes**
  * Improved input validation and safer cleanup on job errors.

* **Tests**
  * Added API and unit tests for overlay endpoints, path resolution, validation, and file handling.

* **Localization**
  * Added/expanded English and French GoPro overlay translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/775)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->