### PR TITLE
fix(backend): resolve Meteociel test slug from nearest commune

### DIFF
--- a/apps/backend/scrapers/meteociel.py
+++ b/apps/backend/scrapers/meteociel.py
@@ -94,16 +94,16 @@ class MeteocielScraper(BaseScraper):
             logger.error(f"Error fetching INSEE code for {city_name}: {e}")
             return None
 
-    async def _get_nearest_insee_code(self, lat: float, lon: float) -> str | None:
+    async def _get_nearest_commune(self, lat: float, lon: float) -> tuple[str, str] | None:
         """
-        Get INSEE code for nearest French city using reverse geocoding
+        Get nearest French city using reverse geocoding
 
         Args:
             lat: Latitude
             lon: Longitude
 
         Returns:
-            INSEE code or None if not in France
+            Tuple of (INSEE code, city name) or None if not in France
         """
         try:
             url = "https://geo.api.gouv.fr/communes"
@@ -120,7 +120,7 @@ class MeteocielScraper(BaseScraper):
                     logger.info(
                         f"Found nearest French city at {lat:.4f},{lon:.4f}: {city_name} (INSEE: {insee_code})"
                     )
-                    return insee_code
+                    return insee_code, city_name
                 else:
                     logger.warning(f"No French city found near coordinates {lat:.4f},{lon:.4f}")
                     return None
@@ -151,19 +151,22 @@ class MeteocielScraper(BaseScraper):
         try:
             # Step 1: Get INSEE code
             insee_code = await self._get_insee_code(site_name)
+            city_name_for_url = site_name
 
             if not insee_code:
                 # Graceful degradation: Try to find nearest French city using coordinates
                 logger.info(
                     f"No INSEE code found for {site_name}, trying reverse geocoding with coordinates"
                 )
-                insee_code = await self._get_nearest_insee_code(lat, lon)
+                nearest_commune = await self._get_nearest_commune(lat, lon)
 
-                if not insee_code:
+                if not nearest_commune:
                     return self._build_response(
                         success=False,
                         error=f"Meteociel only supports French cities. Could not find INSEE code for {site_name} or nearby location.",
                     )
+
+                insee_code, city_name_for_url = nearest_commune
 
             # Step 2: Build URL - Using AROME hourly forecasts (1h resolution)
             # Normalize city name: lowercase, remove accents, replace spaces
@@ -171,7 +174,7 @@ class MeteocielScraper(BaseScraper):
 
             city_normalized = "".join(
                 c
-                for c in unicodedata.normalize("NFD", site_name)
+                for c in unicodedata.normalize("NFD", city_name_for_url)
                 if unicodedata.category(c) != "Mn"
             )
             city_slug = city_normalized.lower().replace(" ", "-").replace("_", "-")

--- a/apps/backend/tests/scrapers/test_meteociel.py
+++ b/apps/backend/tests/scrapers/test_meteociel.py
@@ -4,7 +4,8 @@ Live tests for Meteociel scraper
 
 import pytest
 
-from scrapers.meteociel import fetch_meteociel
+from scrapers import meteociel
+from scrapers.meteociel import MeteocielScraper, fetch_meteociel
 
 ARGUEL_LAT = 47.2
 ARGUEL_LON = 6.0
@@ -28,3 +29,47 @@ async def test_fetch_meteociel_timeout():
     duration = time.time() - start
     assert duration < 30.0
     assert "success" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(monkeypatch):
+    requested_urls = []
+
+    async def fake_get_insee_code(self, city_name):
+        return None
+
+    async def fake_get_nearest_commune(self, lat, lon):
+        return "25056", "Besançon"
+
+    def fake_parse_forecast_tables(self, soup):
+        return [{"hour": 12, "temperature": 20.0}]
+
+    class FakeResponse:
+        text = "<html></html>"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url):
+            requested_urls.append(url)
+            return FakeResponse()
+
+    monkeypatch.setattr(MeteocielScraper, "_get_insee_code", fake_get_insee_code)
+    monkeypatch.setattr(MeteocielScraper, "_get_nearest_commune", fake_get_nearest_commune)
+    monkeypatch.setattr(MeteocielScraper, "_parse_forecast_tables", fake_parse_forecast_tables)
+    monkeypatch.setattr(meteociel.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await fetch_meteociel(47.24, 6.02, site_name="Test Site")
+
+    assert result["success"] is True
+    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/25056/besancon.htm"]


### PR DESCRIPTION
## Summary
- Use the reverse-geocoded commune name when building Meteociel URLs after fallback.
- Add a backend test that verifies the slug becomes `besancon` instead of `test-site`.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend -- tests/scrapers/test_meteociel.py`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Meteociel weather forecast location resolution with reverse-geocoding fallback support when initial location lookup fails.

* **Tests**
  * Added test coverage for reverse-geocoding location lookup workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/797)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->