### PR TITLE
fix(backend): refresh Strava token at startup

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -545,7 +545,7 @@ def schedule_strava_token_refresh_job():
     )
 
 
-async def initial_strava_token_refresh():
+async def initial_strava_token_refresh() -> None:
     """Refresh the Strava token once at startup before the interval job runs."""
 
     from strava import refresh_access_token
@@ -560,7 +560,7 @@ async def initial_strava_token_refresh():
         logger.warning("⚠️ Initial Strava token refresh failed", exc_info=True)
 
 
-def trigger_initial_strava_token_refresh():
+def trigger_initial_strava_token_refresh() -> None:
     """Start the initial Strava token refresh without blocking startup."""
 
     asyncio.create_task(initial_strava_token_refresh())

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -545,6 +545,27 @@ def schedule_strava_token_refresh_job():
     )
 
 
+async def initial_strava_token_refresh():
+    """Refresh the Strava token once at startup before the interval job runs."""
+
+    from strava import refresh_access_token
+
+    try:
+        token = await refresh_access_token(force=True)
+        if token:
+            logger.info("🔑 Initial Strava token refresh completed")
+        else:
+            logger.warning("⚠️ Initial Strava token refresh failed")
+    except Exception:
+        logger.warning("⚠️ Initial Strava token refresh failed", exc_info=True)
+
+
+def trigger_initial_strava_token_refresh():
+    """Start the initial Strava token refresh without blocking startup."""
+
+    asyncio.create_task(initial_strava_token_refresh())
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -586,6 +607,7 @@ async def lifespan(app: FastAPI):
         # Strava token refresh every 4 hours
         schedule_strava_token_refresh_job()
         logger.info("🔑 Strava token refresh scheduled (every 4h)")
+        trigger_initial_strava_token_refresh()
 
         # Initial cache warmup (non-blocking)
         logger.info("🔥 Triggering initial cache warmup...")

--- a/apps/backend/tests/unit/test_main.py
+++ b/apps/backend/tests/unit/test_main.py
@@ -24,12 +24,31 @@ def test_schedule_strava_token_refresh_job_forces_refresh():
 
 
 @pytest.mark.asyncio
+async def test_initial_strava_token_refresh_forces_refresh():
+    """Initial startup refresh should force a token exchange immediately."""
+
+    with patch("strava.refresh_access_token", new=AsyncMock(return_value="token")) as mock_refresh:
+        from main import initial_strava_token_refresh
+
+        await initial_strava_token_refresh()
+
+    mock_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
 async def test_lifespan_starts_strava_job_when_scheduler_enabled():
     """Lifespan should register Strava refresh job when scheduler is enabled."""
 
     class DummyDb:
         def close(self):
             return None
+
+    created_tasks = []
+
+    def fake_create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return object()
 
     with (
         patch("main.config.SCHEDULER_ENABLED", True),
@@ -40,10 +59,11 @@ async def test_lifespan_starts_strava_job_when_scheduler_enabled():
         patch("main.start_video_export_worker"),
         patch("main.stop_video_export_worker") as mock_stop_video_export_worker,
         patch("main.schedule_strava_token_refresh_job") as mock_schedule_strava,
+        patch("main.trigger_initial_strava_token_refresh") as mock_trigger_initial_strava,
         patch("cache.close_redis", new=AsyncMock()) as mock_close_redis,
         patch("emagram_scheduler.emagram_scheduler.setup_emagram_scheduler") as mock_setup_emagram,
         patch("emagram_scheduler.emagram_scheduler.start_scheduler") as mock_start_emagram,
-        patch("main.asyncio.create_task") as mock_create_task,
+        patch("main.asyncio.create_task", side_effect=fake_create_task),
     ):
         mock_session_local.return_value = DummyDb()
         mock_setup_emagram.return_value = object()
@@ -53,11 +73,12 @@ async def test_lifespan_starts_strava_job_when_scheduler_enabled():
         await cm.__aenter__()
 
         assert mock_schedule_strava.call_count == 1
+        mock_trigger_initial_strava.assert_called_once()
         mock_reload_cache.assert_called_once()
         mock_start_weather_scheduler.assert_called_once()
         mock_setup_emagram.assert_called_once_with(app)
         mock_start_emagram.assert_called_once_with(mock_setup_emagram.return_value)
-        mock_create_task.assert_called_once()
+        assert len(created_tasks) == 1
 
         await cm.__aexit__(None, None, None)
 


### PR DESCRIPTION
## Summary
- Refresh Strava token once at backend startup so the token is valid before the periodic job runs.
- Keep the 4h scheduler in place and add coverage for the startup refresh path.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `apps/backend/../../.venv/bin/pytest apps/backend/tests/unit/test_main.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (blocked by long-running existing scraper tests; timeout after 15m)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immediate Strava token refresh on application startup to ensure authentication is current before the scheduled refresh interval begins.

* **Tests**
  * Added test coverage for the startup token refresh functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->