### PR TITLE
fix: map GoPro overlay Docker paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,12 @@ services:
       # Backend - Frontend URL
       - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
 
+      # Backend - GoPro overlay toolchain
+      - BACKEND_GOPRO_OVERLAY_ROOT=/app/gopro-overlay
+      - BACKEND_GOPRO_OVERLAY_BIN=/app/gopro-overlay/venv/bin/gopro-dashboard.py
+      - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay
+      - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/parapente
+
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
       - BACKEND_VERSION_STATE_FILE=${BACKEND_VERSION_STATE_FILE:?BACKEND_VERSION_STATE_FILE is required}


### PR DESCRIPTION
## Summary
- Mount the GoPro overlay toolchain and parapente data into fixed container paths.
- Expose backend GoPro overlay env vars with container-local defaults so only host paths need to be configured.

## Validation
- 