### PR TITLE
Fix flight storage layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,9 +129,11 @@ BACKEND_TELEGRAM_CHAT_ID=
 # Production: Your deployed frontend URL
 BACKEND_FRONTEND_URL=http://localhost:5173
 
-# Flight file storage and GoPro overlay toolchain use fixed Docker mounts:
-# - /media/nas/DS211_Synology_2/parapente -> /app/parapente
-# - /media/usb/data-m2/developement/gopro-overlay-dasboard -> /app/gopro-overlay
+# Host folders mounted at fixed backend container paths.
+# GOPRO_OVERLAY_DATA_HOST_DIR is mounted at /app/parapente.
+# GOPRO_OVERLAY_HOST_DIR is mounted at /app/gopro-overlay.
+GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+GOPRO_OVERLAY_DATA_HOST_DIR=/media/nas/DS211_Synology_2/parapente
 
 # Deployment version state file (required, no application default).
 BACKEND_VERSION_STATE_FILE=/app/db/version_state.json

--- a/.env.example
+++ b/.env.example
@@ -129,11 +129,9 @@ BACKEND_TELEGRAM_CHAT_ID=
 # Production: Your deployed frontend URL
 BACKEND_FRONTEND_URL=http://localhost:5173
 
-# GoPro overlay toolchain and storage.
-# Host folders mounted at the backend's fixed container paths.
-# Toolchain: /app/gopro-overlay, data root: /app/gopro-overlays/parapente.
-GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
-GOPRO_OVERLAY_DATA_HOST_DIR=/media/usb/data-m2/developement/parapente
+# Flight file storage and GoPro overlay toolchain use fixed Docker mounts:
+# - /media/nas/DS211_Synology_2/parapente -> /app/parapente
+# - /media/usb/data-m2/developement/gopro-overlay-dasboard -> /app/gopro-overlay
 
 # Deployment version state file (required, no application default).
 BACKEND_VERSION_STATE_FILE=/app/db/version_state.json

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -25,6 +25,7 @@ BACKEND_ROOT = Path(__file__).parent
 # Charger les variables d'environnement selon le contexte
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
 TESTING = os.getenv("TESTING", "false").lower() == "true"
+IS_TEST_ENV = TESTING or ENVIRONMENT == "test"
 
 if ENVIRONMENT != "production":
     # En développement : chercher .env.development puis .env
@@ -140,9 +141,7 @@ FRONTEND_URL = os.getenv("BACKEND_FRONTEND_URL")
 # FLIGHT FILE STORAGE
 # ============================================================================
 PARAGLIDING_DATA_ROOT = (
-    "/tmp/dashboard-parapente-test/parapente"
-    if TESTING or ENVIRONMENT == "test"
-    else "/app/parapente"
+    "/tmp/dashboard-parapente-test/parapente" if IS_TEST_ENV else "/app/parapente"
 )
 VIDEO_EXPORT_DIR = PARAGLIDING_DATA_ROOT
 VIDEO_TEMP_IMAGES_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "video-frames")
@@ -162,7 +161,7 @@ GOPRO_OVERLAY_UPLOAD_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "gopro-upl
 # ============================================================================
 
 # Valider les variables critiques (sauf en mode test)
-if not TESTING:
+if not IS_TEST_ENV:
     if not JWT_SECRET:
         logger.error("❌ BACKEND_JWT_SECRET is required")
         raise ValueError("BACKEND_JWT_SECRET environment variable is required")

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -137,33 +137,25 @@ TELEGRAM_CHAT_ID = os.getenv("BACKEND_TELEGRAM_CHAT_ID")
 FRONTEND_URL = os.getenv("BACKEND_FRONTEND_URL")
 
 # ============================================================================
-# VIDEO EXPORT
+# FLIGHT FILE STORAGE
 # ============================================================================
-_USE_CONTAINER_VIDEO_PATHS = ENVIRONMENT == "production"
-VIDEO_EXPORT_DIR = (
-    "/app/video-exports" if _USE_CONTAINER_VIDEO_PATHS else str(BACKEND_ROOT / "exports" / "videos")
+PARAGLIDING_DATA_ROOT = (
+    "/tmp/dashboard-parapente-test/parapente"
+    if TESTING or ENVIRONMENT == "test"
+    else "/app/parapente"
 )
-VIDEO_TEMP_IMAGES_DIR = (
-    "/app/video-temp-images"
-    if _USE_CONTAINER_VIDEO_PATHS
-    else str(BACKEND_ROOT / "exports" / "video-temp-images")
-)
+VIDEO_EXPORT_DIR = PARAGLIDING_DATA_ROOT
+VIDEO_TEMP_IMAGES_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "video-frames")
 
 # ============================================================================
 # GOPRO OVERLAY EXPORT
 # ============================================================================
