### PR TITLE
feat(infrastructure): surface GoPro overlay jobs

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -542,6 +542,13 @@ def get_gopro_overlay_job(job_id: str, include_command: bool = False) -> dict[st
     return payload
 
 
+def list_gopro_overlay_jobs() -> list[dict[str, Any]]:
+    with _LOCK:
+        return [
+            {key: value for key, value in job.items() if key != "command"} for job in _JOBS.values()
+        ]
+
+
 def cancel_gopro_overlay_job(job_id: str) -> bool:
     with _LOCK:
         process = _PROCESSES.get(job_id)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -41,6 +41,7 @@ from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
 from gopro_overlay_export import get_gopro_overlay_job
 from gopro_overlay_export import gopro_overlay_output_path
+from gopro_overlay_export import list_gopro_overlay_jobs
 from gopro_overlay_export import list_gopro_overlay_layouts
 from gopro_overlay_export import probe_video_resolution
 from gopro_overlay_export import save_uploaded_file
@@ -305,6 +306,9 @@ def _video_export_public_status(export: dict[str, Any]) -> str:
 
 
 def _video_export_can_cancel(export: dict[str, Any]) -> bool:
+    if export.get("mode") == "gopro_overlay":
+        return export.get("status") in {"queued", "running"} and bool(export.get("job_id"))
+
     internal_status = export.get("internal_status")
     if isinstance(internal_status, str):
         return internal_status in _VIDEO_EXPORT_CANCELLABLE_STATUSES
@@ -314,6 +318,25 @@ def _video_export_can_cancel(export: dict[str, Any]) -> bool:
         "processing",
         *_VIDEO_EXPORT_CANCELLABLE_STATUSES,
     } and bool(export.get("job_id"))
+
+
+def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "job_id": job.get("job_id"),
+        "status": job.get("status"),
+        "internal_status": job.get("status"),
+        "progress": job.get("progress"),
+        "message": job.get("message"),
+        "error": job.get("error"),
+        "mode": "gopro_overlay",
+        "flight_title": job.get("output_filename") or job.get("layout_label"),
+        "flight_name": job.get("layout_label"),
+        "created_at": job.get("created_at"),
+        "updated_at": job.get("updated_at"),
+        "completed_at": job.get("completed_at"),
+        "output_filename": job.get("output_filename"),
+        "layout_label": job.get("layout_label"),
+    }
 
 
 def _build_video_export_jobs_payload(
@@ -4465,7 +4488,9 @@ def list_video_export_jobs(
 ):
     """List video export jobs across all flights."""
     jobs = _build_video_export_jobs_payload(
-        list_exports_manual() + list_exports_stream(),
+        list_exports_manual()
+        + list_exports_stream()
+        + [_gopro_overlay_export_job_payload(job) for job in list_gopro_overlay_jobs()],
         db,
     )
     if active_only:
@@ -4551,6 +4576,8 @@ def cancel_video_export(job_id: str):
     success = cancel_video_export_manual(job_id)
     if not success:
         success = cancel_video_export_stream(job_id)
+    if not success:
+        success = cancel_gopro_overlay_job(job_id)
 
     if not success:
         raise HTTPException(

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -256,6 +256,7 @@ class TestExportStatusAndCancel:
         with (
             patch("routes.cancel_video_export_manual", return_value=False),
             patch("routes.cancel_video_export_stream", return_value=False),
+            patch("routes.cancel_gopro_overlay_job", return_value=False),
         ):
             response = client.delete(f"{API_PREFIX}/exports/job-abc/cancel")
 
@@ -267,12 +268,27 @@ class TestExportStatusAndCancel:
         with (
             patch("routes.cancel_video_export_manual", return_value=False),
             patch("routes.cancel_video_export_stream", return_value=True) as mock_stream,
+            patch("routes.cancel_gopro_overlay_job", return_value=False) as mock_overlay,
         ):
             response = client.delete(f"{API_PREFIX}/exports/job-stream/cancel")
 
         assert response.status_code == 200
         assert response.json()["job_id"] == "job-stream"
         mock_stream.assert_called_once_with("job-stream")
+        mock_overlay.assert_not_called()
+
+    def test_export_cancel_falls_back_to_gopro_overlay_cancel(self, client: TestClient):
+        """Cancel endpoint should stop overlay jobs when no video export matches."""
+        with (
+            patch("routes.cancel_video_export_manual", return_value=False),
+            patch("routes.cancel_video_export_stream", return_value=False),
+            patch("routes.cancel_gopro_overlay_job", return_value=True) as mock_overlay,
+        ):
+            response = client.delete(f"{API_PREFIX}/exports/job-overlay/cancel")
+
+        assert response.status_code == 200
+        assert response.json()["job_id"] == "job-overlay"
+        mock_overlay.assert_called_once_with("job-overlay")
 
     def test_export_resume_requeues_resumable_manual_job(self, client: TestClient):
         """Resume endpoint should pass auth token through to manual exporter."""
@@ -396,18 +412,36 @@ class TestVideoExportJobsEndpoint:
         with (
             patch("routes.list_exports_manual", return_value=manual_jobs),
             patch("routes.list_exports_stream", return_value=[]),
+            patch(
+                "routes.list_gopro_overlay_jobs",
+                return_value=[
+                    {
+                        "job_id": "job-overlay",
+                        "status": "running",
+                        "progress": 50,
+                        "message": "Rendering overlay",
+                        "layout_label": "Parapente 1920x1080",
+                        "output_filename": "flight-overlay.mp4",
+                        "updated_at": "2026-04-30T11:00:00",
+                    }
+                ],
+            ),
         ):
             response = client.get(f"{API_PREFIX}/video-export-jobs")
 
         assert response.status_code == 200
         jobs = response.json()["jobs"]
-        assert jobs[0]["job_id"] == "job-running"
-        assert jobs[0]["status"] == "processing"
+        assert jobs[0]["job_id"] == "job-overlay"
+        assert jobs[0]["status"] == "running"
+        assert jobs[0]["mode"] == "gopro_overlay"
         assert jobs[0]["can_cancel"] is True
-        assert jobs[0]["flight_name"] == sample_flight.name
-        assert jobs[1]["job_id"] == "job-cancelled"
-        assert jobs[1]["status"] == "cancelled"
-        assert jobs[1]["can_cancel"] is False
+        assert jobs[1]["job_id"] == "job-running"
+        assert jobs[1]["status"] == "processing"
+        assert jobs[1]["can_cancel"] is True
+        assert jobs[1]["flight_name"] == sample_flight.name
+        assert jobs[2]["job_id"] == "job-cancelled"
+        assert jobs[2]["status"] == "cancelled"
+        assert jobs[2]["can_cancel"] is False
 
     def test_video_export_jobs_can_filter_active_jobs(self, client: TestClient):
         with (
@@ -438,12 +472,31 @@ class TestVideoExportJobsEndpoint:
                     }
                 ],
             ),
