### PR TITLE
fix: hardcode video export host mounts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,12 +129,6 @@ BACKEND_TELEGRAM_CHAT_ID=
 # Production: Your deployed frontend URL
 BACKEND_FRONTEND_URL=http://localhost:5173
 
-# Video export storage.
-# VIDEO_*_HOST_DIR paths configure the Docker host folders mounted in the container.
-# The backend container paths are fixed.
-VIDEO_EXPORT_HOST_DIR=/home/capic/docker-data/dashboard-parapente/videos
-VIDEO_TEMP_IMAGES_HOST_DIR=/home/capic/docker-data/dashboard-parapente/video-temp-images
-
 # GoPro overlay toolchain and storage.
 # Host folders mounted at the backend's fixed container paths.
 # Toolchain: /app/gopro-overlay, data root: /app/gopro-overlays/parapente.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,8 +107,8 @@ services:
         condition: service_healthy
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
-      - ${VIDEO_EXPORT_HOST_DIR:?VIDEO_EXPORT_HOST_DIR is required}:/app/video-exports
-      - ${VIDEO_TEMP_IMAGES_HOST_DIR:?VIDEO_TEMP_IMAGES_HOST_DIR is required}:/app/video-temp-images
+      - "/media/nas/DS211_Synology_1/DJI shoots/parapente/:/app/video-exports"
+      - "/media/nas/DS211_Synology_1/DJI shoots/parapente/img_tmp/:/app/video-temp-images"
       - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:/app/gopro-overlay:ro
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/gopro-overlays/parapente
     healthcheck:

--- a/env.portainer
+++ b/env.portainer
@@ -112,12 +112,6 @@ BACKEND_OPENROUTER_API_KEY="<redacted: configured in Portainer>"
 # OpenRouter model currently configured in Portainer.
 BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:fre
 
-# Host directory for video exports currently configured in Portainer.
-VIDEO_EXPORT_HOST_DIR="/media/nas/DS211_Synology_1/DJI shoots/parapente/"
-
-# Host directory for temporary video images currently configured in Portainer.
-VIDEO_TEMP_IMAGES_HOST_DIR="/media/nas/DS211_Synology_1/DJI shoots/parapente/img_tmp/"
-
 # Host directory mounted at /app/gopro-overlay.
 GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
 


### PR DESCRIPTION
## Summary
- Remove `VIDEO_EXPORT_HOST_DIR` and `VIDEO_TEMP_IMAGES_HOST_DIR` from env files.
- Mount the current production video export and temp image host directories directly in Docker Compose.

## Validation
- `git diff --check origin/main...HEAD`
- Verified no remaining `VIDEO_EXPORT_HOST_DIR` or `VIDEO_TEMP_IMAGES_HOST_DIR` references.