### PR TITLE
refactor flights video actions

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -30,6 +30,7 @@ import {
   formatSpeedKmh,
   useAppSettingsStore,
 } from '../../stores/appSettingsStore';
+import { FlightVideoExportControls } from './FlightVideoExportControls';
 
 const FlightViewer3D = lazy(() =>
   import('./FlightViewer3D').then((m) => ({
@@ -414,51 +415,73 @@ export function FlightDetails({
             <h2 className="text-lg font-bold text-gray-900 dark:text-white">
               {flightTitle}
             </h2>
-            <div className="flex flex-col gap-2 sm:ml-4 sm:flex-row sm:flex-wrap sm:justify-end">
-              <Button
-                className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-sky-600 text-white rounded-md hover:bg-sky-700 transition-all"
-                onPress={() => setEditingMode(true)}
-                aria-label={t('flights.editFlight')}
-              >
-                {t('flights.editButton')}
-              </Button>
-              {hasGpx && (
-                <Button
-                  className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-all disabled:cursor-not-allowed disabled:bg-gray-400"
-                  onPress={handleGPXDownload}
-                  isDisabled={isDownloadingGpx}
-                >
-                  {isDownloadingGpx
-                    ? t('flights.gpxDownloadInProgress')
-                    : t('flights.downloadGpx')}
-                </Button>
-              )}
-              <Button
-                className="px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm bg-slate-900 text-white rounded-md hover:bg-slate-800 transition-all disabled:cursor-not-allowed disabled:bg-gray-400 dark:bg-cyan-700 dark:hover:bg-cyan-600"
-                onPress={goproOverlayAction}
-                isDisabled={
-                  createGoproOverlayJob.isPending ||
-                  cancelGoproOverlayJob.isPending
-                }
-                title={goproOverlayTitle}
-              >
-                {goproOverlayLabel}
-              </Button>
-              <Button
-                className={`px-4 py-2.5 sm:px-3 sm:py-1.5 text-sm rounded-md transition-all ${
-                  flight.gpx_file_path
-                    ? 'bg-green-600 text-white hover:bg-green-700'
-                    : 'bg-orange-600 text-white hover:bg-orange-700'
-                }`}
-                onPress={() => fileInputRef.current?.click()}
-                isDisabled={uploadGPXMutation.isPending}
-              >
-                {uploadGPXMutation.isPending
-                  ? t('flights.uploadInProgress')
-                  : flight.gpx_file_path
-                    ? t('flights.replaceGpx')
-                    : t('flights.addGpx')}
-              </Button>
+            <div className="grid gap-3 sm:ml-4 sm:min-w-80 sm:max-w-xl sm:grid-cols-2">
+              <div className="rounded-xl border border-sky-100 bg-sky-50 p-3 dark:border-sky-900/60 dark:bg-sky-950/30">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-sky-800 dark:text-sky-200">
+                  {t('flights.videoProductionActions')}
+                </p>
+                <div className="grid gap-2">
+                  {hasGpx && (
+                    <FlightVideoExportControls
+                      flight={flight}
+                      className="min-w-0"
+                      buttonClassName="w-full"
+                      showModeSelector={false}
+                    />
+                  )}
+                  <Button
+                    className="w-full cursor-pointer rounded-md bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400 dark:bg-cyan-700 dark:hover:bg-cyan-600 dark:focus:ring-offset-gray-800"
+                    onPress={goproOverlayAction}
+                    isDisabled={
+                      createGoproOverlayJob.isPending ||
+                      cancelGoproOverlayJob.isPending
+                    }
+                    title={goproOverlayTitle}
+                  >
+                    {goproOverlayLabel}
+                  </Button>
+                </div>
+              </div>
+              <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-900/30">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                  {t('flights.flightFileActions')}
+                </p>
+                <div className="grid gap-2">
+                  <Button
+                    className="w-full cursor-pointer rounded-md bg-sky-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+                    onPress={() => setEditingMode(true)}
+                    aria-label={t('flights.editFlight')}
+                  >
+                    {t('flights.editButton')}
+                  </Button>
+                  {hasGpx && (
+                    <Button
+                      className="w-full cursor-pointer rounded-md bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400 dark:focus:ring-offset-gray-800"
+                      onPress={handleGPXDownload}
+                      isDisabled={isDownloadingGpx}
+                    >
+                      {isDownloadingGpx
+                        ? t('flights.gpxDownloadInProgress')
+                        : t('flights.downloadGpx')}
+                    </Button>
+                  )}
+                  <Button
+                    className={`w-full cursor-pointer rounded-md px-4 py-2.5 text-sm font-semibold text-white transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400 dark:focus:ring-offset-gray-800 ${
+                      flight.gpx_file_path
+                        ? 'bg-green-600 hover:bg-green-700'
+                        : 'bg-orange-600 hover:bg-orange-700'
+                    }`}
+                    onPress={() => fileInputRef.current?.click()}
+                    isDisabled={uploadGPXMutation.isPending}
+                  >
+                    {uploadGPXMutation.isPending
+                      ? t('flights.uploadInProgress')
+                      : flight.gpx_file_path
+                        ? t('flights.replaceGpx')
+                        : t('flights.addGpx')}
+                  </Button>
+                </div>
+              </div>
             </div>
             <input
               ref={fileInputRef}

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
@@ -1,0 +1,179 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Flight } from '@dashboard-parapente/shared-types';
+
+const { apiDelete, apiGet, apiPost, exportStatusMock, mockFlight } = vi.hoisted(
+  () => ({
+    apiDelete: vi.fn(),
+    apiGet: vi.fn(),
+    apiPost: vi.fn(),
+    exportStatusMock: { current: null as unknown },
+    mockFlight: {
+      id: 'flight-1',
+      flight_date: '2026-03-15',
+      title: 'Test flight',
+      gpx_file_path: 'sample.gpx',
+      video_export_status: null as string | null,
+      video_export_job_id: null as string | null,
+      video_file_path: null as string | null,
+    } as Flight,
+  })
+);
+
+vi.mock('@dashboard-parapente/design-system', () => ({
+  Button: ({
+    children,
+    isDisabled,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isDisabled?: boolean;
+  }) => (
+    <button type="button" disabled={isDisabled} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        'flights.viewer.videoExportMode': 'Export mode',
+        'flights.viewer.videoModeManualFast': 'Fast smooth',
+        'flights.viewer.videoModeManual': 'Max quality',
+        'flights.viewer.videoModeManualFastHint': 'Fast hint',
+        'flights.viewer.videoModeManualHint': 'Manual hint',
+        'flights.viewer.generateVideo': 'Generate video',
+        'flights.viewer.downloadVideo': 'Download video',
+        'flights.viewer.resumeVideo': 'Resume generation',
+        'flights.viewer.videoResumeHint': 'frames preserved',
+        'flights.viewer.videoGenerating': 'Generating video',
+        'flights.viewer.videoProgress': 'Progress',
+        'flights.viewer.cancelGeneration': 'Cancel generation',
+        'flights.viewer.regenerateVideo': 'Restart generation',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('../../hooks/flights/useFlight', () => ({
+  useFlight: () => ({ data: mockFlight }),
+}));
+
+vi.mock('../../hooks/flights/useVideoExportStatus', () => ({
+  formatEta: () => null,
+  useVideoExportStatus: () => ({ status: exportStatusMock.current }),
+}));
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    delete: apiDelete,
+    get: apiGet,
+    post: apiPost,
+  },
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ error: vi.fn(), success: vi.fn() }),
+}));
+
+import { FlightVideoExportControls } from './FlightVideoExportControls';
+
+describe('FlightVideoExportControls', () => {
+  beforeEach(() => {
+    apiDelete.mockReset();
+    apiGet.mockReset();
+    apiPost.mockReset();
+    apiPost.mockResolvedValue(undefined);
+    mockFlight.video_export_status = null;
+    mockFlight.video_export_job_id = null;
+    mockFlight.video_file_path = null;
+    exportStatusMock.current = null;
+  });
+
+  it('starts fast smooth export by default', async () => {
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    expect(screen.getByText('Fast hint')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
+        searchParams: { mode: 'manual_fast' },
+      });
+    });
+  });
+
+  it('starts max quality export after switching mode', async () => {
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    fireEvent.change(screen.getByLabelText('Export mode'), {
+      target: { value: 'manual' },
+    });
+
+    expect(screen.getByText('Manual hint')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
+        searchParams: { mode: 'manual' },
+      });
+    });
+  });
+
+  it('resumes a cancelled export when preserved frames are available', async () => {
+    mockFlight.video_export_status = 'cancelled';
+    mockFlight.video_export_job_id = 'job-cancelled';
+    exportStatusMock.current = {
+      job_id: 'job-cancelled',
+      status: 'failed',
+      internal_status: 'cancelled',
+      can_resume: true,
+      frames_captured: 25,
+      resume_from_frame: 25,
+    };
+
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    expect(screen.getByText('frames preserved')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Resume generation/u }));
+
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalledWith('exports/job-cancelled/resume');
+    });
+  });
+
+  it('downloads generated videos without applying the API request timeout', async () => {
+    mockFlight.video_export_status = 'completed';
+    mockFlight.video_export_job_id = 'job-video';
+    mockFlight.video_file_path = '/exports/job-video.mp4';
+    const blob = vi.fn().mockResolvedValue(new Blob(['video']));
+    apiGet.mockReturnValue({ blob });
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:video'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download video/u }));
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith('exports/job-video/download', {
+        timeout: false,
+      });
+      expect(blob).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { HTTPError } from 'ky';
+import { Button } from '@dashboard-parapente/design-system';
+import {
+  VIDEO_EXPORT_IN_PROGRESS_STATUSES,
+  type Flight,
+} from '@dashboard-parapente/shared-types';
+import {
+  formatEta,
+  useVideoExportStatus,
+} from '../../hooks/flights/useVideoExportStatus';
+import { useFlight } from '../../hooks/flights/useFlight';
+import { useToast } from '../../hooks/useToast';
+import { api } from '../../lib/api';
+
+type VideoExportMode = 'manual_fast' | 'manual';
+
+interface FlightVideoExportControlsProps {
+  flight: Flight;
+  className?: string;
+  buttonClassName?: string;
+  showModeSelector?: boolean;
+}
+
+const isVideoExportInProgress = (status?: string | null) =>
+  Boolean(status && VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status));
+
+const hasActiveVideoExport = (
+  flight?: Pick<Flight, 'video_export_job_id' | 'video_export_status'> | null
+) =>
+  Boolean(
+    flight?.video_export_job_id &&
+    isVideoExportInProgress(flight.video_export_status)
+  );
+
+const getHttpErrorDetail = async (error: HTTPError): Promise<string | null> => {
+  try {
+    const body = (await error.response.json()) as {
+      detail?: unknown;
+      message?: unknown;
+    };
+    const raw = body.detail ?? body.message;
+
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      return trimmed || null;
+    }
+
+    if (Array.isArray(raw)) {
+      return raw.map((item) => String(item)).join(' • ');
+    }
+
+    if (raw && typeof raw === 'object') {
+      return JSON.stringify(raw);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+};
+
+export function FlightVideoExportControls({
+  flight: initialFlight,
+  className = '',
+  buttonClassName = '',
+  showModeSelector = true,
+}: FlightVideoExportControlsProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const { data: refreshedFlight } = useFlight(initialFlight.id);
+  const flight = refreshedFlight ?? initialFlight;
+  const [videoExportMode, setVideoExportMode] =
+    useState<VideoExportMode>('manual_fast');
+  const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
+  const isExportActive = hasActiveVideoExport(flight);
+  const shouldReadExportStatus = Boolean(
+    flight.video_export_job_id &&
+    (isExportActive ||
+      flight.video_export_status === 'failed' ||
+      flight.video_export_status === 'cancelled')
+  );
+  const { status: exportStatus } = useVideoExportStatus(
+    flight.video_export_job_id,
+    shouldReadExportStatus
+  );
+  const exportProgress = Math.min(
+    100,
+    Math.max(0, Math.round(exportStatus?.progress ?? 0))
+  );
+  const exportEta = formatEta(exportStatus?.eta_seconds);
+  const canResumeVideoExport = Boolean(
+    flight.video_export_job_id && exportStatus?.can_resume
+  );
+
+  useEffect(() => {
+    if (!flight.id || !exportStatus?.internal_status) {
+      return;
+    }
+
+    if (
+      exportStatus.internal_status === 'completed' ||
+      exportStatus.internal_status === 'failed' ||
+      exportStatus.internal_status === 'cancelled'
+    ) {
+      queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+    }
+  }, [exportStatus?.internal_status, flight.id, queryClient]);
+
+  const startVideoExport = useCallback(async () => {
+    if (isStartingVideoExport) return;
+
+    setIsStartingVideoExport(true);
+    try {
+      await api.post(`flights/${flight.id}/export-video`, {
+        searchParams: { mode: videoExportMode },
+      });
+      await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+    } finally {
+      setIsStartingVideoExport(false);
+    }
+  }, [flight.id, isStartingVideoExport, queryClient, videoExportMode]);
+
+  const resumeVideoExport = useCallback(async () => {
+    if (isStartingVideoExport || !flight.video_export_job_id) return;
+
+    setIsStartingVideoExport(true);
+    try {
+      await api.post(`exports/${flight.video_export_job_id}/resume`);
+      await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+    } finally {
+      setIsStartingVideoExport(false);
+    }
+  }, [
+    flight.id,
+    flight.video_export_job_id,
+    isStartingVideoExport,
+    queryClient,
+  ]);
+
+  const handlePrimaryAction = async () => {
+    if (flight.video_export_status === 'completed' && flight.video_file_path) {
+      try {
+        const blob = await api
+          .get(`exports/${flight.video_export_job_id}/download`, {
+            timeout: false,
+          })
+          .blob();
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `flight-${flight.id}.mp4`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        if (error instanceof HTTPError) {
+          const detail = await getHttpErrorDetail(error);
+          toast.error(detail || t('flights.viewer.videoDownloadError'));
+          return;
+        }
+
+        console.error('Failed to download video:', error);
+        toast.error(t('flights.viewer.videoDownloadError'));
+      }
+      return;
+    }
+
+    if (hasActiveVideoExport(flight)) return;
+
+    try {
+      if (canResumeVideoExport) {
+        await resumeVideoExport();
+      } else {
+        await startVideoExport();
+      }
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const detail = await getHttpErrorDetail(error);
+        toast.error(detail || t('flights.viewer.videoStartError'));
+        return;
+      }
+
+      console.error('Failed to start video generation:', error);
+      toast.error(t('flights.viewer.videoStartGenericError'));
+    }
+  };
+
+  const handleCancelVideoExport = async () => {
+    if (
+      !flight.video_export_job_id ||
+      !confirm(t('flights.viewer.confirmCancelGeneration'))
+    ) {
+      return;
+    }
+
+    try {
+      await api.delete(`exports/${flight.video_export_job_id}/cancel`);
+      queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const detail = await getHttpErrorDetail(error);
+        toast.error(detail || t('flights.viewer.cancelGenerationError'));
+        return;
+      }
+
+      console.error('Failed to cancel video generation:', error);
+      toast.error(t('flights.viewer.cancelError'));
+    }
+  };
+
+  const handleRegenerateVideo = async () => {
+    if (!confirm(t('flights.viewer.confirmRegenerateVideo'))) return;
+
+    try {
+      await startVideoExport();
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        const detail = await getHttpErrorDetail(error);
+        toast.error(detail || t('flights.viewer.regenerateStartError'));
+        return;
+      }
+
+      console.error('Failed to regenerate video:', error);
+      toast.error(t('flights.viewer.regenerateError'));
+    }
+  };
+
+  const primaryButtonTitle = hasActiveVideoExport(flight)
+    ? t('flights.viewer.videoGeneratingTitle')
+    : flight.video_export_status === 'completed'
+      ? t('flights.viewer.videoDownloadTitle')
+      : flight.video_export_status === 'failed' ||
+          flight.video_export_status === 'cancelled'
+        ? canResumeVideoExport
+          ? t('flights.viewer.videoResumeTitle')
+          : t('flights.viewer.videoRegenerateTitle')
+        : t('flights.viewer.videoGenerateTitle');
+
+  const primaryButtonLabel = (() => {
+    if (hasActiveVideoExport(flight))
+      return t('flights.viewer.videoGenerating');
+    if (flight.video_export_status === 'completed') {
+      return t('flights.viewer.downloadVideo');
+    }
+    if (
+      flight.video_export_status === 'failed' ||
+      flight.video_export_status === 'cancelled'
+    ) {
+      return canResumeVideoExport
+        ? t('flights.viewer.resumeVideo')
+        : t('flights.viewer.regenerateVideo');
+    }
+    return t('flights.viewer.generateVideo');
+  })();
+
+  const primaryButtonClassName = [
+    'cursor-pointer rounded-md px-4 py-2.5 text-sm font-semibold text-white transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400',
+    flight.video_export_status === 'completed'
+      ? 'bg-green-600 hover:bg-green-700'
+      : isStartingVideoExport || hasActiveVideoExport(flight)
+        ? 'bg-gray-400'
+        : 'bg-blue-600 hover:bg-blue-700',
+    buttonClassName,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={className}>
+      {showModeSelector &&
+        !isVideoExportInProgress(flight.video_export_status) && (
+          <div className="mb-2 rounded-lg border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900/30">
+            <label
+              htmlFor={`video-export-mode-${flight.id}`}
+              className="mb-1 block text-xs font-semibold text-gray-700 dark:text-gray-200"
+            >
+              {t('flights.viewer.videoExportMode')}
+            </label>
+            <select
+              id={`video-export-mode-${flight.id}`}
+              value={videoExportMode}
+              onChange={(event) =>
+                setVideoExportMode(event.target.value as VideoExportMode)
+              }
+              className="w-full cursor-pointer rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            >
+              <option value="manual_fast">
+                {t('flights.viewer.videoModeManualFast')}
+              </option>
+              <option value="manual">
+                {t('flights.viewer.videoModeManual')}
+              </option>
+            </select>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {videoExportMode === 'manual_fast'
+                ? t('flights.viewer.videoModeManualFastHint')
+                : t('flights.viewer.videoModeManualHint')}
+            </p>
+          </div>
+        )}
+
+      <Button
+        onClick={handlePrimaryAction}
+        isDisabled={isStartingVideoExport || hasActiveVideoExport(flight)}
+        className={primaryButtonClassName}
+        title={primaryButtonTitle}
+      >
+        {primaryButtonLabel}
+      </Button>
+
+      {canResumeVideoExport && !isExportActive && (
+        <p className="mt-2 text-xs text-blue-700 dark:text-blue-300">
+          {t('flights.viewer.videoResumeHint', {
+            count: exportStatus?.frames_captured ?? 0,
+          })}
+        </p>
+      )}
+
+      {hasActiveVideoExport(flight) && (
+        <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-2 dark:border-blue-700 dark:bg-blue-900/20">
+          <div className="mb-1 flex items-center justify-between text-xs font-medium text-blue-900 dark:text-blue-100">
+            <span>{t('flights.viewer.videoProgress')}</span>
+            <span>{exportProgress}%</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded bg-blue-100 dark:bg-blue-950/40">
+            <div
+              className="h-full rounded bg-blue-600 transition-all duration-500"
+              style={{ width: `${exportProgress}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-blue-900 dark:text-blue-100">
+            {exportStatus?.message || t('flights.viewer.videoGenerating')}
+          </p>
+          {exportEta && (
+            <p className="mt-1 text-xs text-blue-900 dark:text-blue-100">
+              {t('flights.viewer.videoEta', { time: exportEta })}
+            </p>
+          )}
+        </div>
+      )}
+
+      {hasActiveVideoExport(flight) && (
+        <Button
+          onClick={handleCancelVideoExport}
+          className="mt-2 w-full cursor-pointer rounded-md bg-red-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+          title={t('flights.viewer.cancelGenerationTitle')}
+        >
+          {t('flights.viewer.cancelGeneration')}
+        </Button>
+      )}
+
+      {flight.video_export_status === 'completed' && (
+        <Button
+          onClick={handleRegenerateVideo}
+          isDisabled={isStartingVideoExport}
+          className="mt-2 w-full cursor-pointer rounded-md bg-orange-500 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-400 dark:focus:ring-offset-gray-800"
+          title={t('flights.viewer.regenerateTitle')}
+        >
+          {t('flights.viewer.regenerateVideo')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -31,10 +31,6 @@ import {
 import { useFlightGPX } from '../../hooks/flights/useFlightGPX';
 import { useFlight } from '../../hooks/flights/useFlight';
 import {
-  formatEta,
-  useVideoExportStatus,
-} from '../../hooks/flights/useVideoExportStatus';
-import {
   getHeadingFromOrientation,
   getOrientationLabel,
   getOrientationOptions,
@@ -50,59 +46,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '../../hooks/useToast';
 import { Button } from '@dashboard-parapente/design-system';
 import { Disclosure, DisclosurePanel } from 'react-aria-components';
-import { HTTPError } from 'ky';
 import { useTranslation } from 'react-i18next';
 
 import type { GPXData } from '@dashboard-parapente/shared-types';
-import {
-  VIDEO_EXPORT_IN_PROGRESS_STATUSES,
-  type Flight,
-} from '@dashboard-parapente/shared-types';
+import type { Flight } from '@dashboard-parapente/shared-types';
 import {
   computeCursorTelemetryLabel,
   type ViewerUnits,
 } from './flightViewerTelemetry';
 import { useAppSettingsStore } from '../../stores/appSettingsStore';
-
-const isVideoExportInProgress = (status?: string | null) =>
-  Boolean(status && VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status));
-
-const hasActiveVideoExport = (
-  flight?: Pick<Flight, 'video_export_job_id' | 'video_export_status'> | null
-) =>
-  Boolean(
-    flight?.video_export_job_id &&
-    isVideoExportInProgress(flight.video_export_status)
-  );
-
-type VideoExportMode = 'manual_fast' | 'manual';
-
-const getHttpErrorDetail = async (error: HTTPError): Promise<string | null> => {
-  try {
-    const body = (await error.response.json()) as {
-      detail?: unknown;
-      message?: unknown;
-    };
-    const raw = body.detail ?? body.message;
-
-    if (typeof raw === 'string') {
-      const trimmed = raw.trim();
-      return trimmed || null;
-    }
-
-    if (Array.isArray(raw)) {
-      return raw.map((item) => String(item)).join(' • ');
-    }
-
-    if (raw && typeof raw === 'object') {
-      return JSON.stringify(raw);
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-};
 
 declare global {
   interface Window {
@@ -343,9 +295,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(compact);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [currentElapsedTime, setCurrentElapsedTime] = useState(0);
-  const [videoExportMode, setVideoExportMode] =
-    useState<VideoExportMode>('manual_fast');
-  const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
   const appUnits = useAppSettingsStore((state) => state.settings.units);
   const viewerUnits: ViewerUnits = useMemo(
     () => ({
@@ -568,43 +517,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     },
     [isActiveViewer, removeTrackEntity]
   );
-
-  const isExportActive = hasActiveVideoExport(flight);
-  const shouldReadExportStatus = Boolean(
-    flight?.video_export_job_id &&
-    (isExportActive ||
-      flight?.video_export_status === 'failed' ||
-      flight?.video_export_status === 'cancelled')
-  );
-  const { status: exportStatus } = useVideoExportStatus(
-    flight?.video_export_job_id,
-    shouldReadExportStatus
-  );
-
-  const exportProgress = Math.min(
-    100,
-    Math.max(0, Math.round(exportStatus?.progress ?? 0))
-  );
-  const exportEta = formatEta(exportStatus?.eta_seconds);
-  const canResumeVideoExport = Boolean(
-    flight?.video_export_job_id && exportStatus?.can_resume
-  );
-
-  useEffect(() => {
-    if (!flightId || !exportStatus?.internal_status) {
-      return;
-    }
-
-    if (
-      exportStatus.internal_status === 'completed' ||
-      exportStatus.internal_status === 'failed' ||
-      exportStatus.internal_status === 'cancelled'
-    ) {
-      queryClient.invalidateQueries({
-        queryKey: ['flights', flightId],
-      });
-    }
-  }, [exportStatus?.internal_status, flightId, queryClient]);
 
   useEffect(() => {
     viewerUnitsRef.current = viewerUnits;
@@ -1722,46 +1634,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     }
   };
 
-  const startVideoExport = useCallback(async () => {
-    if (isStartingVideoExport) {
-      return;
-    }
-
-    setIsStartingVideoExport(true);
-    try {
-      await api.post(`flights/${flightId}/export-video`, {
-        searchParams: {
-          mode: videoExportMode,
-        },
-      });
-
-      await queryClient.invalidateQueries({
-        queryKey: ['flights', flightId],
-      });
-    } finally {
-      setIsStartingVideoExport(false);
-    }
-  }, [flightId, isStartingVideoExport, queryClient, videoExportMode]);
-
-  const resumeVideoExport = useCallback(async () => {
-    if (isStartingVideoExport || !flight?.video_export_job_id) {
-      return;
-    }
-
-    setIsStartingVideoExport(true);
-    try {
-      await api.post(`exports/${flight.video_export_job_id}/resume`);
-      await queryClient.invalidateQueries({ queryKey: ['flights', flightId] });
-    } finally {
-      setIsStartingVideoExport(false);
-    }
-  }, [
-    flight?.video_export_job_id,
-    flightId,
-    isStartingVideoExport,
-    queryClient,
-  ]);
-
   /**
    * Update site orientation
    */
@@ -2170,278 +2042,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                   </div>
                 </AccordionSection>
 
-                {/* ========== SECTION 2: VIDÉO ========== */}
-                {flight?.gpx_file_path && (
-                  <AccordionSection
-                    title={t('flights.viewer.videoSection')}
-                    emoji="📹"
-                    defaultOpen={false}
-                  >
-                    <>
-                      {!isVideoExportInProgress(flight.video_export_status) && (
-                        <div className="mb-3 rounded border border-gray-200 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-900/30">
-                          <label
-                            htmlFor="video-export-mode"
-                            className="mb-1 block text-xs font-semibold text-gray-700 dark:text-gray-200"
-                          >
-                            {t('flights.viewer.videoExportMode')}
-                          </label>
-                          <select
-                            id="video-export-mode"
-                            value={videoExportMode}
-                            onChange={(event) =>
-                              setVideoExportMode(
-                                event.target.value as VideoExportMode
-                              )
-                            }
-                            className="w-full rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-900 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
-                          >
-                            <option value="manual_fast">
-                              {t('flights.viewer.videoModeManualFast')}
-                            </option>
-                            <option value="manual">
-                              {t('flights.viewer.videoModeManual')}
-                            </option>
-                          </select>
-                          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                            {videoExportMode === 'manual_fast'
-                              ? t('flights.viewer.videoModeManualFastHint')
-                              : t('flights.viewer.videoModeManualHint')}
-                          </p>
-                        </div>
-                      )}
-
-                      {/* Download/Generate Button */}
-                      <Button
-                        onClick={async () => {
-                          if (
-                            flight.video_export_status === 'completed' &&
-                            flight.video_file_path
-                          ) {
-                            // Download video with authenticated API client
-                            try {
-                              const blob = await api
-                                .get(
-                                  `exports/${flight.video_export_job_id}/download`,
-                                  { timeout: false }
-                                )
-                                .blob();
-
-                              const url = URL.createObjectURL(blob);
-                              const a = document.createElement('a');
-                              a.href = url;
-                              a.download = `flight-${flightId}.mp4`;
-                              a.click();
-                              URL.revokeObjectURL(url);
-                            } catch (error) {
-                              if (error instanceof HTTPError) {
-                                const detail = await getHttpErrorDetail(error);
-                                toast.error(
-                                  detail ||
-                                    t('flights.viewer.videoDownloadError')
-                                );
-                                return;
-                              }
-
-                              console.error('Failed to download video:', error);
-                              toast.error(
-                                t('flights.viewer.videoDownloadError')
-                              );
-                            }
-                          } else if (!hasActiveVideoExport(flight)) {
-                            // Generate video
-                            try {
-                              if (canResumeVideoExport) {
-                                await resumeVideoExport();
-                              } else {
-                                await startVideoExport();
-                              }
-                            } catch (error) {
-                              if (error instanceof HTTPError) {
-                                const detail = await getHttpErrorDetail(error);
-                                toast.error(
-                                  detail || t('flights.viewer.videoStartError')
-                                );
-                                return;
-                              }
-
-                              console.error(
-                                '❌ Failed to start video generation:',
-                                error
-                              );
-                              toast.error(
-                                t('flights.viewer.videoStartGenericError')
-                              );
-                            }
-                          }
-                        }}
-                        isDisabled={
-                          isStartingVideoExport || hasActiveVideoExport(flight)
-                        }
-                        className={`w-full ${compactControlButtonClassName} text-white rounded ${
-                          flight.video_export_status === 'completed'
-                            ? 'mb-2'
-                            : 'mb-3'
-                        } ${
-                          flight.video_export_status === 'completed'
-                            ? 'bg-green-600 hover:bg-green-700'
-                            : isStartingVideoExport ||
-                                hasActiveVideoExport(flight)
-                              ? 'bg-gray-400 cursor-not-allowed'
-                              : 'bg-blue-600 hover:bg-blue-700'
-                        }`}
-                        title={
-                          hasActiveVideoExport(flight)
-                            ? t('flights.viewer.videoGeneratingTitle')
-                            : flight.video_export_status === 'completed'
-                              ? t('flights.viewer.videoDownloadTitle')
-                              : flight.video_export_status === 'failed' ||
-                                  flight.video_export_status === 'cancelled'
-                                ? canResumeVideoExport
-                                  ? t('flights.viewer.videoResumeTitle')
-                                  : t('flights.viewer.videoRegenerateTitle')
-                                : t('flights.viewer.videoGenerateTitle')
-                        }
-                      >
-                        {hasActiveVideoExport(flight) &&
-                          `⏳ ${t('flights.viewer.videoGenerating')}`}
-                        {flight.video_export_status === 'completed' &&
-                          `📥 ${t('flights.viewer.downloadVideo')}`}
-                        {(flight.video_export_status === 'failed' ||
-                          flight.video_export_status === 'cancelled') &&
-                          (canResumeVideoExport
-                            ? `▶️ ${t('flights.viewer.resumeVideo')}`
-                            : `🔄 ${t('flights.viewer.regenerateVideo')}`)}
-                        {(!flight.video_export_status ||
-                          isVideoExportInProgress(
-                            flight.video_export_status
-                          )) &&
-                          !hasActiveVideoExport(flight) &&
-                          `🎥 ${t('flights.viewer.generateVideo')}`}
-                      </Button>
-
-                      {canResumeVideoExport && !isExportActive && (
-                        <p className="mb-3 text-xs text-blue-700 dark:text-blue-300">
-                          {t('flights.viewer.videoResumeHint', {
-                            count: exportStatus?.frames_captured ?? 0,
-                          })}
-                        </p>
-                      )}
-
-                      {hasActiveVideoExport(flight) && (
-                        <div className="mb-3 rounded border border-blue-200 bg-blue-50 p-2 dark:border-blue-700 dark:bg-blue-900/20">
-                          <div className="mb-1 flex items-center justify-between text-xs font-medium text-blue-900 dark:text-blue-100">
-                            <span>{t('flights.viewer.videoProgress')}</span>
-                            <span>{exportProgress}%</span>
-                          </div>
-                          <div className="h-2 w-full overflow-hidden rounded bg-blue-100 dark:bg-blue-950/40">
-                            <div
-                              className="h-full rounded bg-blue-600 transition-all duration-500"
-                              style={{ width: `${exportProgress}%` }}
-                            />
-                          </div>
-                          <p className="mt-2 text-xs text-blue-900 dark:text-blue-100">
-                            {exportStatus?.message ||
-                              t('flights.viewer.videoGenerating')}
-                          </p>
-                          {exportEta && (
-                            <p className="mt-1 text-xs text-blue-900 dark:text-blue-100">
-                              {t('flights.viewer.videoEta', {
-                                time: exportEta,
-                              })}
-                            </p>
-                          )}
-                        </div>
-                      )}
-
-                      {/* Cancel Button (only when export is active) */}
-                      {hasActiveVideoExport(flight) && (
-                        <Button
-                          onClick={async () => {
-                            if (
-                              !confirm(
-                                t('flights.viewer.confirmCancelGeneration')
-                              )
-                            ) {
-                              return;
-                            }
-
-                            try {
-                              await api.delete(
-                                `exports/${flight.video_export_job_id}/cancel`
-                              );
-
-                              // Refresh flight data to get updated status
-                              queryClient.invalidateQueries({
-                                queryKey: ['flights', flightId],
-                              });
-                            } catch (error) {
-                              if (error instanceof HTTPError) {
-                                const detail = await getHttpErrorDetail(error);
-                                toast.error(
-                                  detail ||
-                                    t('flights.viewer.cancelGenerationError')
-                                );
-                                return;
-                              }
-
-                              console.error(
-                                'Failed to cancel video generation:',
-                                error
-                              );
-                              toast.error(t('flights.viewer.cancelError'));
-                            }
-                          }}
-                          className="w-full px-2 py-1 text-xs bg-red-500 text-white rounded hover:bg-red-600 mb-3"
-                          title={t('flights.viewer.cancelGenerationTitle')}
-                        >
-                          🛑 {t('flights.viewer.cancelGeneration')}
-                        </Button>
-                      )}
-
-                      {/* Regenerate Button (only when video exists) */}
-                      {flight.video_export_status === 'completed' && (
-                        <Button
-                          onClick={async () => {
-                            if (
-                              !confirm(
-                                t('flights.viewer.confirmRegenerateVideo')
-                              )
-                            ) {
-                              return;
-                            }
-
-                            try {
-                              await startVideoExport();
-                            } catch (error) {
-                              if (error instanceof HTTPError) {
-                                const detail = await getHttpErrorDetail(error);
-                                toast.error(
-                                  detail ||
-                                    t('flights.viewer.regenerateStartError')
-                                );
-                                return;
-                              }
-
-                              console.error(
-                                'Failed to regenerate video:',
-                                error
-                              );
-                              toast.error(t('flights.viewer.regenerateError'));
-                            }
-                          }}
-                          isDisabled={isStartingVideoExport}
-                          className="w-full px-2 py-1 text-xs bg-orange-500 text-white rounded hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed mb-3"
-                          title={t('flights.viewer.regenerateTitle')}
-                        >
-                          🔄 {t('flights.viewer.regenerateVideo')}
-                        </Button>
-                      )}
-                    </>
-                  </AccordionSection>
-                )}
-
-                {/* ========== SECTION 3: SITE & CAMÉRA ========== */}
+                {/* ========== SECTION 2: SITE & CAMÉRA ========== */}
                 {flight?.site && (
                   <AccordionSection
                     title={t('flights.viewer.siteCameraSection')}

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -1,20 +1,14 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  apiGet,
-  apiPost,
-  exportStatusMock,
   invalidateQueries,
   mockFlight,
   entityOptions,
   viewerInstances,
   viewerOptions,
 } = vi.hoisted(() => ({
-  apiGet: vi.fn(),
-  apiPost: vi.fn(),
-  exportStatusMock: { current: null as unknown },
   invalidateQueries: vi.fn(),
   entityOptions: [] as unknown[],
   viewerInstances: [] as {
@@ -222,16 +216,6 @@ vi.mock('react-i18next', () => ({
     t: (key: string) =>
       ({
         'flights.viewer.defaultTitle': 'Flight viewer',
-        'flights.viewer.videoExportMode': 'Export mode',
-        'flights.viewer.videoModeManualFast': 'Fast smooth',
-        'flights.viewer.videoModeManual': 'Max quality',
-        'flights.viewer.videoModeManualFastHint': 'Fast hint',
-        'flights.viewer.videoModeManualHint': 'Manual hint',
-        'flights.viewer.generateVideo': 'Generate video',
-        'flights.viewer.downloadVideo': 'Download video',
-        'flights.viewer.resumeVideo': 'Resume generation',
-        'flights.viewer.videoResumeHint': 'frames preserved',
-        'flights.viewer.videoSection': 'Video',
       })[key] ?? key,
   }),
   withTranslation: () => (Component: unknown) => Component,
@@ -257,16 +241,8 @@ vi.mock('../../hooks/flights/useFlight', () => ({
   }),
 }));
 
-vi.mock('../../hooks/flights/useVideoExportStatus', () => ({
-  formatEta: () => null,
-  useVideoExportStatus: () => ({ status: exportStatusMock.current }),
-}));
-
 vi.mock('../../lib/api', () => ({
-  api: {
-    get: apiGet,
-    post: apiPost,
-  },
+  api: {},
 }));
 
 vi.mock('@tanstack/react-query', () => ({
@@ -300,9 +276,6 @@ describe('FlightViewer3D video export mode', () => {
       configurable: true,
       value: 1024,
     });
-    apiPost.mockResolvedValue(undefined);
-    apiGet.mockReset();
-    apiPost.mockClear();
     invalidateQueries.mockClear();
     viewerInstances.length = 0;
     viewerOptions.length = 0;
@@ -310,7 +283,6 @@ describe('FlightViewer3D video export mode', () => {
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
-    exportStatusMock.current = null;
     window._exportMode = undefined;
     window._setExportFrame = undefined;
     window._getExportMetadata = undefined;
@@ -348,49 +320,6 @@ describe('FlightViewer3D video export mode', () => {
     window._cesiumViewer = undefined;
   });
 
-  it('starts fast smooth export by default and shows its hint', async () => {
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    expect(screen.getByText('Fast hint')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
-
-    await waitFor(() => {
-      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
-        searchParams: { mode: 'manual_fast' },
-      });
-    });
-  });
-
-  it('allows generation when an in-progress status has no job id', async () => {
-    mockFlight.video_export_status = 'processing';
-    mockFlight.video_export_job_id = null;
-
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    const button = screen.getByRole('button', { name: /Generate video/u });
-    expect(button).not.toBeDisabled();
-
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
-        searchParams: { mode: 'manual_fast' },
-      });
-    });
-  });
-
-  it('keeps generation disabled when an in-progress status has a job id', () => {
-    mockFlight.video_export_status = 'processing';
-    mockFlight.video_export_job_id = 'job-processing';
-
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    expect(
-      screen.getByRole('button', { name: /flights\.viewer\.videoGenerating/u })
-    ).toBeDisabled();
-  });
-
   it('hides viewer controls in export-only mode', () => {
     render(<FlightViewer3D flightId="flight-1" exportOnly />);
 
@@ -401,7 +330,6 @@ describe('FlightViewer3D video export mode', () => {
     expect(screen.getByTestId('flight-viewer-root')).toHaveClass(
       'flight-viewer-export-only'
     );
-    expect(screen.queryByText('Fast hint')).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /Generate video/u })
     ).not.toBeInTheDocument();
@@ -507,73 +435,5 @@ describe('FlightViewer3D video export mode', () => {
     expect(viewerInstances[viewerInstances.length - 1]?.isDestroyed()).toBe(
       true
     );
-  });
-
-  it('starts max quality export after switching mode', async () => {
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    fireEvent.change(screen.getByLabelText('Export mode'), {
-      target: { value: 'manual' },
-    });
-
-    expect(screen.getByText('Manual hint')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /Generate video/u }));
-
-    await waitFor(() => {
-      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
-        searchParams: { mode: 'manual' },
-      });
-    });
-  });
-
-  it('resumes a cancelled export when preserved frames are available', async () => {
-    mockFlight.video_export_status = 'cancelled';
-    mockFlight.video_export_job_id = 'job-cancelled';
-    exportStatusMock.current = {
-      job_id: 'job-cancelled',
-      status: 'failed',
-      internal_status: 'cancelled',
-      can_resume: true,
-      frames_captured: 25,
-      resume_from_frame: 25,
-    };
-
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    expect(screen.getByText('frames preserved')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: /Resume generation/u }));
-
-    await waitFor(() => {
-      expect(apiPost).toHaveBeenCalledWith('exports/job-cancelled/resume');
-    });
-  });
-
-  it('downloads generated videos without applying the API request timeout', async () => {
-    mockFlight.video_export_status = 'completed';
-    mockFlight.video_export_job_id = 'job-video';
-    mockFlight.video_file_path = '/exports/job-video.mp4';
-    const blob = vi.fn().mockResolvedValue(new Blob(['video']));
-    apiGet.mockReturnValue({ blob });
-    Object.defineProperty(URL, 'createObjectURL', {
-      configurable: true,
-      value: vi.fn(() => 'blob:video'),
-    });
-    Object.defineProperty(URL, 'revokeObjectURL', {
-      configurable: true,
-      value: vi.fn(),
-    });
-
-    render(<FlightViewer3D flightId="flight-1" />);
-
-    fireEvent.click(screen.getByRole('button', { name: /Download video/u }));
-
-    await waitFor(() => {
-      expect(apiGet).toHaveBeenCalledWith('exports/job-video/download', {
-        timeout: false,
-      });
-      expect(blob).toHaveBeenCalled();
-    });
   });
 });

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -648,6 +648,8 @@
       "failed": "Error",
       "cancelled": "Cancelled"
     },
+    "videoProductionActions": "Video production",
+    "flightFileActions": "Flight & files",
     "loading3dViewer": "Loading 3D viewer...",
     "flightOf": "Flight on {{date}}",
     "selectFlightHint": "Select a flight to view details and 3D trajectory",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -652,6 +652,8 @@
       "failed": "Erreur",
       "cancelled": "Annulé"
     },
+    "videoProductionActions": "Production vidéo",
+    "flightFileActions": "Vol & fichiers",
     "loading3dViewer": "Chargement du viewer 3D...",
     "flightOf": "Vol du {{date}}",
     "selectFlightHint": "Sélectionnez un vol pour visualiser les détails et la trajectoire 3D",


### PR DESCRIPTION
## Summary
- Group flight production actions into dedicated video/file sections in FlightDetails.
- Extract reusable video export controls and remove the duplicate video block from the 3D viewer.
- Update flight translation strings and move video export tests to the new component.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts src/components/flights/FlightVideoExportControls.test.tsx src/components/flights/FlightViewer3D.video-export.test.tsx
- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend