### PR TITLE
fix: wait for terrain before video capture

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -4,6 +4,8 @@ import os
 import time
 from datetime import datetime
 
+import pytest
+
 from models import VideoExportJob
 
 import video_export
@@ -147,6 +149,46 @@ def test_ffmpeg_timeout_is_not_limited_to_thirty_minutes():
 def test_ffmpeg_timeout_scales_for_long_videos():
     duration_seconds = 7 * 60 * 60
     assert video_export_manual._ffmpeg_timeout_seconds(duration_seconds) == duration_seconds * 20
+
+
+class _FakeTerrainPage:
+    def __init__(self, tile_states: list[bool]):
+        self.tile_states = tile_states
+        self.evaluate_calls = 0
+
+    async def evaluate(self, _script: str) -> bool:
+        self.evaluate_calls += 1
+        if self.tile_states:
+            return self.tile_states.pop(0)
+        return False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_export_frame_terrain_waits_until_tiles_loaded():
+    page = _FakeTerrainPage([False, False, True])
+
+    tiles_loaded = await video_export_manual._wait_for_export_frame_terrain(
+        page,
+        timeout_seconds=1,
+        poll_seconds=0,
+    )
+
+    assert tiles_loaded is True
+    assert page.evaluate_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_wait_for_export_frame_terrain_returns_false_after_timeout():
+    page = _FakeTerrainPage([False, False, False])
+
+    tiles_loaded = await video_export_manual._wait_for_export_frame_terrain(
+        page,
+        timeout_seconds=0,
+        poll_seconds=0,
+    )
+
+    assert tiles_loaded is False
+    assert page.evaluate_calls == 1
 
 
 def test_ffmpeg_output_file_activity_tracks_size_and_mtime(tmp_path):

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -1193,6 +1193,7 @@ async def _export_video_manual_render(job_id: str):
                 )
                 print(f"▶️  Resuming capture from frame {resume_from_frame}/{total_frames}")
 
+            terrain_wait_enabled = True
             for i in range(resume_from_frame, total_frames):
                 if i % _CANCEL_CHECK_INTERVAL == 0 and _is_cancelled(job_id):
                     print("🛑 Export cancelled by user")
@@ -1217,10 +1218,12 @@ async def _export_video_manual_render(job_id: str):
                 else:
                     tiles_loaded = False
 
-                if not tiles_loaded:
+                if not tiles_loaded and terrain_wait_enabled:
                     tiles_loaded = await _wait_for_export_frame_terrain(page)
                     if not tiles_loaded:
                         print(f"⚠️  Terrain still loading for frame {i} after timeout")
+                        terrain_wait_enabled = False
+                        print("⚠️  Disabling per-frame terrain waits after timeout")
 
                 frame_path = frames_dir / f"frame{i:05d}.png"
                 await page.screenshot(path=str(frame_path), timeout=60000)

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -69,6 +69,8 @@ _JOB_CANCEL_REQUESTS: set[str] = set()
 _CANCEL_CHECK_INTERVAL = 10
 _FFMPEG_STALL_TIMEOUT_SECONDS = 10 * 60
 _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS = 30
+_EXPORT_FRAME_TERRAIN_TIMEOUT_SECONDS = 10.0
+_EXPORT_FRAME_TERRAIN_POLL_SECONDS = 0.1
 
 
 def check_dependencies():
@@ -691,6 +693,45 @@ def _ffmpeg_timeout_seconds(video_duration_seconds: float) -> int:
     return max(6 * 60 * 60, dynamic_timeout)
 
 
+async def _wait_for_export_frame_terrain(
+    page: Any,
+    timeout_seconds: float = _EXPORT_FRAME_TERRAIN_TIMEOUT_SECONDS,
+    poll_seconds: float = _EXPORT_FRAME_TERRAIN_POLL_SECONDS,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        tiles_loaded = await page.evaluate("""
+            () => {
+                const viewer = window._cesiumViewer;
+                const scene = viewer?.scene;
+                const globe = scene?.globe;
+
+                if (!viewer || !scene || !globe) {
+                    return false;
+                }
+
+                try {
+                    scene.requestRender?.();
+                    viewer.render?.();
+                } catch {
+                    return false;
+                }
+
+                return Boolean(globe.tilesLoaded);
+            }
+        """)
+
+        if tiles_loaded:
+            return True
+
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            return False
+
+        await asyncio.sleep(min(poll_seconds, remaining_seconds))
+
+
 def _ffmpeg_output_file_activity(
     output_file: Path, last_size: int, last_mtime_ns: int
 ) -> tuple[bool, int, int]:
@@ -1034,28 +1075,14 @@ async def _export_video_manual_render(job_id: str):
             print("✅ Cesium manual render mode configured")
 
             _update_job(job_id, message="Waiting for terrain")
-            try:
-                await asyncio.wait_for(
-                    page.evaluate("""
-                        () => {
-                            return new Promise((resolve) => {
-                                const viewer = window._cesiumViewer;
-                                const checkTerrain = () => {
-                                    if (viewer.scene.globe.tilesLoaded) {
-                                        console.log('✅ Terrain tiles loaded');
-                                        resolve(true);
-                                    } else {
-                                        setTimeout(checkTerrain, 500);
-                                    }
-                                };
-                                setTimeout(checkTerrain, 1000);
-                            });
-                        }
-                    """),
-                    timeout=60.0,
-                )
+            terrain_ready = await _wait_for_export_frame_terrain(
+                page,
+                timeout_seconds=60.0,
+                poll_seconds=0.5,
+            )
+            if terrain_ready:
                 print("✅ Initial terrain loaded")
-            except TimeoutError:
+            else:
                 print("⚠️  Terrain timeout - continuing anyway")
 
             await asyncio.sleep(2)
@@ -1188,17 +1215,12 @@ async def _export_video_manual_render(job_id: str):
                     )
                     tiles_loaded = bool(frame_state and frame_state.get("tilesLoaded"))
                 else:
-                    tiles_loaded = await page.evaluate("""
-                        () => {
-                            const viewer = window._cesiumViewer;
-                            viewer.scene.requestRender();
-                            viewer.render();
-                            return viewer.scene.globe.tilesLoaded;
-                        }
-                    """)
+                    tiles_loaded = False
 
                 if not tiles_loaded:
-                    await asyncio.sleep(0.1)
+                    tiles_loaded = await _wait_for_export_frame_terrain(page)
+                    if not tiles_loaded:
+                        print(f"⚠️  Terrain still loading for frame {i} after timeout")
 
                 frame_path = frames_dir / f"frame{i:05d}.png"
                 await page.screenshot(path=str(frame_path), timeout=60000)


### PR DESCRIPTION
## Summary
- Wait for Cesium terrain tiles before each export screenshot.
- Add unit coverage for terrain wait success and timeout paths.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py -q --tb=short --no-header`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced terrain loading reliability during manual video exports with improved retry logic and timeout handling for Cesium terrain tiles.

* **Tests**
  * Added test coverage for terrain-loading wait functionality to ensure consistent retry behavior and timeout handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->