### PR TITLE
fix(gopro-overlay): offload overlay setup to worker threads

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -330,7 +330,8 @@ async def create_gopro_overlay_job(
             _validate_file_extension(fallback_pip_path, _VIDEO_EXTENSIONS)
             pip_path = fallback_pip_path
 
-        return _create_gopro_overlay_job_from_paths(
+        return await asyncio.to_thread(
+            _create_gopro_overlay_job_from_paths,
             job_id=job_id,
             video_path=video_path,
             gpx_path=gpx_path,

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4727,7 +4727,8 @@ async def create_flight_gopro_overlay_job(
                     status_code=400,
                     detail="Generate the flight video before creating the GoPro overlay",
                 )
-            return create_gopro_overlay_job_from_paths(
+            return await asyncio.to_thread(
+                create_gopro_overlay_job_from_paths,
                 video_path=resolved_video_path,
                 gpx_path=fallback_gpx_path,
                 pip_path=fallback_pip_path,
@@ -4787,7 +4788,7 @@ async def probe_gopro_overlay_video(
     temp_path = Path("/tmp/dashboard-parapente/gopro-overlays/probe") / f"{uuid.uuid4()}.mp4"
     try:
         saved_path = await save_uploaded_file(video_file, temp_path, {".mp4", ".mov", ".m4v"})
-        width, height = probe_video_resolution(saved_path)
+        width, height = await asyncio.to_thread(probe_video_resolution, saved_path)
         layouts = list_gopro_overlay_layouts(video_width=width, video_height=height)
         return {"width": width, "height": height, "layouts": layouts}
     except ValueError as exc:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -188,6 +188,10 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
             "routes.check_gopro_overlay_dependencies",
             return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
         ),
+        patch(
+            "routes.asyncio.to_thread",
+            AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs)),
+        ) as to_thread,
         patch("routes.create_gopro_overlay_job_from_paths", return_value=expected) as create_job,
     ):
         response = client.post(
@@ -202,6 +206,7 @@ def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(
         )
 
     assert response.status_code == 200
+    assert to_thread.call_args.args[0] is create_job
     assert create_job.call_args.kwargs["video_path"] == video_path
     assert create_job.call_args.kwargs["gpx_path"] == gpx_path
     assert create_job.call_args.kwargs["pip_path"] == pip_path
@@ -681,7 +686,13 @@ async def test_create_gopro_overlay_job_uses_job_unique_output_paths(tmp_path, m
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
 
-    with patch("gopro_overlay_export.threading.Thread") as thread:
+    with (
+        patch(
+            "gopro_overlay_export.asyncio.to_thread",
+            AsyncMock(side_effect=lambda func, *args, **kwargs: func(*args, **kwargs)),
+        ) as to_thread,
+        patch("gopro_overlay_export.threading.Thread") as thread,
+    ):
         first = await create_gopro_overlay_job(
             video_file=_upload("flight.mp4", b"video"),
             gpx_file=_upload("flight.gpx", b"<gpx />"),
@@ -702,6 +713,8 @@ async def test_create_gopro_overlay_job_uses_job_unique_output_paths(tmp_path, m
     assert first["output_path"] != second["output_path"]
     assert Path(first["output_path"]).parent.name == first["job_id"]
     assert Path(second["output_path"]).parent.name == second["job_id"]
+    assert to_thread.call_count == 2
+    assert to_thread.call_args.args[0] is gopro_overlay_export._create_gopro_overlay_job_from_paths
     assert thread.call_count == 2
 
 


### PR DESCRIPTION
## Summary
- Offload GoPro overlay job preparation to `asyncio.to_thread` so the FastAPI event loop is not blocked.
- Keep probe and flight-overlay paths non-blocking as well.
- Add tests that assert the thread handoff for upload and path-based job creation.

## Validation
- `pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py -q --tb=short`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (timed out in the shell after progressing through the backend suite)