### PR TITLE
fix(deploy): publish main image and stabilize backend boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@
 # Environment: development | production
 ENVIRONMENT=development
 
+# Production image used by Portainer. The main tag is updated on every main deployment.
+BACKEND_IMAGE=ghcr.io/capic2/dashboard-parapente/backend:main
+
 # ==========================================
 # BACKEND CONFIGURATION
 # ==========================================

--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -196,6 +196,7 @@ jobs:
             gopro-overlay-src=${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT }}
           tags: |
             ghcr.io/${{ github.repository }}/backend:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository }}/backend:main
             ghcr.io/${{ github.repository }}/backend:sha-${{ github.sha }}
 
       - name: Deploy on production server

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -20,7 +20,16 @@ logger = logging.getLogger(__name__)
 
 # Déterminer le répertoire racine du monorepo
 BACKEND_ROOT = Path(__file__).resolve().parent
-PROJECT_ROOT = BACKEND_ROOT.parents[1]
+
+
+def _resolve_project_root(backend_root: Path) -> Path:
+    if backend_root.parent.name == "apps":
+        return backend_root.parents[1]
+
+    return backend_root
+
+
+PROJECT_ROOT = _resolve_project_root(BACKEND_ROOT)
 
 # Charger les variables d'environnement selon le contexte
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -9,6 +9,14 @@ def test_project_root_points_to_monorepo_root():
     assert (config.PROJECT_ROOT / ".env.example").is_file()
 
 
+def test_project_root_supports_flat_docker_layout():
+    assert config._resolve_project_root(Path("/app")) == Path("/app")
+
+
+def test_project_root_supports_monorepo_layout():
+    assert config._resolve_project_root(Path("/repo/apps/backend")) == Path("/repo")
+
+
 def test_required_env_rejects_missing_variable(monkeypatch):
     monkeypatch.delenv("BACKEND_MISSING_PATH", raising=False)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - parapente-network
 
   backend:
-    image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required}
+    image: ${BACKEND_IMAGE:-ghcr.io/capic2/dashboard-parapente/backend:main}
     container_name: parapente-backend
     restart: unless-stopped
     ports:
@@ -111,16 +111,16 @@ services:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
     healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8001/']
+      test: ['CMD', 'curl', '-f', 'http://localhost:8001/health']
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 5
+      start_period: 120s
     networks:
       - parapente-network
 
   backend-worker:
-    image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required}
+    image: ${BACKEND_IMAGE:-ghcr.io/capic2/dashboard-parapente/backend:main}
     container_name: parapente-backend-worker
     restart: unless-stopped
     command: ['python', 'job_worker.py']

--- a/env.portainer
+++ b/env.portainer
@@ -4,8 +4,14 @@
 # Runtime environment currently configured in Portainer.
 ENVIRONMENT=production
 
+# Backend image pulled by Portainer. The main tag is updated on every main deployment.
+BACKEND_IMAGE=ghcr.io/capic2/dashboard-parapente/backend:main
+
 # Backend database connection currently configured in Portainer.
 BACKEND_DATABASE_URL=sqlite:///./db/dashboard.db
+
+# Required by standalone migration scripts.
+DATABASE_URL=sqlite:///./db/dashboard.db
 
 # Redis host currently configured in Portainer.
 BACKEND_REDIS_HOST=redis
@@ -117,3 +123,6 @@ GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
 
 # Host folder mounted at /app/parapente.
 GOPRO_OVERLAY_DATA_HOST_DIR=/media/nas/DS211_Synology_2/parapente
+
+# Deployment version state file.
+BACKEND_VERSION_STATE_FILE=/app/db/version_state.json


### PR DESCRIPTION
## Summary
- Publish and consume the backend `main` image tag for Portainer deployments.
- Make the backend image boot reliably in the Docker layout used by the built image.
- Document the required Portainer env values and harden the container healthcheck.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend` ✅
- `../../.venv/bin/pytest tests/unit/test_required_env.py -q` ✅
- `docker compose --env-file env.portainer config` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend service now defaults to production image tag with automatic fallback support when not explicitly configured.
  * Enhanced health checks with improved reliability settings, including extended startup grace period and increased retry attempts.

* **Chores**
  * Updated Docker image tagging strategy for deployment workflows.
  * Refined environment configuration for Portainer deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->