### PR TITLE
fix(config): require explicit path env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,10 +26,12 @@ ENVIRONMENT=development
 # BACKEND CONFIGURATION
 # ==========================================
 
-# Database
+# Database (required, no application default)
 # Development: SQLite local (relatif au dossier backend/)
 # Production: Chemin complet ou autre DB
 BACKEND_DATABASE_URL=sqlite:///./db/dashboard.db
+# Required by standalone migration scripts.
+DATABASE_URL=sqlite:///./db/dashboard.db
 
 # Redis Cache
 # Development: Utiliser fake redis (in-memory, pas de Docker requis)
@@ -101,7 +103,7 @@ BACKEND_SCHEDULER_INTERVAL_MINUTES=30
 BACKEND_CACHE_TTL_DEFAULT=3600
 BACKEND_CACHE_TTL_SUMMARY=3600
 
-# Logging
+# Logging (BACKEND_LOG_FILE is required, no application default)
 # Levels: DEBUG | INFO | WARNING | ERROR | CRITICAL
 # Development: DEBUG or INFO
 # Production: INFO or WARNING
@@ -127,13 +129,26 @@ BACKEND_TELEGRAM_CHAT_ID=
 # Production: Your deployed frontend URL
 BACKEND_FRONTEND_URL=http://localhost:5173
 
-# Video export storage.
+# Video export storage (required, no application default).
 # BACKEND_* paths are fixed paths as seen from the backend container.
 # VIDEO_*_HOST_DIR paths configure the Docker host folders mounted there.
 BACKEND_VIDEO_EXPORT_DIR=/app/video-exports
 BACKEND_VIDEO_TEMP_IMAGES_DIR=/app/video-temp-images
 VIDEO_EXPORT_HOST_DIR=/home/capic/docker-data/dashboard-parapente/videos
 VIDEO_TEMP_IMAGES_HOST_DIR=/home/capic/docker-data/dashboard-parapente/video-temp-images
+
+# GoPro overlay toolchain and storage (required, no application default).
+# GOPRO_OVERLAY_HOST_DIR is the Docker host folder mounted at BACKEND_GOPRO_OVERLAY_ROOT.
+GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+BACKEND_GOPRO_OVERLAY_ROOT=/media/usb/data-m2/developement/gopro-overlay-dasboard
+BACKEND_GOPRO_OVERLAY_BIN=/media/usb/data-m2/developement/gopro-overlay-dasboard/venv/bin/gopro-dashboard.py
+BACKEND_GOPRO_OVERLAY_UPLOAD_DIR=/app/gopro-overlays/uploads
+BACKEND_GOPRO_OVERLAY_OUTPUT_DIR=/app/gopro-overlays/outputs
+BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/gopro-overlays/paragliding
+BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+
+# Deployment version state file (required, no application default).
+BACKEND_VERSION_STATE_FILE=/app/db/version_state.json
 
 # ==========================================
 # FRONTEND CONFIGURATION (Vite)

--- a/.env.example
+++ b/.env.example
@@ -138,14 +138,14 @@ VIDEO_EXPORT_HOST_DIR=/home/capic/docker-data/dashboard-parapente/videos
 VIDEO_TEMP_IMAGES_HOST_DIR=/home/capic/docker-data/dashboard-parapente/video-temp-images
 
 # GoPro overlay toolchain and storage (required, no application default).
-# GOPRO_OVERLAY_HOST_DIR is the Docker host folder mounted at BACKEND_GOPRO_OVERLAY_ROOT.
-GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
 BACKEND_GOPRO_OVERLAY_ROOT=/media/usb/data-m2/developement/gopro-overlay-dasboard
 BACKEND_GOPRO_OVERLAY_BIN=/media/usb/data-m2/developement/gopro-overlay-dasboard/venv/bin/gopro-dashboard.py
 BACKEND_GOPRO_OVERLAY_UPLOAD_DIR=/app/gopro-overlays/uploads
 BACKEND_GOPRO_OVERLAY_OUTPUT_DIR=/app/gopro-overlays/outputs
 BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/gopro-overlays/paragliding
 BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+# GOPRO_OVERLAY_HOST_DIR is the Docker host folder mounted at BACKEND_GOPRO_OVERLAY_ROOT.
+GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
 
 # Deployment version state file (required, no application default).
 BACKEND_VERSION_STATE_FILE=/app/db/version_state.json

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -15,6 +15,15 @@ from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        logger.error("Required environment variable %s is missing or empty", name)
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
 # Déterminer le répertoire racine du projet
 PROJECT_ROOT = Path(__file__).parent.parent
 BACKEND_ROOT = Path(__file__).parent
@@ -43,7 +52,7 @@ else:
 # ============================================================================
 # DATABASE
 # ============================================================================
