### PR TITLE
fix(flights): auto-resolve overlay inputs and storage paths

### DIFF
--- a/apps/backend/flight_storage.py
+++ b/apps/backend/flight_storage.py
@@ -17,8 +17,10 @@ def flight_sequence_number(db: Session, flight: Flight) -> int:
         flights.append(flight)
 
     def sort_key(candidate: Flight) -> tuple[str, str]:
-        created_at = candidate.created_at.isoformat() if candidate.created_at else "9999"
-        return created_at, candidate.id
+        departure_time = (
+            candidate.departure_time.isoformat() if candidate.departure_time else "9999"
+        )
+        return departure_time, candidate.id
 
     flights.sort(key=sort_key)
     for index, candidate in enumerate(flights, start=1):
@@ -29,8 +31,8 @@ def flight_sequence_number(db: Session, flight: Flight) -> int:
 
 
 def flight_directory(db: Session, flight: Flight) -> Path:
-    day_dir = flight_storage_root() / flight.flight_date.isoformat()
-    return day_dir / f"{flight_sequence_number(db, flight):02d}"
+    day_dir = flight_storage_root() / flight.flight_date.strftime("%Y%m%d")
+    return day_dir / str(flight_sequence_number(db, flight))
 
 
 def ensure_flight_directory(db: Session, flight: Flight) -> Path:

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -98,6 +98,12 @@ def _output_path_for_video(video_path: Path, output_name: str) -> Path:
     return video_path.expanduser().resolve().parent / output_name
 
 
+def _output_path_for_dir(output_dir: str | None, video_path: Path, output_name: str) -> Path:
+    if not output_dir or not output_dir.strip():
+        return _output_path_for_video(video_path, output_name)
+    return Path(output_dir).expanduser().resolve() / output_name
+
+
 def _prepare_layout_file(layout_path: Path, destination: Path, has_pip: bool) -> Path:
     tree = ET.parse(layout_path)
     root = tree.getroot()
@@ -269,6 +275,7 @@ async def create_gopro_overlay_job(
     output_filename: str | None,
     fallback_gpx_path: Path | None = None,
     fallback_pip_path: Path | None = None,
+    output_dir: str | None = None,
 ) -> dict[str, Any]:
     job_id = str(uuid.uuid4())
     job_upload_dir = _uploaded_job_work_dir(job_id)
@@ -308,6 +315,7 @@ async def create_gopro_overlay_job(
             layout_id=layout_id,
             output_filename=output_filename,
             work_dir=job_upload_dir,
+            output_dir=output_dir,
         )
     except Exception:
         shutil.rmtree(job_upload_dir, ignore_errors=True)
@@ -320,6 +328,7 @@ def create_gopro_overlay_job_from_paths(
     pip_path: Path | None,
     layout_id: str | None,
     output_filename: str | None,
+    output_dir: str | None = None,
 ) -> dict[str, Any]:
     _validate_file_extension(video_path, _VIDEO_EXTENSIONS)
     _validate_file_extension(gpx_path, _GPX_EXTENSIONS)
@@ -339,6 +348,7 @@ def create_gopro_overlay_job_from_paths(
             output_filename=output_filename,
             work_dir=work_dir,
             pin_inputs=True,
+            output_dir=output_dir,
         )
     except Exception:
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -354,11 +364,12 @@ def _create_gopro_overlay_job_from_paths(
     output_filename: str | None,
     work_dir: Path,
     pin_inputs: bool = False,
+    output_dir: str | None = None,
 ) -> dict[str, Any]:
     output_name = _safe_filename(output_filename, f"gopro-overlay-{job_id}.mp4")
     if Path(output_name).suffix.lower() != ".mp4":
         output_name = f"{Path(output_name).stem}.mp4"
-    output_path = _output_path_for_video(video_path, output_name)
+    output_path = _output_path_for_dir(output_dir, video_path, output_name)
 
     if pin_inputs:
         video_path = _copy_job_input(

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -231,13 +231,18 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
         str(merged_gpx_path),
     ]
 
