### PR TITLE
fix(frontend): make flight media badges downloadable

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -11,7 +11,15 @@ import {
   TabPanel,
   Tabs,
 } from '@dashboard-parapente/design-system';
-import { Download, Edit3, FileUp, Pencil, Wand2 } from 'lucide-react';
+import {
+  Download,
+  Edit3,
+  FileText,
+  FileUp,
+  Pencil,
+  Video,
+  Wand2,
+} from 'lucide-react';
 import {
   useUpdateFlight,
   useUploadGPXToFlight,
@@ -96,6 +104,7 @@ export function FlightDetails({
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
   const [hasOpenedReplay, setHasOpenedReplay] = useState(false);
   const [isDownloadingGpx, setIsDownloadingGpx] = useState(false);
+  const [isDownloadingVideo, setIsDownloadingVideo] = useState(false);
   const [goproOverlayJobId, setGoproOverlayJobId] = useState<string | null>(
     null
   );
@@ -215,7 +224,7 @@ export function FlightDetails({
       const blob = await api.get(`flights/${flight.id}/gpx`).blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/g, '_');
+      const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/gu, '_');
 
       a.href = url;
       a.download = `${filename || flight.id}.gpx`;
@@ -226,6 +235,35 @@ export function FlightDetails({
       toast.error(t('flights.gpxDownloadError'));
     } finally {
       setIsDownloadingGpx(false);
+    }
+  };
+
+  const handleVideoDownload = async () => {
+    if (!hasVideo || !flight.video_export_job_id || isDownloadingVideo) {
+      return;
+    }
+
+    setIsDownloadingVideo(true);
+    try {
+      const blob = await api
+        .get(`exports/${flight.video_export_job_id}/download`, {
+          timeout: false,
+        })
+        .blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/gu, '_');
+
+      a.href = url;
+      a.download = `${filename || flight.id}.mp4`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(error, t('flights.viewer.videoDownloadError'))
+      );
+    } finally {
+      setIsDownloadingVideo(false);
     }
   };
 
@@ -547,14 +585,44 @@ export function FlightDetails({
               {(hasGpx || hasVideo) && (
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {hasGpx && (
-                    <span className="inline-flex items-center rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200">
-                      {t('flights.gpxBadge')}
-                    </span>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800"
+                      onClick={() => void handleGPXDownload()}
+                      disabled={isDownloadingGpx}
+                      aria-label={t('flights.downloadGpx')}
+                    >
+                      <FileText className="h-3 w-3" aria-hidden="true" />
+                      {isDownloadingGpx ? (
+                        t('flights.gpxDownloadInProgress')
+                      ) : (
+                        <>
+                          {t('flights.gpxBadge')}
+                          <Download className="h-3 w-3" aria-hidden="true" />
+                        </>
+                      )}
+                    </button>
                   )}
                   {hasVideo && (
-                    <span className="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
-                      {t('flights.videoBadge')}
-                    </span>
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800"
+                      onClick={() => void handleVideoDownload()}
+                      disabled={
+                        isDownloadingVideo || !flight.video_export_job_id
+                      }
+                      aria-label={t('flights.viewer.downloadVideo')}
+                    >
+                      <Video className="h-3 w-3" aria-hidden="true" />
+                      {isDownloadingVideo ? (
+                        t('flights.gpxDownloadInProgress')
+                      ) : (
+                        <>
+                          {t('flights.videoBadge')}
+                          <Download className="h-3 w-3" aria-hidden="true" />
+                        </>
+                      )}
+                    </button>
                   )}
                 </div>
               )}

--- a/apps/frontend/src/components/flights/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.stories.tsx
@@ -20,6 +20,9 @@ const mockFlights: Flight[] = [
     max_speed_kmh: 42,
     departure_time: '2024-03-15T14:30:00',
     gpx_file_path: '/uploads/flight-1.gpx',
+    video_export_job_id: 'job-flight-1',
+    video_export_status: 'completed',
+    video_file_path: '/exports/flight-1.mp4',
     notes: 'Super conditions thermiques',
   },
   {
@@ -105,6 +108,9 @@ function FlightsTableWrapper({
         selectionMode={selectionMode}
         onSelectFlight={(flight) => setSelectedFlightId(flight.id)}
         onDeleteFlight={fn()}
+        onDownloadGpx={fn()}
+        onDownloadVideo={fn()}
+        downloadingMedia={null}
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}
       />

--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -31,6 +31,9 @@ const flights: Flight[] = [
     max_altitude_m: 1465,
     departure_time: '2024-03-15T14:30:00',
     gpx_file_path: '/uploads/flight-1.gpx',
+    video_export_job_id: 'job-flight-1',
+    video_export_status: 'completed',
+    video_file_path: '/exports/flight-1.mp4',
     notes: null,
   },
   {
@@ -49,7 +52,13 @@ const flights: Flight[] = [
   },
 ];
 
-function FlightsTableHarness() {
+function FlightsTableHarness({
+  onDownloadGpx = () => undefined,
+  onDownloadVideo = () => undefined,
+}: {
+  onDownloadGpx?: (flight: Flight) => void;
+  onDownloadVideo?: (flight: Flight) => void;
+}) {
   const [selectedFlightId, setSelectedFlightId] = useState<string | null>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -60,6 +69,9 @@ function FlightsTableHarness() {
       selectionMode={false}
       onSelectFlight={(flight) => setSelectedFlightId(flight.id)}
       onDeleteFlight={() => undefined}
+      onDownloadGpx={onDownloadGpx}
+      onDownloadVideo={onDownloadVideo}
+      downloadingMedia={null}
       rowSelection={rowSelection}
       onRowSelectionChange={setRowSelection}
     />
@@ -75,4 +87,17 @@ test('applies the active style when a flight is selected', () => {
 
   expect(flightRow).toHaveClass('border-sky-700');
   expect(flightRow).toHaveAttribute('aria-selected', 'true');
+});
+
+test('downloads media from badges without selecting the flight', () => {
+  const onDownloadGpx = vi.fn();
+  render(<FlightsTableHarness onDownloadGpx={onDownloadGpx} />);
+
+  const flightRow = screen.getByTestId('flight-row-flight-1');
+
+  fireEvent.click(screen.getByRole('button', { name: 'flights.downloadGpx' }));
+
+  expect(onDownloadGpx).toHaveBeenCalledWith(flights[0]);
+  expect(flightRow).not.toHaveClass('border-sky-700');
+  expect(flightRow).toHaveAttribute('aria-selected', 'false');
 });

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -6,11 +6,14 @@ import { DataList, Button } from '@dashboard-parapente/design-system';
 import {
   Check,
   Clock3,
+  Download,
+  FileText,
   MapPin,
   Mountain,
   Paperclip,
   Ruler,
   Trash2,
+  Video,
 } from 'lucide-react';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
 import type { Flight } from '../../types';
@@ -26,6 +29,9 @@ interface FlightsTableProps {
   selectionMode: boolean;
   onSelectFlight: (flight: Flight) => void;
   onDeleteFlight: (flight: Flight) => void;
+  onDownloadGpx: (flight: Flight) => void;
+  onDownloadVideo: (flight: Flight) => void;
+  downloadingMedia: { flightId: string; type: 'gpx' | 'video' } | null;
   rowSelection: RowSelectionState;
   onRowSelectionChange: OnChangeFn<RowSelectionState>;
 }
@@ -37,6 +43,9 @@ export function FlightsTable({
   selectionMode,
   onSelectFlight,
   onDeleteFlight,
+  onDownloadGpx,
+  onDownloadVideo,
+  downloadingMedia,
   rowSelection,
   onRowSelectionChange,
 }: FlightsTableProps) {
@@ -80,6 +89,12 @@ export function FlightsTable({
     (row: Row<Flight>, { isSelected }: { isSelected: boolean }) => {
       const flight = row.original;
       const isActive = selectedFlightId === flight.id;
+      const isDownloadingGpx =
+        downloadingMedia?.flightId === flight.id &&
+        downloadingMedia.type === 'gpx';
+      const isDownloadingVideo =
+        downloadingMedia?.flightId === flight.id &&
+        downloadingMedia.type === 'video';
       const selectFlight = () => {
         if (!selectionMode) {
           onSelectFlight(flight);
@@ -159,6 +174,59 @@ export function FlightsTable({
               <h3 className={`truncate text-sm font-semibold ${titleColor}`}>
                 {flight.title || t('flights.untitledFlight')}
               </h3>
+              {!selectionMode &&
+                (flight.gpx_file_path || flight.video_file_path) && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {flight.gpx_file_path && (
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDownloadGpx(flight);
+                        }}
+                        onKeyDown={(event) => event.stopPropagation()}
+                        disabled={Boolean(downloadingMedia)}
+                        aria-label={t('flights.downloadGpx')}
+                      >
+                        <FileText className="h-3 w-3" aria-hidden="true" />
+                        {isDownloadingGpx ? (
+                          t('flights.gpxDownloadInProgress')
+                        ) : (
+                          <>
+                            {t('flights.gpxBadge')}
+                            <Download className="h-3 w-3" aria-hidden="true" />
+                          </>
+                        )}
+                      </button>
+                    )}
+                    {flight.video_file_path && (
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDownloadVideo(flight);
+                        }}
+                        onKeyDown={(event) => event.stopPropagation()}
+                        disabled={Boolean(
+                          downloadingMedia || !flight.video_export_job_id
+                        )}
+                        aria-label={t('flights.viewer.downloadVideo')}
+                      >
+                        <Video className="h-3 w-3" aria-hidden="true" />
+                        {isDownloadingVideo ? (
+                          t('flights.gpxDownloadInProgress')
+                        ) : (
+                          <>
+                            {t('flights.videoBadge')}
+                            <Download className="h-3 w-3" aria-hidden="true" />
+                          </>
+                        )}
+                      </button>
+                    )}
+                  </div>
+                )}
             </div>
 
             {/* Badge GPX manquant */}
@@ -247,6 +315,9 @@ export function FlightsTable({
       selectedFlightId,
       onSelectFlight,
       onDeleteFlight,
+      onDownloadGpx,
+      onDownloadVideo,
+      downloadingMedia,
       t,
       i18n,
       units,

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -27,8 +27,20 @@ import {
 } from '@dashboard-parapente/design-system';
 import { useToast, useToastStore } from '../hooks/useToast';
 import { HTTPError } from 'ky';
-import { api } from '../lib/api';
+import { api, getApiErrorMessage } from '../lib/api';
 import { useIsMobile } from '../hooks/useIsMobile';
+
+type DownloadingFlightMedia = {
+  flightId: string;
+  type: 'gpx' | 'video';
+};
+
+function getFlightDownloadName(flight: Flight, extension: string) {
+  const rawName = flight.title?.trim() || flight.name?.trim() || flight.id;
+  const filename = rawName.replace(/[^a-zA-Z0-9._-]+/gu, '_');
+
+  return `${filename || flight.id}.${extension}`;
+}
 
 export default function FlightHistory() {
   const { t } = useTranslation();
@@ -52,6 +64,8 @@ export default function FlightHistory() {
   const [showMobileDetail, setShowMobileDetail] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [gpxFilter, setGpxFilter] = useState<'all' | 'with' | 'missing'>('all');
+  const [downloadingFlightMedia, setDownloadingFlightMedia] =
+    useState<DownloadingFlightMedia | null>(null);
 
   const filteredFlights = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -224,6 +238,65 @@ export default function FlightHistory() {
     t,
   ]);
 
+  const handleDownloadFlightGpx = useCallback(
+    async (flight: Flight) => {
+      if (!flight.gpx_file_path || downloadingFlightMedia) return;
+
+      setDownloadingFlightMedia({ flightId: flight.id, type: 'gpx' });
+      try {
+        const blob = await api.get(`flights/${flight.id}/gpx`).blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = getFlightDownloadName(flight, 'gpx');
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch {
+        toast.error(t('flights.gpxDownloadError'));
+      } finally {
+        setDownloadingFlightMedia(null);
+      }
+    },
+    [downloadingFlightMedia, t, toast]
+  );
+
+  const handleDownloadFlightVideo = useCallback(
+    async (flight: Flight) => {
+      if (
+        !flight.video_file_path ||
+        !flight.video_export_job_id ||
+        downloadingFlightMedia
+      ) {
+        return;
+      }
+
+      setDownloadingFlightMedia({ flightId: flight.id, type: 'video' });
+      try {
+        const blob = await api
+          .get(`exports/${flight.video_export_job_id}/download`, {
+            timeout: false,
+          })
+          .blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = getFlightDownloadName(flight, 'mp4');
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        toast.error(
+          await getApiErrorMessage(
+            error,
+            t('flights.viewer.videoDownloadError')
+          )
+        );
+      } finally {
+        setDownloadingFlightMedia(null);
+      }
+    },
+    [downloadingFlightMedia, t, toast]
+  );
+
   return (
     <div>
       {/* Toast notifications */}
@@ -364,6 +437,9 @@ export default function FlightHistory() {
               selectionMode={selectionMode}
               onSelectFlight={handleSelectFlight}
               onDeleteFlight={setFlightToDelete}
+              onDownloadGpx={handleDownloadFlightGpx}
+              onDownloadVideo={handleDownloadFlightVideo}
+              downloadingMedia={downloadingFlightMedia}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}
             />


### PR DESCRIPTION
## Summary
- Make GPX and video badges in the flight history/details views act as download actions.
- Wire the flight list to download media without changing selection, and keep download state accessible.
- Update story/test coverage for the new badge actions.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightsTable.test.tsx`