### PR TITLE
fix(video): add per-job file actions

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -679,6 +679,24 @@ def gopro_overlay_output_path(job_id: str) -> Path | None:
     return path if path.exists() else None
 
 
+def delete_gopro_overlay_output(job_id: str) -> dict[str, Any] | None:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return None
+        if job["status"] not in _TERMINAL_STATUSES:
+            return {"job_id": job_id, "deleted": False, "error": "active"}
+        output_path = Path(job["output_path"])
+
+    if not output_path.exists():
+        return {"job_id": job_id, "deleted": False, "path": str(output_path)}
+    if output_path.is_dir():
+        return {"job_id": job_id, "deleted": False, "path": str(output_path), "error": "dir"}
+
+    output_path.unlink()
+    return {"job_id": job_id, "deleted": True, "path": str(output_path)}
+
+
 def check_gopro_overlay_dependencies() -> dict[str, bool]:
     gopro_bin = config.GOPRO_OVERLAY_BIN
     has_gopro_dashboard = (

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -45,6 +45,7 @@ from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import check_gopro_overlay_dependencies
 from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
+from gopro_overlay_export import delete_gopro_overlay_output
 from gopro_overlay_export import get_gopro_overlay_job
 from gopro_overlay_export import gopro_overlay_output_path
 from gopro_overlay_export import list_gopro_overlay_jobs
@@ -58,6 +59,7 @@ from models import (
     Flight,
     Site,
     SiteLandingAssociation,
+    VideoExportJob,
     WeatherForecast,
     WeatherSourceConfig,
 )
@@ -328,6 +330,7 @@ def _video_export_can_cancel(export: dict[str, Any]) -> bool:
 
 
 def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
+    output_path = job.get("output_path")
     return {
         "job_id": job.get("job_id"),
         "status": job.get("status"),
@@ -343,6 +346,7 @@ def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "completed_at": job.get("completed_at"),
         "output_filename": job.get("output_filename"),
         "layout_label": job.get("layout_label"),
+        "has_output_file": bool(output_path and Path(str(output_path)).exists()),
     }
 
 
@@ -369,6 +373,9 @@ def _build_video_export_jobs_payload(
         job = dict(export)
         job["status"] = _video_export_public_status(job)
         job["can_cancel"] = _video_export_can_cancel(job)
+        if "has_output_file" not in job:
+            video_path = job.get("video_path")
+            job["has_output_file"] = bool(video_path and Path(str(video_path)).exists())
         if flight:
             job["flight_name"] = flight.name or flight.title
             job["flight_title"] = flight.title or flight.name
@@ -4557,6 +4564,46 @@ def delete_video_export_temp_files() -> VideoExportTempCleanupResponse:
     )
 
 
+@router.delete("/exports/{job_id}/video")
+def delete_exported_video_file(job_id: str, db: Session = Depends(get_db)):
+    """Delete the final video file for a completed, failed, or cancelled export."""
+    status = _resolve_export_status(job_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="Export job not found")
+
+    if _video_export_can_cancel(status):
+        raise HTTPException(status_code=400, detail="Cannot delete video for an active export")
+
+    video_path = status.get("video_path")
+    if not video_path:
+        raise HTTPException(status_code=400, detail="Export has no generated video file")
+
+    path = Path(str(video_path))
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Video file not found")
+    if path.is_dir():
+        raise HTTPException(status_code=400, detail="Video path is not a file")
+
+    path.unlink()
+
+    export_job = db.query(VideoExportJob).filter(VideoExportJob.id == job_id).first()
+    if export_job:
+        export_job.video_path = None
+    flight_id = status.get("flight_id")
+    if flight_id:
+        flight = db.query(Flight).filter(Flight.id == flight_id).first()
+        if flight and flight.video_file_path == str(video_path):
+            flight.video_file_path = None
+    db.commit()
+
+    return {
+        "job_id": job_id,
+        "deleted": True,
+        "path": str(path),
+        "message": "Video file deleted",
+    }
+
+
 @router.get("/exports/{job_id}/stream")
 async def stream_video_export_status(job_id: str, request: Request) -> StreamingResponse:
     """Stream export status updates through Server-Sent Events."""
@@ -4970,6 +5017,27 @@ def download_gopro_overlay_render_job(job_id: str) -> FileResponse:
         raise HTTPException(status_code=400, detail="GoPro overlay video is not ready")
 
     return FileResponse(path=output_path, media_type="video/mp4", filename=output_path.name)
+
+
+@router.delete("/gopro-overlays/jobs/{job_id}/video")
+def delete_gopro_overlay_render_output(job_id: str):
+    """Delete the final GoPro overlay video for a terminal job."""
+    result = delete_gopro_overlay_output(job_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="GoPro overlay job not found")
+    if result.get("error") == "active":
+        raise HTTPException(status_code=400, detail="Cannot delete video for an active overlay")
+    if result.get("error") == "dir":
+        raise HTTPException(status_code=400, detail="Overlay output path is not a file")
+    if not result.get("deleted"):
+        raise HTTPException(status_code=404, detail="GoPro overlay video file not found")
+
+    return {
+        "job_id": job_id,
+        "deleted": True,
+        "path": result.get("path"),
+        "message": "GoPro overlay video file deleted",
+    }
 
 
 @public_router.get(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -633,6 +633,33 @@ def test_download_gopro_overlay_rejects_unfinished_job(client: TestClient):
     assert response.json()["detail"] == "GoPro overlay video is not ready"
 
 
+def test_delete_gopro_overlay_video_removes_completed_output(client: TestClient):
+    with patch(
+        "routes.delete_gopro_overlay_output",
+        return_value={"job_id": "job-gopro", "deleted": True, "path": "/tmp/final.mp4"},
+    ):
+        response = client.delete(f"{API_PREFIX}/gopro-overlays/jobs/job-gopro/video")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "job_id": "job-gopro",
+        "deleted": True,
+        "path": "/tmp/final.mp4",
+        "message": "GoPro overlay video file deleted",
+    }
+
+
+def test_delete_gopro_overlay_video_rejects_running_job(client: TestClient):
+    with patch(
+        "routes.delete_gopro_overlay_output",
+        return_value={"job_id": "job-gopro", "deleted": False, "error": "active"},
+    ):
+        response = client.delete(f"{API_PREFIX}/gopro-overlays/jobs/job-gopro/video")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Cannot delete video for an active overlay"
+
+
 def test_prepare_layout_file_injects_pip_id(tmp_path):
     source = tmp_path / "layout.xml"
     destination = tmp_path / "prepared.xml"

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -345,6 +345,51 @@ class TestExportStatusAndCancel:
         finally:
             Path(video_path).unlink(missing_ok=True)
 
+    def test_export_video_delete_removes_generated_file(
+        self, client: TestClient, db_session, sample_flight, tmp_path
+    ):
+        video_path = tmp_path / "generated.mp4"
+        video_path.write_bytes(b"video")
+        sample_flight.video_file_path = str(video_path)
+        db_session.commit()
+
+        with patch(
+            "routes._resolve_export_status",
+            return_value={
+                "job_id": "job-delete",
+                "flight_id": sample_flight.id,
+                "status": "completed",
+                "internal_status": "completed",
+                "video_path": str(video_path),
+            },
+        ):
+            response = client.delete(f"{API_PREFIX}/exports/job-delete/video")
+
+        assert response.status_code == 200
+        assert response.json()["deleted"] is True
+        assert not video_path.exists()
+        db_session.refresh(sample_flight)
+        assert sample_flight.video_file_path is None
+
+    def test_export_video_delete_rejects_active_job(self, client: TestClient, tmp_path):
+        video_path = tmp_path / "active.mp4"
+        video_path.write_bytes(b"video")
+
+        with patch(
+            "routes._resolve_export_status",
+            return_value={
+                "job_id": "job-active",
+                "status": "processing",
+                "internal_status": "encoding",
+                "video_path": str(video_path),
+            },
+        ):
+            response = client.delete(f"{API_PREFIX}/exports/job-active/video")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Cannot delete video for an active export"
+        assert video_path.exists()
+
     def test_export_status_stream_sends_sse_status_event(self, client: TestClient):
         """SSE endpoint should emit status events for active jobs."""
         active_status = {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -5,44 +5,76 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoExportJobsPanel } from './VideoExportJobsPanel';
 
-const { cancelJob, cleanupTempFiles, toastError, toastSuccess, refetch, jobs } =
-  vi.hoisted(() => ({
-    cancelJob: vi.fn(),
-    cleanupTempFiles: vi.fn(),
-    toastError: vi.fn(),
-    toastSuccess: vi.fn(),
-    refetch: vi.fn(),
-    jobs: [
-      {
-        job_id: 'job-active',
-        flight_title: 'Vol test',
-        status: 'processing',
-        internal_status: 'capturing',
-        progress: 42,
-        message: 'Capturing frames',
-        mode: 'manual_fast',
-        can_cancel: true,
-      },
-      {
-        job_id: 'job-done',
-        flight_title: 'Vol terminé',
-        status: 'completed',
-        internal_status: 'completed',
-        progress: 100,
-        can_cancel: false,
-      },
-      {
-        job_id: 'job-overlay',
-        flight_title: 'vol-overlay.mp4',
-        status: 'running',
-        internal_status: 'running',
-        progress: 50,
-        message: 'Rendering overlay',
-        mode: 'gopro_overlay',
-        can_cancel: true,
-      },
-    ],
-  }));
+const {
+  cancelJob,
+  cleanupTempFiles,
+  deleteOutput,
+  resumeJob,
+  toastError,
+  toastSuccess,
+  refetch,
+  jobs,
+} = vi.hoisted(() => ({
+  cancelJob: vi.fn(),
+  cleanupTempFiles: vi.fn(),
+  deleteOutput: vi.fn(),
+  resumeJob: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  refetch: vi.fn(),
+  jobs: [
+    {
+      job_id: 'job-active',
+      flight_title: 'Vol test',
+      status: 'processing',
+      internal_status: 'capturing',
+      progress: 42,
+      message: 'Capturing frames',
+      mode: 'manual_fast',
+      can_cancel: true,
+    },
+    {
+      job_id: 'job-done',
+      flight_title: 'Vol terminé',
+      status: 'completed',
+      internal_status: 'completed',
+      progress: 100,
+      has_output_file: true,
+      can_cancel: false,
+    },
+    {
+      job_id: 'job-overlay',
+      flight_title: 'vol-overlay.mp4',
+      status: 'running',
+      internal_status: 'running',
+      progress: 50,
+      message: 'Rendering overlay',
+      mode: 'gopro_overlay',
+      can_cancel: true,
+    },
+    {
+      job_id: 'job-resumable',
+      flight_id: 'flight-resumable',
+      flight_title: 'Vol relançable',
+      status: 'cancelled',
+      internal_status: 'cancelled',
+      progress: 30,
+      can_cancel: false,
+      can_resume: true,
+    },
+    {
+      job_id: 'job-overlay-done',
+      flight_title: 'final.mp4',
+      status: 'completed',
+      internal_status: 'completed',
+      progress: 100,
+      message: 'Overlay ready',
+      mode: 'gopro_overlay',
+      has_output_file: true,
+      can_cancel: false,
+    },
+  ],
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -70,6 +102,14 @@ vi.mock('../../hooks/flights/useVideoExportJobs', () => ({
   }),
   useCancelVideoExportJob: () => ({
     mutateAsync: cancelJob,
+    isPending: false,
+  }),
+  useResumeVideoExportJob: () => ({
+    mutateAsync: resumeJob,
+    isPending: false,
+  }),
+  useDeleteVideoExportOutput: () => ({
+    mutateAsync: deleteOutput,
     isPending: false,
   }),
   useCleanupVideoExportTempFiles: () => ({
@@ -100,6 +140,7 @@ describe('VideoExportJobsPanel', () => {
         status: 'completed',
         internal_status: 'completed',
         progress: 100,
+        has_output_file: true,
         can_cancel: false,
       },
       {
@@ -111,6 +152,27 @@ describe('VideoExportJobsPanel', () => {
         message: 'Rendering overlay',
         mode: 'gopro_overlay',
         can_cancel: true,
+      },
+      {
+        job_id: 'job-resumable',
+        flight_id: 'flight-resumable',
+        flight_title: 'Vol relançable',
+        status: 'cancelled',
+        internal_status: 'cancelled',
+        progress: 30,
+        can_cancel: false,
+        can_resume: true,
+      },
+      {
+        job_id: 'job-overlay-done',
+        flight_title: 'final.mp4',
+        status: 'completed',
+        internal_status: 'completed',
+        progress: 100,
+        message: 'Overlay ready',
+        mode: 'gopro_overlay',
+        has_output_file: true,
+        can_cancel: false,
       }
     );
   });
@@ -122,9 +184,22 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('Vol test').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Overlay GoPro').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Stopper' })).toHaveLength(4);
+    expect(
+      screen.getAllByRole('link', { name: 'Voir le vol' })[0]
+    ).toHaveAttribute('href', '/flights/flight-resumable');
+    expect(
+      screen.getAllByRole('button', { name: 'Télécharger' }).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('button', { name: 'Reprendre' }).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole('button', { name: 'Supprimer l’overlay' }).length
+    ).toBeGreaterThan(0);
   });
 
   it('filters jobs by status', () => {
@@ -147,6 +222,38 @@ describe('VideoExportJobsPanel', () => {
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
+  });
+
+  it('resumes a cancelled export', async () => {
+    resumeJob.mockResolvedValue(undefined);
+
+    render(<VideoExportJobsPanel />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Reprendre' })[0]!);
+
+    await waitFor(() =>
+      expect(resumeJob).toHaveBeenCalledWith('job-resumable')
+    );
+    expect(toastSuccess).toHaveBeenCalledWith('Génération relancée');
+  });
+
+  it('deletes a generated overlay after confirmation', async () => {
+    deleteOutput.mockResolvedValue(undefined);
+
+    render(<VideoExportJobsPanel />);
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Supprimer l’overlay' })[0]!
+    );
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'Supprimer l’overlay',
+    });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]!);
+
+    await waitFor(() =>
+      expect(deleteOutput).toHaveBeenCalledWith(
+        expect.objectContaining({ job_id: 'job-overlay-done' })
+      )
+    );
+    expect(toastSuccess).toHaveBeenCalledWith('Overlay GoPro supprimé');
   });
 
   it('cleans temporary files after confirmation', async () => {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -12,8 +12,11 @@ import {
   type VideoExportJob,
   useCancelVideoExportJob,
   useCleanupVideoExportTempFiles,
+  useDeleteVideoExportOutput,
+  useResumeVideoExportJob,
   useVideoExportJobs,
 } from '../../hooks/flights/useVideoExportJobs';
+import { api } from '../../lib/api';
 import { useToast } from '../../hooks/useToast';
 
 const statusLabelFallbacks: Record<string, string> = {
@@ -49,6 +52,9 @@ const statusFilters = [
 type StatusFilter = (typeof statusFilters)[number]['id'];
 
 const columnHelper = createColumnHelper<VideoExportJob>();
+
+const actionButtonClassName =
+  'cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500';
 
 type PendingVideoConfirm = {
   message: string;
@@ -137,6 +143,18 @@ function isJobInFilter(job: VideoExportJob, filter: StatusFilter) {
   return job.status === filter;
 }
 
+function isGoproOverlayJob(job: VideoExportJob) {
+  return job.mode === 'gopro_overlay';
+}
+
+function canDownloadJob(job: VideoExportJob) {
+  return job.status === 'completed' && job.has_output_file !== false;
+}
+
+function canDeleteOutput(job: VideoExportJob) {
+  return !job.can_cancel && job.has_output_file !== false;
+}
+
 function JobStatusBadge({ job }: { job: VideoExportJob }) {
   const { t } = useTranslation();
   const phase = getJobPhase(job);
@@ -193,6 +211,8 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   ]);
   const { data: jobs = [], isLoading, isError, refetch } = useVideoExportJobs();
   const cancelJob = useCancelVideoExportJob();
+  const resumeJob = useResumeVideoExportJob();
+  const deleteOutput = useDeleteVideoExportOutput();
   const cleanupTempFiles = useCleanupVideoExportTempFiles();
 
   const filteredJobs = useMemo(
@@ -229,6 +249,161 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       });
     },
     [cancelJob, t, toast]
+  );
+
+  const handleResume = useCallback(
+    async (job: VideoExportJob) => {
+      try {
+        await resumeJob.mutateAsync(job.job_id);
+        toast.success(t('videoJobs.resumeSuccess', 'Génération relancée'));
+      } catch {
+        toast.error(
+          t('videoJobs.resumeError', 'Impossible de relancer la génération')
+        );
+      }
+    },
+    [resumeJob, t, toast]
+  );
+
+  const handleDownload = useCallback(
+    async (job: VideoExportJob) => {
+      try {
+        const endpoint = isGoproOverlayJob(job)
+          ? `gopro-overlays/jobs/${job.job_id}/download`
+          : `exports/${job.job_id}/download`;
+        const response = await api.get(endpoint, { timeout: false });
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = job.output_filename || `${job.job_id}.mp4`;
+        document.body.append(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(url);
+      } catch {
+        toast.error(
+          t('videoJobs.downloadError', 'Impossible de télécharger la vidéo')
+        );
+      }
+    },
+    [t, toast]
+  );
+
+  const handleDeleteOutput = useCallback(
+    (job: VideoExportJob) => {
+      const isOverlay = isGoproOverlayJob(job);
+      setPendingConfirm({
+        message: isOverlay
+          ? t(
+              'videoJobs.confirmDeleteOverlay',
+              'Supprimer la vidéo overlay GoPro générée ?'
+            )
+          : t(
+              'videoJobs.confirmDeleteVideo',
+              'Supprimer la vidéo générée pour ce traitement ?'
+            ),
+        confirmLabel: isOverlay
+          ? t('videoJobs.deleteOverlay', 'Supprimer l’overlay')
+          : t('videoJobs.deleteVideo', 'Supprimer la vidéo'),
+        onConfirm: async () => {
+          try {
+            await deleteOutput.mutateAsync(job);
+            toast.success(
+              isOverlay
+                ? t('videoJobs.deleteOverlaySuccess', 'Overlay GoPro supprimé')
+                : t('videoJobs.deleteVideoSuccess', 'Vidéo générée supprimée')
+            );
+          } catch {
+            toast.error(
+              isOverlay
+                ? t(
+                    'videoJobs.deleteOverlayError',
+                    'Impossible de supprimer l’overlay GoPro'
+                  )
+                : t(
+                    'videoJobs.deleteVideoError',
+                    'Impossible de supprimer la vidéo générée'
+                  )
+            );
+          }
+        },
+      });
+    },
+    [deleteOutput, t, toast]
+  );
+
+  const renderJobActions = useCallback(
+    (job: VideoExportJob) => (
+      <div className="flex flex-wrap gap-2">
+        {job.flight_id && (
+          <a
+            href={`/flights/${job.flight_id}`}
+            className={`${actionButtonClassName} border border-sky-200 bg-white text-sky-700 hover:bg-sky-50 focus-visible:outline-sky-500 dark:border-sky-800 dark:bg-gray-800 dark:text-sky-300 dark:hover:bg-sky-950/40`}
+          >
+            {t('videoJobs.viewFlight', 'Voir le vol')}
+          </a>
+        )}
+        {canDownloadJob(job) && (
+          <Button
+            onClick={() => void handleDownload(job)}
+            className={`${actionButtonClassName} bg-sky-100 text-sky-800 hover:bg-sky-200 focus-visible:outline-sky-500 dark:bg-sky-900/40 dark:text-sky-200 dark:hover:bg-sky-900/60`}
+          >
+            {t('videoJobs.download', 'Télécharger')}
+          </Button>
+        )}
+        {!isGoproOverlayJob(job) && job.can_resume && (
+          <Button
+            onClick={() => void handleResume(job)}
+            isDisabled={resumeJob.isPending}
+            className={`${actionButtonClassName} bg-green-100 text-green-800 hover:bg-green-200 focus-visible:outline-green-500 dark:bg-green-900/40 dark:text-green-200 dark:hover:bg-green-900/60`}
+          >
+            {resumeJob.isPending
+              ? t('videoJobs.resuming', 'Relance...')
+              : t('videoJobs.resume', 'Reprendre')}
+          </Button>
+        )}
+        {job.can_cancel && (
+          <Button
+            onClick={() => handleCancel(job)}
+            isDisabled={cancelJob.isPending}
+            className={`${actionButtonClassName} bg-red-600 text-white hover:bg-red-700 focus-visible:outline-red-500`}
+          >
+            {cancelJob.isPending
+              ? t('videoJobs.stopping', 'Arrêt...')
+              : t('videoJobs.stop', 'Stopper')}
+          </Button>
+        )}
+        {canDeleteOutput(job) && (
+          <Button
+            onClick={() => handleDeleteOutput(job)}
+            isDisabled={deleteOutput.isPending}
+            className={`${actionButtonClassName} bg-gray-100 text-gray-800 hover:bg-gray-200 focus-visible:outline-gray-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600`}
+          >
+            {isGoproOverlayJob(job)
+              ? t('videoJobs.deleteOverlay', 'Supprimer l’overlay')
+              : t('videoJobs.deleteVideo', 'Supprimer la vidéo')}
+          </Button>
+        )}
+        {!job.flight_id &&
+          !canDownloadJob(job) &&
+          !job.can_resume &&
+          !job.can_cancel &&
+          !canDeleteOutput(job) && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">-</span>
+          )}
+      </div>
+    ),
+    [
+      cancelJob.isPending,
+      deleteOutput.isPending,
+      handleCancel,
+      handleDeleteOutput,
+      handleDownload,
+      handleResume,
+      resumeJob.isPending,
+      t,
+    ]
   );
 
   const columns = useMemo(
@@ -318,23 +493,10 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       columnHelper.display({
         id: 'actions',
         header: t('videoJobs.table.actions', 'Actions'),
-        cell: ({ row }) =>
-          row.original.can_cancel ? (
-            <Button
-              onClick={() => handleCancel(row.original)}
-              isDisabled={cancelJob.isPending}
-              className="cursor-pointer rounded-lg bg-red-600 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:bg-gray-300"
-            >
-              {cancelJob.isPending
-                ? t('videoJobs.stopping', 'Arrêt...')
-                : t('videoJobs.stop', 'Stopper')}
-            </Button>
-          ) : (
-            <span className="text-xs text-gray-400 dark:text-gray-500">-</span>
-          ),
+        cell: ({ row }) => renderJobActions(row.original),
       }),
     ],
-    [cancelJob.isPending, handleCancel, t]
+    [renderJobActions, t]
   );
 
   const table = useReactTable({
@@ -554,17 +716,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                       )}
                     </div>
 
