### PR TITLE
feat(frontend): polish weather dashboard layout

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -25,6 +25,7 @@ import { enUS } from 'date-fns/locale';
 import { WindIndicator } from '../common/WindIndicator';
 import { Button } from '@dashboard-parapente/design-system';
 import type { BestSpotResult } from '@dashboard-parapente/shared-types';
+import { weatherCardClassName } from './weatherUi';
 
 type HourlyBestSpot = BestSpotResult & { hour: number };
 
@@ -192,7 +193,7 @@ export const BestSpotSuggestion = ({
   // Show loading state if no data available
   if (!bestSpot || !bestSpot.site) {
     return (
-      <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-md shadow-slate-200/50 dark:border-slate-700 dark:bg-slate-900/90 dark:shadow-black/20">
+      <div className={`${weatherCardClassName} p-4`}>
         <div className="flex items-center gap-3">
           <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-300">
             <Target className="h-6 w-6" aria-hidden="true" />
@@ -226,13 +227,16 @@ export const BestSpotSuggestion = ({
     100,
     Math.max(0, Math.round(score ?? paraIndex))
   );
-  const localizedReason = reason.replace(/Para-Index/g, t('weather.paraIndex'));
+  const localizedReason = reason.replace(
+    /Para-Index/gu,
+    t('weather.paraIndex')
+  );
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
 
   return (
     <div
-      className={`min-w-0 max-w-full overflow-hidden rounded-2xl border border-slate-200 bg-white/95 shadow-lg shadow-slate-200/70 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/25 ${className}`}
+      className={`${weatherCardClassName} min-w-0 max-w-full overflow-hidden ${className}`}
     >
       {/* Header with colored accent bar */}
       <div className={`h-1.5 ${scoreColor.bg}`} />
@@ -302,7 +306,7 @@ export const BestSpotSuggestion = ({
         {/* Metrics grid */}
         <div className="grid grid-cols-2 gap-3 mb-4">
           {/* Wind */}
-          <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
+          <div className="rounded-xl border border-slate-100 bg-slate-50/90 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
             {windDirection && windSpeed != null ? (
               <WindIndicator
                 windDirection={windDirection}
@@ -338,7 +342,7 @@ export const BestSpotSuggestion = ({
 
           {/* Thermal ceiling */}
           {thermalCeiling != null && (
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
+            <div className="rounded-xl border border-slate-100 bg-slate-50/90 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
               <div className="flex items-center gap-2">
                 <Cloud
                   className="h-5 w-5 shrink-0 text-orange-600 dark:text-orange-400"
@@ -358,7 +362,7 @@ export const BestSpotSuggestion = ({
 
           {/* Wind favorability badge */}
           {windFavorability && (
-            <div className="rounded-xl border border-slate-100 bg-slate-50 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
+            <div className="rounded-xl border border-slate-100 bg-slate-50/90 p-2.5 dark:border-slate-800 dark:bg-slate-950/50">
               <div className="flex items-center gap-2">
                 {getWindFavorabilityIcon(windFavorability)}
                 <div className="flex flex-col">
@@ -429,7 +433,7 @@ export const BestSpotSuggestion = ({
                         onSelectSite(hourlySpot.site.id);
                       }
                     }}
-                    className="min-w-[176px] cursor-pointer flex-col items-stretch justify-start gap-0 whitespace-normal rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-950/60 dark:hover:border-sky-800 dark:hover:bg-slate-950"
+                    className="min-w-[176px] cursor-pointer flex-col items-stretch justify-start gap-0 whitespace-normal rounded-2xl border border-slate-200 bg-white px-3.5 py-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-950/60 dark:hover:border-sky-800 dark:hover:bg-slate-950"
                   >
                     <div className="flex items-start justify-between gap-3">
                       <span className="text-sm font-extrabold text-slate-950 dark:text-white">
@@ -481,7 +485,7 @@ export const BestSpotSuggestion = ({
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
           <Button
             onClick={() => onSelectSite(site.id)}
-            className="cursor-pointer rounded-xl bg-sky-600 px-4 py-2 text-sm font-bold text-white shadow-sm shadow-sky-600/20 transition-colors hover:bg-sky-700"
+            className="cursor-pointer rounded-xl bg-sky-600 px-4 py-2 text-sm font-bold text-white shadow-sm shadow-sky-600/20 transition-colors hover:bg-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
           >
             {t('weather.viewForecast')}
           </Button>

--- a/apps/frontend/src/components/weather/CurrentConditions.tsx
+++ b/apps/frontend/src/components/weather/CurrentConditions.tsx
@@ -5,7 +5,12 @@ import { WindIndicator } from '../common/WindIndicator';
 import CacheTimestamp from '../common/CacheTimestamp';
 import type { WeatherData } from '../../types';
 import { Cloud, Thermometer, Wind, Zap } from 'lucide-react';
-import { getVerdictVisual, weatherCardClassName } from './weatherUi';
+import {
+  getVerdictVisual,
+  weatherCardClassName,
+  weatherMetricTileClassName,
+  weatherSectionTitleClassName,
+} from './weatherUi';
 
 interface CurrentConditionsProps {
   spotId?: string;
@@ -35,15 +40,15 @@ export default function CurrentConditions({
   const isLoading = isOverrideLoading ?? isFetchedLoading;
   const hasError = isOverrideError ?? !!error;
   const orientation = siteOrientation ?? site?.orientation;
-  const cardClassName = `${weatherCardClassName} border-l-4 border-l-sky-600 p-4`;
+  const cardClassName = `${weatherCardClassName} overflow-hidden`;
 
   if (isLoading) {
     return (
-      <div className={cardClassName} aria-live="polite">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
+      <div className={`${cardClassName} p-4`} aria-live="polite">
+        <h2 className={weatherSectionTitleClassName}>
           {t('weather.currentConditions')}
         </h2>
-        <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
+        <div className="py-5 text-center text-sm text-gray-500 dark:text-gray-400">
           {t('common.loading')}
         </div>
       </div>
@@ -52,11 +57,11 @@ export default function CurrentConditions({
 
   if (hasError || !weather) {
     return (
-      <div className={cardClassName} role="alert">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
+      <div className={`${cardClassName} p-4`} role="alert">
+        <h2 className={weatherSectionTitleClassName}>
           {t('weather.currentConditions')}
         </h2>
-        <div className="py-5 text-center text-red-500 dark:text-red-400 text-sm">
+        <div className="py-5 text-center text-sm text-red-500 dark:text-red-400">
           {t('weather.loadError')}
         </div>
       </div>
@@ -68,85 +73,103 @@ export default function CurrentConditions({
 
   return (
     <div className={`${cardClassName} flex flex-1 flex-col`}>
-      <div className="mb-3.5">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-          {t('weather.currentConditionsFor', { name: weather.spot_name })}
-        </h2>
-      </div>
-
-      <div className="flex items-center gap-3 mb-4">
-        <div className="text-4xl sm:text-3xl font-bold text-sky-600 dark:text-sky-400 leading-none">
-          {weather.score != null ? weather.score : weather.para_index}/100
-        </div>
-        <div
-          className={`inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full text-xs font-semibold whitespace-nowrap ${verdictVisual.badgeClassName}`}
-        >
-          <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
-          {weather.verdict.toUpperCase()}
-        </div>
-      </div>
-      {weather.score != null && weather.score !== weather.para_index && (
-        <div className="text-xs text-gray-500 dark:text-gray-400 -mt-3 mb-3">
-          {t('weather.paraIndex')} {weather.para_index}/100
-        </div>
-      )}
-
-      <div className="flex flex-col gap-2">
-        <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
-            <Thermometer className="h-4 w-4 text-red-500" aria-hidden="true" />
-            {t('common.temperature')}
-          </span>
-          <span className="font-semibold text-gray-900 dark:text-white text-right">
-            {weather.temperature}°C
-          </span>
-        </div>
-        <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
-            <Wind className="h-4 w-4 text-sky-500" aria-hidden="true" />
-            {t('common.wind')}
-          </span>
-          <div className="flex flex-col items-end gap-1">
-            <span className="font-semibold text-gray-900 dark:text-white text-right">
-              {weather.wind_speed} km/h {weather.wind_direction}
-            </span>
-            {orientation && (
-              <WindIndicator
-                windDirection={weather.wind_direction}
-                siteOrientation={
-                  Array.isArray(orientation) ? orientation[0] : orientation
-                }
-                windSpeed={weather.wind_speed}
-                showLabel={false}
-                size="sm"
-              />
-            )}
+      <div className="border-l-4 border-l-sky-600 p-4 sm:p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <p className={weatherSectionTitleClassName}>
+              {t('weather.currentConditions')}
+            </p>
+            <h2 className="mt-1 truncate text-xl font-black text-slate-950 dark:text-white">
+              {weather.spot_name}
+            </h2>
+          </div>
+          <div
+            className={`inline-flex w-fit items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-bold whitespace-nowrap ${verdictVisual.badgeClassName}`}
+          >
+            <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            {weather.verdict.toUpperCase()}
           </div>
         </div>
-        {weather.wind_gusts && (
-          <div className="flex justify-between text-sm py-1.5 border-b border-gray-100 dark:border-gray-700">
-            <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
-              <Zap className="h-4 w-4 text-orange-500" aria-hidden="true" />
-              {t('common.gusts')}
+
+        <div className="mt-4 rounded-2xl bg-gradient-to-br from-sky-50 to-white p-4 dark:from-sky-950/40 dark:to-slate-950/40">
+          <div className="text-sm font-bold text-slate-500 dark:text-slate-400">
+            Score météo
+          </div>
+          <div className="mt-1 flex items-end gap-2">
+            <span className="text-5xl font-black leading-none tracking-tight text-sky-600 dark:text-sky-400">
+              {weather.score ?? weather.para_index}
             </span>
-            <span className="font-semibold text-gray-900 dark:text-white text-right">
-              {weather.wind_gusts} km/h
+            <span className="pb-1 text-lg font-bold text-slate-400 dark:text-slate-500">
+              /100
             </span>
+          </div>
+        </div>
+        {weather.score != null && weather.score !== weather.para_index && (
+          <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            {t('weather.paraIndex')} {weather.para_index}/100
           </div>
         )}
-        <div className="flex justify-between text-sm py-1.5">
-          <span className="inline-flex items-center gap-1.5 text-gray-600 dark:text-gray-300 font-medium">
-            <Cloud className="h-4 w-4 text-slate-500" aria-hidden="true" />
-            {t('common.conditions')}
-          </span>
-          <span className="font-semibold text-gray-900 dark:text-white text-right">
-            {weather.conditions}
-          </span>
-        </div>
-      </div>
 
-      <div className="mt-3 text-center pt-2 border-t border-gray-100 dark:border-gray-700">
-        <CacheTimestamp cachedAt={weather.cached_at} />
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className={weatherMetricTileClassName}>
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300">
+              <Thermometer
+                className="h-4 w-4 text-red-500"
+                aria-hidden="true"
+              />
+              {t('common.temperature')}
+            </span>
+            <div className="mt-1 text-lg font-black text-gray-900 dark:text-white">
+              {weather.temperature}°C
+            </div>
+          </div>
+          <div className={weatherMetricTileClassName}>
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300">
+              <Wind className="h-4 w-4 text-sky-500" aria-hidden="true" />
+              {t('common.wind')}
+            </span>
+            <div className="mt-1 flex flex-col gap-1">
+              <span className="text-lg font-black text-gray-900 dark:text-white">
+                {weather.wind_speed} km/h {weather.wind_direction}
+              </span>
+              {orientation && (
+                <WindIndicator
+                  windDirection={weather.wind_direction}
+                  siteOrientation={
+                    Array.isArray(orientation) ? orientation[0] : orientation
+                  }
+                  windSpeed={weather.wind_speed}
+                  showLabel={false}
+                  size="sm"
+                />
+              )}
+            </div>
+          </div>
+          {weather.wind_gusts && (
+            <div className={weatherMetricTileClassName}>
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300">
+                <Zap className="h-4 w-4 text-orange-500" aria-hidden="true" />
+                {t('common.gusts')}
+              </span>
+              <div className="mt-1 text-lg font-black text-gray-900 dark:text-white">
+                {weather.wind_gusts} km/h
+              </div>
+            </div>
+          )}
+          <div className={weatherMetricTileClassName}>
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300">
+              <Cloud className="h-4 w-4 text-slate-500" aria-hidden="true" />
+              {t('common.conditions')}
+            </span>
+            <div className="mt-1 text-base font-black text-gray-900 dark:text-white">
+              {weather.conditions}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 border-t border-gray-100 pt-3 text-center dark:border-gray-700">
+          <CacheTimestamp cachedAt={weather.cached_at} />
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/weather/Forecast7Day.tsx
+++ b/apps/frontend/src/components/weather/Forecast7Day.tsx
@@ -8,7 +8,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import CacheTimestamp from '../common/CacheTimestamp';
 import { Button } from '@dashboard-parapente/design-system';
 import { Wind } from 'lucide-react';
-import { getVerdictVisual, weatherCardClassName } from './weatherUi';
+import {
+  getVerdictVisual,
+  weatherCardClassName,
+  weatherSectionTitleClassName,
+} from './weatherUi';
 
 interface Forecast7DayProps {
   spotId: string;
@@ -63,7 +67,7 @@ export default function Forecast7Day({
   if (isLoading) {
     return (
       <div className={`${weatherCardClassName} p-4`} aria-live="polite">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
+        <h2 className={weatherSectionTitleClassName}>
           {t('weather.forecast7Days')}
         </h2>
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
@@ -76,7 +80,7 @@ export default function Forecast7Day({
   if (error || !dailySummary || !dailySummary.days) {
     return (
       <div className={`${weatherCardClassName} p-4`} role="alert">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
+        <h2 className={weatherSectionTitleClassName}>
           {t('weather.forecast7Days')}
         </h2>
         <div className="py-5 text-center text-red-500 dark:text-red-400 text-sm">
@@ -87,11 +91,16 @@ export default function Forecast7Day({
   }
 
   return (
-    <div className={`${weatherCardClassName} min-w-0 p-4`}>
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-          {t('weather.forecast7Days')}
-        </h2>
+    <div className={`${weatherCardClassName} min-w-0 p-4 sm:p-5`}>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className={weatherSectionTitleClassName}>
+            {t('weather.forecast7Days')}
+          </h2>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            Sélectionnez une journée pour charger le détail horaire.
+          </p>
+        </div>
         <div className="flex items-center gap-2">
           <CacheTimestamp cachedAt={dailySummary.cached_at} />
         </div>
@@ -108,22 +117,22 @@ export default function Forecast7Day({
               key={index}
               onClick={() => onSelectDay?.(index)}
               onMouseEnter={() => handleMouseEnter(index)}
-              className={`min-w-[150px] flex-shrink-0 snap-start sm:min-w-0 sm:flex-shrink bg-gray-50 dark:bg-gray-900 rounded-lg p-3 border-2 transition-colors hover:border-sky-600 hover:shadow-md cursor-pointer relative min-h-[150px] ${
+              className={`relative min-h-[158px] min-w-[150px] flex-shrink-0 snap-start rounded-2xl border p-3 text-left transition-colors hover:border-sky-500 hover:bg-sky-50/70 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:hover:bg-sky-950/30 sm:min-w-0 sm:flex-shrink ${
                 isSelected
-                  ? 'border-sky-600 shadow-lg bg-sky-50 dark:bg-sky-900/20 ring-2 ring-sky-200 dark:ring-sky-700'
-                  : 'border-gray-200 dark:border-gray-700'
+                  ? 'border-sky-600 bg-sky-50 shadow-lg ring-2 ring-sky-200 dark:bg-sky-900/20 dark:ring-sky-700'
+                  : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900'
               }`}
             >
               {isSelected && (
                 <div className="absolute top-1 right-1 w-2 h-2 bg-sky-600 rounded-full" />
               )}
-              <div className="flex h-full flex-col justify-between gap-1">
-                <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 text-center">
+              <div className="flex h-full flex-col justify-between gap-2">
+                <div className="text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">
                   {formatDate(day.date)}
                 </div>
-                <div className="flex items-center justify-center gap-2">
-                  <span className="text-2xl font-bold text-sky-600 dark:text-sky-400">
-                    {day.score != null ? day.score : day.para_index}
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-3xl font-black leading-none text-sky-600 dark:text-sky-400">
+                    {day.score ?? day.para_index}
                   </span>
                   <span
                     className={`inline-flex items-center justify-center rounded-full px-1.5 py-0.5 ${verdictVisual.badgeClassName}`}
@@ -131,17 +140,17 @@ export default function Forecast7Day({
                     <VerdictIcon className="h-4 w-4" aria-hidden="true" />
                   </span>
                 </div>
-                <div className="text-sm text-gray-700 dark:text-gray-300 font-medium text-center">
+                <div className="text-sm font-bold text-gray-800 dark:text-gray-200">
                   {day.temp_min}° - {day.temp_max}°
                 </div>
-                <div className="inline-flex items-center justify-center gap-1 text-xs text-gray-600 dark:text-gray-300 text-center">
+                <div className="inline-flex items-center gap-1 text-xs font-semibold text-gray-600 dark:text-gray-300">
                   <Wind
                     className="h-3.5 w-3.5 text-sky-500"
                     aria-hidden="true"
                   />
                   {Math.round(day.wind_avg)} km/h
                 </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400 text-center leading-tight min-h-8 break-words">
+                <div className="min-h-8 break-words text-xs leading-tight text-gray-500 dark:text-gray-400">
                   {day.verdict}
                 </div>
               </div>

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -18,7 +18,11 @@ import { useWeather } from '../../hooks/weather/useWeather';
 import type { HourlyForecastItem, WeatherData } from '../../types';
 import CacheTimestamp from '../common/CacheTimestamp';
 import WindArrow from './WindArrow';
-import { getVerdictVisual, weatherCardClassName } from './weatherUi';
+import {
+  getVerdictVisual,
+  weatherCardClassName,
+  weatherSectionTitleClassName,
+} from './weatherUi';
 
 interface HourlyForecastProps {
   spotId?: string;
@@ -196,6 +200,11 @@ const formatWindDirectionWithDegrees = (deg: number | null): string => {
   if (deg === null) return '—';
   const cardinal = formatWindDirectionFromDegrees(deg);
   return `${cardinal} (${Math.round(deg)}°)`;
+};
+
+const formatConsensusValue = (value: number | string | null): string => {
+  if (value === null) return '—';
+  return typeof value === 'number' ? value.toFixed(1) : value;
 };
 
 const SOURCE_NAMES: Record<string, string> = {
@@ -536,13 +545,8 @@ const SourceDataTooltip = ({
 
         <div className="border-t border-gray-200 dark:border-gray-700 pt-2 mt-2">
           <div className="text-xs font-bold text-gray-800 dark:text-gray-100">
-            Consensus :{' '}
-            {consensus !== null && consensus !== undefined
-              ? typeof consensus === 'number'
-                ? consensus.toFixed(1)
-                : consensus
-              : '—'}{' '}
-            {consensus !== null && consensus !== undefined ? unit : ''}
+            Consensus : {formatConsensusValue(consensus)}{' '}
+            {consensus === null ? '' : unit}
           </div>
         </div>
       </div>
@@ -774,11 +778,14 @@ export default function HourlyForecast({
   };
 
   return (
-    <div className={`${weatherCardClassName} min-w-0 p-4`}>
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-          Prévisions Horaires
-        </h2>
+    <div className={`${weatherCardClassName} min-w-0 p-4 sm:p-5`}>
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className={weatherSectionTitleClassName}>Prévisions Horaires</h2>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+            Créneaux de vol, consensus des sources et points de vigilance.
+          </p>
+        </div>
         <CacheTimestamp cachedAt={weather.cached_at} />
       </div>
       <div className="grid gap-3 md:hidden">
@@ -800,7 +807,7 @@ export default function HourlyForecast({
             return (
               <article
                 key={index}
-                className={`rounded-xl border border-slate-200 p-3 dark:border-slate-700 ${getVerdictClass(hour.verdict)}`}
+                className={`rounded-2xl border border-slate-200 p-3 shadow-sm dark:border-slate-700 ${getVerdictClass(hour.verdict)}`}
               >
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -829,7 +836,7 @@ export default function HourlyForecast({
                 </div>
 
                 <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
-                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
                     <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                       <Wind
                         className="h-3.5 w-3.5 text-sky-500"
@@ -841,7 +848,7 @@ export default function HourlyForecast({
                       {hour.wind}
                     </div>
                   </div>
-                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
                     <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                       <Zap
                         className="h-3.5 w-3.5 text-orange-500"
@@ -855,7 +862,7 @@ export default function HourlyForecast({
                         : '—'}
                     </div>
                   </div>
-                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
                     <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                       <CloudRain
                         className="h-3.5 w-3.5 text-cyan-500"
@@ -870,7 +877,7 @@ export default function HourlyForecast({
                         : '—'}
                     </div>
                   </div>
-                  <div className="rounded-lg bg-white/80 p-2 dark:bg-slate-950/50">
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
                     <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                       <Cloud
                         className="h-3.5 w-3.5 text-slate-500"
@@ -895,61 +902,61 @@ export default function HourlyForecast({
         )}
       </div>
 
-      <div className="hidden max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-lg border border-gray-100 dark:border-gray-700 md:block">
+      <div className="hidden max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-2xl border border-gray-200 dark:border-gray-700 md:block">
         <table className="w-full min-w-[800px] text-sm">
-          <thead>
-            <tr className="border-b-2 border-gray-200 dark:border-gray-600">
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+          <thead className="sticky top-0 z-10 bg-slate-100/95 backdrop-blur dark:bg-slate-950/95">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Clock size={14} /> Heure
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Gauge size={14} /> {t('weather.paraIndex')}
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Wind size={14} /> Vent (km/h)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Zap size={14} /> Rafales (km/h)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Compass size={14} /> Direction
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Thermometer size={14} /> Temp (°C)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <CloudRain size={14} /> Précip. (mm)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Cloud size={14} /> Nuages (%)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Zap size={14} /> CAPE (J/kg)
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <Flame size={14} /> Thermiques
                 </span>
               </th>
-              <th className="text-center py-2 px-2 font-semibold text-gray-800 dark:text-gray-200">
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
                   <CircleCheck size={14} /> Volabilité
                 </span>
@@ -976,7 +983,7 @@ export default function HourlyForecast({
                 return (
                   <tr
                     key={index}
-                    className={`border-b border-gray-100 dark:border-gray-700 ${getVerdictClass(hour.verdict)}`}
+                    className={`border-b border-gray-100 transition-colors dark:border-gray-700 ${getVerdictClass(hour.verdict)}`}
                   >
                     <td className="py-2.5 px-2 font-medium text-center">
                       {hour.hour}
@@ -1034,13 +1041,13 @@ export default function HourlyForecast({
                           aria-label={`Direction ${hour.hour}`}
                           className="w-full p-0 bg-transparent border-none cursor-help rounded hover:bg-violet-50 dark:hover:bg-violet-900/20 transition-colors flex justify-center"
                         >
-                          {hour.wind_direction_deg != null ? (
+                          {hour.wind_direction_deg == null ? (
+                            '—'
+                          ) : (
                             <WindArrow
                               degrees={hour.wind_direction_deg}
                               className="text-violet-600 dark:text-violet-400"
                             />
-                          ) : (
-                            '—'
                           )}
                         </Button>
                         <Tooltip offset={8} className="z-50">

--- a/apps/frontend/src/components/weather/WeatherMultiLanding.tsx
+++ b/apps/frontend/src/components/weather/WeatherMultiLanding.tsx
@@ -3,7 +3,11 @@ import {
   useLandingAssociations,
   useLandingWeather,
 } from '../../hooks/sites/useLandingAssociations';
-import { getVerdictVisual, weatherCardClassName } from './weatherUi';
+import {
+  getVerdictVisual,
+  weatherCardClassName,
+  weatherSectionTitleClassName,
+} from './weatherUi';
 
 interface WeatherMultiLandingProps {
   spotId: string;
@@ -21,90 +25,105 @@ export default function WeatherMultiLanding({
   // Don't render anything if no associations
   if (!associations || associations.length === 0) return null;
 
-  return (
-    <div
-      className={`${weatherCardClassName} border-l-4 border-l-indigo-500 p-4`}
-    >
-      <div className="mb-3">
-        <h2 className="text-sm text-gray-600 dark:text-gray-400 font-semibold">
-          {t('weather.landings')}
-        </h2>
-      </div>
-
-      {isLoading ? (
+  const content = (() => {
+    if (isLoading) {
+      return (
         <div
           className="py-3 text-center text-gray-500 dark:text-gray-400 text-sm"
           aria-live="polite"
         >
           {t('weather.loadingLandings')}
         </div>
-      ) : !weatherData || weatherData.length === 0 ? (
+      );
+    }
+
+    if (!weatherData || weatherData.length === 0) {
+      return (
         <div className="py-3 text-center text-gray-400 dark:text-gray-400 text-sm">
           {t('weather.noWeatherData')}
         </div>
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {weatherData.map((entry) => {
-            const weather = entry.weather;
-            const hasError = !!weather.error;
-            const verdict = weather.verdict || '';
-            const verdictVisual = getVerdictVisual(verdict);
-            const VerdictIcon = verdictVisual.Icon;
+      );
+    }
 
-            return (
-              <div
-                key={entry.landing_site_id}
-                className={`rounded-lg border-l-4 p-3 ${
-                  hasError
-                    ? 'border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700'
-                    : verdictVisual.borderSoftClassName
-                } ${entry.is_primary ? 'ring-2 ring-indigo-400 ring-offset-1 dark:ring-offset-gray-800' : ''}`}
-              >
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200 truncate">
-                    {entry.landing_site_name}
-                  </h3>
-                  <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0 ml-2">
-                    {entry.distance_km != null ? `${entry.distance_km} km` : ''}
-                  </span>
-                </div>
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {weatherData.map((entry) => {
+          const weather = entry.weather;
+          const hasError = !!weather.error;
+          const verdict = weather.verdict || '';
+          const verdictVisual = getVerdictVisual(verdict);
+          const VerdictIcon = verdictVisual.Icon;
 
-                {hasError ? (
-                  <p
-                    className="text-xs text-red-500 dark:text-red-400"
-                    role="alert"
-                  >
-                    {weather.error}
-                  </p>
-                ) : (
-                  <div className="flex items-center gap-3">
-                    <VerdictIcon
-                      className={`h-5 w-5 shrink-0 ${verdictVisual.textClassName}`}
-                      aria-hidden="true"
-                    />
-                    <div>
-                      <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        {verdict}
-                      </div>
-                      {weather.para_index != null && (
-                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                          Para Index: {weather.para_index}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {entry.is_primary && (
-                  <span className="inline-block mt-2 text-xs bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 px-2 py-0.5 rounded-full">
-                    {t('weather.primary')}
-                  </span>
-                )}
+          return (
+            <div
+              key={entry.landing_site_id}
+              className={`rounded-2xl border border-l-4 p-3 shadow-sm ${
+                hasError
+                  ? 'border-gray-300 bg-gray-50 dark:border-gray-600 dark:bg-gray-800'
+                  : verdictVisual.borderSoftClassName
+              } ${entry.is_primary ? 'ring-2 ring-indigo-400 ring-offset-2 dark:ring-offset-gray-900' : ''}`}
+            >
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <h3 className="truncate text-sm font-black text-gray-900 dark:text-gray-100">
+                  {entry.landing_site_name}
+                </h3>
+                <span className="ml-2 flex-shrink-0 rounded-full bg-white/70 px-2 py-0.5 text-xs font-semibold text-gray-600 dark:bg-slate-950/40 dark:text-gray-300">
+                  {entry.distance_km == null ? '' : `${entry.distance_km} km`}
+                </span>
               </div>
-            );
-          })}
-        </div>
-      )}
+
+              {hasError ? (
+                <p
+                  className="text-xs text-red-500 dark:text-red-400"
+                  role="alert"
+                >
+                  {weather.error}
+                </p>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <VerdictIcon
+                    className={`h-5 w-5 shrink-0 ${verdictVisual.textClassName}`}
+                    aria-hidden="true"
+                  />
+                  <div>
+                    <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {verdict}
+                    </div>
+                    {weather.para_index != null && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        Para Index: {weather.para_index}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {entry.is_primary && (
+                <span className="mt-3 inline-block rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-bold text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300">
+                  {t('weather.primary')}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  })();
+
+  return (
+    <div
+      className={`${weatherCardClassName} border-l-4 border-l-indigo-500 p-4 sm:p-5`}
+    >
+      <div className="mb-4">
+        <h2 className={weatherSectionTitleClassName}>
+          {t('weather.landings')}
+        </h2>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+          Conditions aux atterrissages associés au site sélectionné.
+        </p>
+      </div>
+
+      {content}
     </div>
   );
 }

--- a/apps/frontend/src/components/weather/weatherUi.tsx
+++ b/apps/frontend/src/components/weather/weatherUi.tsx
@@ -62,7 +62,13 @@ const verdictVisuals: Record<VerdictTone, VerdictVisual> = {
 };
 
 export const weatherCardClassName =
-  'rounded-2xl border border-slate-200 bg-white/95 shadow-md shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/20';
+  'rounded-2xl border border-slate-200 bg-white/95 shadow-lg shadow-slate-200/60 dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/25';
+
+export const weatherSectionTitleClassName =
+  'text-sm font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400';
+
+export const weatherMetricTileClassName =
+  'rounded-xl border border-slate-100 bg-slate-50/90 p-3 dark:border-slate-800 dark:bg-slate-950/50';
 
 export const getVerdictVisual = (verdict: string): VerdictVisual => {
   const normalized = verdict.toLowerCase();

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -28,6 +28,11 @@ import {
 import { useCoordinateWeather } from '../hooks/weather/useCityWeather';
 import { transformWeatherResponse } from '../hooks/weather/useWeather';
 import { useAppSettingsStore } from '../stores/appSettingsStore';
+import { CalendarDays, MapPin, Search, Wind } from 'lucide-react';
+import {
+  weatherCardClassName,
+  weatherSectionTitleClassName,
+} from '../components/weather/weatherUi';
 
 const isSpotSearchTarget = (
   target: CityWeatherTarget | null
@@ -81,6 +86,7 @@ export default function WeatherPage() {
     favoriteSites[0]?.id ??
     sites[0]?.id ??
     '';
+  const selectedSite = sites.find((site) => site.id === selectedSiteId);
   const selectedSearchTitle = getSearchTargetName(selectedSearchTarget);
   const selectedSearchLocation = getSearchTargetLocation(selectedSearchTarget);
   const coordinateWeather = useCoordinateWeather(
@@ -112,38 +118,81 @@ export default function WeatherPage() {
     siteId: selectedSiteId,
     day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
   };
+  const selectedDayLabel = getSearchDayLabel(selectedDayIndex, t);
+  const activeWeatherName = selectedSearchTarget
+    ? selectedSearchTitle
+    : selectedSite?.name;
 
   return (
-    <div className="grid w-full min-w-0 gap-3 sm:gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
-      <aside className="min-w-0 space-y-3 sm:space-y-4 xl:sticky xl:top-4 xl:self-start">
-        <section className="rounded-2xl border border-sky-100 bg-white p-3 shadow-md dark:border-gray-700 dark:bg-gray-800 sm:p-4">
-          <div className="mb-3">
-            <div>
-              <p className="text-sm font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
-                Choix du site
-              </p>
-              <h2 className="text-lg font-bold text-gray-950 dark:text-white sm:text-xl">
-                Sélection météo
-              </h2>
-            </div>
+    <div className="grid w-full min-w-0 gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
+      <aside className="min-w-0 space-y-4 xl:sticky xl:top-4 xl:self-start">
+        <section className={`${weatherCardClassName} overflow-hidden`}>
+          <div className="border-b border-slate-100 bg-gradient-to-br from-sky-50 via-white to-white p-4 dark:border-slate-800 dark:from-sky-950/40 dark:via-slate-900 dark:to-slate-900 sm:p-5">
+            <p className={weatherSectionTitleClassName}>Choix du site</p>
+            <h2 className="mt-1 text-xl font-black tracking-tight text-slate-950 dark:text-white">
+              Sélection météo
+            </h2>
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+              Favoris, sites configurés ou recherche par ville.
+            </p>
           </div>
-          <Tabs
-            selectedKey={selectionTab}
-            onSelectionChange={(key) => {
-              const nextTab = key as SelectionTab;
-              setSelectionTab(nextTab);
-              if (nextTab === 'favorites') setSelectedSearchTarget(null);
-            }}
-          >
-            <TabList className="grid-cols-2 bg-gray-50 shadow-none dark:bg-gray-900/60">
-              <Tab id="favorites">Favoris</Tab>
-              <Tab id="search">Recherche</Tab>
-            </TabList>
-            <TabPanel id="favorites">
-              {sites.length > 0 ? (
-                <SiteSelector
-                  selectedSiteId={selectedSearchTarget ? '' : selectedSiteId}
-                  onSelectSite={(siteId) => {
+          <div className="p-3 sm:p-4">
+            <Tabs
+              selectedKey={selectionTab}
+              onSelectionChange={(key) => {
+                const nextTab = key as SelectionTab;
+                setSelectionTab(nextTab);
+                if (nextTab === 'favorites') setSelectedSearchTarget(null);
+              }}
+            >
+              <TabList className="grid-cols-2 bg-slate-100 shadow-none dark:bg-slate-950/70">
+                <Tab id="favorites">Favoris</Tab>
+                <Tab id="search">Recherche</Tab>
+              </TabList>
+              <TabPanel id="favorites">
+                {sites.length > 0 ? (
+                  <SiteSelector
+                    selectedSiteId={selectedSearchTarget ? '' : selectedSiteId}
+                    onSelectSite={(siteId) => {
+                      setSelectedSearchTarget(null);
+                      setSelectionTab('favorites');
+                      void navigate({
+                        to: '/weather',
+                        search: {
+                          siteId,
+                          day:
+                            selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                        },
+                      });
+                    }}
+                    weatherData={weatherDataMap}
+                  />
+                ) : (
+                  <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
+                    <p className="font-semibold text-gray-900 dark:text-white">
+                      {t('dashboard.noSites')}
+                    </p>
+                    <p className="mt-1">{t('dashboard.noSitesDescription')}</p>
+                    <Button
+                      onPress={() => void navigate({ to: '/sites' })}
+                      className="mt-3 rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
+                    >
+                      {t('dashboard.addSite')}
+                    </Button>
+                  </div>
+                )}
+              </TabPanel>
+              <TabPanel id="search">
+                <CityWeatherSearch
+                  dayIndex={selectedDayIndex}
+                  selectedTarget={selectedSearchTarget}
+                  favoriteSites={sites}
+                  isEmbedded
+                  onSelectTarget={(target) => {
+                    setSelectedSearchTarget(target);
+                    setSelectionTab('search');
+                  }}
+                  onFavoriteCreated={(siteId) => {
                     setSelectedSearchTarget(null);
                     setSelectionTab('favorites');
                     void navigate({
@@ -155,47 +204,10 @@ export default function WeatherPage() {
                       },
                     });
                   }}
-                  weatherData={weatherDataMap}
                 />
-              ) : (
-                <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
-                  <p className="font-semibold text-gray-900 dark:text-white">
-                    {t('dashboard.noSites')}
-                  </p>
-                  <p className="mt-1">{t('dashboard.noSitesDescription')}</p>
-                  <Button
-                    onPress={() => void navigate({ to: '/sites' })}
-                    className="mt-3 rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
-                  >
-                    {t('dashboard.addSite')}
-                  </Button>
-                </div>
-              )}
-            </TabPanel>
-            <TabPanel id="search">
-              <CityWeatherSearch
-                dayIndex={selectedDayIndex}
-                selectedTarget={selectedSearchTarget}
-                favoriteSites={sites}
-                isEmbedded
-                onSelectTarget={(target) => {
-                  setSelectedSearchTarget(target);
-                  setSelectionTab('search');
-                }}
-                onFavoriteCreated={(siteId) => {
-                  setSelectedSearchTarget(null);
-                  setSelectionTab('favorites');
-                  void navigate({
-                    to: '/weather',
-                    search: {
-                      siteId,
-                      day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
-                    },
-                  });
-                }}
-              />
-            </TabPanel>
-          </Tabs>
+              </TabPanel>
+            </Tabs>
+          </div>
         </section>
 
         <BestSpotSuggestion
@@ -217,9 +229,51 @@ export default function WeatherPage() {
         />
       </aside>
 
-      <div className="min-w-0 space-y-3 sm:space-y-4">
+      <div className="min-w-0 space-y-4">
+        <section className="overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-br from-sky-700 via-blue-700 to-slate-950 p-4 text-white shadow-xl shadow-sky-900/20 dark:border-slate-700 sm:p-5 lg:p-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div className="min-w-0">
+              <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-sky-100">
+                <Wind className="h-3.5 w-3.5" aria-hidden="true" />
+                Météo de vol
+              </div>
+              <h1 className="mt-3 truncate text-2xl font-black tracking-tight sm:text-3xl">
+                {activeWeatherName ?? 'Prévisions météo'}
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-sky-100 sm:text-base">
+                Vue consolidée des conditions, du meilleur créneau et des
+                risques météo pour préparer le vol.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:justify-end">
+              <div className="rounded-2xl border border-white/15 bg-white/10 px-3 py-2 backdrop-blur">
+                <span className="flex items-center gap-1.5 text-xs font-semibold text-sky-100">
+                  <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                  Jour
+                </span>
+                <strong className="mt-1 block text-sm">
+                  {selectedDayLabel}
+                </strong>
+              </div>
+              <div className="rounded-2xl border border-white/15 bg-white/10 px-3 py-2 backdrop-blur">
+                <span className="flex items-center gap-1.5 text-xs font-semibold text-sky-100">
+                  {selectedSearchTarget ? (
+                    <Search className="h-3.5 w-3.5" aria-hidden="true" />
+                  ) : (
+                    <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                  )}
+                  Source
+                </span>
+                <strong className="mt-1 block truncate text-sm">
+                  {selectedSearchTarget ? 'Recherche' : 'Site favori'}
+                </strong>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {!selectedSearchTarget && !selectedSiteId && (
-          <section className="rounded-xl border border-sky-100 bg-white p-6 text-center shadow-md dark:border-gray-700 dark:bg-gray-800">
+          <section className={`${weatherCardClassName} p-6 text-center`}>
             <h2 className="text-xl font-bold text-gray-950 dark:text-white">
               Choisissez une météo
             </h2>
@@ -231,7 +285,7 @@ export default function WeatherPage() {
         )}
 
         {selectedSearchTarget && (
-          <section className="rounded-xl border border-sky-100 bg-white p-4 shadow-md dark:border-gray-700 dark:bg-gray-800">
+          <section className={`${weatherCardClassName} p-4`}>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
@@ -261,7 +315,7 @@ export default function WeatherPage() {
                       })
                     }
                     role="tab"
-                    className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
+                    className={`cursor-pointer rounded-xl px-3 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
                       day === selectedDayIndex
                         ? 'bg-sky-600 text-white'
                         : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-700'
@@ -293,7 +347,9 @@ export default function WeatherPage() {
         )}
 
         {!selectedSearchTarget && selectedSiteId && (
-          <section className="bg-white dark:bg-gray-800 rounded-xl shadow-md p-4 sm:p-6 border border-gray-100 dark:border-gray-700">
+          <section
+            className={`${weatherCardClassName} border-l-4 border-l-cyan-500 p-4 sm:p-5`}
+          >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
@@ -307,7 +363,7 @@ export default function WeatherPage() {
                 href="https://www.spotair.mobi/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center justify-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-sky-700"
+                className="inline-flex cursor-pointer items-center justify-center rounded-xl bg-slate-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:bg-cyan-500 dark:text-slate-950 dark:hover:bg-cyan-400"
               >
                 {t('weather.liveWindOpenSpotair')}
               </a>


### PR DESCRIPTION
## Summary
- Refresh the weather page with a stronger hero, clearer context, and a more polished left rail.
- Harmonize weather cards and improve readability for current conditions, 7-day forecast, hourly forecast, landings, and best-spot suggestions.
- Tighten hover/focus states and responsive spacing without changing weather logic.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` (passes on touched files; repo-wide run still has pre-existing unrelated issues)
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `vitest run --config vitest.config.ts src/components/weather/HourlyForecast.test.ts src/components/weather/HourlyForecast.behavior.test.tsx` ✅