### PR TITLE
Fix orphan GoPro exports blocking generation

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -137,9 +137,30 @@ def _video_export_mode_label(mode: str) -> str:
     return "manual render"
 
 
-def _ensure_no_active_export(flight: Flight):
-    if flight.video_export_status in _VIDEO_EXPORT_IN_PROGRESS_STATUSES:
-        raise HTTPException(status_code=400, detail="Video conversion already in progress")
+def _ensure_no_active_export(flight: Flight) -> None:
+    if flight.video_export_status not in _VIDEO_EXPORT_IN_PROGRESS_STATUSES:
+        return
+
+    if not flight.video_export_job_id:
+        logger.warning(
+            "Flight %s has orphan video export status %s without job id; allowing restart",
+            flight.id,
+            flight.video_export_status,
+        )
+        return
+
+    if not _resolve_export_status(flight.video_export_job_id):
+        logger.warning(
+            "Flight %s references missing video export job %s; allowing restart",
+            flight.id,
+            flight.video_export_job_id,
+        )
+        return
+
+    raise HTTPException(
+        status_code=400,
+        detail="Video conversion already in progress",
+    )
 
 
 def _mark_flight_export_processing(db: Session, flight: Flight, job_id: str):

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -184,12 +184,48 @@ class TestGenerateVideoEndpoint:
     ):
         """In-progress internal states must be treated as running conversions."""
         sample_flight.video_export_status = "capturing"
+        sample_flight.video_export_job_id = "job-capturing"
         sample_flight.gpx_file_path = "db/gpx/sample.gpx"
         db_session.commit()
 
-        response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+        with patch("routes._resolve_export_status", return_value={"status": "capturing"}):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+
         assert response.status_code == 400
         assert response.json()["detail"] == "Video conversion already in progress"
+
+    def test_generate_video_allows_orphan_in_progress_status(
+        self, client: TestClient, db_session, sample_flight
+    ):
+        """Stale in-progress flight state without a job id should not block generation."""
+        sample_flight.video_export_status = "processing"
+        sample_flight.video_export_job_id = None
+        sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+        db_session.commit()
+
+        with patch("routes.start_video_export_manual", return_value="job-manual"):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+
+        assert response.status_code == 200
+        assert response.json()["job_id"] == "job-manual"
+
+    def test_generate_video_allows_missing_in_progress_job(
+        self, client: TestClient, db_session, sample_flight
+    ):
+        """Stale in-progress flight state pointing to a missing job should not block generation."""
+        sample_flight.video_export_status = "processing"
+        sample_flight.video_export_job_id = "job-missing"
+        sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+        db_session.commit()
+
+        with (
+            patch("routes._resolve_export_status", return_value=None),
+            patch("routes.start_video_export_manual", return_value="job-manual"),
+        ):
+            response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
+
+        assert response.status_code == 200
+        assert response.json()["job_id"] == "job-manual"
 
 
 class TestExportStatusAndCancel:

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -67,6 +67,14 @@ import { useAppSettingsStore } from '../../stores/appSettingsStore';
 const isVideoExportInProgress = (status?: string | null) =>
   Boolean(status && VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status));
 
+const hasActiveVideoExport = (
+  flight?: Pick<Flight, 'video_export_job_id' | 'video_export_status'> | null
+) =>
+  Boolean(
+    flight?.video_export_job_id &&
+    isVideoExportInProgress(flight.video_export_status)
+  );
+
 type VideoExportMode = 'manual_fast' | 'manual';
 
 const getHttpErrorDetail = async (error: HTTPError): Promise<string | null> => {
@@ -561,7 +569,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     [isActiveViewer, removeTrackEntity]
   );
 
-  const isExportActive = isVideoExportInProgress(flight?.video_export_status);
+  const isExportActive = hasActiveVideoExport(flight);
   const shouldReadExportStatus = Boolean(
     flight?.video_export_job_id &&
     (isExportActive ||
@@ -2240,11 +2248,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                                 t('flights.viewer.videoDownloadError')
                               );
                             }
-                          } else if (
-                            !flight.video_export_status ||
-                            flight.video_export_status === 'failed' ||
-                            flight.video_export_status === 'cancelled'
-                          ) {
+                          } else if (!hasActiveVideoExport(flight)) {
                             // Generate video
                             try {
                               if (canResumeVideoExport) {
@@ -2272,8 +2276,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           }
                         }}
                         isDisabled={
-                          isStartingVideoExport ||
-                          isVideoExportInProgress(flight.video_export_status)
+                          isStartingVideoExport || hasActiveVideoExport(flight)
                         }
                         className={`w-full ${compactControlButtonClassName} text-white rounded ${
                           flight.video_export_status === 'completed'
@@ -2283,14 +2286,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           flight.video_export_status === 'completed'
                             ? 'bg-green-600 hover:bg-green-700'
                             : isStartingVideoExport ||
-                                isVideoExportInProgress(
-                                  flight.video_export_status
-                                )
+                                hasActiveVideoExport(flight)
                               ? 'bg-gray-400 cursor-not-allowed'
                               : 'bg-blue-600 hover:bg-blue-700'
                         }`}
                         title={
-                          isVideoExportInProgress(flight.video_export_status)
+                          hasActiveVideoExport(flight)
                             ? t('flights.viewer.videoGeneratingTitle')
                             : flight.video_export_status === 'completed'
                               ? t('flights.viewer.videoDownloadTitle')
@@ -2302,7 +2303,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                                 : t('flights.viewer.videoGenerateTitle')
                         }
                       >
