### PR TITLE
fix(ci): harden production deploy labeling

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: deploy-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -499,50 +499,6 @@ jobs:
           echo "Failed to verify deployed version $EXPECTED_VERSION via $VERSION_ENDPOINT_URL"
           exit 1
 
-      - name: Mark deployment as successful
-        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
-        uses: actions/github-script@v9
-        env:
-          TAG_NAME: ${{ steps.version.outputs.success_tag_name }}
-          TARGET_SHA: ${{ github.sha }}
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const tagName = process.env.TAG_NAME;
-            const targetSha = process.env.TARGET_SHA;
-
-            try {
-              await github.request('POST /repos/{owner}/{repo}/git/refs', {
-                owner,
-                repo,
-                ref: `refs/tags/${tagName}`,
-                sha: targetSha,
-              });
-              core.info(`Created success tag ${tagName} on ${targetSha}`);
-            } catch (error) {
-              if (error.status === 422) {
-                const existingRef = await github.request(
-                  'GET /repos/{owner}/{repo}/git/ref/{ref}',
-                  {
-                    owner,
-                    repo,
-                    ref: `tags/${tagName}`,
-                  }
-                );
-
-                if (existingRef.data.object.sha !== targetSha) {
-                  throw new Error(
-                    `Tag ${tagName} already exists on ${existingRef.data.object.sha}, expected ${targetSha}`
-                  );
-                }
-
-                core.info(`Success tag ${tagName} already exists on ${targetSha}, skipping creation`);
-              } else {
-                throw error;
-              }
-            }
-
       - name: Cleanup unused Docker images
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
         continue-on-error: true
@@ -564,6 +520,7 @@ jobs:
             fi
 
       - name: Label merged PRs with deployed version
+        id: label_deployed_prs
         if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success'
         uses: actions/github-script@v9
         env:
@@ -582,6 +539,8 @@ jobs:
             const currentSha = process.env.CURRENT_SHA;
             const currentPrNumber = process.env.CURRENT_PR_NUMBER;
             const prNumbers = new Set();
+
+            core.info(`Deployment label range: ${previousDeploySha || '<none>'}...${currentSha}`);
 
             if (currentPrNumber) {
               prNumbers.add(Number(currentPrNumber));
@@ -662,7 +621,11 @@ jobs:
             }
 
             if (prNumbers.size === 0) {
-              core.info('No merged pull requests found to label for this deployment');
+              if (previousDeploySha && previousDeploySha !== currentSha) {
+                core.warning('No merged pull requests found to label despite a non-empty deployment range');
+              } else {
+                core.info('No merged pull requests found to label for this deployment');
+              }
               return;
             }
 
@@ -693,6 +656,50 @@ jobs:
                 .sort((a, b) => a - b)
                 .join(', ')}`
             );
+
+      - name: Mark deployment as successful
+        if: steps.trigger_deploy.conclusion == 'success' && steps.verify_deploy.outcome == 'success' && steps.label_deployed_prs.outcome == 'success'
+        uses: actions/github-script@v9
+        env:
+          TAG_NAME: ${{ steps.version.outputs.success_tag_name }}
+          TARGET_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tagName = process.env.TAG_NAME;
+            const targetSha = process.env.TARGET_SHA;
+
+            try {
+              await github.request('POST /repos/{owner}/{repo}/git/refs', {
+                owner,
+                repo,
+                ref: `refs/tags/${tagName}`,
+                sha: targetSha,
+              });
+              core.info(`Created success tag ${tagName} on ${targetSha}`);
+            } catch (error) {
+              if (error.status === 422) {
+                const existingRef = await github.request(
+                  'GET /repos/{owner}/{repo}/git/ref/{ref}',
+                  {
+                    owner,
+                    repo,
+                    ref: `tags/${tagName}`,
+                  }
+                );
+
+                if (existingRef.data.object.sha !== targetSha) {
+                  throw new Error(
+                    `Tag ${tagName} already exists on ${existingRef.data.object.sha}, expected ${targetSha}`
+                  );
+                }
+
+                core.info(`Success tag ${tagName} already exists on ${targetSha}, skipping creation`);
+              } else {
+                throw error;
+              }
+            }
 
       - name: Label current PR as non deployed when deployment fails
         if: (steps.trigger_deploy.conclusion != 'success' || steps.verify_deploy.outcome != 'success') && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- prevent overlapping prod deploys from canceling in-progress runs
- create the deploy-success tag only after PR labels are applied
- add deploy-range logging and a warning when no PRs are found

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-portainer.yml', encoding='utf-8'))"`
- `git diff --check`