+            patch(
+                "routes.list_gopro_overlay_jobs",
+                return_value=[
+                    {
+                        "job_id": "job-overlay-running",
+                        "status": "running",
+                        "progress": 50,
+                    },
+                    {
+                        "job_id": "job-overlay-complete",
+                        "status": "completed",
+                        "progress": 100,
+                    },
+                ],
+            ),
         ):
             response = client.get(f"{API_PREFIX}/video-export-jobs?active_only=true")
 
         assert response.status_code == 200
         jobs = response.json()["jobs"]
-        assert {job["job_id"] for job in jobs} == {"job-queued", "job-stream-encoding"}
+        assert {job["job_id"] for job in jobs} == {
+            "job-queued",
+            "job-stream-encoding",
+            "job-overlay-running",
+        }
         assert all(job["can_cancel"] is True for job in jobs)
 
     def test_video_export_jobs_temp_files_endpoint_cleans_known_exports(self, client: TestClient):

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -31,6 +31,16 @@ const { cancelJob, cleanupTempFiles, toastError, toastSuccess, refetch, jobs } =
         progress: 100,
         can_cancel: false,
       },
+      {
+        job_id: 'job-overlay',
+        flight_title: 'vol-overlay.mp4',
+        status: 'running',
+        internal_status: 'running',
+        progress: 50,
+        message: 'Rendering overlay',
+        mode: 'gopro_overlay',
+        can_cancel: true,
+      },
     ],
   }));
 
@@ -91,6 +101,16 @@ describe('VideoExportJobsPanel', () => {
         internal_status: 'completed',
         progress: 100,
         can_cancel: false,
+      },
+      {
+        job_id: 'job-overlay',
+        flight_title: 'vol-overlay.mp4',
+        status: 'running',
+        internal_status: 'running',
+        progress: 50,
+        message: 'Rendering overlay',
+        mode: 'gopro_overlay',
+        can_cancel: true,
       }
     );
   });
@@ -101,15 +121,17 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getByText('Générations vidéo')).toBeInTheDocument();
     expect(screen.getByText('Vol test')).toBeInTheDocument();
     expect(screen.getByText('Vol terminé')).toBeInTheDocument();
