### PR TITLE
Fix flights list page size

### DIFF
--- a/apps/frontend/src/components/flights/useFlightsTable.ts
+++ b/apps/frontend/src/components/flights/useFlightsTable.ts
@@ -83,7 +83,7 @@ export function useFlightsTable({
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     initialState: {
-      pagination: { pageIndex: 0, pageSize: 20 },
+      pagination: { pageIndex: 0, pageSize: 10 },
     },
   });
 


### PR DESCRIPTION
## Summary
- Show 10 flights per page in the flights list.
- Keep the change scoped to the frontend table pagination defaults.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` ⚠️ started but did not complete in time; it kept running after multiple minutes with existing unrelated test output.