-    result = subprocess.run(
-        command,
-        cwd=config.GOPRO_OVERLAY_ROOT or None,
-        capture_output=True,
-        check=False,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            command,
+            cwd=config.GOPRO_OVERLAY_ROOT or None,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as exc:
+        detail = exc.stderr or exc.stdout or "OSV merge timed out"
+        raise ValueError(detail) from exc
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "OSV merge failed"
         raise ValueError(detail)
@@ -4630,12 +4635,16 @@ async def create_flight_gopro_overlay_job(
     title = flight.title or flight.name or flight.id
     input_dir = ensure_flight_directory(db, flight)
     use_input_output_dir = not output_dir or not output_dir.strip()
-    resolved_output_dir = str(input_dir) if use_input_output_dir else output_dir
     resolved_output_filename = (
         "final.mp4" if use_input_output_dir else output_filename or f"{title}-overlay.mp4"
     )
 
     try:
+        resolved_output_dir = (
+            str(input_dir)
+            if use_input_output_dir
+            else str(_resolve_gopro_paragliding_path(output_dir))
+        )
         resolved_video_path = _resolve_gopro_paragliding_path(video_path)
         resolved_gpx_path = _resolve_gopro_paragliding_path(gpx_path)
         resolved_pip_path = _resolve_gopro_paragliding_path(pip_path)
@@ -4652,8 +4661,11 @@ async def create_flight_gopro_overlay_job(
             resolved_pip_path or auto_pip_path or _resolve_flight_file_path(flight.video_file_path)
         )
         if fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
-            fallback_gpx_path = _merge_osv_files_with_gpx(
-                auto_osv_paths, fallback_gpx_path, input_dir
+            fallback_gpx_path = await asyncio.to_thread(
+                _merge_osv_files_with_gpx,
+                auto_osv_paths,
+                fallback_gpx_path,
+                input_dir,
             )
 
         if resolved_video_path:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3,6 +3,7 @@ import json
 import logging
 import math
 import os
+import subprocess
 import uuid
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -197,6 +198,52 @@ def _resolve_gopro_paragliding_path(file_path: str | None) -> Path | None:
     if resolved != root_path and root_path not in resolved.parents:
         raise ValueError("GoPro overlay path must be inside the paragliding root")
     return resolved
+
+
+def _latest_matching_file(directory: Path, pattern: str) -> Path | None:
+    matches = [path for path in directory.glob(pattern) if path.is_file()]
+    if not matches:
+        return None
+    return max(matches, key=lambda path: path.stat().st_mtime)
+
+
+def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
+    matches = [path for path in directory.glob(pattern) if path.is_file()]
+    return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
+
+
+def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
+    if not osv_paths:
+        return gpx_path
+
+    merge_script = Path(config.GOPRO_OVERLAY_ROOT) / "osv_merge.py"
+    if not merge_script.exists():
+        raise ValueError(f"OSV merge script not found: {merge_script}")
+
+    work_dir = input_dir / ".gopro-overlay-work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    merged_gpx_path = work_dir / f"merged-{uuid.uuid4()}.gpx"
+    command = [
+        "python3",
+        str(merge_script),
+        *(str(path) for path in osv_paths),
+        str(gpx_path),
+        str(merged_gpx_path),
+    ]
+
+    result = subprocess.run(
+        command,
+        cwd=config.GOPRO_OVERLAY_ROOT or None,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "OSV merge failed"
+        raise ValueError(detail)
+    if not merged_gpx_path.exists():
+        raise ValueError("OSV merge did not create a GPX file")
+    return merged_gpx_path
 
 
 def _resolve_export_status(job_id: str) -> dict[str, Any] | None:
@@ -4562,6 +4609,7 @@ async def create_flight_gopro_overlay_job(
     video_path: str | None = Form(None),
     gpx_path: str | None = Form(None),
     pip_path: str | None = Form(None),
+    output_dir: str | None = Form(None),
     layout_id: str | None = Form(None),
     output_filename: str | None = Form(None),
     db: Session = Depends(get_db),
@@ -4580,15 +4628,33 @@ async def create_flight_gopro_overlay_job(
         raise HTTPException(status_code=404, detail="Flight not found")
 
     title = flight.title or flight.name or flight.id
-    resolved_output_filename = output_filename or f"{title}-overlay.mp4"
-    output_dir = str(ensure_flight_directory(db, flight))
+    input_dir = ensure_flight_directory(db, flight)
+    use_input_output_dir = not output_dir or not output_dir.strip()
+    resolved_output_dir = str(input_dir) if use_input_output_dir else output_dir
+    resolved_output_filename = (
+        "final.mp4" if use_input_output_dir else output_filename or f"{title}-overlay.mp4"
+    )
 
     try:
         resolved_video_path = _resolve_gopro_paragliding_path(video_path)
         resolved_gpx_path = _resolve_gopro_paragliding_path(gpx_path)
         resolved_pip_path = _resolve_gopro_paragliding_path(pip_path)
-        fallback_gpx_path = resolved_gpx_path or _resolve_flight_file_path(flight.gpx_file_path)
-        fallback_pip_path = resolved_pip_path or _resolve_flight_file_path(flight.video_file_path)
+        auto_video_path = input_dir / "camera.mp4"
+        auto_gpx_path = _latest_matching_file(input_dir, "Zepp*.gpx")
+        auto_pip_path = _latest_matching_file(input_dir, "flight*.mp4")
+        auto_osv_paths = _matching_files_by_mtime(input_dir, "*.osv")
+        if not resolved_video_path and auto_video_path.exists():
+            resolved_video_path = auto_video_path
+        fallback_gpx_path = (
+            resolved_gpx_path or auto_gpx_path or _resolve_flight_file_path(flight.gpx_file_path)
+        )
+        fallback_pip_path = (
+            resolved_pip_path or auto_pip_path or _resolve_flight_file_path(flight.video_file_path)
+        )
+        if fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
+            fallback_gpx_path = _merge_osv_files_with_gpx(
+                auto_osv_paths, fallback_gpx_path, input_dir
+            )
 
         if resolved_video_path:
             if not resolved_video_path.exists():
@@ -4606,7 +4672,7 @@ async def create_flight_gopro_overlay_job(
                 pip_path=fallback_pip_path,
                 layout_id=layout_id,
                 output_filename=resolved_output_filename,
-                output_dir=output_dir,
+                output_dir=resolved_output_dir,
             )
 
         if not video_file or not video_file.filename:
@@ -4631,7 +4697,7 @@ async def create_flight_gopro_overlay_job(
             pip_file=osv_video_file,
             layout_id=layout_id,
             output_filename=resolved_output_filename,
-            output_dir=output_dir,
+            output_dir=resolved_output_dir,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -91,6 +91,7 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
     db_session,
     sample_flight,
     tmp_path,
+    monkeypatch,
 ):
     video_path = tmp_path / "flight.mp4"
     gpx_path = tmp_path / "flight.gpx"
@@ -100,6 +101,9 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
     sample_flight.gpx_file_path = str(gpx_path)
     sample_flight.title = "Arguel test"
     db_session.commit()
+    paragliding_root = tmp_path / "parapente"
+    output_dir = paragliding_root / "exports"
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
 
     expected = {
         "job_id": "job-flight-gopro",
@@ -128,7 +132,7 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
             },
             data={
                 "output_filename": "Arguel test-overlay.mp4",
-                "output_dir": str(tmp_path / "exports"),
+                "output_dir": str(output_dir),
             },
         )
 
@@ -140,7 +144,7 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
     assert create_job.call_args.kwargs["fallback_pip_path"] == video_path
     assert create_job.call_args.kwargs["pip_file"] is not None
     assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
-    assert create_job.call_args.kwargs["output_dir"] == str(tmp_path / "exports")
+    assert create_job.call_args.kwargs["output_dir"] == str(output_dir)
 
 
 def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
@@ -154,6 +158,7 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
     video_path = paragliding_root / "camera" / "flight.mp4"
     gpx_path = paragliding_root / "tracks" / "flight.gpx"
     pip_path = paragliding_root / "pip" / "flight-pip.mp4"
+    output_dir = paragliding_root / "exports"
     video_path.parent.mkdir(parents=True)
     gpx_path.parent.mkdir(parents=True)
     pip_path.parent.mkdir(parents=True)
@@ -190,7 +195,7 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
                 "gpx_path": "tracks/flight.gpx",
                 "pip_path": "pip/flight-pip.mp4",
                 "output_filename": "Arguel test-overlay.mp4",
-                "output_dir": str(tmp_path / "exports"),
+                "output_dir": str(output_dir),
             },
         )
 
@@ -199,7 +204,7 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
     assert create_job.call_args.kwargs["gpx_path"] == gpx_path
     assert create_job.call_args.kwargs["pip_path"] == pip_path
     assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
-    assert create_job.call_args.kwargs["output_dir"] == str(tmp_path / "exports")
+    assert create_job.call_args.kwargs["output_dir"] == str(output_dir)
 
 
 def test_create_flight_gopro_overlay_job_uses_auto_flight_directory_files(
@@ -387,6 +392,31 @@ def test_create_flight_gopro_overlay_job_rejects_paths_outside_paragliding_root(
         response = client.post(
             f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay",
             data={"video_path": str(outside_video)},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "GoPro overlay path must be inside the paragliding root"
+
+
+def test_create_flight_gopro_overlay_job_rejects_output_dir_outside_paragliding_root(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    paragliding_root = tmp_path / "paragliding"
+    outside_output_dir = tmp_path / "outside"
+    db_session.commit()
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
+
+    with patch(
+        "routes.check_gopro_overlay_dependencies",
+        return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+    ):
+        response = client.post(
+            f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay",
+            data={"output_dir": str(outside_output_dir)},
         )
 
     assert response.status_code == 400

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,4 +1,6 @@
+from datetime import date, datetime
 from io import BytesIO
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -14,6 +16,7 @@ from gopro_overlay_export import _prepare_layout_file
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
+from models import Flight
 
 API_PREFIX = "/api"
 
@@ -123,7 +126,10 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
                 "video_file": ("camera.mp4", b"camera", "video/mp4"),
                 "osv_video_file": ("osv.mp4", b"osv", "video/mp4"),
             },
-            data={"output_filename": "Arguel test-overlay.mp4"},
+            data={
+                "output_filename": "Arguel test-overlay.mp4",
+                "output_dir": str(tmp_path / "exports"),
+            },
         )
 
     assert response.status_code == 200
@@ -134,6 +140,7 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
     assert create_job.call_args.kwargs["fallback_pip_path"] == video_path
     assert create_job.call_args.kwargs["pip_file"] is not None
     assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
+    assert create_job.call_args.kwargs["output_dir"] == str(tmp_path / "exports")
 
 
 def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
@@ -183,6 +190,7 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
                 "gpx_path": "tracks/flight.gpx",
                 "pip_path": "pip/flight-pip.mp4",
                 "output_filename": "Arguel test-overlay.mp4",
+                "output_dir": str(tmp_path / "exports"),
             },
         )
 
@@ -191,6 +199,171 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
     assert create_job.call_args.kwargs["gpx_path"] == gpx_path
     assert create_job.call_args.kwargs["pip_path"] == pip_path
     assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
+    assert create_job.call_args.kwargs["output_dir"] == str(tmp_path / "exports")
+
+
+def test_create_flight_gopro_overlay_job_uses_auto_flight_directory_files(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    paragliding_root = tmp_path / "parapente"
+    input_dir = paragliding_root / "20260315" / "1"
+    input_dir.mkdir(parents=True)
+    camera_path = input_dir / "camera.mp4"
+    old_gpx_path = input_dir / "Zepp-old.gpx"
+    new_gpx_path = input_dir / "Zepp-new.gpx"
+    old_pip_path = input_dir / "flight-old.mp4"
+    new_pip_path = input_dir / "flight-new.mp4"
+    camera_path.write_bytes(b"camera")
+    old_gpx_path.write_text("<gpx>old</gpx>")
+    new_gpx_path.write_text("<gpx>new</gpx>")
+    old_pip_path.write_bytes(b"old")
+    new_pip_path.write_bytes(b"new")
+    os.utime(old_gpx_path, (1, 1))
+    os.utime(old_pip_path, (1, 1))
+    os.utime(new_gpx_path, (2, 2))
+    os.utime(new_pip_path, (2, 2))
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(paragliding_root))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
+
+    expected = {
+        "job_id": "job-flight-gopro-auto",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "final.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 200
+    assert create_job.call_args.kwargs["video_path"] == camera_path
+    assert create_job.call_args.kwargs["gpx_path"] == new_gpx_path
+    assert create_job.call_args.kwargs["pip_path"] == new_pip_path
+    assert create_job.call_args.kwargs["output_dir"] == str(input_dir)
+    assert create_job.call_args.kwargs["output_filename"] == "final.mp4"
+
+
+def test_create_flight_gopro_overlay_job_uses_daily_departure_index(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    earlier = Flight(
+        id="flight-earlier",
+        flight_date=date(2026, 3, 15),
+        departure_time=datetime(2026, 3, 15, 8, 0),
+    )
+    db_session.add(earlier)
+    db_session.commit()
+    paragliding_root = tmp_path / "parapente"
+    input_dir = paragliding_root / "20260315" / "2"
+    input_dir.mkdir(parents=True)
+    camera_path = input_dir / "camera.mp4"
+    gpx_path = input_dir / "Zepp-track.gpx"
+    pip_path = input_dir / "flight-pip.mp4"
+    camera_path.write_bytes(b"camera")
+    gpx_path.write_text("<gpx />")
+    pip_path.write_bytes(b"pip")
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(paragliding_root))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
+
+    expected = {
+        "job_id": "job-flight-gopro-second",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "final.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 200
+    assert create_job.call_args.kwargs["video_path"] == camera_path
+    assert create_job.call_args.kwargs["gpx_path"] == gpx_path
+    assert create_job.call_args.kwargs["pip_path"] == pip_path
+
+
+def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    paragliding_root = tmp_path / "parapente"
+    input_dir = paragliding_root / "20260315" / "1"
+    input_dir.mkdir(parents=True)
+    camera_path = input_dir / "camera.mp4"
+    gpx_path = input_dir / "Zepp-track.gpx"
+    pip_path = input_dir / "flight-pip.mp4"
+    first_osv = input_dir / "first.osv"
+    second_osv = input_dir / "second.osv"
+    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    camera_path.write_bytes(b"camera")
+    gpx_path.write_text("<gpx />")
+    pip_path.write_bytes(b"pip")
+    first_osv.write_bytes(b"first")
+    second_osv.write_bytes(b"second")
+    merged_gpx_path.parent.mkdir(parents=True)
+    merged_gpx_path.write_text("<gpx>merged</gpx>")
+    os.utime(first_osv, (1, 1))
+    os.utime(second_osv, (2, 2))
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(paragliding_root))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
+
+    expected = {
+        "job_id": "job-flight-gopro-osv",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "final.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes._merge_osv_files_with_gpx", return_value=merged_gpx_path) as merge_osv,
+        patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
+    ):
+        response = client.post(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay")
+
+    assert response.status_code == 200
+    assert merge_osv.call_args.args == ([first_osv, second_osv], gpx_path, input_dir)
+    assert create_job.call_args.kwargs["gpx_path"] == merged_gpx_path
 
 
 def test_create_flight_gopro_overlay_job_rejects_paths_outside_paragliding_root(

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -5,6 +5,7 @@ import config
 import flight_storage
 from flight_storage import ensure_flight_directory
 from flight_storage import flight_directory
+from flight_storage import flight_sequence_number
 from flight_storage import get_video_output_path
 from flight_storage import write_flight_text_file
 from models import Flight
@@ -57,6 +58,57 @@ def test_flight_directory_uses_departure_time_order(db_session, monkeypatch, tmp
 
     assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
     assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
+
+
+def test_flight_directory_sequence_changes_when_departure_order_reverses(
+    db_session, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    first = Flight(
+        id="flight-first",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 9, 0),
+    )
+    second = Flight(
+        id="flight-second",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 14, 0),
+    )
+    db_session.add_all([first, second])
+    db_session.commit()
+
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "1"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "2"
+
+    first.departure_time = datetime(2026, 5, 15, 15, 0)
+    second.departure_time = datetime(2026, 5, 15, 8, 0)
+    db_session.commit()
+
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
+
+
+def test_flight_sequence_places_missing_departure_time_last(db_session, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
+    morning = Flight(
+        id="flight-morning",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 9, 0),
+    )
+    afternoon = Flight(
+        id="flight-afternoon",
+        flight_date=date(2026, 5, 15),
+        departure_time=datetime(2026, 5, 15, 14, 0),
+    )
+    missing_a = Flight(id="flight-missing-a", flight_date=date(2026, 5, 15))
+    missing_b = Flight(id="flight-missing-b", flight_date=date(2026, 5, 15))
+    db_session.add_all([missing_b, afternoon, missing_a, morning])
+    db_session.commit()
+
+    assert flight_sequence_number(db_session, morning) == 1
+    assert flight_sequence_number(db_session, afternoon) == 2
+    assert flight_sequence_number(db_session, missing_a) == 3
+    assert flight_sequence_number(db_session, missing_b) == 4
 
 
 def test_write_flight_text_file_creates_file_in_flight_directory(db_session, monkeypatch, tmp_path):

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -27,11 +27,11 @@ def test_flight_directory_uses_date_and_daily_sequence(db_session, monkeypatch, 
     db_session.add_all([first, second])
     db_session.commit()
 
-    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
-    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "1"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "2"
 
 
-def test_flight_directory_is_stable_when_departure_time_changes(db_session, monkeypatch, tmp_path):
+def test_flight_directory_uses_departure_time_order(db_session, monkeypatch, tmp_path):
     monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
     first = Flight(
         id="flight-first",
@@ -48,15 +48,15 @@ def test_flight_directory_is_stable_when_departure_time_changes(db_session, monk
     db_session.add_all([first, second])
     db_session.commit()
 
-    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
-    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
 
     first.departure_time = datetime(2026, 5, 15, 8, 0)
     second.departure_time = datetime(2026, 5, 15, 7, 0)
     db_session.commit()
 
-    assert flight_directory(db_session, first) == tmp_path / "2026-05-15" / "01"
-    assert flight_directory(db_session, second) == tmp_path / "2026-05-15" / "02"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
 
 
 def test_write_flight_text_file_creates_file_in_flight_directory(db_session, monkeypatch, tmp_path):
@@ -67,7 +67,7 @@ def test_write_flight_text_file_creates_file_in_flight_directory(db_session, mon
 
     file_path = write_flight_text_file(db_session, flight, "watch.gpx", "<gpx />")
 
-    assert file_path == tmp_path / "2026-05-15" / "01" / "watch.gpx"
+    assert file_path == tmp_path / "20260515" / "1" / "watch.gpx"
     assert file_path.read_text() == "<gpx />"
 
 
@@ -79,7 +79,7 @@ def test_ensure_flight_directory_creates_directory(db_session, monkeypatch, tmp_
 
     directory = ensure_flight_directory(db_session, flight)
 
-    assert directory == Path(tmp_path / "2026-05-16" / "01")
+    assert directory == Path(tmp_path / "20260516" / "1")
     assert directory.is_dir()
 
 
@@ -92,7 +92,7 @@ def test_get_video_output_path_uses_flight_directory(db_session, monkeypatch, tm
 
     output_path = get_video_output_path("flight-video", "20260517-120000")
 
-    assert output_path == tmp_path / "2026-05-17" / "01" / "history-20260517-120000.mp4"
+    assert output_path == tmp_path / "20260517" / "1" / "history-20260517-120000.mp4"
 
 
 def test_get_video_output_path_falls_back_to_export_root(monkeypatch, tmp_path, test_db):

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -94,6 +94,7 @@ export function FlightDetails({
   const [goproOverlayVideoPath, setGoproOverlayVideoPath] = useState('');
   const [goproOverlayGpxPath, setGoproOverlayGpxPath] = useState('');
   const [goproOverlayPipPath, setGoproOverlayPipPath] = useState('');
+  const [goproOverlayOutputDir, setGoproOverlayOutputDir] = useState('');
   const [goproOverlayOutputFilename, setGoproOverlayOutputFilename] =
     useState('');
 
@@ -127,6 +128,7 @@ export function FlightDetails({
     setGoproOverlayVideoPath('');
     setGoproOverlayGpxPath('');
     setGoproOverlayPipPath('');
+    setGoproOverlayOutputDir('');
     setGoproOverlayOutputFilename('');
     resetGoproOverlayJob();
   }, [flight.id, resetGoproOverlayJob]);
@@ -205,12 +207,6 @@ export function FlightDetails({
 
   const handleStartGoproOverlay = () => {
     if (isGoproOverlayRunning) return;
-
-    if (!goproOverlayOutputFilename) {
-      setGoproOverlayOutputFilename(
-        `${sanitizeOverlayBasename(flightTitle)}-overlay.mp4`
-      );
-    }
     setShowGoproOverlayForm(true);
   };
 
@@ -222,34 +218,25 @@ export function FlightDetails({
     const videoPath = goproOverlayVideoPath.trim();
     const gpxPath = goproOverlayGpxPath.trim();
     const pipPath = goproOverlayPipPath.trim();
+    const outputDir = goproOverlayOutputDir.trim();
     const outputFilename = goproOverlayOutputFilename.trim();
-
-    if (!videoPath) {
-      toast.error(t('flights.goproOverlayNeedsCameraVideo'));
-      return;
-    }
-    if (!gpxPath && !hasGpx) {
-      toast.error(t('flights.goproOverlayNeedsGpx'));
-      return;
-    }
-    if (!pipPath && !hasVideo) {
-      toast.error(t('flights.goproOverlayNeedsPipVideo'));
-      return;
-    }
-    if (!outputFilename) {
-      toast.error(t('flights.goproOverlayNeedsOutputFilename'));
-      return;
-    }
 
     const requestedFlightId = flight.id;
     const formData = new FormData();
-    formData.append('video_path', videoPath);
-    formData.append('output_filename', outputFilename);
+    if (videoPath) {
+      formData.append('video_path', videoPath);
+    }
     if (gpxPath) {
       formData.append('gpx_path', gpxPath);
     }
     if (pipPath) {
       formData.append('pip_path', pipPath);
+    }
+    if (outputDir) {
+      formData.append('output_dir', outputDir);
+    }
+    if (outputFilename) {
+      formData.append('output_filename', outputFilename);
     }
 
     try {
@@ -326,8 +313,7 @@ export function FlightDetails({
               className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               type="text"
               value={goproOverlayVideoPath}
-              required
-              placeholder="camera/GX010001.mp4"
+              placeholder="camera.mp4"
               onChange={(event) => setGoproOverlayVideoPath(event.target.value)}
             />
             <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
@@ -346,7 +332,7 @@ export function FlightDetails({
             <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
               {hasGpx
                 ? t('flights.goproOverlayGpxFallback')
-                : t('flights.goproOverlayNeedsGpx')}
+                : t('flights.goproOverlayAutoPathHelp')}
             </span>
           </label>
           <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -361,7 +347,20 @@ export function FlightDetails({
             <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
               {hasVideo
                 ? t('flights.goproOverlayPipFallback')
-                : t('flights.goproOverlayNeedsPipVideo')}
+                : t('flights.goproOverlayAutoPathHelp')}
+            </span>
+          </label>
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            {t('flights.goproOverlayOutputDir')}
+            <input
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+              type="text"
+              value={goproOverlayOutputDir}
+              placeholder="exports/overlays"
+              onChange={(event) => setGoproOverlayOutputDir(event.target.value)}
+            />
+            <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+              {t('flights.goproOverlayOutputDirFallback')}
             </span>
           </label>
           <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -370,7 +369,6 @@ export function FlightDetails({
               className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
               type="text"
               value={goproOverlayOutputFilename}
-              required
               placeholder={`${sanitizeOverlayBasename(flightTitle)}-overlay.mp4`}
               onChange={(event) =>
                 setGoproOverlayOutputFilename(event.target.value)
@@ -487,11 +485,10 @@ export function FlightDetails({
                     className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                     type="text"
                     value={goproOverlayVideoPath}
-                    required
                     onChange={(event) =>
                       setGoproOverlayVideoPath(event.target.value)
                     }
-                    placeholder="camera/GX010001.mp4"
+                    placeholder="camera.mp4"
                   />
                   <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
                     {t('flights.goproOverlayPathHelp')}
@@ -511,7 +508,7 @@ export function FlightDetails({
                   <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
                     {hasGpx
                       ? t('flights.goproOverlayGpxFallback')
-                      : t('flights.goproOverlayNeedsGpx')}
+                      : t('flights.goproOverlayAutoPathHelp')}
                   </span>
                 </label>
                 <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -528,7 +525,22 @@ export function FlightDetails({
                   <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
                     {hasVideo
                       ? t('flights.goproOverlayPipFallback')
-                      : t('flights.goproOverlayNeedsPipVideo')}
+                      : t('flights.goproOverlayAutoPathHelp')}
+                  </span>
+                </label>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                  {t('flights.goproOverlayOutputDir')}
+                  <input
+                    className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                    type="text"
+                    value={goproOverlayOutputDir}
+                    onChange={(event) =>
+                      setGoproOverlayOutputDir(event.target.value)
+                    }
+                    placeholder="exports/overlays"
+                  />
+                  <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+                    {t('flights.goproOverlayOutputDirFallback')}
                   </span>
                 </label>
                 <label className="text-sm font-medium text-gray-700 dark:text-gray-200">
@@ -537,7 +549,6 @@ export function FlightDetails({
                     className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                     type="text"
                     value={goproOverlayOutputFilename}
-                    required
                     placeholder={`${sanitizeOverlayBasename(flightTitle)}-overlay.mp4`}
                     onChange={(event) =>
                       setGoproOverlayOutputFilename(event.target.value)

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -637,7 +637,7 @@
     "goproOverlayOsvVideo": "Optional PIP video path",
     "goproOverlayPipFallback": "If no path is entered, the generated flight video will be used.",
     "goproOverlayPathHelp": "If empty, files are auto-detected in parapente/YYYYMMDD/N.",
-    "goproOverlayAutoPathHelp": "If empty, files are auto-detected in parapente/YYYYMMDD/N.",
+    "goproOverlayAutoPathHelp": "If empty, this asset will be auto-detected from the flight folder.",
     "goproOverlayOutputDir": "Optional output folder",
     "goproOverlayOutputDirFallback": "If empty, writes final.mp4 in the flight folder.",
     "goproOverlayOutputFilename": "Output file name",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -636,7 +636,10 @@
     "goproOverlayGpxFallback": "If no path is entered, the flight GPX will be used.",
     "goproOverlayOsvVideo": "Optional PIP video path",
     "goproOverlayPipFallback": "If no path is entered, the generated flight video will be used.",
-    "goproOverlayPathHelp": "Path relative to GOPRO_OVERLAY_PARAGLIDING_ROOT or absolute.",
+    "goproOverlayPathHelp": "If empty, files are auto-detected in parapente/YYYYMMDD/N.",
+    "goproOverlayAutoPathHelp": "If empty, files are auto-detected in parapente/YYYYMMDD/N.",
+    "goproOverlayOutputDir": "Optional output folder",
+    "goproOverlayOutputDirFallback": "If empty, writes final.mp4 in the flight folder.",
     "goproOverlayOutputFilename": "Output file name",
     "goproOverlayStatus": {
       "queued": "Queued",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -641,7 +641,7 @@
     "goproOverlayOsvVideo": "Chemin vidéo PIP optionnel",
     "goproOverlayPipFallback": "Si aucun chemin n'est renseigné, la vidéo générée du vol sera utilisée.",
     "goproOverlayPathHelp": "Si vide, recherche automatique dans parapente/YYYYMMDD/N.",
-    "goproOverlayAutoPathHelp": "Si vide, recherche automatique dans parapente/YYYYMMDD/N.",
+    "goproOverlayAutoPathHelp": "Si vide, ce fichier sera recherché automatiquement dans le dossier du vol.",
     "goproOverlayOutputDir": "Dossier de sortie optionnel",
     "goproOverlayOutputDirFallback": "Si vide, écrit final.mp4 dans le dossier du vol.",
     "goproOverlayOutputFilename": "Nom du fichier de sortie",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -640,7 +640,10 @@
     "goproOverlayGpxFallback": "Si aucun chemin n'est renseigné, le GPX du vol sera utilisé.",
     "goproOverlayOsvVideo": "Chemin vidéo PIP optionnel",
     "goproOverlayPipFallback": "Si aucun chemin n'est renseigné, la vidéo générée du vol sera utilisée.",
-    "goproOverlayPathHelp": "Chemin relatif à GOPRO_OVERLAY_PARAGLIDING_ROOT ou absolu.",
+    "goproOverlayPathHelp": "Si vide, recherche automatique dans parapente/YYYYMMDD/N.",
+    "goproOverlayAutoPathHelp": "Si vide, recherche automatique dans parapente/YYYYMMDD/N.",
+    "goproOverlayOutputDir": "Dossier de sortie optionnel",
+    "goproOverlayOutputDirFallback": "Si vide, écrit final.mp4 dans le dossier du vol.",
     "goproOverlayOutputFilename": "Nom du fichier de sortie",
     "goproOverlayStatus": {
       "queued": "En attente",


### PR DESCRIPTION
## Summary
- Normalize flight storage to `YYYYMMDD/N` using departure time ordering.
- Auto-resolve GoPro overlay inputs from the flight folder, including multi-OSV merging.
- Make the flight overlay form accept optional paths and default to `final.mp4` when output dir is empty.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `TESTING=true ... pytest tests/unit/test_flight_storage.py tests/api/test_gopro_overlay_endpoints.py -q`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --projects=frontend --parallel=5 --base=origin/main --head=HEAD` (no tasks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional output directory parameter for GoPro overlay file rendering
  * Improved auto-detection messaging for flight video, GPX, and PIP assets

* **UI/UX Updates**
  * Added output directory input field to GoPro overlay form
  * Enhanced help text for automatic path detection across camera and overlay inputs
  * Updated form field placeholders and optional field handling

* **Localization**
  * Updated English and French translations for overlay configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/866)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->