-GOPRO_OVERLAY_ROOT = (os.getenv("BACKEND_GOPRO_OVERLAY_ROOT") or "/app/gopro-overlay").strip()
-GOPRO_OVERLAY_DATA_ROOT = (
-    os.getenv("BACKEND_GOPRO_OVERLAY_DATA_ROOT") or "/app/gopro-overlays/parapente"
-).strip()
-GOPRO_OVERLAY_BIN = os.getenv(
-    "BACKEND_GOPRO_OVERLAY_BIN",
-    str(Path(GOPRO_OVERLAY_ROOT) / "venv" / "bin" / "gopro-dashboard.py"),
-)
-GOPRO_OVERLAY_LAYOUT_DIR = os.getenv("BACKEND_GOPRO_OVERLAY_LAYOUT_DIR", GOPRO_OVERLAY_ROOT)
-GOPRO_OVERLAY_PARAGLIDING_ROOT = GOPRO_OVERLAY_DATA_ROOT
-GOPRO_OVERLAY_OUTPUT_DIR = str(Path(GOPRO_OVERLAY_DATA_ROOT) / "input-overlay")
-GOPRO_OVERLAY_UPLOAD_DIR = str(Path(GOPRO_OVERLAY_OUTPUT_DIR) / "uploads")
+GOPRO_OVERLAY_ROOT = "/app/gopro-overlay"
+GOPRO_OVERLAY_BIN = str(Path(GOPRO_OVERLAY_ROOT) / "venv" / "bin" / "gopro-dashboard.py")
+GOPRO_OVERLAY_LAYOUT_DIR = GOPRO_OVERLAY_ROOT
+GOPRO_OVERLAY_PARAGLIDING_ROOT = PARAGLIDING_DATA_ROOT
+GOPRO_OVERLAY_OUTPUT_DIR = PARAGLIDING_DATA_ROOT
+GOPRO_OVERLAY_UPLOAD_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "gopro-uploads")
 
 # ============================================================================
 # VALIDATION

--- a/apps/backend/conftest.py
+++ b/apps/backend/conftest.py
@@ -13,8 +13,6 @@ os.environ["TESTING"] = "true"
 os.environ["BACKEND_USE_FAKE_REDIS"] = "true"
 os.environ["BACKEND_DATABASE_URL"] = "sqlite:///./test.db"
 os.environ["BACKEND_LOG_FILE"] = "logs/test-dashboard.log"
-os.environ["BACKEND_GOPRO_OVERLAY_ROOT"] = "/tmp/dashboard-parapente-test/gopro-overlay"
-os.environ["BACKEND_GOPRO_OVERLAY_DATA_ROOT"] = "/tmp/dashboard-parapente-test/paragliding"
 os.environ["BACKEND_VERSION_STATE_FILE"] = "/tmp/dashboard-parapente-test/version_state.json"
 
 # Set dummy API keys for tests

--- a/apps/backend/flight_storage.py
+++ b/apps/backend/flight_storage.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 import config
+from database import SessionLocal
 from models import Flight
 
 
@@ -15,19 +16,16 @@ def flight_sequence_number(db: Session, flight: Flight) -> int:
     if not any(existing.id == flight.id for existing in flights):
         flights.append(flight)
 
-    def sort_key(candidate: Flight) -> tuple[str, str, str]:
-        departure_time = (
-            candidate.departure_time.isoformat() if candidate.departure_time else "9999"
-        )
+    def sort_key(candidate: Flight) -> tuple[str, str]:
         created_at = candidate.created_at.isoformat() if candidate.created_at else "9999"
-        return departure_time, created_at, candidate.id
+        return created_at, candidate.id
 
     flights.sort(key=sort_key)
     for index, candidate in enumerate(flights, start=1):
         if candidate.id == flight.id:
             return index
 
-    return len(flights) + 1
+    raise RuntimeError(f"Flight {flight.id} was not found in daily sequence")
 
 
 def flight_directory(db: Session, flight: Flight) -> Path:
@@ -45,3 +43,15 @@ def write_flight_text_file(db: Session, flight: Flight, filename: str, content: 
     file_path = ensure_flight_directory(db, flight) / filename
     file_path.write_text(content, encoding="utf-8")
     return file_path
+
+
+def get_video_output_path(flight_id: str, timestamp: str) -> Path:
+    try:
+        with SessionLocal() as db:
+            flight = db.query(Flight).filter(Flight.id == flight_id).first()
+            if flight:
+                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
+    except Exception as exc:
+        print(f"⚠️ Could not resolve flight storage directory: {exc}")
+
+    return Path(config.VIDEO_EXPORT_DIR) / f"flight-{flight_id}-{timestamp}.mp4"

--- a/apps/backend/flight_storage.py
+++ b/apps/backend/flight_storage.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+import config
+from models import Flight
+
+
+def flight_storage_root() -> Path:
+    return Path(config.PARAGLIDING_DATA_ROOT)
+
+
+def flight_sequence_number(db: Session, flight: Flight) -> int:
+    flights = list(db.query(Flight).filter(Flight.flight_date == flight.flight_date).all())
+    if not any(existing.id == flight.id for existing in flights):
+        flights.append(flight)
+
+    def sort_key(candidate: Flight) -> tuple[str, str, str]:
+        departure_time = (
+            candidate.departure_time.isoformat() if candidate.departure_time else "9999"
+        )
+        created_at = candidate.created_at.isoformat() if candidate.created_at else "9999"
+        return departure_time, created_at, candidate.id
+
+    flights.sort(key=sort_key)
+    for index, candidate in enumerate(flights, start=1):
+        if candidate.id == flight.id:
+            return index
+
+    return len(flights) + 1
+
+
+def flight_directory(db: Session, flight: Flight) -> Path:
+    day_dir = flight_storage_root() / flight.flight_date.isoformat()
+    return day_dir / f"{flight_sequence_number(db, flight):02d}"
+
+
+def ensure_flight_directory(db: Session, flight: Flight) -> Path:
+    directory = flight_directory(db, flight)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def write_flight_text_file(db: Session, flight: Flight, filename: str, content: str) -> Path:
+    file_path = ensure_flight_directory(db, flight) / filename
+    file_path.write_text(content, encoding="utf-8")
+    return file_path

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -32,6 +32,8 @@ from auth import authenticate_user, create_access_token, get_current_user
 from database import get_db
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_backfill import calculate_and_persist_missing_max_speed
+from flight_storage import ensure_flight_directory
+from flight_storage import write_flight_text_file
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import check_gopro_overlay_dependencies
 from gopro_overlay_export import create_gopro_overlay_job
@@ -3290,7 +3292,6 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
         download_gpx,
         get_activities_by_period,
         match_site_by_coordinates,
-        save_gpx_file,
     )
 
     date_from = request.get("date_from")
@@ -3331,14 +3332,7 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
                 # 4. Télécharger GPX
                 gpx_content = await download_gpx(strava_id)
 
-                gpx_path = None
-                if gpx_content:
-                    # 5. Sauvegarder GPX
-                    gpx_path = save_gpx_file(gpx_content, strava_id)
-
-                    if not gpx_path:
-                        logger.warning(f"Failed to save GPX for activity {strava_id}")
-                else:
+                if not gpx_content:
                     logger.warning(f"No GPX available for activity {strava_id}")
 
                 # 6. Détecter le site depuis les coordonnées GPX
@@ -3395,11 +3389,14 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
                         if activity.get("total_elevation_gain")
                         else None
                     ),
-                    gpx_file_path=gpx_path,
                     external_url=f"https://www.strava.com/activities/{strava_id}",
                     created_at=datetime.utcnow(),
                     updated_at=datetime.utcnow(),
                 )