-                        {isVideoExportInProgress(flight.video_export_status) &&
+                        {hasActiveVideoExport(flight) &&
                           `⏳ ${t('flights.viewer.videoGenerating')}`}
                         {flight.video_export_status === 'completed' &&
                           `📥 ${t('flights.viewer.downloadVideo')}`}
@@ -2311,7 +2312,11 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                           (canResumeVideoExport
                             ? `▶️ ${t('flights.viewer.resumeVideo')}`
                             : `🔄 ${t('flights.viewer.regenerateVideo')}`)}
-                        {!flight.video_export_status &&
+                        {(!flight.video_export_status ||
+                          isVideoExportInProgress(
+                            flight.video_export_status
+                          )) &&
+                          !hasActiveVideoExport(flight) &&
                           `🎥 ${t('flights.viewer.generateVideo')}`}
                       </Button>
 
@@ -2323,79 +2328,76 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                         </p>
                       )}
 
-                      {isVideoExportInProgress(flight.video_export_status) &&
-                        flight.video_export_job_id && (
-                          <div className="mb-3 rounded border border-blue-200 bg-blue-50 p-2 dark:border-blue-700 dark:bg-blue-900/20">
-                            <div className="mb-1 flex items-center justify-between text-xs font-medium text-blue-900 dark:text-blue-100">
-                              <span>{t('flights.viewer.videoProgress')}</span>
-                              <span>{exportProgress}%</span>
-                            </div>
-                            <div className="h-2 w-full overflow-hidden rounded bg-blue-100 dark:bg-blue-950/40">
-                              <div
-                                className="h-full rounded bg-blue-600 transition-all duration-500"
-                                style={{ width: `${exportProgress}%` }}
-                              />
-                            </div>
-                            <p className="mt-2 text-xs text-blue-900 dark:text-blue-100">
-                              {exportStatus?.message ||
-                                t('flights.viewer.videoGenerating')}
-                            </p>
-                            {exportEta && (
-                              <p className="mt-1 text-xs text-blue-900 dark:text-blue-100">
-                                {t('flights.viewer.videoEta', {
-                                  time: exportEta,
-                                })}
-                              </p>
-                            )}
+                      {hasActiveVideoExport(flight) && (
+                        <div className="mb-3 rounded border border-blue-200 bg-blue-50 p-2 dark:border-blue-700 dark:bg-blue-900/20">
+                          <div className="mb-1 flex items-center justify-between text-xs font-medium text-blue-900 dark:text-blue-100">
+                            <span>{t('flights.viewer.videoProgress')}</span>
+                            <span>{exportProgress}%</span>
                           </div>
-                        )}
+                          <div className="h-2 w-full overflow-hidden rounded bg-blue-100 dark:bg-blue-950/40">
+                            <div
+                              className="h-full rounded bg-blue-600 transition-all duration-500"
+                              style={{ width: `${exportProgress}%` }}
+                            />
+                          </div>
+                          <p className="mt-2 text-xs text-blue-900 dark:text-blue-100">
+                            {exportStatus?.message ||
+                              t('flights.viewer.videoGenerating')}
+                          </p>
+                          {exportEta && (
+                            <p className="mt-1 text-xs text-blue-900 dark:text-blue-100">
+                              {t('flights.viewer.videoEta', {
+                                time: exportEta,
+                              })}
+                            </p>
+                          )}
+                        </div>
+                      )}
 
                       {/* Cancel Button (only when export is active) */}
