### PR TITLE
fix: keep long-running exports alive with scoped job tokens

### DIFF
--- a/apps/backend/auth.py
+++ b/apps/backend/auth.py
@@ -19,6 +19,9 @@ from models import User
 logger = logging.getLogger(__name__)
 
 ALGORITHM = "HS256"
+ACCESS_TOKEN_PURPOSE = "access"
+JOB_TOKEN_PURPOSES = {"video_export", "gopro_overlay"}
+JOB_TOKEN_EXPIRE_HOURS = 12
 
 
 def _extract_access_token(request: Request) -> str | None:
@@ -55,7 +58,43 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 
 def create_access_token(email: str) -> str:
     expire = datetime.now(timezone.utc) + timedelta(hours=config.JWT_EXPIRE_HOURS)
-    return jwt.encode({"sub": email, "exp": expire}, config.JWT_SECRET, algorithm=ALGORITHM)
+    return jwt.encode(
+        {"sub": email, "purpose": ACCESS_TOKEN_PURPOSE, "exp": expire},
+        config.JWT_SECRET,
+        algorithm=ALGORITHM,
+    )
+
+
+def create_job_token(
+    *,
+    purpose: str,
+    job_id: str,
+    flight_id: str | None = None,
+) -> str:
+    if purpose not in JOB_TOKEN_PURPOSES:
+        raise ValueError("Unsupported job token purpose")
+
+    expire = datetime.now(timezone.utc) + timedelta(hours=JOB_TOKEN_EXPIRE_HOURS)
+    payload = {"purpose": purpose, "job_id": job_id, "exp": expire}
+    if flight_id:
+        payload["flight_id"] = flight_id
+    return jwt.encode(payload, config.JWT_SECRET, algorithm=ALGORITHM)
+
+
+def decode_job_token(token: str, *, purpose: str, job_id: str) -> dict:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid or expired job token",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, config.JWT_SECRET, algorithms=[ALGORITHM])
+    except JWTError as e:
+        raise credentials_exception from e
+
+    if payload.get("purpose") != purpose or payload.get("job_id") != job_id:
+        raise credentials_exception
+    return payload
 
 
 def get_current_user(
@@ -75,7 +114,7 @@ def get_current_user(
     try:
         payload = jwt.decode(token, config.JWT_SECRET, algorithms=[ALGORITHM])
         email: str | None = payload.get("sub")
-        if email is None:
+        if payload.get("purpose", ACCESS_TOKEN_PURPOSE) != ACCESS_TOKEN_PURPOSE or email is None:
             raise credentials_exception
     except JWTError as e:
         raise credentials_exception from e

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -29,7 +29,13 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 import config
-from auth import authenticate_user, create_access_token, get_current_user
+from auth import (
+    authenticate_user,
+    create_access_token,
+    create_job_token,
+    decode_job_token,
+    get_current_user,
+)
 from database import get_db
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_backfill import calculate_and_persist_missing_max_speed
@@ -95,6 +101,7 @@ from video_export import start_video_export_background
 from video_export_manual import cancel_video_export as cancel_video_export_manual
 from video_export_manual import cleanup_video_export_temp_files
 from video_export_manual import get_export_status as get_export_status_manual
+from video_export_manual import get_video_export_job_token
 from video_export_manual import list_exports as list_exports_manual
 from video_export_manual import resolve_frontend_url
 from video_export_manual import resume_video_export
@@ -4268,6 +4275,40 @@ def _extract_bearer_token(request: Request) -> str | None:
     return token or None
 
 
+def _extract_job_access_token(request: Request) -> str | None:
+    query_token = request.query_params.get("access_token")
+    if query_token:
+        return query_token.strip() or None
+    token = _extract_bearer_token(request)
+    if token:
+        return token
+    return None
+
+
+def _require_job_token(request: Request, *, purpose: str, job_id: str) -> dict[str, Any]:
+    token = _extract_job_access_token(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing job token")
+    return decode_job_token(token, purpose=purpose, job_id=job_id)
+
+
+def _with_video_export_job_token(payload: dict[str, Any], job_id: str) -> dict[str, Any]:
+    try:
+        token = get_video_export_job_token(job_id)
+    except Exception:
+        logger.debug("Unable to attach video export job token for %s", job_id, exc_info=True)
+        token = None
+    return {**payload, "job_token": token} if token else payload
+
+
+def _with_gopro_overlay_job_token(payload: dict[str, Any]) -> dict[str, Any]:
+    job_id = payload["job_id"]
+    return {
+        **payload,
+        "job_token": create_job_token(purpose="gopro_overlay", job_id=job_id),
+    }
+
+
 @router.post("/flights/{flight_id}/export-video")
 def start_flight_video_export(
     request: Request,
@@ -4392,12 +4433,15 @@ def start_flight_video_export(
         effective_mode = "stream"
         _mark_flight_export_processing(db=db, flight=flight, job_id=job_id)
 
-    return {
-        "job_id": job_id,
-        "message": f"Video export started ({_video_export_mode_label(effective_mode)})",
-        "mode": effective_mode,
-        "status_url": f"/api/exports/{job_id}/status",
-    }
+    return _with_video_export_job_token(
+        {
+            "job_id": job_id,
+            "message": f"Video export started ({_video_export_mode_label(effective_mode)})",
+            "mode": effective_mode,
+            "status_url": f"/api/exports/{job_id}/status",
+        },
+        job_id,
+    )
 
 
 @router.post("/flights/{flight_id}/generate-video")
@@ -4461,11 +4505,14 @@ def generate_flight_video(
 
     logger.info(f" Video generation started: job_id={job_id}")
 
-    return {
-        "job_id": job_id,
-        "message": started_message,
-        "status_url": f"/api/exports/{job_id}/status",
-    }
+    return _with_video_export_job_token(
+        {
+            "job_id": job_id,
+            "message": started_message,
+            "status_url": f"/api/exports/{job_id}/status",
+        },
+        job_id,
+    )
 
 
 @router.get("/exports/{job_id}/status")
@@ -4598,7 +4645,10 @@ def resume_cancelled_video_export(request: Request, job_id: str):
             detail="Export job not found or cannot be resumed",
         )
 
-    return {"message": "Export resume enqueued", "job_id": job_id}
+    return _with_video_export_job_token(
+        {"message": "Export resume enqueued", "job_id": job_id},
+        job_id,
+    )
 
 
 @router.get("/exports/{job_id}/download")
@@ -4623,6 +4673,43 @@ def download_exported_video(job_id: str):
 
     filename = os.path.basename(video_path)
     return FileResponse(path=video_path, media_type="video/mp4", filename=filename)
+
+
+@public_router.get("/job-access/exports/{job_id}/stream")
+async def stream_video_export_status_with_job_token(
+    job_id: str,
+    request: Request,
+) -> StreamingResponse:
+    """Stream video export status with a scoped job token."""
+    _require_job_token(request, purpose="video_export", job_id=job_id)
+    return await stream_video_export_status(job_id, request)
+
+
+@public_router.get("/job-access/exports/{job_id}/status")
+def get_video_export_status_with_job_token(job_id: str, request: Request):
+    """Get video export status with a scoped job token."""
+    _require_job_token(request, purpose="video_export", job_id=job_id)
+    return get_video_export_status(job_id)
+
+
+@public_router.get("/export-viewer/jobs/{job_id}/flight")
+def get_export_viewer_flight(job_id: str, request: Request, db: Session = Depends(get_db)):
+    """Return flight data for the headless export viewer using a scoped job token."""
+    payload = _require_job_token(request, purpose="video_export", job_id=job_id)
+    flight_id = payload.get("flight_id")
+    if not isinstance(flight_id, str):
+        raise HTTPException(status_code=401, detail="Invalid job token")
+    return get_flight(flight_id, db)
+
+
+@public_router.get("/export-viewer/jobs/{job_id}/gpx-data")
+def get_export_viewer_gpx_data(job_id: str, request: Request, db: Session = Depends(get_db)):
+    """Return GPX data for the headless export viewer using a scoped job token."""
+    payload = _require_job_token(request, purpose="video_export", job_id=job_id)
+    flight_id = payload.get("flight_id")
+    if not isinstance(flight_id, str):
+        raise HTTPException(status_code=401, detail="Invalid job token")
+    return get_flight_gpx_data(flight_id, db)
 
 
 @router.get("/flights/{flight_id}/exports")
@@ -4727,7 +4814,7 @@ async def create_flight_gopro_overlay_job(
                     status_code=400,
                     detail="Generate the flight video before creating the GoPro overlay",
                 )
-            return await asyncio.to_thread(
+            job = await asyncio.to_thread(
                 create_gopro_overlay_job_from_paths,
                 video_path=resolved_video_path,
                 gpx_path=fallback_gpx_path,
@@ -4736,6 +4823,7 @@ async def create_flight_gopro_overlay_job(
                 output_filename=resolved_output_filename,
                 output_dir=resolved_output_dir,
             )
+            return _with_gopro_overlay_job_token(job)
 
         if not video_file or not video_file.filename:
             raise HTTPException(status_code=400, detail="GoPro camera video is required")
@@ -4751,7 +4839,7 @@ async def create_flight_gopro_overlay_job(
                 detail="Generate the flight video before creating the GoPro overlay",
             )
 
-        return await create_gopro_overlay_job(
+        job = await create_gopro_overlay_job(
             video_file=video_file,
             gpx_file=gpx_file,
             fallback_gpx_path=fallback_gpx_path,
@@ -4761,6 +4849,7 @@ async def create_flight_gopro_overlay_job(
             output_filename=resolved_output_filename,
             output_dir=resolved_output_dir,
         )
+        return _with_gopro_overlay_job_token(job)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -4819,13 +4908,14 @@ async def create_gopro_overlay_render_job(
         )
 
     try:
-        return await create_gopro_overlay_job(
+        job = await create_gopro_overlay_job(
             video_file=video_file,
             gpx_file=gpx_file,
             pip_file=pip_file,
             layout_id=layout_id,
             output_filename=output_filename,
         )
+        return _with_gopro_overlay_job_token(job)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -4880,6 +4970,46 @@ def download_gopro_overlay_render_job(job_id: str) -> FileResponse:
         raise HTTPException(status_code=400, detail="GoPro overlay video is not ready")
 
     return FileResponse(path=output_path, media_type="video/mp4", filename=output_path.name)
+
+
+@public_router.get(
+    "/job-access/gopro-overlays/jobs/{job_id}/status",
+    response_model=GoproOverlayJob,
+)
+def get_gopro_overlay_status_with_job_token(job_id: str, request: Request) -> GoproOverlayJob:
+    """Get GoPro overlay status with a scoped job token."""
+    _require_job_token(request, purpose="gopro_overlay", job_id=job_id)
+    return get_gopro_overlay_render_job_status(job_id)
+
+
+@public_router.get("/job-access/gopro-overlays/jobs/{job_id}/stream")
+async def stream_gopro_overlay_status_with_job_token(
+    job_id: str,
+    request: Request,
+) -> StreamingResponse:
+    """Stream GoPro overlay status with a scoped job token."""
+    _require_job_token(request, purpose="gopro_overlay", job_id=job_id)
+    return await stream_gopro_overlay_render_job_status(job_id, request)
+
+
+@public_router.get("/job-access/gopro-overlays/jobs/{job_id}/download")
+def download_gopro_overlay_with_job_token(job_id: str, request: Request) -> FileResponse:
+    """Download a completed GoPro overlay with a scoped job token."""
+    _require_job_token(request, purpose="gopro_overlay", job_id=job_id)
+    return download_gopro_overlay_render_job(job_id)
+
+
+@public_router.delete(
+    "/job-access/gopro-overlays/jobs/{job_id}/cancel",
+    response_model=GoproOverlayCancelResponse,
+)
+def cancel_gopro_overlay_with_job_token(
+    job_id: str,
+    request: Request,
+) -> GoproOverlayCancelResponse:
+    """Cancel a GoPro overlay with a scoped job token."""
+    _require_job_token(request, purpose="gopro_overlay", job_id=job_id)
+    return cancel_gopro_overlay_render_job(job_id)
 
 
 # ============================================================================

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -43,6 +43,7 @@ class GoproOverlayJob(BaseModel):
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None = None
+    job_token: str | None = None
 
 
 class GoproOverlayCancelResponse(BaseModel):

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -12,6 +12,7 @@ from starlette.datastructures import UploadFile
 
 import config
 import gopro_overlay_export
+from auth import create_job_token
 import routes
 from gopro_overlay_export import _prepare_layout_file
 from gopro_overlay_export import _progress_from_output_chunk
@@ -84,9 +85,34 @@ def test_create_gopro_overlay_job_passes_uploaded_files(client: TestClient):
 
     assert response.status_code == 200
     assert response.json()["job_id"] == "job-gopro"
+    assert response.json()["job_token"]
     assert create_job.call_args.kwargs["layout_id"] == "parapente-1080"
     assert create_job.call_args.kwargs["output_filename"] == "flight-overlay.mp4"
     assert create_job.call_args.kwargs["pip_file"] is not None
+
+
+def test_gopro_overlay_job_access_status_accepts_job_token(client: TestClient):
+    token = create_job_token(purpose="gopro_overlay", job_id="job-gopro")
+    expected = {
+        "job_id": "job-gopro",
+        "status": "completed",
+        "progress": 100,
+        "message": "ready",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "flight-overlay.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with patch("routes.get_gopro_overlay_job", return_value=expected):
+        response = client.get(
+            f"{API_PREFIX}/job-access/gopro-overlays/jobs/job-gopro/status",
+            params={"access_token": token},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["job_id"] == "job-gopro"
 
 
 def test_create_flight_gopro_overlay_job_uses_flight_files(

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
+from auth import create_job_token
+
 API_PREFIX = "/api"
 
 
@@ -378,6 +380,33 @@ class TestExportStatusAndCancel:
 
         assert response.status_code == 404
         assert response.json()["detail"] == "Export job not found"
+
+    def test_job_access_export_viewer_returns_flight_with_job_token(
+        self, client: TestClient, sample_flight
+    ):
+        token = create_job_token(
+            purpose="video_export",
+            job_id="job-export-viewer",
+            flight_id=sample_flight.id,
+        )
+
+        response = client.get(
+            f"{API_PREFIX}/export-viewer/jobs/job-export-viewer/flight",
+            params={"access_token": token},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] == sample_flight.id
+
+    def test_job_access_export_viewer_rejects_wrong_job_token(self, client: TestClient):
+        token = create_job_token(purpose="video_export", job_id="other-job")
+
+        response = client.get(
+            f"{API_PREFIX}/export-viewer/jobs/job-export-viewer/flight",
+            params={"access_token": token},
+        )
+
+        assert response.status_code == 401
 
 
 class TestVideoExportJobsEndpoint:

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 from sqlalchemy.orm import Session
 
 import config
+from auth import create_job_token
 from database import SessionLocal
 from flight_storage import get_video_output_path
 from models import Flight, VideoExportJob
@@ -269,6 +270,10 @@ def _get_job_auth_token(job_id: str) -> str | None:
         return job.auth_token
 
 
+def get_video_export_job_token(job_id: str) -> str | None:
+    return _get_job_auth_token(job_id)
+
+
 def _clear_job_auth_token(job_id: str):
     _set_job_auth_token(job_id, None)
 
@@ -288,6 +293,10 @@ def _build_playwright_init_script(auth_token: str | None) -> str:
             }}
         }})();
     """
+
+
+def _create_video_export_job_token(job_id: str, flight_id: str) -> str:
+    return create_job_token(purpose="video_export", job_id=job_id, flight_id=flight_id)
 
 
 def _get_job(job_id: str, db: Session | None = None) -> VideoExportJob | None:
@@ -854,7 +863,7 @@ def _enqueue_video_export_job(
         _set_memory_snapshot(job_id, _snapshot_from_job(job))
         _set_job_runtime(job_id, phase=_STATUS_QUEUED)
 
-    _set_job_auth_token(job_id, auth_token)
+    _set_job_auth_token(job_id, auth_token or _create_video_export_job_token(job_id, flight_id))
 
     start_video_export_worker()
     return job_id
@@ -966,8 +975,12 @@ async def _export_video_manual_render(job_id: str):
             page.on("console", lambda msg: print(f"🖥️  [{msg.type}]: {msg.text}"))
             page.on("pageerror", lambda err: print(f"❌ Browser error: {err}"))
 
-            url = f"{frontend_url}/export-viewer?flightId={flight_id}"
-            print(f"📺 Opening {url}")
+            url = f"{frontend_url}/export-viewer?flightId={flight_id}&jobId={job_id}"
+            log_url = url
+            if auth_token:
+                url = f"{url}&exportToken={auth_token}"
+                log_url = f"{log_url}&exportToken=<redacted>"
+            print(f"📺 Opening {log_url}")
 
             _update_job(job_id, message="Loading export viewer")
             response = await page.goto(url, wait_until="networkidle", timeout=60000)
@@ -1516,7 +1529,7 @@ def resume_video_export(job_id: str, auth_token: str | None = None) -> bool:
         completed_at=None,
         cancelled_at=None,
     )
-    _set_job_auth_token(job_id, auth_token)
+    _set_job_auth_token(job_id, auth_token or _create_video_export_job_token(job_id, job.flight_id))
     _set_job_runtime(
         job_id,
         phase=_STATUS_QUEUED,

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -99,6 +99,9 @@ export function FlightDetails({
   const [goproOverlayJobId, setGoproOverlayJobId] = useState<string | null>(
     null
   );
+  const [goproOverlayJobToken, setGoproOverlayJobToken] = useState<
+    string | null
+  >(null);
   const [showGoproOverlayForm, setShowGoproOverlayForm] = useState(false);
   const [goproOverlayVideoPath, setGoproOverlayVideoPath] = useState('');
   const [goproOverlayGpxPath, setGoproOverlayGpxPath] = useState('');
@@ -112,8 +115,10 @@ export function FlightDetails({
 
   const hasGpx = Boolean(flight.gpx_file_path);
   const hasVideo = Boolean(flight.video_file_path);
-  const { job: streamedGoproOverlayJob } =
-    useGoproOverlayJobStream(goproOverlayJobId);
+  const { job: streamedGoproOverlayJob } = useGoproOverlayJobStream(
+    goproOverlayJobId,
+    goproOverlayJobToken
+  );
   const goproOverlayJob = streamedGoproOverlayJob ?? createGoproOverlayJob.data;
   const isGoproOverlayRunning =
     goproOverlayJob?.status === 'queued' ||
@@ -137,6 +142,7 @@ export function FlightDetails({
     setEditingMode(false);
     setEditingNotes(false);
     setGoproOverlayJobId(null);
+    setGoproOverlayJobToken(null);
     setShowGoproOverlayForm(false);
     setGoproOverlayVideoPath('');
     setGoproOverlayGpxPath('');
@@ -279,6 +285,7 @@ export function FlightDetails({
       const job = await createGoproOverlayJob.mutateAsync(formData);
       if (activeFlightIdRef.current !== requestedFlightId) return;
       setGoproOverlayJobId(job.job_id);
+      setGoproOverlayJobToken(job.job_token ?? null);
       setShowGoproOverlayForm(false);
       toast.success(t('flights.goproOverlayStarted'));
     } catch (error) {
@@ -292,7 +299,10 @@ export function FlightDetails({
     if (!goproOverlayJob) return;
 
     try {
-      await cancelGoproOverlayJob.mutateAsync(goproOverlayJob.job_id);
+      await cancelGoproOverlayJob.mutateAsync({
+        jobId: goproOverlayJob.job_id,
+        jobToken: goproOverlayJobToken,
+      });
       toast.success(t('flights.goproOverlayCancelled'));
     } catch {
       toast.error(t('flights.goproOverlayCancelError'));
@@ -303,8 +313,14 @@ export function FlightDetails({
     if (!goproOverlayJob || goproOverlayJob.status !== 'completed') return;
 
     try {
+      const downloadPath = goproOverlayJobToken
+        ? `job-access/gopro-overlays/jobs/${goproOverlayJob.job_id}/download`
+        : `gopro-overlays/jobs/${goproOverlayJob.job_id}/download`;
       const blob = await api
-        .get(`gopro-overlays/jobs/${goproOverlayJob.job_id}/download`, {
+        .get(downloadPath, {
+          searchParams: goproOverlayJobToken
+            ? { access_token: goproOverlayJobToken }
+            : undefined,
           timeout: false,
         })
         .blob();

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -78,6 +78,9 @@ export function FlightVideoExportControls({
   const [videoExportMode, setVideoExportMode] =
     useState<VideoExportMode>('manual_fast');
   const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
+  const [videoExportJobToken, setVideoExportJobToken] = useState<string | null>(
+    null
+  );
   const isExportActive = hasActiveVideoExport(flight);
   const shouldReadExportStatus = Boolean(
     flight.video_export_job_id &&
@@ -87,7 +90,8 @@ export function FlightVideoExportControls({
   );
   const { status: exportStatus } = useVideoExportStatus(
     flight.video_export_job_id,
-    shouldReadExportStatus
+    shouldReadExportStatus,
+    videoExportJobToken
   );
   const exportProgress = Math.min(
     100,
@@ -117,9 +121,12 @@ export function FlightVideoExportControls({
 
     setIsStartingVideoExport(true);
     try {
-      await api.post(`flights/${flight.id}/export-video`, {
-        searchParams: { mode: videoExportMode },
-      });
+      const payload = await api
+        .post(`flights/${flight.id}/export-video`, {
+          searchParams: { mode: videoExportMode },
+        })
+        .json<{ job_token?: string | null }>();
+      setVideoExportJobToken(payload.job_token ?? null);
       await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
     } finally {
       setIsStartingVideoExport(false);
@@ -131,7 +138,10 @@ export function FlightVideoExportControls({
 
     setIsStartingVideoExport(true);
     try {
-      await api.post(`exports/${flight.video_export_job_id}/resume`);
+      const payload = await api
+        .post(`exports/${flight.video_export_job_id}/resume`)
+        .json<{ job_token?: string | null }>();
+      setVideoExportJobToken(payload.job_token ?? null);
       await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
     } finally {
       setIsStartingVideoExport(false);

--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -82,6 +82,8 @@ interface FlightViewer3DProps {
   flightTitle?: string;
   compact?: boolean;
   exportOnly?: boolean;
+  exportJobId?: string | null;
+  exportToken?: string | null;
 }
 
 interface ScenePositionState {
@@ -273,11 +275,20 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   flightTitle,
   compact = false,
   exportOnly = false,
+  exportJobId,
+  exportToken,
 }) => {
   const { t } = useTranslation();
   const resolvedFlightTitle = flightTitle || t('flights.viewer.defaultTitle');
-  const { data: gpxData, isLoading, error } = useFlightGPX(flightId);
-  const { data: flight } = useFlight(flightId);
+  const {
+    data: gpxData,
+    isLoading,
+    error,
+  } = useFlightGPX(flightId, {
+    exportJobId,
+    exportToken,
+  });
+  const { data: flight } = useFlight(flightId, { exportJobId, exportToken });
   const queryClient = useQueryClient();
   const toast = useToast();
   const containerRef = useRef<HTMLDivElement>(null);

--- a/apps/frontend/src/hooks/flights/useFlight.ts
+++ b/apps/frontend/src/hooks/flights/useFlight.ts
@@ -9,13 +9,35 @@ import {
 const isExportInProgress = (status?: string | null) =>
   status ? VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status) : false;
 
+type ExportViewerAccess = {
+  exportJobId?: string | null;
+  exportToken?: string | null;
+};
+
 /**
  * Fetch flight details including video export status
  */
-export const useFlight = (flightId: string) => {
+export const useFlight = (
+  flightId: string,
+  access: ExportViewerAccess = {}
+) => {
+  const hasExportAccess = Boolean(access.exportJobId && access.exportToken);
+
   return useQuery<Flight>({
-    queryKey: ['flights', flightId],
+    queryKey: [
+      'flights',
+      flightId,
+      hasExportAccess ? 'export-viewer' : 'user',
+      access.exportJobId ?? null,
+    ],
     queryFn: async () => {
+      if (hasExportAccess) {
+        return await api
+          .get(`export-viewer/jobs/${access.exportJobId}/flight`, {
+            searchParams: { access_token: access.exportToken ?? '' },
+          })
+          .json();
+      }
       return await api.get(`flights/${flightId}`).json();
     },
     enabled: !!flightId,

--- a/apps/frontend/src/hooks/flights/useFlightGPX.ts
+++ b/apps/frontend/src/hooks/flights/useFlightGPX.ts
@@ -13,16 +13,39 @@ interface GPXData {
   flight_duration_seconds: number;
 }
 
+type ExportViewerAccess = {
+  exportJobId?: string | null;
+  exportToken?: string | null;
+};
+
 /**
  * Fetch GPX data for a specific flight
  * Returns parsed coordinates and elevation profile
  */
-export const useFlightGPX = (flightId: string) => {
+export const useFlightGPX = (
+  flightId: string,
+  access: ExportViewerAccess = {}
+) => {
+  const hasExportAccess = Boolean(access.exportJobId && access.exportToken);
+
   return useQuery<GPXData>({
-    queryKey: ['flights', flightId, 'gpx'],
+    queryKey: [
+      'flights',
+      flightId,
+      'gpx',
+      hasExportAccess ? 'export-viewer' : 'user',
+      access.exportJobId ?? null,
+    ],
     queryFn: async () => {
       const data = await api
-        .get(`flights/${flightId}/gpx-data`)
+        .get(
+          hasExportAccess
+            ? `export-viewer/jobs/${access.exportJobId}/gpx-data`
+            : `flights/${flightId}/gpx-data`,
+          hasExportAccess
+            ? { searchParams: { access_token: access.exportToken ?? '' } }
+            : undefined
+        )
         .json<{ data: GPXData }>();
       console.log('🔍 DEBUG useFlightGPX - Raw API response:', data);
       console.log(

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
@@ -102,7 +102,11 @@ export function formatEta(etaSeconds?: number): string | null {
   return `${hours} h ${minutes.toString().padStart(2, '0')} min`;
 }
 
-export function useVideoExportStatus(jobId?: string | null, enabled = true) {
+export function useVideoExportStatus(
+  jobId?: string | null,
+  enabled = true,
+  jobToken?: string | null
+) {
   const [state, setState] = useState<HookState>(initialState);
   const token = useAuthStore((s) => s.token);
 
@@ -113,8 +117,13 @@ export function useVideoExportStatus(jobId?: string | null, enabled = true) {
       return;
     }
 
-    const streamUrl = new URL(`/api/exports/${jobId}/stream`, window.location.origin);
-    if (token) {
+    const path = jobToken
+      ? `/api/job-access/exports/${jobId}/stream`
+      : `/api/exports/${jobId}/stream`;
+    const streamUrl = new URL(path, window.location.origin);
+    if (jobToken) {
+      streamUrl.searchParams.set('access_token', jobToken);
+    } else if (token) {
       streamUrl.searchParams.set('access_token', token);
     }
 
@@ -156,7 +165,7 @@ export function useVideoExportStatus(jobId?: string | null, enabled = true) {
       eventSource.removeEventListener('error', handleError);
       eventSource.close();
     };
-  }, [enabled, jobId, token]);
+  }, [enabled, jobId, jobToken, token]);
 
   return state;
 }

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -26,6 +26,7 @@ export type GoproOverlayJob = {
   created_at: string;
   updated_at: string;
   completed_at?: string | null;
+  job_token?: string | null;
 };
 
 type LayoutsResponse = {
@@ -83,8 +84,19 @@ export function useCreateFlightGoproOverlayJob(flightId: string) {
 
 export function useCancelGoproOverlayJob() {
   return useMutation({
-    mutationFn: async (jobId: string) => {
-      await api.delete(`gopro-overlays/jobs/${jobId}/cancel`).json();
+    mutationFn: async (
+      input: string | { jobId: string; jobToken?: string | null }
+    ) => {
+      const jobId = typeof input === 'string' ? input : input.jobId;
+      const jobToken = typeof input === 'string' ? null : input.jobToken;
+      const path = jobToken
+        ? `job-access/gopro-overlays/jobs/${jobId}/cancel`
+        : `gopro-overlays/jobs/${jobId}/cancel`;
+      await api
+        .delete(path, {
+          searchParams: jobToken ? { access_token: jobToken } : undefined,
+        })
+        .json();
     },
   });
 }
@@ -94,7 +106,10 @@ const initialState = {
   isConnected: false,
 };
 
-export function useGoproOverlayJobStream(jobId?: string | null) {
+export function useGoproOverlayJobStream(
+  jobId?: string | null,
+  jobToken?: string | null
+) {
   const [state, setState] = useState(initialState);
 
   useEffect(() => {
@@ -103,10 +118,13 @@ export function useGoproOverlayJobStream(jobId?: string | null) {
       return;
     }
 
-    const url = new URL(
-      `/api/gopro-overlays/jobs/${jobId}/stream`,
-      window.location.origin
-    );
+    const path = jobToken
+      ? `/api/job-access/gopro-overlays/jobs/${jobId}/stream`
+      : `/api/gopro-overlays/jobs/${jobId}/stream`;
+    const url = new URL(path, window.location.origin);
+    if (jobToken) {
+      url.searchParams.set('access_token', jobToken);
+    }
     const eventSource = new EventSource(url.toString(), {
       withCredentials: true,
     });
@@ -132,7 +150,7 @@ export function useGoproOverlayJobStream(jobId?: string | null) {
       eventSource.removeEventListener('error', onError);
       eventSource.close();
     };
-  }, [jobId]);
+  }, [jobId, jobToken]);
 
   return state;
 }

--- a/apps/frontend/src/pages/GoproOverlay.tsx
+++ b/apps/frontend/src/pages/GoproOverlay.tsx
@@ -81,6 +81,7 @@ export default function GoproOverlayPage() {
   const [selectedLayoutId, setSelectedLayoutId] = useState('');
   const [outputFilename, setOutputFilename] = useState('');
   const [jobId, setJobId] = useState<string | null>(null);
+  const [jobToken, setJobToken] = useState<string | null>(null);
 
   const layoutsQuery = useGoproOverlayLayouts(
     resolution?.width,
@@ -88,7 +89,7 @@ export default function GoproOverlayPage() {
   );
   const createJob = useCreateGoproOverlayJob();
   const cancelJob = useCancelGoproOverlayJob();
-  const { job } = useGoproOverlayJobStream(jobId);
+  const { job } = useGoproOverlayJobStream(jobId, jobToken);
   const activeJob = job ?? createJob.data ?? null;
   const isRunning =
     activeJob?.status === 'queued' || activeJob?.status === 'running';
@@ -139,6 +140,7 @@ export default function GoproOverlayPage() {
     try {
       const created = await createJob.mutateAsync(formData);
       setJobId(created.job_id);
+      setJobToken(created.job_token ?? null);
       toast.success('Génération GoPro lancée');
     } catch (error) {
       toast.error(
@@ -156,8 +158,12 @@ export default function GoproOverlayPage() {
     }
 
     try {
+      const downloadPath = jobToken
+        ? `job-access/gopro-overlays/jobs/${activeJob.job_id}/download`
+        : `gopro-overlays/jobs/${activeJob.job_id}/download`;
       const blob = await api
-        .get(`gopro-overlays/jobs/${activeJob.job_id}/download`, {
+        .get(downloadPath, {
+          searchParams: jobToken ? { access_token: jobToken } : undefined,
           timeout: false,
         })
         .blob();
@@ -177,7 +183,7 @@ export default function GoproOverlayPage() {
       return;
     }
     try {
-      await cancelJob.mutateAsync(activeJob.job_id);
+      await cancelJob.mutateAsync({ jobId: activeJob.job_id, jobToken });
       toast.success('Génération annulée');
     } catch {
       toast.error("Impossible d'annuler la génération");

--- a/apps/frontend/src/routes/export-viewer.lazy.tsx
+++ b/apps/frontend/src/routes/export-viewer.lazy.tsx
@@ -14,6 +14,8 @@ export const Route = createLazyFileRoute('/export-viewer')({
 function ExportViewer() {
   const search = new URLSearchParams(window.location.search);
   const flightId = search.get('flightId') || '';
+  const exportJobId = search.get('jobId') || null;
+  const exportToken = search.get('exportToken') || null;
 
   if (!flightId) {
     return (
@@ -34,7 +36,12 @@ function ExportViewer() {
           </div>
         }
       >
-        <FlightViewer3D flightId={flightId} exportOnly />
+        <FlightViewer3D
+          flightId={flightId}
+          exportOnly
+          exportJobId={exportJobId}
+          exportToken={exportToken}
+        />
       </Suspense>
     </div>
   );

--- a/apps/frontend/src/routes/export-viewer.tsx
+++ b/apps/frontend/src/routes/export-viewer.tsx
@@ -1,6 +1,3 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { requireAuth } from '../lib/authGuard';
 
-export const Route = createFileRoute('/export-viewer')({
-  beforeLoad: requireAuth,
-});
+export const Route = createFileRoute('/export-viewer')({});


### PR DESCRIPTION
## Summary
- Add scoped JWT job tokens for long-running video export and GoPro overlay jobs.
- Use job-specific access for export viewer, SSE status, download, and cancel flows.
- Keep the user session JWT separate so long jobs survive auth expiry.

## Validation
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest apps/backend/tests/api/test_video_export_endpoints.py apps/backend/tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/ruff check apps/backend/auth.py apps/backend/routes.py apps/backend/video_export_manual.py apps/backend/schemas.py apps/backend/tests/api/test_video_export_endpoints.py apps/backend/tests/api/test_gopro_overlay_endpoints.py`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced secure job-specific tokens for video exports and GoPro overlays.
  * Public endpoints now support scoped token-based access to job status, downloads, and flight data.
  * Video export and GoPro overlay creation now returns access tokens.
  * Export viewer is now accessible via public job tokens without user authentication.

* **Tests**
  * Added test coverage for job token validation and protected endpoint access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->