### PR TITLE
fix(config): remove obsolete video export env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,11 +129,9 @@ BACKEND_TELEGRAM_CHAT_ID=
 # Production: Your deployed frontend URL
 BACKEND_FRONTEND_URL=http://localhost:5173
 
-# Video export storage (required, no application default).
-# BACKEND_* paths are fixed paths as seen from the backend container.
-# VIDEO_*_HOST_DIR paths configure the Docker host folders mounted there.
-BACKEND_VIDEO_EXPORT_DIR=/app/video-exports
-BACKEND_VIDEO_TEMP_IMAGES_DIR=/app/video-temp-images
+# Video export storage.
+# VIDEO_*_HOST_DIR paths configure the Docker host folders mounted in the container.
+# The backend container paths are fixed.
 VIDEO_EXPORT_HOST_DIR=/home/capic/docker-data/dashboard-parapente/videos
 VIDEO_TEMP_IMAGES_HOST_DIR=/home/capic/docker-data/dashboard-parapente/video-temp-images
 

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -139,8 +139,15 @@ FRONTEND_URL = os.getenv("BACKEND_FRONTEND_URL")
 # ============================================================================
 # VIDEO EXPORT
 # ============================================================================
-VIDEO_EXPORT_DIR = required_env("BACKEND_VIDEO_EXPORT_DIR")
-VIDEO_TEMP_IMAGES_DIR = required_env("BACKEND_VIDEO_TEMP_IMAGES_DIR")
+_USE_CONTAINER_VIDEO_PATHS = ENVIRONMENT == "production"
+VIDEO_EXPORT_DIR = (
+    "/app/video-exports" if _USE_CONTAINER_VIDEO_PATHS else str(BACKEND_ROOT / "exports" / "videos")
+)
+VIDEO_TEMP_IMAGES_DIR = (
+    "/app/video-temp-images"
+    if _USE_CONTAINER_VIDEO_PATHS
+    else str(BACKEND_ROOT / "exports" / "video-temp-images")
+)
 
 # ============================================================================
 # GOPRO OVERLAY EXPORT

--- a/apps/backend/conftest.py
+++ b/apps/backend/conftest.py
@@ -13,8 +13,6 @@ os.environ["TESTING"] = "true"
 os.environ["BACKEND_USE_FAKE_REDIS"] = "true"
 os.environ["BACKEND_DATABASE_URL"] = "sqlite:///./test.db"
 os.environ["BACKEND_LOG_FILE"] = "logs/test-dashboard.log"
