### PR TITLE
chore(portainer): add env template

### DIFF
--- a/env.portainer
+++ b/env.portainer
@@ -1,0 +1,8 @@
+# Portainer API configuration template.
+# Copy values from your secure secret store before sourcing this file.
+
+PORTAINER_URL="https://portainer.example.com"
+PORTAINER_API_TOKEN=""
+PORTAINER_ENDPOINT_ID=""
+PORTAINER_STACK_ID=""
+PORTAINER_STACK_NAME="dashboard-parapente"

--- a/env.portainer
+++ b/env.portainer
@@ -1,8 +1,128 @@
-# Portainer API configuration template.
-# Copy values from your secure secret store before sourcing this file.
+# Portainer stack environment exported from /data/compose/47/stack.env.
+# Sensitive values are intentionally redacted and must stay in Portainer/secrets.
 
-PORTAINER_URL="https://portainer.example.com"
-PORTAINER_API_TOKEN=""
-PORTAINER_ENDPOINT_ID=""
-PORTAINER_STACK_ID=""
-PORTAINER_STACK_NAME="dashboard-parapente"
+# Runtime environment currently configured in Portainer.
+ENVIRONMENT=production
+
+# Backend database connection currently configured in Portainer.
+BACKEND_DATABASE_URL=sqlite:///./db/dashboard.db
+
+# Redis host currently configured in Portainer.
+BACKEND_REDIS_HOST=redis
+
+# Redis port currently configured in Portainer.
+BACKEND_REDIS_PORT=6379
+
+# Fake Redis toggle currently configured in Portainer.
+BACKEND_USE_FAKE_REDIS=false
+
+# Backend API bind host currently configured in Portainer.
+BACKEND_API_HOST=0.0.0.0
+
+# Backend API port currently configured in Portainer.
+BACKEND_API_PORT=8001
+
+# Backend debug mode currently configured in Portainer.
+BACKEND_API_DEBUG=false
+
+# WeatherAPI credential currently configured in Portainer.
+BACKEND_WEATHERAPI_KEY="<redacted: configured in Portainer>"
+
+# Meteoblue credential currently configured in Portainer.
+BACKEND_METEOBLUE_API_KEY="<redacted: configured in Portainer>"
+
+# Strava application client id currently configured in Portainer.
+BACKEND_STRAVA_CLIENT_ID=73115
+
+# Strava client secret currently configured in Portainer.
+BACKEND_STRAVA_CLIENT_SECRET="<redacted: configured in Portainer>"
+
+# Strava access token currently configured in Portainer.
+BACKEND_STRAVA_ACCESS_TOKEN="<redacted: configured in Portainer>"
+
+# Strava refresh token currently configured in Portainer.
+BACKEND_STRAVA_REFRESH_TOKEN="<redacted: configured in Portainer>"
+
+# Strava webhook verify token currently configured in Portainer.
+BACKEND_STRAVA_VERIFY_TOKEN="<redacted: configured in Portainer>"
+
+# Google API credential currently configured in Portainer.
+BACKEND_GOOGLE_API_KEY="<redacted: configured in Portainer>"
+
+# Gemini model currently configured in Portainer.
+BACKEND_GEMINI_MODEL=gemini-2.5-flash
+
+# Scheduler toggle currently configured in Portainer.
+BACKEND_SCHEDULER_ENABLED=true
+
+# Scheduler interval currently configured in Portainer.
+BACKEND_SCHEDULER_INTERVAL_MINUTES=30
+
+# Backend log level currently configured in Portainer.
+BACKEND_LOG_LEVEL=INFO
+
+# Backend log file currently configured in Portainer.
+BACKEND_LOG_FILE=logs/dashboard.log
+
+# Telegram bot token currently configured in Portainer.
+BACKEND_TELEGRAM_BOT_TOKEN="<redacted: configured in Portainer>"
+
+# Telegram chat id currently configured in Portainer.
+BACKEND_TELEGRAM_CHAT_ID=
+
+# Frontend URL known by the backend currently configured in Portainer.
+BACKEND_FRONTEND_URL=http://localhost:5173
+
+# Frontend mock-service-worker toggle currently configured in Portainer.
+VITE_ENABLE_MSW=false
+
+# Frontend API URL currently configured in Portainer.
+VITE_API_URL=http://localhost:8001
+
+# Groq credential currently configured in Portainer.
+BACKEND_GROQ_API_KEY="<redacted: configured in Portainer>"
+
+# Backend JWT signing secret currently configured in Portainer.
+BACKEND_JWT_SECRET="<redacted: configured in Portainer>"
+
+# Admin email currently configured in Portainer.
+BACKEND_ADMIN_EMAIL=vcapic@gmail.com
+
+# Admin password currently configured in Portainer.
+BACKEND_ADMIN_PASSWORD="<redacted: configured in Portainer>"
+
+# Strava token log history limit currently configured in Portainer.
+BACKEND_STRAVA_TOKEN_LOG_HISTORY_LIMIT=5
+
+# Metrics endpoint token currently configured in Portainer.
+BACKEND_METRICS_TOKEN="<redacted: configured in Portainer>"
+
+# Cesium Ion token currently configured in Portainer.
+VITE_CESIUM_ION_TOKEN="<redacted: configured in Portainer>"
+
+# LLM fallback order currently configured in Portainer.
+BACKEND_LLM_FALLBACK_ORDER=groq,openrouter,google
+
+# Groq model currently configured in Portainer.
+BACKEND_GROQ_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+
+# OpenRouter credential currently configured in Portainer.
+BACKEND_OPENROUTER_API_KEY="<redacted: configured in Portainer>"
+
+# OpenRouter model currently configured in Portainer.
+BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:fre
+
+# Host directory for video exports currently configured in Portainer.
+VIDEO_EXPORT_HOST_DIR="/media/nas/DS211_Synology_1/DJI shoots/parapente/"
+
+# Host directory for temporary video images currently configured in Portainer.
+VIDEO_TEMP_IMAGES_HOST_DIR="/media/nas/DS211_Synology_1/DJI shoots/parapente/img_tmp/"
+
+# GoPro overlay project root currently configured in Portainer.
+BACKEND_GOPRO_OVERLAY_ROOT=/media/usb/data-m2/developement/gopro-overlay-dasboard
+
+# GoPro overlay executable currently configured in Portainer.
+BACKEND_GOPRO_OVERLAY_BIN=/media/usb/data-m2/developement/gopro-overlay-dasboard/venv/bin/gopro-dashboard.py
+
+# GoPro overlay layout directory currently configured in Portainer.
+BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard


### PR DESCRIPTION
## Summary
- Add `env.portainer` from the current Portainer stack environment (`/data/compose/47/stack.env`).
- Add a comment for every variable explaining what it represents.
- Keep sensitive values redacted so credentials are not committed.

## Validation
- Not run: environment documentation file only.