-DATABASE_URL = os.getenv("BACKEND_DATABASE_URL", "sqlite:///./db/dashboard.db")
+DATABASE_URL = required_env("BACKEND_DATABASE_URL")
 
 # ============================================================================
 # REDIS
@@ -117,7 +126,7 @@ ADMIN_PASSWORD = os.getenv("BACKEND_ADMIN_PASSWORD")
 # LOGGING
 # ============================================================================
 LOG_LEVEL = os.getenv("BACKEND_LOG_LEVEL", "INFO")
-LOG_FILE = os.getenv("BACKEND_LOG_FILE", "logs/dashboard.log")
+LOG_FILE = required_env("BACKEND_LOG_FILE")
 
 # Monitoring
 METRICS_TOKEN = os.getenv("BACKEND_METRICS_TOKEN")
@@ -136,56 +145,18 @@ FRONTEND_URL = os.getenv("BACKEND_FRONTEND_URL")
 # ============================================================================
 # VIDEO EXPORT
 # ============================================================================
-_USE_CONTAINER_VIDEO_PATHS = ENVIRONMENT == "production"
-VIDEO_EXPORT_DIR = os.getenv(
-    "BACKEND_VIDEO_EXPORT_DIR",
-    (
-        "/app/video-exports"
-        if _USE_CONTAINER_VIDEO_PATHS
-        else str(BACKEND_ROOT / "exports" / "videos")
-    ),
-)
-VIDEO_TEMP_IMAGES_DIR = os.getenv(
-    "BACKEND_VIDEO_TEMP_IMAGES_DIR",
-    (
-        "/app/video-temp-images"
-        if _USE_CONTAINER_VIDEO_PATHS
-        else str(BACKEND_ROOT / "exports" / "video-temp-images")
-    ),
-)
+VIDEO_EXPORT_DIR = required_env("BACKEND_VIDEO_EXPORT_DIR")
+VIDEO_TEMP_IMAGES_DIR = required_env("BACKEND_VIDEO_TEMP_IMAGES_DIR")
 
 # ============================================================================
 # GOPRO OVERLAY EXPORT
 # ============================================================================
-_GOPRO_OVERLAY_ROOT_DEFAULT = ""
-GOPRO_OVERLAY_ROOT = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_ROOT",
-    _GOPRO_OVERLAY_ROOT_DEFAULT,
-)
-GOPRO_OVERLAY_BIN = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_BIN",
-    (
-        str(Path(GOPRO_OVERLAY_ROOT) / "venv" / "bin" / "gopro-dashboard.py")
-        if GOPRO_OVERLAY_ROOT
-        else "gopro-dashboard.py"
-    ),
-)
-GOPRO_OVERLAY_UPLOAD_DIR = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_UPLOAD_DIR",
-    str(BACKEND_ROOT / "exports" / "gopro-overlays" / "uploads"),
-)
-GOPRO_OVERLAY_OUTPUT_DIR = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_OUTPUT_DIR",
-    str(BACKEND_ROOT / "exports" / "gopro-overlays" / "outputs"),
-)
-GOPRO_OVERLAY_PARAGLIDING_ROOT = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT",
-    "",
-)
-GOPRO_OVERLAY_LAYOUT_DIR = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_LAYOUT_DIR",
-    GOPRO_OVERLAY_ROOT or str(BACKEND_ROOT / "gopro-overlay-layouts"),
-)
+GOPRO_OVERLAY_ROOT = required_env("BACKEND_GOPRO_OVERLAY_ROOT")
+GOPRO_OVERLAY_BIN = required_env("BACKEND_GOPRO_OVERLAY_BIN")
+GOPRO_OVERLAY_UPLOAD_DIR = required_env("BACKEND_GOPRO_OVERLAY_UPLOAD_DIR")
+GOPRO_OVERLAY_OUTPUT_DIR = required_env("BACKEND_GOPRO_OVERLAY_OUTPUT_DIR")
+GOPRO_OVERLAY_PARAGLIDING_ROOT = required_env("BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT")
+GOPRO_OVERLAY_LAYOUT_DIR = required_env("BACKEND_GOPRO_OVERLAY_LAYOUT_DIR")
 
 # ============================================================================
 # VALIDATION

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -13,15 +13,9 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from env_utils import required_env
+
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        logger.error("Required environment variable %s is missing or empty", name)
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 # Déterminer le répertoire racine du projet

--- a/apps/backend/conftest.py
+++ b/apps/backend/conftest.py
@@ -11,6 +11,25 @@ import pytest
 # Set testing mode before importing config
 os.environ["TESTING"] = "true"
 os.environ["BACKEND_USE_FAKE_REDIS"] = "true"
+os.environ["BACKEND_DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["BACKEND_LOG_FILE"] = "logs/test-dashboard.log"
+os.environ["BACKEND_VIDEO_EXPORT_DIR"] = "/tmp/dashboard-parapente-test/video-exports"
+os.environ["BACKEND_VIDEO_TEMP_IMAGES_DIR"] = "/tmp/dashboard-parapente-test/video-temp-images"
+os.environ["BACKEND_GOPRO_OVERLAY_ROOT"] = "/tmp/dashboard-parapente-test/gopro-overlay"
+os.environ["BACKEND_GOPRO_OVERLAY_BIN"] = (
+    "/tmp/dashboard-parapente-test/gopro-overlay/gopro-dashboard.py"
+)
+os.environ["BACKEND_GOPRO_OVERLAY_UPLOAD_DIR"] = (
+    "/tmp/dashboard-parapente-test/gopro-overlays/uploads"
+)
+os.environ["BACKEND_GOPRO_OVERLAY_OUTPUT_DIR"] = (
+    "/tmp/dashboard-parapente-test/gopro-overlays/outputs"
+)
+os.environ["BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT"] = "/tmp/dashboard-parapente-test/paragliding"
+os.environ["BACKEND_GOPRO_OVERLAY_LAYOUT_DIR"] = (
+    "/tmp/dashboard-parapente-test/gopro-overlay-layouts"
+)
+os.environ["BACKEND_VERSION_STATE_FILE"] = "/tmp/dashboard-parapente-test/version_state.json"
 
 # Set dummy API keys for tests
 os.environ["BACKEND_WEATHERAPI_KEY"] = "test_weather_key"

--- a/apps/backend/env_utils.py
+++ b/apps/backend/env_utils.py
@@ -1,0 +1,12 @@
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        logger.error("Required environment variable %s is missing or empty", name)
+        raise ValueError(f"{name} environment variable is required")
+    return value.strip()

--- a/apps/backend/migrations/006_add_app_settings.py
+++ b/apps/backend/migrations/006_add_app_settings.py
@@ -14,8 +14,16 @@ from sqlalchemy import create_engine, text
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
 # Database connection
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+DATABASE_URL = required_env("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
 
 

--- a/apps/backend/migrations/006_add_app_settings.py
+++ b/apps/backend/migrations/006_add_app_settings.py
@@ -5,21 +5,15 @@ Description: Adds key-value settings table for configurable cache, scheduler, an
 """
 
 import logging
-import os
 from datetime import datetime
 
 from sqlalchemy import create_engine, text
 
+from env_utils import required_env
+
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 # Database connection

--- a/apps/backend/migrations/007_add_emagram_max_age_setting.py
+++ b/apps/backend/migrations/007_add_emagram_max_age_setting.py
@@ -5,20 +5,14 @@ Description: Seeds emagram_max_age_minutes in app_settings for existing deployme
 """
 
 import logging
-import os
 from datetime import datetime
 
 from sqlalchemy import create_engine, text
 
+from env_utils import required_env
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 DATABASE_URL = required_env("DATABASE_URL")

--- a/apps/backend/migrations/007_add_emagram_max_age_setting.py
+++ b/apps/backend/migrations/007_add_emagram_max_age_setting.py
@@ -13,7 +13,15 @@ from sqlalchemy import create_engine, text
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+DATABASE_URL = required_env("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
 
 SETTING_KEY = "emagram_max_age_minutes"

--- a/apps/backend/migrations/add_emagram_analysis.py
+++ b/apps/backend/migrations/add_emagram_analysis.py
@@ -12,22 +12,30 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
 # Database connection
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+DATABASE_URL = required_env("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
 
 
 def upgrade():
     """Create emagram_analysis table"""
-    
+
     logger.info("🔧 Creating emagram_analysis table...")
-    
+
     # Create the table
     with engine.connect() as conn:
         conn.execute(text("""
             CREATE TABLE IF NOT EXISTS emagram_analysis (
                 id TEXT PRIMARY KEY,
-                
+
                 -- Metadata
                 analysis_date DATE NOT NULL,
                 analysis_time TIME NOT NULL,
@@ -37,7 +45,7 @@ def upgrade():
                 station_latitude REAL NOT NULL,
                 station_longitude REAL NOT NULL,
                 distance_km REAL NOT NULL,
-                
+
                 -- Data source
                 data_source TEXT NOT NULL DEFAULT 'wyoming',
                 sounding_time TEXT NOT NULL,
@@ -46,7 +54,7 @@ def upgrade():
                 llm_tokens_used INTEGER,
                 llm_cost_usd REAL,
                 analysis_method TEXT NOT NULL,
-                
+
                 -- AI Analysis Results (JSON from LLM)
                 plafond_thermique_m INTEGER,
                 force_thermique_ms REAL,
@@ -58,12 +66,12 @@ def upgrade():
                 heures_volables_total REAL,
                 risque_orage TEXT,
                 score_volabilite INTEGER,
-                
+
                 -- AI Textual Output
                 resume_conditions TEXT,
                 conseils_vol TEXT,
                 alertes_securite TEXT,
-                
+
                 -- Classic Meteorology Fallback
                 lcl_m INTEGER,
                 lfc_m INTEGER,
@@ -74,64 +82,64 @@ def upgrade():
                 showalter_index REAL,
                 wind_shear_0_3km_ms REAL,
                 wind_shear_0_6km_ms REAL,
-                
+
                 -- Raw Data Storage
                 skewt_image_path TEXT,
                 raw_sounding_data TEXT,
                 ai_raw_response TEXT,
-                
+
                 -- Status
                 analysis_status TEXT NOT NULL DEFAULT 'completed',
                 error_message TEXT,
-                
+
                 -- Timestamps
                 created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
         """))
-        
+
         # Create indexes for common queries
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_emagram_datetime 
+            CREATE INDEX IF NOT EXISTS idx_emagram_datetime
             ON emagram_analysis(analysis_datetime DESC)
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_emagram_date 
+            CREATE INDEX IF NOT EXISTS idx_emagram_date
             ON emagram_analysis(analysis_date DESC)
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_emagram_station 
+            CREATE INDEX IF NOT EXISTS idx_emagram_station
             ON emagram_analysis(station_code)
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_emagram_status 
+            CREATE INDEX IF NOT EXISTS idx_emagram_status
             ON emagram_analysis(analysis_status)
         """))
-        
+
         conn.commit()
-    
+
     logger.info("✅ emagram_analysis table created successfully")
     logger.info("📊 Indexes created: datetime, date, station, status")
 
 
 def downgrade():
     """Drop emagram_analysis table"""
-    
+
     logger.info("🔧 Dropping emagram_analysis table...")
-    
+
     with engine.connect() as conn:
         conn.execute(text("DROP TABLE IF EXISTS emagram_analysis"))
         conn.commit()
-    
+
     logger.info("✅ Table dropped successfully")
 
 
 if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) > 1 and sys.argv[1] == "downgrade":
         downgrade()
     else:

--- a/apps/backend/migrations/add_emagram_analysis.py
+++ b/apps/backend/migrations/add_emagram_analysis.py
@@ -5,19 +5,13 @@ Description: Adds emagram (sounding) analysis table for AI-powered thermal forec
 """
 
 from sqlalchemy import create_engine, text
-import os
 import logging
+
+from env_utils import required_env
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 # Database connection

--- a/apps/backend/migrations/add_emagram_feedback.py
+++ b/apps/backend/migrations/add_emagram_feedback.py
@@ -11,15 +11,23 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+DATABASE_URL = required_env("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
 
 
 def upgrade():
     """Create emagram_feedback table"""
-    
+
     logger.info("🔧 Creating emagram_feedback table...")
-    
+
     with engine.connect() as conn:
         conn.execute(text("""
             CREATE TABLE IF NOT EXISTS emagram_feedback (
@@ -28,7 +36,7 @@ def upgrade():
                 pilot_name TEXT,
                 feedback_date DATE NOT NULL,
                 flight_took_place BOOLEAN NOT NULL,
-                
+
                 -- Actual conditions reported by pilot
                 actual_plafond_m INTEGER,
                 actual_force_ms REAL,
@@ -36,54 +44,54 @@ def upgrade():
                 actual_hours_start TIME,
                 actual_hours_end TIME,
                 actual_risk_level TEXT,
-                
+
                 -- Accuracy rating (1-5)
                 accuracy_plafond INTEGER,
                 accuracy_force INTEGER,
                 accuracy_hours INTEGER,
                 accuracy_overall INTEGER,
-                
+
                 -- Comments
                 comments TEXT,
                 would_recommend BOOLEAN,
-                
+
                 -- Metadata
                 created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                
+
                 FOREIGN KEY (emagram_analysis_id) REFERENCES emagram_analysis(id)
             )
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_feedback_analysis 
+            CREATE INDEX IF NOT EXISTS idx_feedback_analysis
             ON emagram_feedback(emagram_analysis_id)
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_feedback_date 
+            CREATE INDEX IF NOT EXISTS idx_feedback_date
             ON emagram_feedback(feedback_date DESC)
         """))
-        
+
         conn.commit()
-    
+
     logger.info("✅ emagram_feedback table created")
 
 
 def downgrade():
     """Drop emagram_feedback table"""
     logger.info("🔧 Dropping emagram_feedback table...")
-    
+
     with engine.connect() as conn:
         conn.execute(text("DROP TABLE IF EXISTS emagram_feedback"))
         conn.commit()
-    
+
     logger.info("✅ Table dropped")
 
 
 if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) > 1 and sys.argv[1] == "downgrade":
         downgrade()
     else:

--- a/apps/backend/migrations/add_emagram_feedback.py
+++ b/apps/backend/migrations/add_emagram_feedback.py
@@ -5,18 +5,12 @@ Description: Pilot feedback system to compare predictions vs reality
 """
 
 from sqlalchemy import create_engine, text
-import os
 import logging
+
+from env_utils import required_env
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 DATABASE_URL = required_env("DATABASE_URL")

--- a/apps/backend/migrations/add_weather_source_config.py
+++ b/apps/backend/migrations/add_weather_source_config.py
@@ -14,16 +14,24 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
+def required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
 # Database connection
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./db/dashboard.db")
+DATABASE_URL = required_env("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
 
 
 def upgrade():
     """Create weather_source_config table and insert default sources"""
-    
+
     logger.info("🔧 Creating weather_source_config table...")
-    
+
     # Create the table
     with engine.connect() as conn:
         conn.execute(text("""
@@ -49,29 +57,29 @@ def upgrade():
                 updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
         """))
-        
+
         # Create indexes
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_weather_source_name 
+            CREATE INDEX IF NOT EXISTS idx_weather_source_name
             ON weather_source_config(source_name)
         """))
-        
+
         conn.execute(text("""
-            CREATE INDEX IF NOT EXISTS idx_weather_source_enabled 
+            CREATE INDEX IF NOT EXISTS idx_weather_source_enabled
             ON weather_source_config(is_enabled)
         """))
-        
+
         conn.commit()
-    
+
     logger.info("✅ Table created successfully")
-    
+
     # Insert default sources
     logger.info("📦 Inserting default weather sources...")
-    
+
     # Get API keys from environment
     weatherapi_key = os.getenv("WEATHERAPI_KEY")
     meteoblue_key = os.getenv("METEOBLUE_API_KEY")
-    
+
     default_sources = [
         {
             "id": str(uuid.uuid4()),
@@ -89,7 +97,7 @@ def upgrade():
             "error_count": 0,
             "total_response_time_ms": 0,
             "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
+            "updated_at": datetime.utcnow().isoformat(),
         },
         {
             "id": str(uuid.uuid4()),
@@ -107,7 +115,7 @@ def upgrade():
             "error_count": 0,
             "total_response_time_ms": 0,
             "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
+            "updated_at": datetime.utcnow().isoformat(),
         },
         {
             "id": str(uuid.uuid4()),
@@ -125,7 +133,7 @@ def upgrade():
             "error_count": 0,
             "total_response_time_ms": 0,
             "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
+            "updated_at": datetime.utcnow().isoformat(),
         },
         {
             "id": str(uuid.uuid4()),
@@ -143,7 +151,7 @@ def upgrade():
             "error_count": 0,
             "total_response_time_ms": 0,
             "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
+            "updated_at": datetime.utcnow().isoformat(),
         },
         {
             "id": str(uuid.uuid4()),
@@ -161,18 +169,18 @@ def upgrade():
             "error_count": 0,
             "total_response_time_ms": 0,
             "created_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat()
-        }
+            "updated_at": datetime.utcnow().isoformat(),
+        },
     ]
-    
+
     with engine.connect() as conn:
         for source in default_sources:
             # Check if source already exists
             result = conn.execute(
                 text("SELECT id FROM weather_source_config WHERE source_name = :name"),
-                {"name": source["source_name"]}
+                {"name": source["source_name"]},
             )
-            
+
             if result.fetchone() is None:
                 # Insert source
                 conn.execute(
@@ -191,15 +199,15 @@ def upgrade():
                             :created_at, :updated_at
                         )
                     """),
-                    source
+                    source,
                 )
                 status = "✅" if source["is_enabled"] else "⚠️ (disabled - no API key)"
                 logger.info(f"  {status} Inserted: {source['display_name']}")
             else:
                 logger.info(f"  ⏭️  Skipped (exists): {source['display_name']}")
-        
+
         conn.commit()
-    
+
     logger.info("✅ Default sources inserted successfully")
     logger.info("🎉 Migration completed!")
 
@@ -207,17 +215,17 @@ def upgrade():
 def downgrade():
     """Drop weather_source_config table (rollback)"""
     logger.info("⚠️  Rolling back weather_source_config table...")
-    
+
     with engine.connect() as conn:
         conn.execute(text("DROP TABLE IF EXISTS weather_source_config"))
         conn.commit()
-    
+
     logger.info("✅ Table dropped successfully")
 
 
 if __name__ == "__main__":
     import sys
-    
+
     if len(sys.argv) > 1 and sys.argv[1] == "downgrade":
         downgrade()
     else:

--- a/apps/backend/migrations/add_weather_source_config.py
+++ b/apps/backend/migrations/add_weather_source_config.py
@@ -10,16 +10,11 @@ from datetime import datetime
 import uuid
 import logging
 
+from env_utils import required_env
+
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-
-def required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise ValueError(f"{name} environment variable is required")
-    return value
 
 
 # Database connection

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -1,0 +1,17 @@
+import pytest
+
+import config
+
+
+def test_required_env_rejects_missing_variable(monkeypatch):
+    monkeypatch.delenv("BACKEND_MISSING_PATH", raising=False)
+
+    with pytest.raises(ValueError, match="BACKEND_MISSING_PATH environment variable is required"):
+        config.required_env("BACKEND_MISSING_PATH")
+
+
+def test_required_env_rejects_empty_variable(monkeypatch):
+    monkeypatch.setenv("BACKEND_EMPTY_PATH", "   ")
+
+    with pytest.raises(ValueError, match="BACKEND_EMPTY_PATH environment variable is required"):
+        config.required_env("BACKEND_EMPTY_PATH")

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -15,3 +15,9 @@ def test_required_env_rejects_empty_variable(monkeypatch):
 
     with pytest.raises(ValueError, match="BACKEND_EMPTY_PATH environment variable is required"):
         config.required_env("BACKEND_EMPTY_PATH")
+
+
+def test_required_env_accepts_non_empty_variable(monkeypatch):
+    monkeypatch.setenv("BACKEND_VALID_PATH", "  /valid/path  ")
+
+    assert config.required_env("BACKEND_VALID_PATH") == "/valid/path"

--- a/apps/backend/versioning.py
+++ b/apps/backend/versioning.py
@@ -10,22 +10,22 @@ import fcntl
 
 logger = logging.getLogger(__name__)
 
-VERSION_STATE_FILE = Path(
-    os.getenv(
-        "BACKEND_VERSION_STATE_FILE",
-        Path(__file__).parent / "db" / "version_state.json",
-    )
-)
+
+def _required_env(name: str) -> str:
+    value = os.getenv(name)
+    if value is None or not value.strip():
+        logger.error("Required environment variable %s is missing or empty", name)
+        raise ValueError(f"{name} environment variable is required")
+    return value
+
+
+VERSION_STATE_FILE = Path(_required_env("BACKEND_VERSION_STATE_FILE"))
 
 _current_version_payload: dict[str, int | str | None] | None = None
 
 
 def _today_string() -> str:
     return datetime.now(timezone.utc).strftime("%Y.%m.%d")
-
-
-def _is_testing_mode() -> bool:
-    return os.getenv("TESTING", "false").lower() == "true"
 
 
 def _release_notes_url() -> str | None:
@@ -93,15 +93,6 @@ def initialize_deployment_version() -> dict[str, int | str | None]:
             "release_notes_url": _release_notes_url(),
         }
         logger.info("Deployment version forced from BACKEND_DEPLOY_VERSION: %s", forced_version)
-        return _current_version_payload
-
-    if _is_testing_mode() and "BACKEND_VERSION_STATE_FILE" not in os.environ:
-        _current_version_payload = {
-            "version": f"{today}.0",
-            "build_date": today,
-            "build_number": 0,
-            "release_notes_url": _release_notes_url(),
-        }
         return _current_version_payload
 
     VERSION_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/apps/backend/versioning.py
+++ b/apps/backend/versioning.py
@@ -8,18 +8,11 @@ from urllib.parse import urlparse
 
 import fcntl
 
+from env_utils import required_env
+
 logger = logging.getLogger(__name__)
 
-
-def _required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        logger.error("Required environment variable %s is missing or empty", name)
-        raise ValueError(f"{name} environment variable is required")
-    return value
-
-
-VERSION_STATE_FILE = Path(_required_env("BACKEND_VERSION_STATE_FILE"))
+VERSION_STATE_FILE = Path(required_env("BACKEND_VERSION_STATE_FILE"))
 
 _current_version_payload: dict[str, int | str | None] | None = None
 

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -8,6 +8,7 @@ function globalSetup(): void {
   const scriptPath = path.join(backendPath, 'init_e2e_db.py');
   const dbPath = path.join(backendPath, 'test.db');
   const absoluteDbUrl = `sqlite:///${dbPath}`;
+  const e2eRuntimeDir = path.join(backendPath, 'e2e-runtime');
 
   // Use python3 on Unix systems, python on Windows
   const pythonCmd = process.platform === 'win32' ? 'python' : 'python3';
@@ -22,6 +23,16 @@ function globalSetup(): void {
         ENVIRONMENT: 'test',
         TESTING: 'false',
         BACKEND_DATABASE_URL: absoluteDbUrl,
+        BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
+        BACKEND_VIDEO_EXPORT_DIR: path.join(e2eRuntimeDir, 'video-exports'),
+        BACKEND_VIDEO_TEMP_IMAGES_DIR: path.join(e2eRuntimeDir, 'video-temp-images'),
+        BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
+        BACKEND_GOPRO_OVERLAY_BIN: path.join(e2eRuntimeDir, 'gopro-overlay', 'gopro-dashboard.py'),
+        BACKEND_GOPRO_OVERLAY_UPLOAD_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'uploads'),
+        BACKEND_GOPRO_OVERLAY_OUTPUT_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'outputs'),
+        BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT: path.join(e2eRuntimeDir, 'paragliding'),
+        BACKEND_GOPRO_OVERLAY_LAYOUT_DIR: path.join(e2eRuntimeDir, 'gopro-overlay-layouts'),
+        BACKEND_VERSION_STATE_FILE: path.join(e2eRuntimeDir, 'version_state.json'),
         BACKEND_JWT_SECRET: process.env.BACKEND_JWT_SECRET || 'e2e-test-secret',
         BACKEND_ADMIN_EMAIL: process.env.BACKEND_ADMIN_EMAIL || 'e2e@test.local',
         BACKEND_ADMIN_PASSWORD: process.env.BACKEND_ADMIN_PASSWORD || 'e2e-test-password',

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 const backendDir = path.resolve(__dirname, '..', 'backend');
 const dbPath = path.join(backendDir, 'test.db');
 const absoluteDbUrl = `sqlite:///${dbPath}`;
+const e2eRuntimeDir = path.join(backendDir, 'e2e-runtime');
 
 // Run only Chromium in CI for speed, all browsers locally
 const ciOnly = !!process.env.CI;
@@ -64,7 +65,17 @@ export default defineConfig({
       env: {
         ENVIRONMENT: 'test',
         TESTING: 'false',
-        BACKEND_DATABASE_URL: process.env.BACKEND_DATABASE_URL || absoluteDbUrl,
+        BACKEND_DATABASE_URL: absoluteDbUrl,
+        BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
+        BACKEND_VIDEO_EXPORT_DIR: path.join(e2eRuntimeDir, 'video-exports'),
+        BACKEND_VIDEO_TEMP_IMAGES_DIR: path.join(e2eRuntimeDir, 'video-temp-images'),
+        BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
+        BACKEND_GOPRO_OVERLAY_BIN: path.join(e2eRuntimeDir, 'gopro-overlay', 'gopro-dashboard.py'),
+        BACKEND_GOPRO_OVERLAY_UPLOAD_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'uploads'),
+        BACKEND_GOPRO_OVERLAY_OUTPUT_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'outputs'),
+        BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT: path.join(e2eRuntimeDir, 'paragliding'),
+        BACKEND_GOPRO_OVERLAY_LAYOUT_DIR: path.join(e2eRuntimeDir, 'gopro-overlay-layouts'),
+        BACKEND_VERSION_STATE_FILE: path.join(e2eRuntimeDir, 'version_state.json'),
         BACKEND_WEATHERAPI_KEY: process.env.BACKEND_WEATHERAPI_KEY || 'test_key',
         BACKEND_METEOBLUE_API_KEY: process.env.BACKEND_METEOBLUE_API_KEY || 'test_key',
         BACKEND_STRAVA_VERIFY_TOKEN: process.env.BACKEND_STRAVA_VERIFY_TOKEN || 'PARAPENTE_E2E_TEST',

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,6 +26,9 @@ echo ""
 
 # Étape 2 : Rebuild Docker en production
 echo "🐳 Étape 2/3 : Rebuild Docker..."
+echo "Validation de la configuration Docker Compose..."
+docker compose config >/dev/null
+
 echo "Arrêt des conteneurs..."
 docker compose down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - ENVIRONMENT=${ENVIRONMENT:-production}
 
       # Backend - Database
-      - BACKEND_DATABASE_URL=${BACKEND_DATABASE_URL:-sqlite:///./db/dashboard.db}
+      - BACKEND_DATABASE_URL=${BACKEND_DATABASE_URL:?BACKEND_DATABASE_URL is required}
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
 
       # Backend - Redis
       - BACKEND_REDIS_HOST=redis
@@ -79,7 +80,7 @@ services:
 
       # Backend - Logging
       - BACKEND_LOG_LEVEL=${BACKEND_LOG_LEVEL:-INFO}
-      - BACKEND_LOG_FILE=${BACKEND_LOG_FILE:-logs/dashboard.log}
+      - BACKEND_LOG_FILE=${BACKEND_LOG_FILE:?BACKEND_LOG_FILE is required}
 
       # Backend - Monitoring
       - BACKEND_METRICS_TOKEN=${BACKEND_METRICS_TOKEN:?required}
@@ -97,24 +98,28 @@ services:
       - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
 
       # Backend - Video export storage
-      - BACKEND_VIDEO_EXPORT_DIR=${BACKEND_VIDEO_EXPORT_DIR:-/app/video-exports}
-      - BACKEND_VIDEO_TEMP_IMAGES_DIR=${BACKEND_VIDEO_TEMP_IMAGES_DIR:-/app/video-temp-images}
+      - BACKEND_VIDEO_EXPORT_DIR=${BACKEND_VIDEO_EXPORT_DIR:?BACKEND_VIDEO_EXPORT_DIR is required}
+      - BACKEND_VIDEO_TEMP_IMAGES_DIR=${BACKEND_VIDEO_TEMP_IMAGES_DIR:?BACKEND_VIDEO_TEMP_IMAGES_DIR is required}
 
       # Backend - GoPro overlay toolchain
-      - BACKEND_GOPRO_OVERLAY_ROOT=${BACKEND_GOPRO_OVERLAY_ROOT:-/media/usb/data-m2/developement/gopro-overlay-dasboard}
-      - BACKEND_GOPRO_OVERLAY_BIN=${BACKEND_GOPRO_OVERLAY_BIN:-/media/usb/data-m2/developement/gopro-overlay-dasboard/venv/bin/gopro-dashboard.py}
-      - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=${BACKEND_GOPRO_OVERLAY_LAYOUT_DIR:-/media/usb/data-m2/developement/gopro-overlay-dasboard}
+      - BACKEND_GOPRO_OVERLAY_ROOT=${BACKEND_GOPRO_OVERLAY_ROOT:?BACKEND_GOPRO_OVERLAY_ROOT is required}
+      - BACKEND_GOPRO_OVERLAY_BIN=${BACKEND_GOPRO_OVERLAY_BIN:?BACKEND_GOPRO_OVERLAY_BIN is required}
+      - BACKEND_GOPRO_OVERLAY_UPLOAD_DIR=${BACKEND_GOPRO_OVERLAY_UPLOAD_DIR:?BACKEND_GOPRO_OVERLAY_UPLOAD_DIR is required}
+      - BACKEND_GOPRO_OVERLAY_OUTPUT_DIR=${BACKEND_GOPRO_OVERLAY_OUTPUT_DIR:?BACKEND_GOPRO_OVERLAY_OUTPUT_DIR is required}
+      - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=${BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT:?BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT is required}
+      - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=${BACKEND_GOPRO_OVERLAY_LAYOUT_DIR:?BACKEND_GOPRO_OVERLAY_LAYOUT_DIR is required}
 
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
+      - BACKEND_VERSION_STATE_FILE=${BACKEND_VERSION_STATE_FILE:?BACKEND_VERSION_STATE_FILE is required}
     depends_on:
       redis:
         condition: service_healthy
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
-      - ${VIDEO_EXPORT_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/videos}:/app/video-exports
-      - ${VIDEO_TEMP_IMAGES_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/video-temp-images}:/app/video-temp-images
-      - ${GOPRO_OVERLAY_HOST_DIR:-/media/usb/data-m2/developement/gopro-overlay-dasboard}:${BACKEND_GOPRO_OVERLAY_ROOT:-/media/usb/data-m2/developement/gopro-overlay-dasboard}:ro
+      - ${VIDEO_EXPORT_HOST_DIR:?VIDEO_EXPORT_HOST_DIR is required}:${BACKEND_VIDEO_EXPORT_DIR:?BACKEND_VIDEO_EXPORT_DIR is required}
+      - ${VIDEO_TEMP_IMAGES_HOST_DIR:?VIDEO_TEMP_IMAGES_HOST_DIR is required}:${BACKEND_VIDEO_TEMP_IMAGES_DIR:?BACKEND_VIDEO_TEMP_IMAGES_DIR is required}
+      - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:${BACKEND_GOPRO_OVERLAY_ROOT:?BACKEND_GOPRO_OVERLAY_ROOT is required}:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
       interval: 30s


### PR DESCRIPTION
## Summary
- Require explicit path-related environment variables in backend config and versioning.
- Fail fast in Docker Compose/deploy when required paths are missing.
- Document the missing variables in `.env.example` and update test/E2E setup.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `./.venv/bin/pytest apps/backend/tests/unit/test_required_env.py apps/backend/tests/unit/test_versioning.py apps/backend/tests/api/test_routes_version.py apps/backend/tests/api/test_gopro_overlay_endpoints.py -q`
- `docker compose config` with required env vars set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configuration requirements tightened: environment variables for database, logging, and video/media processing paths are now mandatory with no default fallbacks.
  * Docker Compose validation added to deployment process.
  * GoPro overlay toolchain configuration expanded with additional required paths.

* **Tests**
  * Test infrastructure updated to configure all required environment variables for consistent test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/828)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->