### PR TITLE
fix(backend): load root env for strava token

### DIFF
--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -18,9 +18,9 @@ from env_utils import required_env
 logger = logging.getLogger(__name__)
 
 
-# Déterminer le répertoire racine du projet
-PROJECT_ROOT = Path(__file__).parent.parent
-BACKEND_ROOT = Path(__file__).parent
+# Déterminer le répertoire racine du monorepo
+BACKEND_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = BACKEND_ROOT.parents[1]
 
 # Charger les variables d'environnement selon le contexte
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -5,6 +5,10 @@ import pytest
 import config
 
 
+def test_project_root_points_to_monorepo_root():
+    assert (config.PROJECT_ROOT / ".env.example").is_file()
+
+
 def test_required_env_rejects_missing_variable(monkeypatch):
     monkeypatch.delenv("BACKEND_MISSING_PATH", raising=False)
 


### PR DESCRIPTION
## Summary
- Load backend `.env` files from the monorepo root instead of `apps/`
- Add a regression test for the detected project root

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend` ✅
- `TESTING=true /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/unit/test_required_env.py -q --tb=short --no-header` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e --base=origin/main --head=HEAD` → no tasks were run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend configuration path resolution logic
  * Added validation test to verify project root configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->