### PR TITLE
feat(gopro-overlay): show live render progress

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1,12 +1,13 @@
 import asyncio
 import json
 import os
+import re
 import shutil
 import subprocess
 import threading
 import uuid
 import xml.etree.ElementTree as ET
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,6 +28,7 @@ _VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
 _GPX_EXTENSIONS = {".gpx", ".fit"}
 _UPLOAD_WORK_ROOT = Path("/tmp/dashboard-parapente/gopro-overlays")
 _PATH_WORK_DIR_NAME = ".gopro-overlay-work"
+_PROGRESS_PERCENT_RE = re.compile(r"(?P<percent>\d{1,3})\s*%")
 
 
 @dataclass(frozen=True)
@@ -154,6 +156,27 @@ def _update_job(job_id: str, **changes: Any) -> dict[str, Any]:
         job.update(changes)
         job["updated_at"] = _utc_now()
         return job.copy()
+
+
+def _progress_from_output_chunk(chunk: str) -> int | None:
+    matches = list(_PROGRESS_PERCENT_RE.finditer(chunk))
+    if not matches:
+        return None
+    percent = int(matches[-1].group("percent"))
+    return max(5, min(percent, 99))
+
+
+def _read_process_updates(stream: Any) -> Iterator[str]:
+    current = ""
+    while char := stream.read(1):
+        if char in {"\n", "\r"}:
+            if current.strip():
+                yield current.strip()
+            current = ""
+            continue
+        current += char
+    if current.strip():
+        yield current.strip()
 
 
 def _transition_job_to_running(job_id: str, command: list[str]) -> dict[str, Any] | None:
@@ -484,11 +507,17 @@ def _run_job(job_id: str) -> None:
     output_lines: list[str] = []
     try:
         if process.stdout:
-            for line in process.stdout:
-                output_lines.append(line.rstrip())
+            for line in _read_process_updates(process.stdout):
+                output_lines.append(line)
                 if len(output_lines) > 50:
                     output_lines = output_lines[-50:]
-                _update_job(job_id, progress=50, message=line.strip() or "Rendering overlay")
+                progress = _progress_from_output_chunk(line)
+                if progress is None:
+                    _update_job(job_id, message=line or "Rendering overlay")
+                else:
+                    _update_job(
+                        job_id, progress=progress, message=f"Rendering overlay: {progress}%"
+                    )
 
         return_code = process.wait()
         with _LOCK:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -13,6 +13,8 @@ import config
 import gopro_overlay_export
 import routes
 from gopro_overlay_export import _prepare_layout_file
+from gopro_overlay_export import _progress_from_output_chunk
+from gopro_overlay_export import _read_process_updates
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
@@ -617,6 +619,34 @@ def test_prepare_layout_file_removes_pip_without_video(tmp_path):
     _prepare_layout_file(source, destination, has_pip=False)
 
     assert 'type="video"' not in destination.read_text()
