### PR TITLE
fix(frontend): refresh flight selection in virtual list

### DIFF
--- a/apps/frontend/src/components/flights/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '../../../.storybook/preview';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { useState } from 'react';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { FlightsTable } from './FlightsTable';
@@ -124,6 +124,22 @@ const meta = preview.meta({
 export const Default = meta.story({
   name: 'Default',
   render: () => <FlightsTableWrapper flights={mockFlights} />,
+});
+
+export const SelectionUpdatesActiveStyle = meta.story({
+  name: 'Selection updates active style',
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => <FlightsTableWrapper flights={mockFlights} />,
+  async play({ canvasElement }) {
+    const canvas = within(canvasElement);
+    const flightRow = canvas.getByTestId('flight-row-flight-1');
+
+    await userEvent.click(flightRow);
+
+    await expect(flightRow).toHaveClass('border-sky-700');
+  },
 });
 
 export const SelectionMode = meta.story({

--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import type { RowSelectionState } from '@tanstack/react-table';
+import type * as ReactI18next from 'react-i18next';
+import { expect, test, vi } from 'vitest';
+import type { Flight } from '../../types';
+import { FlightsTable } from './FlightsTable';
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18next>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+      i18n: { language: 'fr' },
+    }),
+  };
+});
+
+const flights: Flight[] = [
+  {
+    id: 'flight-1',
+    flight_date: '2024-03-15',
+    site_name: 'Puy de Dôme',
+    site_id: 'site-1',
+    title: 'Vol thermique',
+    name: 'Thermique',
+    duration_minutes: 90,
+    distance_km: 12.5,
+    max_altitude_m: 1465,
+    departure_time: '2024-03-15T14:30:00',
+    gpx_file_path: '/uploads/flight-1.gpx',
+    notes: null,
+  },
+  {
+    id: 'flight-2',
+    flight_date: '2024-03-10',
+    site_name: 'Col de la Forclaz',
+    site_id: 'site-2',
+    title: 'Autre vol',
+    name: 'Autre',
+    duration_minutes: 45,
+    distance_km: 5.2,
+    max_altitude_m: 920,
+    departure_time: '2024-03-10T11:00:00',
+    gpx_file_path: null,
+    notes: null,
+  },
+];
+
+function FlightsTableHarness() {
+  const [selectedFlightId, setSelectedFlightId] = useState<string | null>(null);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  return (
+    <FlightsTable
+      flights={flights}
+      selectedFlightId={selectedFlightId}
+      selectionMode={false}
+      onSelectFlight={(flight) => setSelectedFlightId(flight.id)}
+      onDeleteFlight={() => undefined}
+      rowSelection={rowSelection}
+      onRowSelectionChange={setRowSelection}
+    />
+  );
+}
+
+test('applies the active style when a flight is selected', () => {
+  render(<FlightsTableHarness />);
+
+  const flightRow = screen.getByTestId('flight-row-flight-1');
+
+  fireEvent.click(flightRow);
+
+  expect(flightRow).toHaveClass('border-sky-700');
+  expect(flightRow).toHaveAttribute('aria-selected', 'true');
+});

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -264,6 +264,7 @@ export function FlightsTable({
       className="flex h-full flex-col lg:min-h-[calc(100vh-22rem)]"
       itemsClassName="min-h-72 flex-1 overflow-y-auto pr-1"
       virtualizedLayoutOptions={{ estimatedRowSize: 136, gap: 8 }}
+      renderDependencies={[selectedFlightId, selectionMode, rowSelection]}
       selectionMode={selectionMode ? 'multiple' : 'none'}
       selectedKeys={selectedKeys}
       onSelectionChange={handleSelectionChange}

--- a/libs/design-system/src/components/DataList/DataList.tsx
+++ b/libs/design-system/src/components/DataList/DataList.tsx
@@ -104,6 +104,7 @@ export interface DataListProps<TData> {
   layout?: 'stack' | 'grid';
   isVirtualized?: boolean;
   virtualizedLayoutOptions?: ListLayoutOptions;
+  renderDependencies?: readonly unknown[];
   selectionMode?: 'none' | 'single' | 'multiple';
   selectedKeys?: Selection;
   onSelectionChange?: (keys: Selection) => void;
@@ -131,6 +132,7 @@ export function DataList<TData>({
   layout = 'stack',
   isVirtualized = false,
   virtualizedLayoutOptions,
+  renderDependencies,
   selectionMode = 'none',
   selectedKeys,
   onSelectionChange,
@@ -209,6 +211,7 @@ export function DataList<TData>({
           <ListBox
             aria-label={ariaLabel}
             items={rows}
+            dependencies={renderDependencies}
             layout={layout}
             selectionMode={isSelectable ? selectionMode : undefined}
             selectedKeys={isSelectable ? selectedKeys : undefined}
@@ -236,6 +239,7 @@ export function DataList<TData>({
         <ListBox
           aria-label={ariaLabel}
           items={rows}
+          dependencies={renderDependencies}
           layout={layout}
           selectionMode={isSelectable ? selectionMode : undefined}
           selectedKeys={isSelectable ? selectedKeys : undefined}


### PR DESCRIPTION
## Summary
- Invalidate the virtualized flights collection when the selected flight changes so the active card style updates reliably.
- Add a focused unit test for the selection highlight behavior.
- Keep the story-level regression check for the virtualized flight list.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit src/components/flights/FlightsTable.test.tsx --reporter verbose`

## Note
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` stalled in the browser/Vite optimizer in this environment, which matches prior repo behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for flight selection behavior, ensuring proper visual feedback when selecting flights.

* **Chores**
  * Enhanced component infrastructure to improve rendering performance and state management consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->