### PR TITLE
fix: resolve GoPro overlay flight data directories

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -229,7 +229,7 @@ def _gopro_overlay_flight_directory(db: Session, flight: Flight) -> Path:
         )
     date_dir = flight.flight_date.strftime("%Y%m%d")
     sequence = flight_sequence_number(db, flight)
-    directory = Path(root).expanduser().resolve() / "parapente" / date_dir / f"{sequence:02d}"
+    directory = Path(root).expanduser().resolve() / date_dir / f"{sequence:02d}"
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -215,7 +215,7 @@ def test_create_flight_gopro_overlay_job_uses_auto_flight_directory_files(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "01"
+    input_dir = paragliding_root / "20260315" / "01"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     first_gpx_path = input_dir / "Zepp-a.gpx"
@@ -270,7 +270,7 @@ def test_create_flight_gopro_overlay_job_requires_auto_zepp_gpx(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "01"
+    input_dir = paragliding_root / "20260315" / "01"
     input_dir.mkdir(parents=True)
     (input_dir / "camera.mp4").write_bytes(b"camera")
     (input_dir / "flight-pip.mp4").write_bytes(b"pip")
@@ -304,7 +304,7 @@ def test_create_flight_gopro_overlay_job_uses_daily_departure_index(
     db_session.add(earlier)
     db_session.commit()
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "02"
+    input_dir = paragliding_root / "20260315" / "02"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     gpx_path = input_dir / "Zepp-track.gpx"
@@ -349,7 +349,7 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     monkeypatch,
 ):
     paragliding_root = tmp_path / "gopro-root"
-    input_dir = paragliding_root / "parapente" / "20260315" / "01"
+    input_dir = paragliding_root / "20260315" / "01"
     input_dir.mkdir(parents=True)
     camera_path = input_dir / "camera.mp4"
     gpx_path = input_dir / "Zepp-track.gpx"


### PR DESCRIPTION
## Summary
- Resolve automatic GoPro overlay flight directories directly under the configured data root.
- Match the NAS layout that uses zero-padded daily flight folders such as `20260508/01`.

## Validation
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/ruff check . --output-format=github`
- `PYTHONPATH=. /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`