### PR TITLE
chore(deploy): prune buildx cache after deployments

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -559,6 +559,9 @@ jobs:
             if ! docker image prune -f; then
               echo "Docker image cleanup failed; deployment remains successful"
             fi
+            if ! docker buildx prune -af; then
+              echo "Docker buildx cleanup failed; deployment remains successful"
+            fi
 
       - name: Label merged PRs with deployed version
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,6 +40,11 @@ if ! docker image prune -f; then
   echo "⚠️  Nettoyage des images ignoré (échec non bloquant)"
 fi
 
+echo "Nettoyage du cache Docker Buildx..."
+if ! docker buildx prune -af; then
+  echo "⚠️  Nettoyage Buildx ignoré (échec non bloquant)"
+fi
+
 echo "✅ Docker redémarré"
 echo ""
 


### PR DESCRIPTION
## Summary
- Run `docker buildx prune -af` after successful deployments in the SSH workflow.
- Mirror the same cleanup in the manual `deploy.sh` script.

## Validation
- `bash -n deploy.sh`
- `git diff --check`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-portainer.yml'))"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production deployment workflows with enhanced Docker build cache cleanup. Cache pruning now occurs during deployment to reduce server storage usage. Non-blocking operations ensure deployments remain successful even if cleanup steps encounter failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/819)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->