-os.environ["BACKEND_VIDEO_EXPORT_DIR"] = "/tmp/dashboard-parapente-test/video-exports"
-os.environ["BACKEND_VIDEO_TEMP_IMAGES_DIR"] = "/tmp/dashboard-parapente-test/video-temp-images"
 os.environ["BACKEND_GOPRO_OVERLAY_ROOT"] = "/tmp/dashboard-parapente-test/gopro-overlay"
 os.environ["BACKEND_GOPRO_OVERLAY_BIN"] = (
     "/tmp/dashboard-parapente-test/gopro-overlay/gopro-dashboard.py"

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -21,3 +21,10 @@ def test_required_env_accepts_non_empty_variable(monkeypatch):
     monkeypatch.setenv("BACKEND_VALID_PATH", "  /valid/path  ")
 
     assert config.required_env("BACKEND_VALID_PATH") == "/valid/path"
+
+
+def test_video_export_paths_are_fixed():
+    assert config.VIDEO_EXPORT_DIR == str(config.BACKEND_ROOT / "exports" / "videos")
+    assert config.VIDEO_TEMP_IMAGES_DIR == str(
+        config.BACKEND_ROOT / "exports" / "video-temp-images"
+    )

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -24,8 +24,6 @@ function globalSetup(): void {
         TESTING: 'false',
         BACKEND_DATABASE_URL: absoluteDbUrl,
         BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
-        BACKEND_VIDEO_EXPORT_DIR: path.join(e2eRuntimeDir, 'video-exports'),
-        BACKEND_VIDEO_TEMP_IMAGES_DIR: path.join(e2eRuntimeDir, 'video-temp-images'),
         BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
         BACKEND_GOPRO_OVERLAY_BIN: path.join(e2eRuntimeDir, 'gopro-overlay', 'gopro-dashboard.py'),
         BACKEND_GOPRO_OVERLAY_UPLOAD_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'uploads'),

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -67,8 +67,6 @@ export default defineConfig({
         TESTING: 'false',
         BACKEND_DATABASE_URL: absoluteDbUrl,
         BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
-        BACKEND_VIDEO_EXPORT_DIR: path.join(e2eRuntimeDir, 'video-exports'),
-        BACKEND_VIDEO_TEMP_IMAGES_DIR: path.join(e2eRuntimeDir, 'video-temp-images'),
         BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
         BACKEND_GOPRO_OVERLAY_BIN: path.join(e2eRuntimeDir, 'gopro-overlay', 'gopro-dashboard.py'),
         BACKEND_GOPRO_OVERLAY_UPLOAD_DIR: path.join(e2eRuntimeDir, 'gopro-overlays', 'uploads'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,6 @@ services:
       - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
 
       # Backend - Video export storage
-      - BACKEND_VIDEO_EXPORT_DIR=${BACKEND_VIDEO_EXPORT_DIR:?BACKEND_VIDEO_EXPORT_DIR is required}
-      - BACKEND_VIDEO_TEMP_IMAGES_DIR=${BACKEND_VIDEO_TEMP_IMAGES_DIR:?BACKEND_VIDEO_TEMP_IMAGES_DIR is required}
 
       # Backend - GoPro overlay toolchain
       - BACKEND_GOPRO_OVERLAY_ROOT=${BACKEND_GOPRO_OVERLAY_ROOT:?BACKEND_GOPRO_OVERLAY_ROOT is required}
@@ -117,8 +115,8 @@ services:
         condition: service_healthy
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
-      - ${VIDEO_EXPORT_HOST_DIR:?VIDEO_EXPORT_HOST_DIR is required}:${BACKEND_VIDEO_EXPORT_DIR:?BACKEND_VIDEO_EXPORT_DIR is required}
-      - ${VIDEO_TEMP_IMAGES_HOST_DIR:?VIDEO_TEMP_IMAGES_HOST_DIR is required}:${BACKEND_VIDEO_TEMP_IMAGES_DIR:?BACKEND_VIDEO_TEMP_IMAGES_DIR is required}
+      - ${VIDEO_EXPORT_HOST_DIR:?VIDEO_EXPORT_HOST_DIR is required}:/app/video-exports
+      - ${VIDEO_TEMP_IMAGES_HOST_DIR:?VIDEO_TEMP_IMAGES_HOST_DIR is required}:/app/video-temp-images
       - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:${BACKEND_GOPRO_OVERLAY_ROOT:?BACKEND_GOPRO_OVERLAY_ROOT is required}:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']


### PR DESCRIPTION
## Summary
- Remove obsolete BACKEND_VIDEO_EXPORT_DIR and BACKEND_VIDEO_TEMP_IMAGES_DIR usage from backend config, compose, and test bootstrap paths.
- Keep video mount points fixed in the container and add a regression test for the backend paths.

## Validation
- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx lint backend
- ../../.venv/bin/pytest tests/unit/test_required_env.py tests/api/test_video_export_endpoints.py -q

## Notes
- The full `nx affected -t test --uncommitted` backend run hit a long-running test path and timed out in the shell after the backend target reported success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified video export storage configuration in environment setup guide.

* **Refactor**
  * Removed requirement to manually configure backend video export directories; paths are now automatically derived and consistently set.

* **Tests**
  * Added test to verify video export path configuration.

* **Chores**
  * Updated Docker Compose configuration to use fixed container paths for video storage mounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/832)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->