### PR TITLE
fix(gopro-overlay): surface launch failures

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import re
 import shutil
@@ -16,6 +17,8 @@ from typing import Any
 from fastapi import UploadFile
 
 import config
+
+logger = logging.getLogger(__name__)
 
 _STATUS_QUEUED = "queued"
 _STATUS_RUNNING = "running"
@@ -451,6 +454,13 @@ def _create_gopro_overlay_job_from_paths(
     with _LOCK:
         _JOBS[job_id] = job
 
+    logger.info(
+        "Queued GoPro overlay job %s with layout %s and output %s",
+        job_id,
+        selected_layout.id,
+        output_path,
+    )
+
     thread = threading.Thread(target=_run_job, args=(job_id,), daemon=True)
     thread.start()
     return job.copy()
@@ -479,6 +489,7 @@ def _run_job(job_id: str) -> None:
 
     if not _transition_job_to_running(job_id, command):
         return
+    logger.info("Starting GoPro overlay job %s", job_id)
     try:
         process = subprocess.Popen(
             command,
@@ -488,12 +499,24 @@ def _run_job(job_id: str) -> None:
             text=True,
         )
     except FileNotFoundError as exc:
+        logger.exception("GoPro overlay binary not found for job %s", job_id)
         _finish_job(
             job_id,
             status=_STATUS_FAILED,
             progress=100,
             message="gopro-dashboard.py not found",
             error=str(exc),
+            completed_at=_utc_now(),
+        )
+        return
+    except Exception as exc:
+        logger.exception("Failed to start GoPro overlay job %s", job_id)
+        _finish_job(
+            job_id,
+            status=_STATUS_FAILED,
+            progress=100,
+            message="Overlay rendering failed to start",
+            error=str(exc) or exc.__class__.__name__,
             completed_at=_utc_now(),
         )
         return
@@ -527,17 +550,27 @@ def _run_job(job_id: str) -> None:
             return
 
         if return_code != 0:
+            error = "\n".join(output_lines[-20:]) or f"Process exited with {return_code}"
+            logger.error(
+                "GoPro overlay job %s failed with exit code %s: %s",
+                job_id,
+                return_code,
+                error,
+            )
             _finish_job(
                 job_id,
                 status=_STATUS_FAILED,
                 progress=100,
                 message="Overlay rendering failed",
-                error="\n".join(output_lines[-20:]) or f"Process exited with {return_code}",
+                error=error,
                 completed_at=_utc_now(),
             )
             return
 
         if not Path(job["output_path"]).exists():
+            logger.error(
+                "GoPro overlay job %s did not create output %s", job_id, job["output_path"]
+            )
             _finish_job(
                 job_id,
                 status=_STATUS_FAILED,
@@ -553,6 +586,17 @@ def _run_job(job_id: str) -> None:
             status=_STATUS_COMPLETED,
             progress=100,
             message="Overlay ready",
+            completed_at=_utc_now(),
+        )
+        logger.info("Completed GoPro overlay job %s", job_id)
+    except Exception as exc:
+        logger.exception("GoPro overlay job %s failed unexpectedly", job_id)
+        _finish_job(
+            job_id,
+            status=_STATUS_FAILED,
+            progress=100,
+            message="Overlay rendering failed unexpectedly",
+            error=str(exc) or exc.__class__.__name__,
             completed_at=_utc_now(),
         )
     finally:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,6 +1,7 @@
+import logging
+import os
 from datetime import date, datetime
 from io import BytesIO
-import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -801,6 +802,42 @@ def test_cancelled_queued_job_does_not_start_process():
             gopro_overlay_export._run_job(job_id)
         assert not popen.called
         assert gopro_overlay_export._JOBS[job_id]["status"] == "cancelled"
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
+
+
+def test_run_job_marks_unexpected_start_error_failed(caplog):
+    job_id = "start-error-job"
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    try:
+        with (
+            caplog.at_level(logging.ERROR),
+            patch(
+                "gopro_overlay_export.subprocess.Popen",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            gopro_overlay_export._run_job(job_id)
+
+        job = gopro_overlay_export._JOBS[job_id]
+        assert job["status"] == "failed"
+        assert job["message"] == "Overlay rendering failed to start"
+        assert job["error"] == "boom"
+        assert "Failed to start GoPro overlay job start-error-job" in caplog.text
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -22,7 +22,7 @@ import {
   useGoproOverlayJobStream,
 } from '../../hooks/gopro/useGoproOverlay';
 import { useToast } from '../../hooks/useToast';
-import { api } from '../../lib/api';
+import { api, getApiErrorMessage } from '../../lib/api';
 import type { Flight, FlightFormData, Site } from '../../types';
 import { FlightEditForm } from './FlightEditForm';
 import {
@@ -281,8 +281,10 @@ export function FlightDetails({
       setGoproOverlayJobId(job.job_id);
       setShowGoproOverlayForm(false);
       toast.success(t('flights.goproOverlayStarted'));
-    } catch {
-      toast.error(t('flights.goproOverlayStartError'));
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(error, t('flights.goproOverlayStartError'))
+      );
     }
   };
 

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,6 +1,10 @@
 import ky from 'ky';
 import { useAuthStore } from '../stores/authStore';
 
+type ApiErrorPayload = {
+  detail?: unknown;
+};
+
 // API logging: enabled in dev, disabled in tests via overrideApi({ logs: false })
 let _apiLogsEnabled = import.meta.env.DEV;
 
@@ -18,7 +22,7 @@ export let api = ky.create({
   },
   hooks: {
     beforeRequest: [
-      ({request}) => {
+      ({ request }) => {
         // Attach JWT token if available
         const token = useAuthStore.getState().token;
         if (token) {
@@ -32,7 +36,7 @@ export let api = ky.create({
       },
     ],
     afterResponse: [
-      async ({request, response}) => {
+      async ({ request, response }) => {
         // On 401, clear auth and redirect to login
         if (response.status === 401) {
           const { isAuthenticated, logout } = useAuthStore.getState();
@@ -64,6 +68,28 @@ export function overrideApi(
     _apiLogsEnabled = logs;
   }
   api = api.extend(kyOptions);
+}
+
+export async function getApiErrorMessage(error: unknown, fallback: string) {
+  if (!(error instanceof Error) || !('response' in error)) {
+    return fallback;
+  }
+
+  const response = error.response;
+  if (!(response instanceof Response)) {
+    return fallback;
+  }
+
+  try {
+    const payload = (await response.clone().json()) as ApiErrorPayload;
+    if (typeof payload.detail === 'string' && payload.detail.trim()) {
+      return payload.detail;
+    }
+  } catch {
+    // Keep the user-facing fallback when the response is not JSON.
+  }
+
+  return fallback;
 }
 
 // Apply persisted timeout on load and react to changes

--- a/apps/frontend/src/pages/GoproOverlay.tsx
+++ b/apps/frontend/src/pages/GoproOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 import { Button } from '@dashboard-parapente/design-system';
-import { api } from '../lib/api';
+import { api, getApiErrorMessage } from '../lib/api';
 import { useToast } from '../hooks/useToast';
 import {
   type GoproOverlayJob,
@@ -140,8 +140,13 @@ export default function GoproOverlayPage() {
       const created = await createJob.mutateAsync(formData);
       setJobId(created.job_id);
       toast.success('Génération GoPro lancée');
-    } catch {
-      toast.error('Impossible de lancer la génération GoPro');
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(
+          error,
+          'Impossible de lancer la génération GoPro'
+        )
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- Add backend logging and failure handling for GoPro overlay job startup/rendering.
- Surface backend error details in the frontend toast on both overlay launch flows.
- Add a backend test for unexpected process-start failures.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (ran, but the full suite exceeded the shell timeout)