### PR TITLE
docs: streamline repository skill guidance

### DIFF
--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -7,28 +7,22 @@ description: Guides implementation, debugging, review, validation, and GitHub wo
 
 ## Quick Start
 
-Use this skill for repository workflow decisions, validation strategy, GitHub operations, and frontend/backend conventions.
+Use this skill for repository workflow decisions, GitHub operations, and frontend/backend conventions.
 
 1. Read the closest applicable `AGENTS.md`.
 2. Inspect the current structure before editing.
 3. Keep changes minimal and scoped.
 4. Do not modify unrelated dirty files.
-5. Prefer affected Nx tasks for validation.
+5. Load `local-machine-stack` before running pnpm, Nx, lint, test, build, or type-check commands.
 
 Projects: `frontend` in `apps/frontend`, `backend` in `apps/backend`, `design-system` in `libs/design-system`, `shared-types` in `libs/shared-types`.
-
-Package manager:
-
-```bash
-/home/capic/.local/share/pnpm/pnpm
-```
 
 ## Tooling
 
 - Use `Glob` for file discovery, `Grep` for code search, and `Read` for known files.
 - Use `apply_patch` for manual edits; avoid shell-based file editing.
 - Never use destructive git commands.
-- Load `local-machine-stack` for pnpm, dependency readiness, command timeouts, and machine-specific command details.
+- Use `local-machine-stack` as the source of truth for pnpm paths, dependency readiness, command timeouts, and Nx validation commands.
 
 ## Worktrees
 
@@ -48,13 +42,7 @@ Applies to `apps/frontend/**`; follow `apps/frontend/AGENTS.md`.
 - Keep Storybook stories focused and use CSF Factory.
 - Update `apps/frontend/chromatic.config.json` when stories are added or restructured.
 
-Frontend validation:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test,build --parallel=5 --exclude=e2e
-```
-
-Run frontend build when behavior, routing, bundling, or UI code changes.
+Run frontend build when behavior, routing, bundling, or UI code changes. Use `local-machine-stack` for the exact validation command.
 
 ## Backend
 
@@ -66,21 +54,11 @@ Applies to `apps/backend/**`; follow `apps/backend/AGENTS.md`.
 - Follow existing SQLAlchemy patterns.
 - Add pytest coverage for new business behavior or bug fixes.
 
-Backend validation:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test --parallel=5 --exclude=e2e
-```
+Use `local-machine-stack` for the exact backend validation command.
 
 ## Validation
 
-Prefer this command for implementation and PR validation:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e
-```
-
-Use direct project targets only after an affected run identifies a failing project, or when explicitly requested. Use `run-many` only when affected detection is inappropriate or a full-repo check is required.
+Prefer affected Nx validation from `local-machine-stack` for implementation and PR validation. Use direct project targets only after an affected run identifies a failing project, or when explicitly requested. Use `run-many` only when affected detection is inappropriate or a full-repo check is required.
 
 For long validation runs, prefer a validation subagent that runs commands from the active worktree and returns a concise pass/fail report. The main agent fixes failures and decides whether more validation is needed.
 

--- a/.agents/skills/local-machine-stack/SKILL.md
+++ b/.agents/skills/local-machine-stack/SKILL.md
@@ -7,7 +7,7 @@ description: Documents the local machine setup for this Nx monorepo, including t
 
 ## Quick Start
 
-Use this pnpm binary on this machine:
+Run repository commands from the active checkout or worktree root. Use this pnpm binary on this machine:
 
 ```bash
 /home/capic/.local/share/pnpm/pnpm
@@ -15,66 +15,48 @@ Use this pnpm binary on this machine:
 
 Do not assume `pnpm`, `npm`, `npx`, `yarn`, or `corepack` are available in `PATH`.
 
-Before running Nx commands, verify local dependencies exist. If `node_modules/.bin/nx` or required packages such as `typescript` are missing, run:
+Before Nx commands, verify local dependencies exist. If `node_modules/.bin/nx` or required packages such as `typescript` are missing, run:
 
 ```bash
 CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile
 ```
 
-For new worktrees, prefer the `worktree-bootstrap` subagent to perform this dependency readiness check in parallel with implementation work. The subagent should only run install when dependencies are missing or unusable.
+For new worktrees, prefer the `worktree-bootstrap` subagent for this readiness check. It should only run install when dependencies are missing or unusable.
 
 Do not enable pnpm's global virtual store in this repository. Nx and Knip expect dependency resolution from the workspace-local `node_modules` layout, and CI can fail when packages resolve through a global virtual store path.
 
 ## Repository
 
-Workspace root:
-
-```bash
-/media/nas/usb2/developement/moi/dashboard-parapente
-```
-
-This is an Nx monorepo with these main projects:
+This is an Nx monorepo. Main projects:
 
 - `frontend`
 - `backend`
 - `design-system`
 - `shared-types`
 
-## Lint
+## Validation Commands
 
-For Nx lint tasks, prefer `affected`, disable Nx Cloud noise, and use a long timeout.
+For Nx tasks, prefer `affected`, disable Nx Cloud noise, and use Bash timeout `360000` or higher.
 
-Bash tool settings:
-
-- `workdir`: `/media/nas/usb2/developement/moi/dashboard-parapente`
-- `timeout`: `360000`
-
-Command:
+Full implementation and PR validation:
 
 ```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
+NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e
 ```
 
-Only use a full-repo direct Nx command when affected detection is explicitly inappropriate:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run-many -t lint --all
-```
-
-When output is very large, verify success with the exit code:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm lint >/tmp/dashboard-parapente-lint.log 2>&1; status=$?; printf 'lint_exit_code=%s\n' "$status"; exit "$status"
-```
-
-## Affected Nx Commands
-
-Use affected commands for Nx validation, even when only one project appears impacted:
+Individual affected targets:
 
 ```bash
 NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
 NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e
 NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e
+```
+
+Only use full-repo direct Nx commands when affected detection is explicitly inappropriate:
+
+```bash
+NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run-many -t lint --all
+NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run-many -t test --all
 ```
 
 Use direct project targets such as `nx affected lint frontend` or `nx affected test backend` only as follow-up diagnostics after an affected run identifies a failing project, or when explicitly requested.
@@ -86,17 +68,7 @@ For direct Oxlint checks on frontend/design-system:
 /home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json libs/design-system/src
 ```
 
-## Tests And Build
-
-Use the same pnpm binary and disable Nx Cloud if running through Nx:
-
-```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e
-```
-
-Use a longer Bash timeout for full-repo tasks:
+Use longer Bash timeouts for full-repo tasks:
 
 - affected: `360000`
 - lint: `360000`
@@ -106,6 +78,8 @@ Use a longer Bash timeout for full-repo tasks:
 ## Notes
 
 Lint can produce many warnings while still succeeding. Treat the process exit code as authoritative for pass/fail.
+
+When output is very large, redirect logs and print the exit code.
 
 If a command creates temporary build artifacts such as `*.tsbuildinfo`, remove untracked generated artifacts unless they are intentionally part of the task.
 

--- a/.agents/skills/ui-ux-pro-max/SKILL.md
+++ b/.agents/skills/ui-ux-pro-max/SKILL.md
@@ -9,12 +9,7 @@ Use this skill for concrete UI/UX work: design systems, frontend screens, visual
 
 ## Required Workflow
 
-1. Extract the request context before searching:
-- Product type: SaaS, e-commerce, portfolio, dashboard, landing page, mobile app, etc.
-- Industry: healthcare, fintech, gaming, education, beauty, service, etc.
-- Style keywords: minimal, playful, professional, elegant, dark, brutalist, etc.
-- Target surface: landing page, app screen, dashboard, chart, form, settings, etc.
-- Stack: use the user's stack, otherwise default to `html-tailwind`.
+1. Extract the request context before searching: product type, industry, style keywords, target surface, and stack. Use the user's stack, otherwise default to `html-tailwind`.
 
 2. Generate a design system first. Do this before implementation or critique:
 
@@ -34,10 +29,7 @@ python3 .agents/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system
 python3 .agents/skills/ui-ux-pro-max/scripts/search.py "<query>" --design-system --persist -p "<Project Name>" --page "<page>"
 ```
 
-5. For a persisted project, use hierarchical retrieval:
-- Check `design-system/<project-slug>/pages/<page>.md` first.
-- If the page file exists, its rules override `MASTER.md`.
-- If no page file exists, follow `design-system/<project-slug>/MASTER.md`.
+5. For a persisted project, check `design-system/<project-slug>/pages/<page>.md` first. Page rules override `MASTER.md`; otherwise follow `MASTER.md`.
 
 6. Supplement with focused searches only when needed:
 
@@ -56,32 +48,9 @@ python3 .agents/skills/ui-ux-pro-max/scripts/search.py "layout responsive forms"
 
 ## Search Reference
 
-Available domains:
-- `product`: product type recommendations.
-- `style`: visual styles, effects, CSS keywords, prompt keywords.
-- `typography`: font pairings and Google Fonts guidance.
-- `color`: palettes by product type and mood.
-- `landing`: section order, CTA placement, conversion strategy.
-- `chart`: chart type, color guidance, chart accessibility.
-- `ux`: usability, accessibility, loading, motion, z-index, mobile behavior.
-- `icons`: icon library and icon usage guidance.
-- `react`: React and Next.js performance guidance.
-- `web`: semantic HTML, ARIA, forms, focus, keyboard, virtualization.
+Available domains: `product`, `style`, `typography`, `color`, `landing`, `chart`, `ux`, `icons`, `react`, `web`.
 
-Available stacks:
-- `html-tailwind`
-- `react`
-- `nextjs`
-- `astro`
-- `vue`
-- `nuxtjs`
-- `nuxt-ui`
-- `svelte`
-- `swiftui`
-- `react-native`
-- `flutter`
-- `shadcn`
-- `jetpack-compose`
+Available stacks: `html-tailwind`, `react`, `nextjs`, `astro`, `vue`, `nuxtjs`, `nuxt-ui`, `svelte`, `swiftui`, `react-native`, `flutter`, `shadcn`, `jetpack-compose`.
 
 ## Implementation Rules
 

--- a/.agents/skills/write-skill/SKILL.md
+++ b/.agents/skills/write-skill/SKILL.md
@@ -7,21 +7,11 @@ description: Create new agent skills with proper structure, progressive disclosu
 
 ## Process
 
-1. **Gather requirements** - ask user about:
-    - What task/domain does the skill cover?
-    - What specific use cases should it handle?
-    - Does it need executable scripts or just instructions?
-    - Any reference materials to include?
+1. **Gather requirements** - ask what task/domain the skill covers, which use cases it handles, whether it needs scripts or just instructions, and which reference materials to include.
 
-2. **Draft the skill** - create:
-    - SKILL.md with concise instructions
-    - Additional reference files if content exceeds 500 lines
-    - Utility scripts if deterministic operations needed
+2. **Draft the skill** - create `SKILL.md` with concise instructions, add reference files if content exceeds 500 lines, and add utility scripts for deterministic operations.
 
-3. **Review with user** - present draft and ask:
-    - Does this cover your use cases?
-    - Anything missing or unclear?
-    - Should any section be more/less detailed?
+3. **Review with user** - present the draft and ask whether it covers the use cases, whether anything is missing or unclear, and whether any section needs more or less detail.
 
 ## Skill Structure
 
@@ -61,10 +51,7 @@ description: Brief description of capability. Use when [specific triggers].
 
 The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
 
-**Goal**: Give your agent just enough info to know:
-
-1. What capability this skill provides
-2. When/why to trigger it (specific keywords, contexts, file types)
+**Goal**: Give your agent just enough info to know what capability the skill provides and when to trigger it, using specific keywords, contexts, and file types.
 
 **Format**:
 
@@ -79,13 +66,7 @@ The description is **the only thing your agent sees** when deciding which skill 
 Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
 ```
 
-**Bad example**:
-
-```
-Helps with documents.
-```
-
-The bad example gives your agent no way to distinguish this from other document skills.
+Avoid vague descriptions such as `Helps with documents.` because they do not distinguish the skill from related document skills.
 
 ## When to Add Scripts
 

--- a/.agents/skills/write-skill/SKILL.md
+++ b/.agents/skills/write-skill/SKILL.md
@@ -9,7 +9,7 @@ description: Create new agent skills with proper structure, progressive disclosu
 
 1. **Gather requirements** - ask what task/domain the skill covers, which use cases it handles, whether it needs scripts or just instructions, and which reference materials to include.
 
-2. **Draft the skill** - create `SKILL.md` with concise instructions, add reference files if content exceeds 500 lines, and add utility scripts for deterministic operations.
+2. **Draft the skill** - create `SKILL.md` with concise instructions, add reference files if content exceeds 100 lines, and add utility scripts for deterministic operations.
 
 3. **Review with user** - present the draft and ask whether it covers the use cases, whether anything is missing or unclear, and whether any section needs more or less detail.
 


### PR DESCRIPTION
## Summary
- Reduce duplication between the repo workflow and local machine skill docs
- Remove stale workspace-root guidance from the local machine skill
- Tighten the writing and UI/UX skill docs to fit the skill format guidance

## Validation
- `git diff --check`
- Commit hook: `knip`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified dashboard skill docs to defer command specifics to the local-machine-stack reference.
  * Expanded local-machine-stack guidance for running pnpm, readiness checks, dependency resolution, and standardized Nx validation commands.
  * Simplified UI/UX and write-skill workflows for clearer, shorter guidance and expectations.
  * Removed redundant/duplicated guidance across skill docs for consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/776)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->