-                      {isVideoExportInProgress(flight.video_export_status) &&
-                        flight.video_export_job_id && (
-                          <Button
-                            onClick={async () => {
-                              if (
-                                !confirm(
-                                  t('flights.viewer.confirmCancelGeneration')
-                                )
-                              ) {
+                      {hasActiveVideoExport(flight) && (
+                        <Button
+                          onClick={async () => {
+                            if (
+                              !confirm(
+                                t('flights.viewer.confirmCancelGeneration')
+                              )
+                            ) {
+                              return;
+                            }
+
+                            try {
+                              await api.delete(
+                                `exports/${flight.video_export_job_id}/cancel`
+                              );
+
+                              // Refresh flight data to get updated status
+                              queryClient.invalidateQueries({
+                                queryKey: ['flights', flightId],
+                              });
+                            } catch (error) {
+                              if (error instanceof HTTPError) {
+                                const detail = await getHttpErrorDetail(error);
+                                toast.error(
+                                  detail ||
+                                    t('flights.viewer.cancelGenerationError')
+                                );
                                 return;
                               }
 
-                              try {
-                                await api.delete(
-                                  `exports/${flight.video_export_job_id}/cancel`
-                                );
-
-                                // Refresh flight data to get updated status
-                                queryClient.invalidateQueries({
-                                  queryKey: ['flights', flightId],
-                                });
-                              } catch (error) {
-                                if (error instanceof HTTPError) {
-                                  const detail =
-                                    await getHttpErrorDetail(error);
-                                  toast.error(
-                                    detail ||
-                                      t('flights.viewer.cancelGenerationError')
-                                  );
-                                  return;
-                                }
-
-                                console.error(
-                                  'Failed to cancel video generation:',
-                                  error
-                                );
-                                toast.error(t('flights.viewer.cancelError'));
-                              }
-                            }}
-                            className="w-full px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 mb-3"
-                            title={t('flights.viewer.cancelGenerationTitle')}
-                          >
-                            🛑 {t('flights.viewer.cancelGeneration')}
-                          </Button>
-                        )}
+                              console.error(
+                                'Failed to cancel video generation:',
+                                error
+                              );
+                              toast.error(t('flights.viewer.cancelError'));
+                            }
+                          }}
+                          className="w-full px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 mb-3"
+                          title={t('flights.viewer.cancelGenerationTitle')}
+                        >
+                          🛑 {t('flights.viewer.cancelGeneration')}
+                        </Button>
+                      )}
 
                       {/* Regenerate Button (only when video exists) */}
                       {flight.video_export_status === 'completed' && (

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -195,9 +195,12 @@ vi.mock('cesium', () => {
 vi.mock('@dashboard-parapente/design-system', () => ({
   Button: ({
     children,
+    isDisabled,
     ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button type="button" {...props}>
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isDisabled?: boolean;
+  }) => (
+    <button type="button" disabled={isDisabled} {...props}>
       {children}
     </button>
   ),
@@ -350,13 +353,42 @@ describe('FlightViewer3D video export mode', () => {
 
     expect(screen.getByText('Fast hint')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Generate video/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
 
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
         searchParams: { mode: 'manual_fast' },
       });
     });
+  });
+
+  it('allows generation when an in-progress status has no job id', async () => {
+    mockFlight.video_export_status = 'processing';
+    mockFlight.video_export_job_id = null;
+
+    render(<FlightViewer3D flightId="flight-1" />);
+
+    const button = screen.getByRole('button', { name: /Generate video/u });
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
+        searchParams: { mode: 'manual_fast' },
+      });
+    });
+  });
+
+  it('keeps generation disabled when an in-progress status has a job id', () => {
+    mockFlight.video_export_status = 'processing';
+    mockFlight.video_export_job_id = 'job-processing';
+
+    render(<FlightViewer3D flightId="flight-1" />);
+
+    expect(
+      screen.getByRole('button', { name: /flights\.viewer\.videoGenerating/u })
+    ).toBeDisabled();
   });
 
   it('hides viewer controls in export-only mode', () => {
@@ -371,7 +403,7 @@ describe('FlightViewer3D video export mode', () => {
     );
     expect(screen.queryByText('Fast hint')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: /Generate video/ })
+      screen.queryByRole('button', { name: /Generate video/u })
     ).not.toBeInTheDocument();
   });
 
@@ -486,7 +518,7 @@ describe('FlightViewer3D video export mode', () => {
 
     expect(screen.getByText('Manual hint')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Generate video/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
 
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
@@ -511,7 +543,7 @@ describe('FlightViewer3D video export mode', () => {
 
     expect(screen.getByText('frames preserved')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Resume generation/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Resume generation/u }));
 
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith('exports/job-cancelled/resume');
@@ -535,7 +567,7 @@ describe('FlightViewer3D video export mode', () => {
 
     render(<FlightViewer3D flightId="flight-1" />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Download video/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Download video/u }));
 
     await waitFor(() => {
       expect(apiGet).toHaveBeenCalledWith('exports/job-video/download', {


### PR DESCRIPTION
## Summary
- Allow flight video generation to restart when an export status is stale but no live job exists.
- Keep the GoPro flight viewer button enabled for orphaned in-progress states while preserving the disable state for real active jobs.
- Add backend and frontend tests for orphan and active export cases.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightViewer3D.video-export.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `.venv/bin/pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export restart handling for in-progress exports with orphaned or unresolvable jobs, allowing safe recovery and resumption.
  * Enhanced video export UI consistency for better status indication and button state management across various export states.

* **Tests**
  * Expanded test coverage for video export status scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/786)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->