### PR TITLE
fix(gopro-overlay): package toolchain in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,13 @@ COPY apps/backend/requirements.txt ./
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir -r requirements.txt
 
+# Installer GoPro Dashboard Overlay dans un venv créé dans l'image.
+COPY --from=gopro-overlay-src / /app/gopro-overlay
+RUN rm -rf /app/gopro-overlay/venv && \
+    python -m venv /app/gopro-overlay/venv && \
+    /app/gopro-overlay/venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    /app/gopro-overlay/venv/bin/pip install --no-cache-dir -e /app/gopro-overlay
+
 # Installer Chromium pour Playwright
 RUN playwright install chromium
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      additional_contexts:
+        gopro-overlay-src: ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}
       args:
         - VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN:?required}
     image: parapente-backend:nx-latest
@@ -112,7 +114,6 @@ services:
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
-      - ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}:/app/gopro-overlay:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
       interval: 30s


### PR DESCRIPTION
## Summary
- Copy the GoPro overlay source into the backend image and recreate the venv inside Docker.
- Stop bind-mounting the host overlay tree over `/app/gopro-overlay`, which was masking the container venv.

## Validation
- `docker compose build backend`