+
+                if gpx_content:
+                    gpx_path = write_flight_text_file(db, flight, "strava.gpx", gpx_content)
+                    flight.gpx_file_path = str(gpx_path)
 
                 db.add(flight)
                 imported_flights.append(
@@ -3452,23 +3449,11 @@ async def upload_gpx_to_flight(
         gpx_content = await gpx_file.read()
         gpx_str = gpx_content.decode("utf-8")
 
-        # 3. Sauvegarder fichier
-        gpx_dir = Path(__file__).parent / "db" / "gpx"
-        gpx_dir.mkdir(parents=True, exist_ok=True)
-
-        # Utiliser strava_id si disponible, sinon flight_id
-        if flight.strava_id:
-            file_name = f"strava_{flight.strava_id}.gpx"
-        else:
-            file_name = f"manual_{flight_id}.gpx"
-
-        file_path = gpx_dir / file_name
-
-        with open(file_path, "w", encoding="utf-8") as f:
-            f.write(gpx_str)
+        file_name = "strava.gpx" if flight.strava_id else "watch.gpx"
+        file_path = write_flight_text_file(db, flight, file_name, gpx_str)
 
         # 4. Mettre à jour SEULEMENT le chemin du fichier (pas les stats!)
-        flight.gpx_file_path = f"db/gpx/{file_name}"
+        flight.gpx_file_path = str(file_path)
         flight.updated_at = datetime.utcnow()
 
         db.commit()
@@ -3608,17 +3593,10 @@ async def create_flight_from_gpx(
             updated_at=datetime.utcnow(),
         )
 
-        # 6. Sauvegarder le fichier (GPX ou IGC)
-        gpx_dir = Path(__file__).parent / "db" / "gpx"
-        gpx_dir.mkdir(parents=True, exist_ok=True)
-
-        file_name = f"manual_{flight_id}.{file_type}"
-        file_path = gpx_dir / file_name
-
-        with open(file_path, "w", encoding="utf-8") as f:
-            f.write(file_str)
-
-        flight.gpx_file_path = f"db/gpx/{file_name}"
+        # 6. Sauvegarder le fichier dans le dossier du vol.
+        file_name = f"watch.{file_type}"
+        file_path = write_flight_text_file(db, flight, file_name, file_str)
+        flight.gpx_file_path = str(file_path)
 
         # 7. Enregistrer en base
         db.add(flight)
@@ -4600,6 +4578,7 @@ async def create_flight_gopro_overlay_job(
 
     title = flight.title or flight.name or flight.id
     resolved_output_filename = output_filename or f"{title}-overlay.mp4"
+    output_dir = str(ensure_flight_directory(db, flight))
 
     try:
         resolved_video_path = _resolve_gopro_paragliding_path(video_path)
@@ -4624,6 +4603,7 @@ async def create_flight_gopro_overlay_job(
                 pip_path=fallback_pip_path,
                 layout_id=layout_id,
                 output_filename=resolved_output_filename,
+                output_dir=output_dir,
             )
 
         if not video_file or not video_file.filename:
@@ -4648,6 +4628,7 @@ async def create_flight_gopro_overlay_job(
             pip_file=osv_video_file,
             layout_id=layout_id,
             output_filename=resolved_output_filename,
+            output_dir=output_dir,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3394,11 +3394,12 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
                     updated_at=datetime.utcnow(),
                 )
 
+                db.add(flight)
+                db.flush()
                 if gpx_content:
                     gpx_path = write_flight_text_file(db, flight, "strava.gpx", gpx_content)
                     flight.gpx_file_path = str(gpx_path)
 
-                db.add(flight)
                 imported_flights.append(
                     {
                         "id": flight.id,
@@ -3593,13 +3594,15 @@ async def create_flight_from_gpx(
             updated_at=datetime.utcnow(),
         )
 
+        db.add(flight)
+        db.flush()
+
         # 6. Sauvegarder le fichier dans le dossier du vol.
         file_name = f"watch.{file_type}"
         file_path = write_flight_text_file(db, flight, file_name, file_str)
         flight.gpx_file_path = str(file_path)
 
         # 7. Enregistrer en base
-        db.add(flight)
         db.commit()
         db.refresh(flight)
 

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -1,0 +1,51 @@
+from datetime import date, datetime
+from pathlib import Path
+
+import config
+from flight_storage import ensure_flight_directory
+from flight_storage import flight_directory
+from flight_storage import write_flight_text_file
+from models import Flight
+
+
+def test_flight_directory_uses_date_and_daily_sequence(db_session, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    first = Flight(
+        id="flight-first",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 9, 0),
+    )
+    second = Flight(
+        id="flight-second",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 14, 0),
+    )
+    db_session.add_all([first, second])
+    db_session.commit()
+
+    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
+    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+
+
+def test_write_flight_text_file_creates_file_in_flight_directory(db_session, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    flight = Flight(id="flight-gpx", flight_date=date(2026, 5, 15))
+    db_session.add(flight)
+    db_session.commit()
+
+    file_path = write_flight_text_file(db_session, flight, "watch.gpx", "<gpx />")
+
+    assert file_path == tmp_path / "2026-05-15" / "01" / "watch.gpx"
+    assert file_path.read_text() == "<gpx />"
+
+
+def test_ensure_flight_directory_creates_directory(db_session, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    flight = Flight(id="flight-dir", flight_date=date(2026, 5, 16))
+    db_session.add(flight)
+    db_session.commit()
+
+    directory = ensure_flight_directory(db_session, flight)
+
+    assert directory == Path(tmp_path / "2026-05-16" / "01")
+    assert directory.is_dir()

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -2,8 +2,10 @@ from datetime import date, datetime
 from pathlib import Path
 
 import config
+import flight_storage
 from flight_storage import ensure_flight_directory
 from flight_storage import flight_directory
+from flight_storage import get_video_output_path
 from flight_storage import write_flight_text_file
 from models import Flight
 
@@ -14,13 +16,43 @@ def test_flight_directory_uses_date_and_daily_sequence(db_session, monkeypatch, 
         id="flight-first",
         flight_date=date(2026, 5, 15),
         departure_time=datetime(2026, 5, 15, 9, 0),
+        created_at=datetime(2026, 5, 15, 9, 1),
     )
     second = Flight(
         id="flight-second",
         flight_date=date(2026, 5, 15),
         departure_time=datetime(2026, 5, 15, 14, 0),
+        created_at=datetime(2026, 5, 15, 14, 1),
     )
     db_session.add_all([first, second])
+    db_session.commit()
+
+    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
+    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+
+
+def test_flight_directory_is_stable_when_departure_time_changes(db_session, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    first = Flight(
+        id="flight-first",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 14, 0),
+        created_at=datetime(2026, 5, 15, 9, 1),
+    )
+    second = Flight(
+        id="flight-second",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 9, 0),
+        created_at=datetime(2026, 5, 15, 14, 1),
+    )
+    db_session.add_all([first, second])
+    db_session.commit()
+
+    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
+    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+
+    first.departure_time = datetime(2026, 5, 15, 8, 0)
+    second.departure_time = datetime(2026, 5, 15, 7, 0)
     db_session.commit()
 
     assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
@@ -49,3 +81,24 @@ def test_ensure_flight_directory_creates_directory(db_session, monkeypatch, tmp_
 
     assert directory == Path(tmp_path / "2026-05-16" / "01")
     assert directory.is_dir()
+
+
+def test_get_video_output_path_uses_flight_directory(db_session, monkeypatch, tmp_path, test_db):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    monkeypatch.setattr(flight_storage, "SessionLocal", test_db)
+    flight = Flight(id="flight-video", flight_date=date(2026, 5, 17))
+    db_session.add(flight)
+    db_session.commit()
+
+    output_path = get_video_output_path("flight-video", "20260517-120000")
+
+    assert output_path == tmp_path / "2026-05-17" / "01" / "history-20260517-120000.mp4"
+
+
+def test_get_video_output_path_falls_back_to_export_root(monkeypatch, tmp_path, test_db):
+    monkeypatch.setattr(config, "VIDEO_EXPORT_DIR", str(tmp_path / "videos"))
+    monkeypatch.setattr(flight_storage, "SessionLocal", test_db)
+
+    output_path = get_video_output_path("missing-flight", "20260517-120000")
+
+    assert output_path == tmp_path / "videos" / "flight-missing-flight-20260517-120000.mp4"

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -26,15 +26,15 @@ def test_required_env_accepts_non_empty_variable(monkeypatch):
 
 
 def test_video_export_paths_are_fixed():
-    assert config.VIDEO_EXPORT_DIR == str(config.BACKEND_ROOT / "exports" / "videos")
-    assert config.VIDEO_TEMP_IMAGES_DIR == str(
-        config.BACKEND_ROOT / "exports" / "video-temp-images"
-    )
+    data_root = Path(config.PARAGLIDING_DATA_ROOT)
+
+    assert Path(config.VIDEO_EXPORT_DIR) == data_root
+    assert Path(config.VIDEO_TEMP_IMAGES_DIR) == data_root / ".tmp" / "video-frames"
 
 
-def test_gopro_overlay_paths_are_derived_from_data_root():
-    data_root = Path(config.GOPRO_OVERLAY_DATA_ROOT)
+def test_gopro_overlay_paths_are_derived_from_paragliding_root():
+    data_root = Path(config.PARAGLIDING_DATA_ROOT)
 
     assert Path(config.GOPRO_OVERLAY_PARAGLIDING_ROOT) == data_root
-    assert Path(config.GOPRO_OVERLAY_OUTPUT_DIR) == data_root / "input-overlay"
-    assert Path(config.GOPRO_OVERLAY_UPLOAD_DIR) == data_root / "input-overlay" / "uploads"
+    assert Path(config.GOPRO_OVERLAY_OUTPUT_DIR) == data_root
+    assert Path(config.GOPRO_OVERLAY_UPLOAD_DIR) == data_root / ".tmp" / "gopro-uploads"

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -200,9 +200,7 @@ def test_encoding_progress_percent_spans_encoding_phase_range():
 def test_video_output_path_uses_configured_export_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: tmp_path / "videos")
 
-    output_path = video_export_manual._video_output_path(
-        video_export_manual._video_export_dir(), "flight-123", "20260430-120000"
-    )
+    output_path = video_export_manual._video_output_path("flight-123", "20260430-120000")
 
     assert output_path == tmp_path / "videos" / "flight-flight-123-20260430-120000.mp4"
 
@@ -355,7 +353,7 @@ def test_stream_export_paths_use_configured_storage_dirs(tmp_path, monkeypatch):
     temp_root = video_export._video_temp_images_dir()
     temp_dir = video_export._job_temp_dir(temp_root, "job-123")
     debug_dir = video_export._job_debug_dir(temp_root, "job-123")
-    output_path = video_export._video_output_path(export_root, "flight-123", "20260430-120000")
+    output_path = video_export._video_output_path("flight-123", "20260430-120000")
 
     video_export._prepare_export_dirs(export_root, temp_dir, debug_dir)
 

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -198,7 +198,11 @@ def test_encoding_progress_percent_spans_encoding_phase_range():
 
 
 def test_video_output_path_uses_configured_export_dir(tmp_path, monkeypatch):
-    monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: tmp_path / "videos")
+    monkeypatch.setattr(
+        video_export_manual,
+        "get_video_output_path",
+        lambda flight_id, timestamp: tmp_path / "videos" / f"flight-{flight_id}-{timestamp}.mp4",
+    )
 
     output_path = video_export_manual._video_output_path("flight-123", "20260430-120000")
 
@@ -348,6 +352,11 @@ def test_cleanup_temp_dir_removes_nested_files(tmp_path):
 def test_stream_export_paths_use_configured_storage_dirs(tmp_path, monkeypatch):
     monkeypatch.setattr(video_export, "_video_export_dir", lambda: tmp_path / "videos")
     monkeypatch.setattr(video_export, "_video_temp_images_dir", lambda: tmp_path / "temp-images")
+    monkeypatch.setattr(
+        video_export,
+        "get_video_output_path",
+        lambda flight_id, timestamp: tmp_path / "videos" / f"flight-{flight_id}-{timestamp}.mp4",
+    )
 
     export_root = video_export._video_export_dir()
     temp_root = video_export._video_temp_images_dir()

--- a/apps/backend/video_export.py
+++ b/apps/backend/video_export.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import config
 from database import SessionLocal
-from flight_storage import ensure_flight_directory
+from flight_storage import get_video_output_path
 from models import Flight
 
 # Storage for export jobs
@@ -83,15 +83,7 @@ def _job_debug_dir(temp_root: Path, job_id: str) -> Path:
 
 
 def _video_output_path(flight_id: str, timestamp: str) -> Path:
-    try:
-        with SessionLocal() as db:
-            flight = db.query(Flight).filter(Flight.id == flight_id).first()
-            if flight:
-                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
-    except Exception as exc:
-        print(f"⚠️ Could not resolve flight storage directory: {exc}")
-
-    return _video_export_dir() / f"flight-{flight_id}-{timestamp}.mp4"
+    return get_video_output_path(flight_id, timestamp)
 
 
 def _prepare_export_dirs(export_root: Path, temp_dir: Path, debug_dir: Path) -> None:

--- a/apps/backend/video_export.py
+++ b/apps/backend/video_export.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import config
 from database import SessionLocal
+from flight_storage import ensure_flight_directory
 from models import Flight
 
 # Storage for export jobs
@@ -81,8 +82,16 @@ def _job_debug_dir(temp_root: Path, job_id: str) -> Path:
     return _job_temp_dir(temp_root, job_id) / "debug"
 
 
-def _video_output_path(export_root: Path, flight_id: str, timestamp: str) -> Path:
-    return export_root / f"flight-{flight_id}-{timestamp}.mp4"
+def _video_output_path(flight_id: str, timestamp: str) -> Path:
+    try:
+        with SessionLocal() as db:
+            flight = db.query(Flight).filter(Flight.id == flight_id).first()
+            if flight:
+                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
+    except Exception as exc:
+        print(f"⚠️ Could not resolve flight storage directory: {exc}")
+
+    return _video_export_dir() / f"flight-{flight_id}-{timestamp}.mp4"
 
 
 def _prepare_export_dirs(export_root: Path, temp_dir: Path, debug_dir: Path) -> None:
@@ -543,7 +552,7 @@ async def _export_video_playwright(
             export_jobs[job_id]["progress"] = 50
             export_jobs[job_id]["message"] = "Converting WebM to MP4..."
 
-            output_file = _video_output_path(export_root, flight_id, timestamp)
+            output_file = _video_output_path(flight_id, timestamp)
 
             # Convert WebM to MP4
             ffmpeg_cmd = [

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 
 import config
 from database import SessionLocal
-from flight_storage import ensure_flight_directory
+from flight_storage import get_video_output_path
 from models import Flight, VideoExportJob
 
 # Storage for export jobs (compatibility snapshot)
@@ -640,15 +640,7 @@ def _job_frames_dir(temp_root: Path, job_id: str) -> Path:
 
 
 def _video_output_path(flight_id: str, timestamp: str) -> Path:
-    try:
-        with SessionLocal() as db:
-            flight = db.query(Flight).filter(Flight.id == flight_id).first()
-            if flight:
-                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
-    except Exception as exc:
-        print(f"⚠️ Could not resolve flight storage directory: {exc}")
-
-    return _video_export_dir() / f"flight-{flight_id}-{timestamp}.mp4"
+    return get_video_output_path(flight_id, timestamp)
 
 
 def _capture_progress_percent(frame_count: int, total_frames: int) -> int:

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 import config
 from database import SessionLocal
+from flight_storage import ensure_flight_directory
 from models import Flight, VideoExportJob
 
 # Storage for export jobs (compatibility snapshot)
@@ -638,8 +639,16 @@ def _job_frames_dir(temp_root: Path, job_id: str) -> Path:
     return _job_temp_dir(temp_root, job_id) / "frames"
 
 
-def _video_output_path(export_root: Path, flight_id: str, timestamp: str) -> Path:
-    return export_root / f"flight-{flight_id}-{timestamp}.mp4"
+def _video_output_path(flight_id: str, timestamp: str) -> Path:
+    try:
+        with SessionLocal() as db:
+            flight = db.query(Flight).filter(Flight.id == flight_id).first()
+            if flight:
+                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
+    except Exception as exc:
+        print(f"⚠️ Could not resolve flight storage directory: {exc}")
+
+    return _video_export_dir() / f"flight-{flight_id}-{timestamp}.mp4"
 
 
 def _capture_progress_percent(frame_count: int, total_frames: int) -> int:
@@ -1256,7 +1265,7 @@ async def _export_video_manual_render(job_id: str):
             _set_job_runtime(job_id, phase=_STATUS_ENCODING, eta_seconds=None)
 
             timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
-            output_file = _video_output_path(export_root, flight_id, timestamp)
+            output_file = _video_output_path(flight_id, timestamp)
             ffmpeg_preset, ffmpeg_crf = _ffmpeg_encoding_settings(is_fast_mode)
 
             ffmpeg_cmd = [

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -24,8 +24,6 @@ function globalSetup(): void {
         TESTING: 'false',
         BACKEND_DATABASE_URL: absoluteDbUrl,
         BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
-        BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
-        BACKEND_GOPRO_OVERLAY_DATA_ROOT: path.join(e2eRuntimeDir, 'paragliding'),
         BACKEND_VERSION_STATE_FILE: path.join(e2eRuntimeDir, 'version_state.json'),
         BACKEND_JWT_SECRET: process.env.BACKEND_JWT_SECRET || 'e2e-test-secret',
         BACKEND_ADMIN_EMAIL: process.env.BACKEND_ADMIN_EMAIL || 'e2e@test.local',

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -67,8 +67,6 @@ export default defineConfig({
         TESTING: 'false',
         BACKEND_DATABASE_URL: absoluteDbUrl,
         BACKEND_LOG_FILE: path.join(e2eRuntimeDir, 'dashboard.log'),
-        BACKEND_GOPRO_OVERLAY_ROOT: path.join(e2eRuntimeDir, 'gopro-overlay'),
-        BACKEND_GOPRO_OVERLAY_DATA_ROOT: path.join(e2eRuntimeDir, 'paragliding'),
         BACKEND_VERSION_STATE_FILE: path.join(e2eRuntimeDir, 'version_state.json'),
         BACKEND_WEATHERAPI_KEY: process.env.BACKEND_WEATHERAPI_KEY || 'test_key',
         BACKEND_METEOBLUE_API_KEY: process.env.BACKEND_METEOBLUE_API_KEY || 'test_key',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,8 +97,6 @@ services:
       # Backend - Frontend URL
       - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
 
-      # Backend - Video export storage
-
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
       - BACKEND_VERSION_STATE_FILE=${BACKEND_VERSION_STATE_FILE:?BACKEND_VERSION_STATE_FILE is required}
@@ -107,10 +105,8 @@ services:
         condition: service_healthy
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
-      - "/media/nas/DS211_Synology_1/DJI shoots/parapente/:/app/video-exports"
-      - "/media/nas/DS211_Synology_1/DJI shoots/parapente/img_tmp/:/app/video-temp-images"
-      - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:/app/gopro-overlay:ro
-      - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/gopro-overlays/parapente
+      - /media/nas/DS211_Synology_2/parapente:/app/parapente
+      - /media/usb/data-m2/developement/gopro-overlay-dasboard:/app/gopro-overlay:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,8 @@ services:
         condition: service_healthy
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
-      - /media/nas/DS211_Synology_2/parapente:/app/parapente
-      - /media/usb/data-m2/developement/gopro-overlay-dasboard:/app/gopro-overlay:ro
+      - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
+      - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:/app/gopro-overlay:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
       interval: 30s

--- a/env.portainer
+++ b/env.portainer
@@ -112,6 +112,8 @@ BACKEND_OPENROUTER_API_KEY="<redacted: configured in Portainer>"
 # OpenRouter model currently configured in Portainer.
 BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:fre
 
-# Flight file storage and GoPro overlay toolchain use fixed Docker mounts:
-# - /media/nas/DS211_Synology_2/parapente -> /app/parapente
-# - /media/usb/data-m2/developement/gopro-overlay-dasboard -> /app/gopro-overlay
+# Host folder mounted at /app/gopro-overlay.
+GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+
+# Host folder mounted at /app/parapente.
+GOPRO_OVERLAY_DATA_HOST_DIR=/media/nas/DS211_Synology_2/parapente

--- a/env.portainer
+++ b/env.portainer
@@ -112,8 +112,6 @@ BACKEND_OPENROUTER_API_KEY="<redacted: configured in Portainer>"
 # OpenRouter model currently configured in Portainer.
 BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:fre
 
-# Host directory mounted at /app/gopro-overlay.
-GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
-
-# Host directory mounted at /app/gopro-overlays/parapente.
-GOPRO_OVERLAY_DATA_HOST_DIR=/media/usb/data-m2/developement/parapente
+# Flight file storage and GoPro overlay toolchain use fixed Docker mounts:
+# - /media/nas/DS211_Synology_2/parapente -> /app/parapente
+# - /media/usb/data-m2/developement/gopro-overlay-dasboard -> /app/gopro-overlay


### PR DESCRIPTION
## Summary
- Store flight-related files under `/app/parapente/YYYY-MM-DD/NN`.
- Remove redundant storage env vars and hardcode the container paths.
- Update backend tests and e2e config for the new layout.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `python3 -m py_compile` on changed backend files
- `pytest` targeted suite: 92 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized backend storage configuration to use a unified data root directory for all flight data, video exports, and overlays.
  * Simplified GoPro overlay configuration with a standardized directory structure.
  * Implemented centralized flight file storage management for improved consistency.
  * Updated Docker configuration for streamlined volume mounting and data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/863)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->