### PR TITLE
fix(frontend): expose GoPro overlay downloads

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -663,6 +663,21 @@ export function FlightDetails({
                 max={100}
                 aria-label={t('flights.goproOverlayJobTitle')}
               />
+              {goproOverlayJob.status === 'completed' && (
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 dark:border-emerald-800 dark:bg-emerald-950/30">
+                  <span className="text-xs font-semibold text-emerald-900 dark:text-emerald-100">
+                    {goproOverlayJob.output_filename}
+                  </span>
+                  <Button
+                    type="button"
+                    className="min-h-9 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700"
+                    onPress={handleDownloadGoproOverlay}
+                  >
+                    <Download className="h-4 w-4" aria-hidden="true" />
+                    {t('flights.goproOverlayDownload')}
+                  </Button>
+                </div>
+              )}
               {goproOverlayJob.error && (
                 <pre className="mt-2 max-h-36 overflow-auto rounded bg-red-950 p-2 text-xs text-red-50">
                   {goproOverlayJob.error}

--- a/apps/frontend/src/pages/GoproOverlay.tsx
+++ b/apps/frontend/src/pages/GoproOverlay.tsx
@@ -358,6 +358,20 @@ export default function GoproOverlayPage() {
             max={100}
             aria-label="Avancement de la génération overlay GoPro"
           />
+          {activeJob.status === 'completed' && (
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3 dark:border-emerald-800 dark:bg-emerald-950/30">
+              <p className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                Overlay prêt : {activeJob.output_filename}
+              </p>
+              <Button
+                type="button"
+                onClick={handleDownload}
+                className="cursor-pointer rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:focus:ring-offset-slate-900"
+              >
+                Télécharger overlay
+              </Button>
+            </div>
+          )}
           {activeJob.error && (
             <pre className="mt-3 max-h-56 overflow-auto rounded-lg bg-red-950 p-3 text-xs text-red-50">
               {activeJob.error}


### PR DESCRIPTION
## Summary
- Add an explicit download CTA for completed GoPro overlay jobs on the dedicated page.
- Surface the same download action inside flight details so the result is obvious when the render finishes.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --project unit
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend