### PR TITLE
fix(video-export): pad daily flight sequence numbers

### DIFF
--- a/apps/backend/flight_storage.py
+++ b/apps/backend/flight_storage.py
@@ -33,7 +33,7 @@ def flight_sequence_number(db: Session, flight: Flight) -> int:
 
 def flight_directory(db: Session, flight: Flight) -> Path:
     day_dir = flight_storage_root() / flight.flight_date.strftime("%Y%m%d")
-    return day_dir / str(flight_sequence_number(db, flight))
+    return day_dir / f"{flight_sequence_number(db, flight):02d}"
 
 
 def ensure_flight_directory(db: Session, flight: Flight) -> Path:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -229,7 +229,7 @@ def _gopro_overlay_flight_directory(db: Session, flight: Flight) -> Path:
         )
     date_dir = flight.flight_date.strftime("%Y%m%d")
     sequence = flight_sequence_number(db, flight)
-    directory = Path(root).expanduser().resolve() / "parapente" / date_dir / str(sequence)
+    directory = Path(root).expanduser().resolve() / "parapente" / date_dir / f"{sequence:02d}"
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -215,7 +215,7 @@ def test_create_flight_gopro_overlay_job_uses_auto_flight_directory_files(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "1"
+    input_dir = paragliding_root / "parapente" / "20260315" / "01"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     first_gpx_path = input_dir / "Zepp-a.gpx"
@@ -270,7 +270,7 @@ def test_create_flight_gopro_overlay_job_requires_auto_zepp_gpx(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "1"
+    input_dir = paragliding_root / "parapente" / "20260315" / "01"
     input_dir.mkdir(parents=True)
     (input_dir / "camera.mp4").write_bytes(b"camera")
     (input_dir / "flight-pip.mp4").write_bytes(b"pip")
@@ -304,7 +304,7 @@ def test_create_flight_gopro_overlay_job_uses_daily_departure_index(
     db_session.add(earlier)
     db_session.commit()
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "2"
+    input_dir = paragliding_root / "parapente" / "20260315" / "02"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     gpx_path = input_dir / "Zepp-track.gpx"
@@ -349,7 +349,7 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "1"
+    input_dir = paragliding_root / "parapente" / "20260315" / "01"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     gpx_path = input_dir / "Zepp-track.gpx"

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -28,8 +28,8 @@ def test_flight_directory_uses_date_and_daily_sequence(db_session, monkeypatch, 
     db_session.add_all([first, second])
     db_session.commit()
 
-    assert flight_directory(db_session, first) == tmp_path / "20260515" / "1"
-    assert flight_directory(db_session, second) == tmp_path / "20260515" / "2"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "01"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "02"
 
 
 def test_flight_directory_uses_departure_time_order(db_session, monkeypatch, tmp_path):
@@ -49,15 +49,15 @@ def test_flight_directory_uses_departure_time_order(db_session, monkeypatch, tmp
     db_session.add_all([first, second])
     db_session.commit()
 
-    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
-    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "01"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "02"
 
     first.departure_time = datetime(2026, 5, 15, 8, 0)
     second.departure_time = datetime(2026, 5, 15, 7, 0)
     db_session.commit()
 
-    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
-    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "01"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "02"
 
 
 def test_flight_directory_sequence_changes_when_departure_order_reverses(
@@ -77,15 +77,15 @@ def test_flight_directory_sequence_changes_when_departure_order_reverses(
     db_session.add_all([first, second])
     db_session.commit()
 
-    assert flight_directory(db_session, first) == tmp_path / "20260515" / "1"
-    assert flight_directory(db_session, second) == tmp_path / "20260515" / "2"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "01"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "02"
 
     first.departure_time = datetime(2026, 5, 15, 15, 0)
     second.departure_time = datetime(2026, 5, 15, 8, 0)
     db_session.commit()
 
-    assert flight_directory(db_session, second) == tmp_path / "20260515" / "1"
-    assert flight_directory(db_session, first) == tmp_path / "20260515" / "2"
+    assert flight_directory(db_session, second) == tmp_path / "20260515" / "01"
+    assert flight_directory(db_session, first) == tmp_path / "20260515" / "02"
 
 
 def test_flight_sequence_places_missing_departure_time_last(db_session, monkeypatch, tmp_path):
@@ -100,8 +100,16 @@ def test_flight_sequence_places_missing_departure_time_last(db_session, monkeypa
         flight_date=date(2026, 5, 15),
         departure_time=datetime(2026, 5, 15, 14, 0),
     )
-    missing_a = Flight(id="flight-missing-a", flight_date=date(2026, 5, 15))
-    missing_b = Flight(id="flight-missing-b", flight_date=date(2026, 5, 15))
+    missing_a = Flight(
+        id="flight-missing-a",
+        flight_date=date(2026, 5, 15),
+        created_at=datetime(2026, 5, 15, 15, 0),
+    )
+    missing_b = Flight(
+        id="flight-missing-b",
+        flight_date=date(2026, 5, 15),
+        created_at=datetime(2026, 5, 15, 16, 0),
+    )
     db_session.add_all([missing_b, afternoon, missing_a, morning])
     db_session.commit()
 
@@ -119,7 +127,7 @@ def test_write_flight_text_file_creates_file_in_flight_directory(db_session, mon
 
     file_path = write_flight_text_file(db_session, flight, "watch.gpx", "<gpx />")
 
-    assert file_path == tmp_path / "20260515" / "1" / "watch.gpx"
+    assert file_path == tmp_path / "20260515" / "01" / "watch.gpx"
     assert file_path.read_text() == "<gpx />"
 
 
@@ -131,7 +139,7 @@ def test_ensure_flight_directory_creates_directory(db_session, monkeypatch, tmp_
 
     directory = ensure_flight_directory(db_session, flight)
 
-    assert directory == Path(tmp_path / "20260516" / "1")
+    assert directory == Path(tmp_path / "20260516" / "01")
     assert directory.is_dir()
 
 
@@ -144,7 +152,7 @@ def test_get_video_output_path_uses_flight_directory(db_session, monkeypatch, tm
 
     output_path = get_video_output_path("flight-video", "20260517-120000")
 
-    assert output_path == tmp_path / "20260517" / "1" / "history-20260517-120000.mp4"
+    assert output_path == tmp_path / "20260517" / "01" / "history-20260517-120000.mp4"
 
 
 def test_get_video_output_path_falls_back_to_export_root(monkeypatch, tmp_path, test_db):


### PR DESCRIPTION
## Summary
- Format video/export flight directories as `parapente/YYYYMMDD/NN` with a 2-digit daily sequence.
- Align GoPro overlay input paths and backend storage helpers with the same numbering.
- Update backend tests to cover the padded paths.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `pytest tests/unit/test_flight_storage.py tests/api/test_gopro_overlay_endpoints.py` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e --files=apps/backend/flight_storage.py,apps/backend/routes.py,apps/backend/tests/unit/test_flight_storage.py,apps/backend/tests/api/test_gopro_overlay_endpoints.py` ran, but the full backend Nx test target timed out on long-running scraper coverage after already passing the touched backend suites.