### PR TITLE
fix(gopro-overlay): make overlay font configurable

### DIFF
--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -155,6 +155,10 @@ GOPRO_OVERLAY_LAYOUT_DIR = GOPRO_OVERLAY_ROOT
 GOPRO_OVERLAY_PARAGLIDING_ROOT = PARAGLIDING_DATA_ROOT
 GOPRO_OVERLAY_OUTPUT_DIR = PARAGLIDING_DATA_ROOT
 GOPRO_OVERLAY_UPLOAD_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "gopro-uploads")
+GOPRO_OVERLAY_FONT = os.getenv(
+    "BACKEND_GOPRO_OVERLAY_FONT",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+)
 
 # ============================================================================
 # VALIDATION

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -482,6 +482,8 @@ def _run_job(job_id: str) -> None:
         "--layout-xml",
         job["layout_path"],
     ]
+    if config.GOPRO_OVERLAY_FONT:
+        command.extend(["--font", config.GOPRO_OVERLAY_FONT])
     if job.get("video_width") and job.get("video_height"):
         command.extend(["--overlay-size", f"{job['video_width']}x{job['video_height']}"])
     if job.get("pip_path"):

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -820,6 +820,42 @@ def test_cancelled_queued_job_does_not_start_process():
         gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
+def test_run_job_passes_configured_font(monkeypatch):
+    job_id = "font-job"
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_FONT", "/fonts/LiberationSans-Regular.ttf")
+
+    class FailedProcess:
+        stdout: list[str] = []
+
+        def wait(self) -> int:
+            return 1
+
+    try:
+        with patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen:
+            gopro_overlay_export._run_job(job_id)
+
+        command = popen.call_args.args[0]
+        assert "--font" in command
+        assert command[command.index("--font") + 1] == "/fonts/LiberationSans-Regular.ttf"
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
+
+
 def test_run_job_marks_unexpected_start_error_failed(caplog):
     job_id = "start-error-job"
     gopro_overlay_export._JOBS[job_id] = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       - BACKEND_GOPRO_OVERLAY_BIN=/app/gopro-overlay/venv/bin/gopro-dashboard.py
       - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay
       - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/parapente
+      - BACKEND_GOPRO_OVERLAY_FONT=/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
 
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}


### PR DESCRIPTION
## Summary
- Make the GoPro overlay font configurable and default it to Liberation Sans in Docker.
- Pass `--font` to the overlay renderer so the job no longer depends on Roboto being present.
- Add a backend test covering the generated command.

## Validation
- `TESTING=true BACKEND_DATABASE_URL='sqlite:///./test.db' BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GoPro overlay rendering now supports configurable fonts. Users can specify a custom font via environment variable, with Liberation Sans as the default.

* **Tests**
  * Added test coverage for the font configuration feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->