### PR TITLE
Fix backend video export default

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4387,7 +4387,7 @@ def generate_flight_video(
     Generate video for a flight (simple endpoint with optimal defaults)
     Used for flights that don't have a video yet.
 
-    Uses optimal settings: 1080p, 15 FPS, Manual Render
+    Uses optimal settings: 1080p, 15 FPS, Manual Fast Render
     """
     logger.info(f"🎥 Manual video generation requested: flight_id={flight_id}")
 
@@ -4408,9 +4408,9 @@ def generate_flight_video(
     # Determine frontend URL
     frontend_url = resolve_frontend_url(config.FRONTEND_URL)
 
-    # Prefer manual render (high quality), fallback to stream if needed
+    # Prefer deterministic manual-fast render, fallback to stream if needed
     try:
-        job_id = start_video_export_manual(
+        job_id = start_video_export_manual_fast(
             flight_id=flight_id,
             quality="1080p",
             fps=15,
@@ -4419,10 +4419,10 @@ def generate_flight_video(
             update_db=True,
             auth_token=_extract_bearer_token(request),
         )
-        started_message = "Video generation started (Manual Render, ~60-90 min)"
+        started_message = "Video generation started (Manual Fast Render)"
     except Exception as e:
         logger.warning(
-            "⚠️ Manual generation failed, falling back to stream for flight %s: %s",
+            "⚠️ Manual fast generation failed, falling back to stream for flight %s: %s",
             flight_id,
             e,
         )

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -133,14 +133,16 @@ class TestVideoExportStartEndpoint:
 class TestGenerateVideoEndpoint:
     """Tests for POST /flights/{flight_id}/generate-video"""
 
-    def test_generate_video_uses_manual_by_default(
+    def test_generate_video_uses_manual_fast_by_default(
         self, client: TestClient, sample_flight, db_session
     ):
-        """Generation should default to manual render when available."""
+        """Generation should default to manual fast render when available."""
         sample_flight.gpx_file_path = "db/gpx/sample.gpx"
         db_session.commit()
 
-        with patch("routes.start_video_export_manual", return_value="job-manual") as mock_start:
+        with patch(
+            "routes.start_video_export_manual_fast", return_value="job-manual-fast"
+        ) as mock_start:
             response = client.post(
                 f"{API_PREFIX}/flights/flight-test-001/generate-video",
                 headers={"Authorization": "Bearer token-generate"},
@@ -148,23 +150,24 @@ class TestGenerateVideoEndpoint:
 
         assert response.status_code == 200
         payload = response.json()
-        assert payload["job_id"] == "job-manual"
-        assert payload["message"] == "Video generation started (Manual Render, ~60-90 min)"
+        assert payload["job_id"] == "job-manual-fast"
+        assert payload["message"] == "Video generation started (Manual Fast Render)"
         assert mock_start.call_args.kwargs["auth_token"] == "token-generate"
 
-    def test_generate_video_falls_back_to_stream_on_manual_error(
+    def test_generate_video_falls_back_to_stream_on_manual_fast_error(
         self,
         client: TestClient,
         db_session,
         sample_flight,
     ):
-        """Generation should fallback to stream mode if manual start fails."""
+        """Generation should fallback to stream mode if manual fast start fails."""
         sample_flight.gpx_file_path = "db/gpx/sample.gpx"
         db_session.commit()
 
         with (
             patch(
-                "routes.start_video_export_manual", side_effect=RuntimeError("manual unavailable")
+                "routes.start_video_export_manual_fast",
+                side_effect=RuntimeError("manual fast unavailable"),
             ),
             patch("routes._start_video_export_stream", return_value="job-stream"),
         ):
@@ -203,11 +206,11 @@ class TestGenerateVideoEndpoint:
         sample_flight.gpx_file_path = "db/gpx/sample.gpx"
         db_session.commit()
 
-        with patch("routes.start_video_export_manual", return_value="job-manual"):
+        with patch("routes.start_video_export_manual_fast", return_value="job-manual-fast"):
             response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
 
         assert response.status_code == 200
-        assert response.json()["job_id"] == "job-manual"
+        assert response.json()["job_id"] == "job-manual-fast"
 
     def test_generate_video_allows_missing_in_progress_job(
         self, client: TestClient, db_session, sample_flight
@@ -220,12 +223,12 @@ class TestGenerateVideoEndpoint:
 
         with (
             patch("routes._resolve_export_status", return_value=None),
-            patch("routes.start_video_export_manual", return_value="job-manual"),
+            patch("routes.start_video_export_manual_fast", return_value="job-manual-fast"),
         ):
             response = client.post(f"{API_PREFIX}/flights/flight-test-001/generate-video")
 
         assert response.status_code == 200
-        assert response.json()["job_id"] == "job-manual"
+        assert response.json()["job_id"] == "job-manual-fast"
 
 
 class TestExportStatusAndCancel:

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -335,6 +335,29 @@ def test_resume_video_export_waits_for_running_cancel_to_finish(test_db, tmp_pat
         video_export_manual._clear_job_cancel_requested(job_id)
 
 
+def test_trigger_auto_export_uses_manual_fast(db_session, sample_flight, monkeypatch):
+    sample_flight.gpx_file_path = "db/gpx/sample.gpx"
+    db_session.commit()
+
+    def fail_manual_export(**_kwargs):
+        raise AssertionError("classic manual export should not be used")
+
+    monkeypatch.setattr(video_export_manual, "start_video_export_manual", fail_manual_export)
+    monkeypatch.setattr(
+        video_export_manual,
+        "start_video_export_manual_fast",
+        lambda **_kwargs: "job-manual-fast",
+    )
+
+    job_id = video_export_manual.trigger_auto_export(
+        sample_flight.id,
+        db_session,
+        frontend_url="http://frontend.test",
+    )
+
+    assert job_id == "job-manual-fast"
+
+
 def test_cleanup_temp_dir_removes_nested_files(tmp_path):
     temp_dir = tmp_path / "temp-images" / "job-123"
     frames_dir = temp_dir / "frames"

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -1559,9 +1559,9 @@ def trigger_auto_export(
         )
         return None
 
-    print(f"🚀 Auto-triggering video export for flight {flight_id}")
+    print(f"🚀 Auto-triggering fast video export for flight {flight_id}")
     try:
-        job_id = start_video_export_manual(
+        job_id = start_video_export_manual_fast(
             flight_id=flight_id,
             quality="1080p",
             fps=15,
@@ -1569,10 +1569,10 @@ def trigger_auto_export(
             frontend_url=frontend_url,
             update_db=True,
         )
-        print(f"✅ Manual auto export job {job_id} started for flight {flight_id}")
+        print(f"✅ Manual fast auto export job {job_id} started for flight {flight_id}")
         return job_id
     except Exception as e:
-        print(f"⚠️ Manual auto-export failed for flight {flight_id}, fallback stream: {e}")
+        print(f"⚠️ Manual fast auto-export failed for flight {flight_id}, fallback stream: {e}")
         from video_export import start_video_export_background
 
         job_id = start_video_export_background(


### PR DESCRIPTION
## Summary
- Default flight video generation and auto-export to the faster deterministic manual-fast path.
- Keep the existing stream fallback when fast manual startup fails.
- Update backend tests to cover the new default path.

## Validation
- NX_DAEMON=false NX_NO_CLOUD=true PATH=/media/usb/data-m2/developement/dashboard-parapente/.venv/bin:$PATH /home/capic/.local/share/pnpm/pnpm nx lint backend
- NX_DAEMON=false NX_NO_CLOUD=true PATH=/media/usb/data-m2/developement/dashboard-parapente/.venv/bin:$PATH /home/capic/.local/share/pnpm/pnpm nx test backend
- TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/api/test_video_export_endpoints.py tests/unit/test_video_export_manual.py -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml