### PR TITLE
fix(deploy): support git worktree deploy paths

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -187,7 +187,7 @@ jobs:
               path="$1"
               cd "$path"
 
-              if [ ! -d .git ]; then
+              if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
                 echo "Deploy path is not a git repository: $path"
                 return 1
               fi


### PR DESCRIPTION
## Summary
- Accept Git worktree deploy paths in the production deployment workflow.
- Replace the `.git` directory check with `git rev-parse --is-inside-work-tree`, so worktrees are treated as valid Git repositories.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`