+    expect(screen.getByText('vol-overlay.mp4')).toBeInTheDocument();
+    expect(screen.getByText('Overlay GoPro')).toBeInTheDocument();
     expect(screen.getByText('42%')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Stopper' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Stopper' })).toHaveLength(2);
   });
 
   it('cancels a running job after confirmation', async () => {
     cancelJob.mockResolvedValue(undefined);
 
     render(<VideoExportJobsPanel />);
-    fireEvent.click(screen.getByRole('button', { name: 'Stopper' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Stopper' })[0]!);
     const stopButtons = screen.getAllByRole('button', { name: 'Stopper' });
     fireEvent.click(stopButtons[stopButtons.length - 1]!);
 

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -48,6 +48,13 @@ function getStatusLabelParts(job: VideoExportJob) {
   return { key: `videoJobs.status.${status}`, fallback };
 }
 
+function getModeLabelParts(mode: string) {
+  if (mode === 'gopro_overlay') {
+    return { key: 'videoJobs.mode.goproOverlay', fallback: 'Overlay GoPro' };
+  }
+  return { key: `videoJobs.mode.${mode}`, fallback: mode };
+}
+
 function getProgress(job: VideoExportJob) {
   if (typeof job.progress !== 'number' || !Number.isFinite(job.progress)) {
     return 0;
@@ -169,7 +176,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
           <Button
             onClick={handleCleanupTempFiles}
             isDisabled={cleanupTempFiles.isPending}
-            className="rounded-lg bg-amber-100 px-3 py-2 text-sm font-medium text-amber-800 hover:bg-amber-200 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 dark:bg-amber-900/40 dark:text-amber-200 dark:hover:bg-amber-900/60 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+            className="cursor-pointer rounded-lg bg-amber-100 px-3 py-2 text-sm font-medium text-amber-800 transition-colors hover:bg-amber-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 dark:bg-amber-900/40 dark:text-amber-200 dark:hover:bg-amber-900/60 dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
           >
             {cleanupTempFiles.isPending
               ? t('videoJobs.cleaningTempFiles', 'Nettoyage...')
@@ -177,7 +184,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
           </Button>
           <Button
             onClick={() => refetch()}
-            className="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+            className="cursor-pointer rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
           >
             {t('common.retry', 'Rafraîchir')}
           </Button>
@@ -221,6 +228,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
               statusClassNames[job.status] ||
               statusClassNames[phase] ||
               statusClassNames.processing;
+            const modeLabel = job.mode ? getModeLabelParts(job.mode) : null;
 
             return (
               <article key={job.job_id} className="p-4">
@@ -232,9 +240,9 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                       >
                         {t(statusLabel.key, statusLabel.fallback)}
                       </span>
-                      {job.mode && (
+                      {modeLabel && (
                         <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-200">
-                          {job.mode}
+                          {t(modeLabel.key, modeLabel.fallback)}
                         </span>
                       )}
                       {dateLabel && (
@@ -266,7 +274,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                     <Button
                       onClick={() => handleCancel(job)}
                       isDisabled={cancelJob.isPending}
-                      className="rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-gray-300"
+                      className="cursor-pointer rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:bg-gray-300"
                     >
                       {cancelJob.isPending
                         ? t('videoJobs.stopping', 'Arrêt...')

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -25,6 +25,8 @@ export type VideoExportJob = {
   can_resume?: boolean;
   frames_captured?: number | null;
   resume_from_frame?: number | null;
+  output_filename?: string | null;
+  layout_label?: string | null;
   can_cancel: boolean;
 };
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -84,6 +84,9 @@
     "cleanupError": "Unable to delete temporary files",
     "loadError": "Unable to load video generations",
     "empty": "No video generation yet.",
+    "mode": {
+      "goproOverlay": "GoPro overlay"
+    },
     "status": {
       "queued": "Queued",
       "running": "Starting",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -84,6 +84,9 @@
     "cleanupError": "Impossible de supprimer les fichiers temporaires",
     "loadError": "Impossible de charger les générations vidéo",
     "empty": "Aucune génération vidéo pour le moment.",
+    "mode": {
+      "goproOverlay": "Overlay GoPro"
+    },
     "status": {
       "queued": "En attente",
       "running": "Démarrage",


### PR DESCRIPTION
## Summary
- Surface GoPro overlay jobs in Infrastructure > Video exports alongside the existing export jobs.
- Add backend cancellation/listing support plus frontend labels, tests, and translations.
- Keep the panel accessible with clearer hover and focus states.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- src/components/flights/VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header`