-                    {job.can_cancel && (
-                      <Button
-                        onClick={() => handleCancel(job)}
-                        isDisabled={cancelJob.isPending}
-                        className="cursor-pointer rounded-lg bg-red-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-500 disabled:cursor-not-allowed disabled:bg-gray-300"
-                      >
-                        {cancelJob.isPending
-                          ? t('videoJobs.stopping', 'Arrêt...')
-                          : t('videoJobs.stop', 'Stopper')}
-                      </Button>
-                    )}
+                    {renderJobActions(job)}
                   </div>
 
                   <div className="mt-3">

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -27,6 +27,7 @@ export type VideoExportJob = {
   resume_from_frame?: number | null;
   output_filename?: string | null;
   layout_label?: string | null;
+  has_output_file?: boolean;
   can_cancel: boolean;
 };
 
@@ -67,6 +68,38 @@ export function useCancelVideoExportJob() {
   return useMutation({
     mutationFn: async (jobId: string) => {
       await api.delete(`exports/${jobId}/cancel`).json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });
+      queryClient.invalidateQueries({ queryKey: ['flights'] });
+    },
+  });
+}
+
+export function useResumeVideoExportJob() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (jobId: string) => {
+      await api.post(`exports/${jobId}/resume`).json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });
+      queryClient.invalidateQueries({ queryKey: ['flights'] });
+    },
+  });
+}
+
+export function useDeleteVideoExportOutput() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (job: VideoExportJob) => {
+      const endpoint =
+        job.mode === 'gopro_overlay'
+          ? `gopro-overlays/jobs/${job.job_id}/video`
+          : `exports/${job.job_id}/video`;
+      await api.delete(endpoint).json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -222,6 +222,23 @@ const initialMockVideoJobs: VideoExportJob[] = [
     mode: 'manual',
     started_at: '2026-01-14T12:20:00Z',
     completed_at: '2026-01-14T13:35:00Z',
+    has_output_file: true,
+    output_filename: 'chalais-export.mp4',
+    can_cancel: false,
+  },
+  {
+    job_id: 'job-gopro-completed',
+    flight_title: 'final.mp4',
+    status: 'completed',
+    internal_status: 'completed',
+    progress: 100,
+    message: 'Overlay ready',
+    mode: 'gopro_overlay',
+    updated_at: '2026-01-14T14:05:00Z',
+    completed_at: '2026-01-14T14:05:00Z',
+    output_filename: 'final.mp4',
+    layout_label: 'Overlay GoPro',
+    has_output_file: true,
     can_cancel: false,
   },
 ];