+
+
+def test_gopro_overlay_progress_is_parsed_from_render_output():
+    assert _progress_from_output_chunk("Render: 42 [42%] [1.2/s] ETA: 00:10") == 42
+
+
+def test_gopro_overlay_progress_is_clamped_until_output_is_ready():
+    assert _progress_from_output_chunk("Render: 100 [100%]") == 99
+
+
+def test_gopro_overlay_process_updates_split_carriage_returns():
+    class Stream:
+        def __init__(self, value: str):
+            self.value = value
+            self.index = 0
+
+        def read(self, size: int) -> str:
+            if self.index >= len(self.value):
+                return ""
+            chunk = self.value[self.index : self.index + size]
+            self.index += size
+            return chunk
+
+    assert list(_read_process_updates(Stream("Render: 1%\rRender: 2%\nDone"))) == [
+        "Render: 1%",
+        "Render: 2%",
+        "Done",
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -59,6 +59,18 @@ const labelClass = 'text-xs text-gray-600 dark:text-gray-300';
 const valueClass =
   'block text-sm font-medium text-gray-900 dark:text-white mt-1';
 
+function clampProgress(progress: number) {
+  return Math.max(0, Math.min(Math.round(progress), 100));
+}
+
+function goproOverlayProgressClass(status: string) {
+  if (status === 'completed') return 'accent-emerald-500';
+  if (status === 'failed') return 'accent-red-500';
+  if (status === 'cancelled') return 'accent-slate-500';
+  if (status === 'queued') return 'accent-amber-500';
+  return 'accent-cyan-500';
+}
+
 export function FlightDetails({
   flight,
   sites,
@@ -106,6 +118,7 @@ export function FlightDetails({
   const isGoproOverlayRunning =
     goproOverlayJob?.status === 'queued' ||
     goproOverlayJob?.status === 'running';
+  const goproOverlayProgress = clampProgress(goproOverlayJob?.progress ?? 0);
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
     normalizedTitle ||
@@ -603,8 +616,8 @@ export function FlightDetails({
           />
 
           {goproOverlayJob && (
-            <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
-              <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
+              <div className="mb-3 flex items-start justify-between gap-3">
                 <div>
                   <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
                     {t('flights.goproOverlayJobTitle')}
@@ -618,20 +631,20 @@ export function FlightDetails({
                   {t(`flights.goproOverlayStatus.${goproOverlayJob.status}`)}
                 </span>
               </div>
-              <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
-                <div
-                  className="h-full rounded-full bg-cyan-500 transition-all duration-300"
-                  style={{
-                    width: `${Math.max(
-                      0,
-                      Math.min(goproOverlayJob.progress, 100)
-                    )}%`,
-                  }}
-                />
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
+                  {goproOverlayJob.message}
+                </span>
+                <span className="font-mono text-sm font-bold text-slate-950 dark:text-white">
+                  {goproOverlayProgress}%
+                </span>
               </div>
-              <p className="mt-2 text-xs text-slate-700 dark:text-slate-200">
-                {goproOverlayJob.message}
-              </p>
+              <progress
+                className={`h-2.5 w-full overflow-hidden rounded-full bg-slate-200 ring-1 ring-slate-300 transition-[accent-color] duration-300 motion-reduce:transition-none dark:bg-slate-800 dark:ring-slate-700 ${goproOverlayProgressClass(goproOverlayJob.status)}`}
+                value={goproOverlayProgress}
+                max={100}
+                aria-label={t('flights.goproOverlayJobTitle')}
+              />
               {goproOverlayJob.error && (
                 <pre className="mt-2 max-h-36 overflow-auto rounded bg-red-950 p-2 text-xs text-red-50">
                   {goproOverlayJob.error}

--- a/apps/frontend/src/pages/GoproOverlay.tsx
+++ b/apps/frontend/src/pages/GoproOverlay.tsx
@@ -3,6 +3,7 @@ import { Button } from '@dashboard-parapente/design-system';
 import { api } from '../lib/api';
 import { useToast } from '../hooks/useToast';
 import {
+  type GoproOverlayJob,
   useCancelGoproOverlayJob,
   useCreateGoproOverlayJob,
   useGoproOverlayJobStream,
@@ -20,6 +21,39 @@ const labelClass =
   'mb-1 block text-sm font-semibold text-slate-700 dark:text-slate-200';
 const inputClass =
   'w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100';
+
+const statusLabel: Record<GoproOverlayJob['status'], string> = {
+  queued: 'En file',
+  running: 'En cours',
+  completed: 'Terminé',
+  failed: 'Échec',
+  cancelled: 'Annulé',
+};
+
+const statusTone: Record<GoproOverlayJob['status'], string> = {
+  queued:
+    'border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200',
+  running:
+    'border-sky-200 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200',
+  completed:
+    'border-emerald-200 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-200',
+  failed:
+    'border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200',
+  cancelled:
+    'border-slate-200 bg-slate-50 text-slate-800 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200',
+};
+
+const progressTone: Record<GoproOverlayJob['status'], string> = {
+  queued: 'accent-amber-500',
+  running: 'accent-sky-500',
+  completed: 'accent-emerald-500',
+  failed: 'accent-red-500',
+  cancelled: 'accent-slate-500',
+};
+
+function clampProgress(progress: number) {
+  return Math.max(0, Math.min(Math.round(progress), 100));
+}
 
 function detectVideoResolution(file: File): Promise<VideoResolution> {
   return new Promise((resolve, reject) => {
@@ -77,7 +111,7 @@ export default function GoproOverlayPage() {
 
     try {
       setResolution(await detectVideoResolution(file));
-      const basename = file.name.replace(/\.[^.]+$/, '');
+      const basename = file.name.replace(/\.[^.]+$/u, '');
       setOutputFilename(`${basename}-overlay.mp4`);
     } catch {
       toast.error('Impossible de lire la résolution de la vidéo');
@@ -249,7 +283,7 @@ export default function GoproOverlayPage() {
           <Button
             type="submit"
             isDisabled={createJob.isPending || isRunning}
-            className="rounded-lg bg-sky-600 px-5 py-2 text-white hover:bg-sky-700 disabled:bg-slate-400"
+            className="cursor-pointer rounded-lg bg-sky-600 px-5 py-2 text-white transition-colors hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-400 dark:focus:ring-offset-slate-900"
           >
             {createJob.isPending || isRunning
               ? 'Génération en cours'
@@ -260,7 +294,7 @@ export default function GoproOverlayPage() {
               type="button"
               onClick={handleCancel}
               isDisabled={cancelJob.isPending}
-              className="rounded-lg bg-red-600 px-5 py-2 text-white hover:bg-red-700 disabled:bg-slate-400"
+              className="cursor-pointer rounded-lg bg-red-600 px-5 py-2 text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-400 dark:focus:ring-offset-slate-900"
             >
               Annuler
             </Button>
@@ -269,7 +303,7 @@ export default function GoproOverlayPage() {
             <Button
               type="button"
               onClick={handleDownload}
-              className="rounded-lg bg-emerald-600 px-5 py-2 text-white hover:bg-emerald-700"
+              className="cursor-pointer rounded-lg bg-emerald-600 px-5 py-2 text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
             >
               Télécharger
             </Button>
@@ -278,8 +312,8 @@ export default function GoproOverlayPage() {
       </form>
 
       {activeJob && (
-        <section className={cardClass}>
-          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <section className={`${cardClass} overflow-hidden`}>
+          <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
             <div>
               <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100">
                 Job {activeJob.job_id.slice(0, 8)}
@@ -288,21 +322,31 @@ export default function GoproOverlayPage() {
                 {activeJob.layout_label} · {activeJob.output_filename}
               </p>
             </div>
-            <span className="rounded-full bg-slate-100 px-3 py-1 text-sm font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-              {activeJob.status}
+            <span
+              className={`rounded-full border px-3 py-1 text-sm font-semibold ${statusTone[activeJob.status]}`}
+            >
+              {statusLabel[activeJob.status]}
             </span>
           </div>
-          <div className="h-3 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
-            <div
-              className="h-full rounded-full bg-sky-500 transition-all duration-500"
-              style={{
-                width: `${Math.max(0, Math.min(activeJob.progress, 100))}%`,
-              }}
-            />
+          <div className="mb-3 flex items-end justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Avancement
+              </p>
+              <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">
+                {activeJob.message}
+              </p>
+            </div>
+            <strong className="font-mono text-3xl leading-none text-slate-950 dark:text-white">
+              {clampProgress(activeJob.progress)}%
+            </strong>
           </div>
-          <p className="mt-3 text-sm text-slate-700 dark:text-slate-200">
-            {activeJob.message}
-          </p>
+          <progress
+            className={`h-4 w-full overflow-hidden rounded-full bg-slate-100 ring-1 ring-slate-200 transition-[accent-color] duration-300 motion-reduce:transition-none dark:bg-slate-800 dark:ring-slate-700 ${progressTone[activeJob.status]}`}
+            value={clampProgress(activeJob.progress)}
+            max={100}
+            aria-label="Avancement de la génération overlay GoPro"
+          />
           {activeJob.error && (
             <pre className="mt-3 max-h-56 overflow-auto rounded-lg bg-red-950 p-3 text-xs text-red-50">
               {activeJob.error}


### PR DESCRIPTION
## Summary
- Show live GoPro overlay render progress in the frontend UI
- Stream backend progress updates and surface job state in the flight details card
- Add backend coverage for progress parsing and streaming updates

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`