### PR TITLE
Fix Portainer backend build preservation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,12 @@ services:
       - parapente-network
 
   backend:
-    image: ${BACKEND_IMAGE:-parapente-backend:nx-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN:?required}
+    image: parapente-backend:nx-latest
     container_name: parapente-backend
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,7 @@ services:
       - parapente-network
 
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - BUILDKIT_INLINE_CACHE=1
-        - VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN:?required}
-    image: parapente-backend:nx-latest
+    image: ${BACKEND_IMAGE:-parapente-backend:nx-latest}
     container_name: parapente-backend
     restart: unless-stopped
     ports:
@@ -101,6 +95,11 @@ services:
       - BACKEND_VIDEO_EXPORT_DIR=${BACKEND_VIDEO_EXPORT_DIR:-/app/video-exports}
       - BACKEND_VIDEO_TEMP_IMAGES_DIR=${BACKEND_VIDEO_TEMP_IMAGES_DIR:-/app/video-temp-images}
 
+      # Backend - GoPro overlay toolchain
+      - BACKEND_GOPRO_OVERLAY_ROOT=${BACKEND_GOPRO_OVERLAY_ROOT:-/media/usb/data-m2/developement/gopro-overlay-dasboard}
+      - BACKEND_GOPRO_OVERLAY_BIN=${BACKEND_GOPRO_OVERLAY_BIN:-/media/usb/data-m2/developement/gopro-overlay-dasboard/venv/bin/gopro-dashboard.py}
+      - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=${BACKEND_GOPRO_OVERLAY_LAYOUT_DIR:-/media/usb/data-m2/developement/gopro-overlay-dasboard}
+
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
     depends_on:
@@ -110,6 +109,7 @@ services:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${VIDEO_EXPORT_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/videos}:/app/video-exports
       - ${VIDEO_TEMP_IMAGES_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/video-temp-images}:/app/video-temp-images
+      - ${GOPRO_OVERLAY_HOST_DIR:-/media/usb/data-m2/developement/gopro-overlay-dasboard}:${BACKEND_GOPRO_OVERLAY_ROOT:-/media/usb/data-m2/developement/gopro-overlay-dasboard}:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
       interval: 30s


### PR DESCRIPTION
## Summary
- Restore the backend `build` block so Portainer deploys still include the latest backend code.
- Keep the GoPro overlay runtime env and volume defaults from the previous deploy fix.
- Remove only `BUILDKIT_INLINE_CACHE=1` to avoid the slow inline-cache export step seen in Portainer logs.

## Validation
- YAML validation of `docker-compose.yml` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified the backend service container configuration to build from a local Dockerfile with proper credential passing, ensuring dependencies are correctly initialized during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/792)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->