@@ -532,6 +549,37 @@ export const videoExportHandlers = [
     }
 
     return HttpResponse.json({ success: true });
+  }),
+
+  http.post('*/api/exports/:jobId/resume', ({ params }) => {
+    const job = mockVideoJobs.find((item) => item.job_id === params.jobId);
+    if (job) {
+      job.status = 'processing';
+      job.internal_status = 'queued';
+      job.can_cancel = true;
+      job.can_resume = false;
+      job.message = 'Resume enqueued';
+    }
+
+    return HttpResponse.json({ success: true });
+  }),
+
+  http.delete('*/api/exports/:jobId/video', ({ params }) => {
+    const job = mockVideoJobs.find((item) => item.job_id === params.jobId);
+    if (job) {
+      job.has_output_file = false;
+    }
+
+    return HttpResponse.json({ success: true, deleted: true });
+  }),
+
+  http.delete('*/api/gopro-overlays/jobs/:jobId/video', ({ params }) => {
+    const job = mockVideoJobs.find((item) => item.job_id === params.jobId);
+    if (job) {
+      job.has_output_file = false;
+    }
+
+    return HttpResponse.json({ success: true, deleted: true });
   }),
 ];
 


### PR DESCRIPTION
## Summary
- Add per-job actions in Infrastructure > Files for flights and GoPro overlays: view flight, download, resume, stop, and delete output.
- Add backend delete endpoints for generated video files and GoPro overlay outputs.
- Update tests and MSW stories to cover the new actions.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` (repo-wide warnings only, no errors)
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest apps/backend/tests/api/test_video_export_endpoints.py apps/backend/tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/ruff check apps/backend/routes.py apps/backend/gopro_overlay_export.py apps/backend/tests/api/test_video_export_endpoints.py apps/backend/tests/api/test_gopro_overlay_endpoints.py`

## Notes
- `nx test backend` and `nx lint backend` in the worktree require `apps/backend/.venv`; the direct pytest/ruff checks passed with the workspace venv.