### PR TITLE
docs: use origin main for workflow analysis

### DIFF
--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -24,6 +24,14 @@ Projects: `frontend` in `apps/frontend`, `backend` in `apps/backend`, `design-sy
 - Never use destructive git commands.
 - Use `local-machine-stack` as the source of truth for pnpm paths, dependency readiness, command timeouts, and Nx validation commands.
 
+## Analysis Source Of Truth
+
+- Use `origin/main` as the default source of truth for repository analysis, diagnostics, code review, and behavior checks.
+- Before drawing conclusions from the current checkout, check whether it is aligned with `origin/main`.
+- If the current checkout is stale, dirty, or ambiguous, inspect `origin/main` directly or create/use a clean worktree from `origin/main`.
+- Only analyze local uncommitted changes, a non-main branch, or a specific worktree when the user explicitly asks for that target.
+- State which target is being analyzed when the distinction matters: local checkout, `origin/main`, or a named worktree.
+
 ## Worktrees
 
 Load `implementation-worktree-strategy` before implementation tasks: feature work, bug fixes, refactors, and code changes.

--- a/.agents/skills/implementation-worktree-strategy/SKILL.md
+++ b/.agents/skills/implementation-worktree-strategy/SKILL.md
@@ -19,6 +19,13 @@ Before any implementation task:
 Create worktrees in `.codenomad/worktree` with names starting with `wt-`.
 Whenever a worktree is created, immediately name the current AI session with the exact worktree name.
 
+## Analysis Baseline
+
+- Treat `origin/main` as the baseline for implementation analysis before editing.
+- Do not rely on local `main` for conclusions unless it has been verified aligned with `origin/main`.
+- If local `main` is stale, dirty, or ambiguous, create the implementation worktree from `origin/main` and continue analysis there.
+- If the user asks about local uncommitted changes or a specific branch/worktree, analyze that explicit target and say so.
+
 ## Worktree Bootstrap Subagent
 
 After creating a worktree, launch the `worktree-bootstrap` subagent immediately and let it run in parallel with the main implementation work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ This file defines global rules for the entire monorepo.
 - Always limit changes to what is required by the task.
 - Follow existing conventions before introducing a new pattern.
 - Never modify out-of-scope files without an explicit reason.
+- Treat `origin/main` as the default source of truth for code analysis,
+  diagnostics, reviews, and functional behavior checks. Do not conclude from a
+  local `main` checkout until its alignment with `origin/main` has been checked.
+- If the local checkout is stale, dirty, or otherwise ambiguous, analyze
+  `origin/main` directly or use a clean worktree created from `origin/main`,
+  unless the user explicitly asks to inspect local uncommitted changes or a
+  specific branch/worktree.
 
 ## Git
 


### PR DESCRIPTION
## Summary
- Treat `origin/main` as the default source of truth for repository analysis, diagnostics, reviews, and behavior checks.
- Document fallback to direct `origin/main` inspection or a clean `origin/main` worktree when the local checkout is stale, dirty, or ambiguous.
- Align dashboard workflow and implementation worktree guidance with that baseline.

## Validation
- `git diff --check`
- Pre-commit hook: lint-staged found no matching staged files; `knip` completed with existing configuration hints.

## Notes
- Documentation/workflow-only change; no Nx project was impacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal analysis and workflow guidelines to establish consistent reference points for code diagnostics and reviews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->