### PR TITLE
fix(frontend): expand flight list height

### DIFF
--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -261,7 +261,8 @@ export function FlightsTable({
       emptyMessage={t('flights.noFlights')}
       ariaLabel={t('flights.listAriaLabel')}
       isVirtualized
-      itemsClassName="max-h-[min(640px,calc(100vh-22rem))] min-h-72 overflow-y-auto pr-1"
+      className="flex h-full flex-col lg:min-h-[calc(100vh-22rem)]"
+      itemsClassName="min-h-72 flex-1 overflow-y-auto pr-1"
       virtualizedLayoutOptions={{ estimatedRowSize: 136, gap: 8 }}
       selectionMode={selectionMode ? 'multiple' : 'none'}
       selectedKeys={selectedKeys}

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -357,7 +357,7 @@ export default function FlightHistory() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
         {/* Flight List */}
         {(!isMobile || !showMobileDetail) && (
-          <div className={isMobile ? '' : 'lg:col-span-1'}>
+          <div className={isMobile ? '' : 'lg:col-span-1 lg:h-full'}>
             <FlightsTable
               flights={filteredFlights}
               selectedFlightId={selectedFlightId}


### PR DESCRIPTION
## Summary
- Increase the flights list height on desktop so it fills the list column when a flight is selected.
- Remove the previous 640px cap and let the list flex to the available vertical space.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit`

## Note
- `nx test frontend` did not complete in this environment because the storybook/browser Vitest project stalled at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved flights table layout with enhanced scrolling capabilities and optimized spacing.
  * Refined responsive design for larger screens to better utilize vertical space in the flights list display.
  * Adjusted container height behavior across different screen sizes to enhance visibility and usability of flight information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->