### PR TITLE
fix(design-system): keep tabs readable on mobile

### DIFF
--- a/libs/design-system/src/Tabs.stories.tsx
+++ b/libs/design-system/src/Tabs.stories.tsx
@@ -10,7 +10,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'Accessible tabs built on react-aria-components with a visible selected state and dark mode support.',
+          'Accessible tabs built on react-aria-components with a visible selected state, horizontal mobile scrolling, and dark mode support.',
       },
     },
   },
@@ -53,13 +53,13 @@ Default.test('shows selected tab state', async ({ canvas }) => {
 
 export const Responsive = meta.story({
   render: () => (
-    <div className="w-[min(36rem,calc(100vw-2rem))]">
+    <div className="w-[min(24rem,calc(100vw-2rem))]">
       <Tabs defaultSelectedKey="sites">
         <TabList className="grid-cols-2 sm:flex">
           <Tab id="general">General</Tab>
-          <Tab id="sites">Sites</Tab>
-          <Tab id="weather">Weather</Tab>
-          <Tab id="data">Data</Tab>
+          <Tab id="sites">Favorite sites</Tab>
+          <Tab id="weather">Weather sources</Tab>
+          <Tab id="data">Data management</Tab>
         </TabList>
         <TabPanel id="general">General settings</TabPanel>
         <TabPanel id="sites">Favorite sites</TabPanel>

--- a/libs/design-system/src/Tabs.test.tsx
+++ b/libs/design-system/src/Tabs.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { TAB_BASE_CLASS, TAB_LIST_BASE_CLASS } from './Tabs';
+
+describe('Tabs', () => {
+  it('keeps tab labels on one line and scrollable on mobile', () => {
+    expect(TAB_LIST_BASE_CLASS).toContain('overflow-x-auto');
+    expect(TAB_LIST_BASE_CLASS).toContain('sm:grid');
+    expect(TAB_BASE_CLASS).toContain('whitespace-nowrap');
+    expect(TAB_BASE_CLASS).toContain('min-w-max');
+  });
+});

--- a/libs/design-system/src/Tabs.tsx
+++ b/libs/design-system/src/Tabs.tsx
@@ -13,6 +13,12 @@ import type {
 } from 'react-aria-components';
 import { twMerge } from 'tailwind-merge';
 
+export const TAB_LIST_BASE_CLASS =
+  'flex max-w-full gap-2 overflow-x-auto rounded-xl bg-white p-2 shadow-md dark:bg-gray-800 sm:grid sm:overflow-visible';
+
+export const TAB_BASE_CLASS =
+  'min-w-max flex-1 cursor-pointer whitespace-nowrap rounded-lg bg-gray-100 px-4 py-2 text-center font-medium text-gray-700 outline-none transition-all hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 data-[selected]:bg-sky-600 data-[selected]:text-white data-[selected]:shadow-md dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:focus-visible:ring-offset-gray-800';
+
 export function Tabs({ className, ...props }: TabsProps) {
   return (
     <AriaTabs
@@ -32,10 +38,7 @@ export function TabList<T extends object>({
     <AriaTabList
       {...props}
       className={composeRenderProps(className, (className) =>
-        twMerge(
-          'grid gap-2 rounded-xl bg-white p-2 shadow-md dark:bg-gray-800',
-          className
-        )
+        twMerge(TAB_LIST_BASE_CLASS, className)
       )}
     />
   );
@@ -46,10 +49,7 @@ export function Tab({ className, ...props }: TabProps) {
     <AriaTab
       {...props}
       className={composeRenderProps(className, (className) =>
-        twMerge(
-          'flex-1 cursor-pointer rounded-lg bg-gray-100 px-4 py-2 text-center font-medium text-gray-700 outline-none transition-all hover:bg-gray-200 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 data-[selected]:bg-sky-600 data-[selected]:text-white data-[selected]:shadow-md dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:focus-visible:ring-offset-gray-800',
-          className
-        )
+        twMerge(TAB_BASE_CLASS, className)
       )}
     />
   );


### PR DESCRIPTION
## Summary
- Make `TabList` horizontally scrollable on mobile while keeping the existing desktop layout.
- Prevent tab labels from wrapping so long labels stay readable.
- Add a focused unit test for the tab layout classes.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `CI=true /home/capic/.local/share/pnpm/pnpm vitest run --config vitest.config.ts src/Tabs.test.tsx --project unit`