### PR TITLE
feat: mix GoPro and video jobs in infrastructure

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -625,6 +625,103 @@ def list_gopro_overlay_jobs() -> list[dict[str, Any]]:
         ]
 
 
+def _path_usage(path: Path) -> tuple[int, int, int]:
+    if not path.exists():
+        return 0, 0, 0
+
+    if path.is_file() or path.is_symlink():
+        try:
+            return 1, 0, path.stat().st_size
+        except OSError:
+            return 1, 0, 0
+
+    files_count = 0
+    dirs_count = 1
+    bytes_count = 0
+    for item in path.rglob("*"):
+        if item.is_dir() and not item.is_symlink():
+            dirs_count += 1
+            continue
+        files_count += 1
+        try:
+            bytes_count += item.stat().st_size
+        except OSError:
+            pass
+    return files_count, dirs_count, bytes_count
+
+
+def _is_path_inside(path: Path, directory: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(directory.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _job_work_dir(job: dict[str, Any]) -> Path | None:
+    layout_path = job.get("layout_path")
+    if not layout_path:
+        return None
+    return Path(str(layout_path)).parent
+
+
+def _can_delete_work_dir(work_dir: Path) -> bool:
+    if _is_path_inside(work_dir, _UPLOAD_WORK_ROOT):
+        return True
+    return work_dir.parent.name == _PATH_WORK_DIR_NAME
+
+
+def delete_gopro_overlay_job(job_id: str) -> dict[str, Any] | None:
+    with _LOCK:
+        job = _JOBS.get(job_id)
+        if not job:
+            return None
+        if job["status"] not in _TERMINAL_STATUSES:
+            return {"job_id": job_id, "deleted": False, "error": "active"}
+        work_dir = _job_work_dir(job)
+
+    result: dict[str, Any] = {
+        "job_id": job_id,
+        "deleted": False,
+        "files_deleted": 0,
+        "dirs_deleted": 0,
+        "bytes_deleted": 0,
+        "paths_deleted": [],
+        "errors": [],
+    }
+
+    if work_dir and work_dir.exists():
+        if not _can_delete_work_dir(work_dir):
+            result["errors"].append(
+                {
+                    "path": str(work_dir),
+                    "error": "Refusing to delete outside overlay work directory",
+                }
+            )
+            return result
+
+        files_count, dirs_count, bytes_count = _path_usage(work_dir)
+        try:
+            if work_dir.is_dir() and not work_dir.is_symlink():
+                shutil.rmtree(work_dir)
+            else:
+                work_dir.unlink()
+        except OSError as exc:
+            result["errors"].append({"path": str(work_dir), "error": str(exc)})
+            return result
+
+        result["files_deleted"] = files_count
+        result["dirs_deleted"] = dirs_count
+        result["bytes_deleted"] = bytes_count
+        result["paths_deleted"] = [str(work_dir)]
+
+    with _LOCK:
+        _JOBS.pop(job_id, None)
+
+    result["deleted"] = True
+    return result
+
+
 def cancel_gopro_overlay_job(job_id: str) -> bool:
     with _LOCK:
         process = _PROCESSES.get(job_id)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -45,6 +45,7 @@ from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import check_gopro_overlay_dependencies
 from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
+from gopro_overlay_export import delete_gopro_overlay_job
 from gopro_overlay_export import delete_gopro_overlay_output
 from gopro_overlay_export import get_gopro_overlay_job
 from gopro_overlay_export import gopro_overlay_output_path
@@ -99,8 +100,10 @@ from schemas import (
 from video_export import get_export_status as get_export_status_stream
 from video_export import list_exports as list_exports_stream
 from video_export import cancel_video_export as cancel_video_export_stream
+from video_export import delete_export_job as delete_video_export_stream_job
 from video_export import start_video_export_background
 from video_export_manual import cancel_video_export as cancel_video_export_manual
+from video_export_manual import delete_video_export_job as delete_video_export_manual_job
 from video_export_manual import cleanup_video_export_temp_files
 from video_export_manual import get_export_status as get_export_status_manual
 from video_export_manual import get_video_export_job_token
@@ -4562,6 +4565,44 @@ def delete_video_export_temp_files() -> VideoExportTempCleanupResponse:
     return VideoExportTempCleanupResponse.model_validate(
         cleanup_video_export_temp_files(list_exports_manual() + list_exports_stream())
     )
+
+
+@router.delete("/video-export-jobs/{job_id}")
+def delete_video_export_job_row(job_id: str):
+    """Remove an inactive job from the infrastructure list and clean its temp files."""
+    overlay_result = delete_gopro_overlay_job(job_id)
+    if overlay_result is not None:
+        if overlay_result.get("error") == "active":
+            raise HTTPException(status_code=400, detail="Cannot delete an active job")
+        if overlay_result.get("errors"):
+            raise HTTPException(status_code=500, detail=overlay_result["errors"])
+        return overlay_result
+
+    manual_result = delete_video_export_manual_job(job_id)
+    if manual_result is not None:
+        if manual_result.get("error") == "active":
+            raise HTTPException(status_code=400, detail="Cannot delete an active job")
+        if manual_result.get("errors"):
+            raise HTTPException(status_code=500, detail=manual_result["errors"])
+        return manual_result
+
+    stream_status = get_export_status_stream(job_id)
+    if stream_status:
+        if _video_export_can_cancel(stream_status):
+            raise HTTPException(status_code=400, detail="Cannot delete an active job")
+        stream_deleted = delete_video_export_stream_job(job_id)
+        if stream_deleted:
+            return {
+                "job_id": job_id,
+                "deleted": True,
+                "files_deleted": 0,
+                "dirs_deleted": 0,
+                "bytes_deleted": 0,
+                "paths_deleted": [],
+                "errors": [],
+            }
+
+    raise HTTPException(status_code=404, detail="Export job not found")
 
 
 @router.delete("/exports/{job_id}/video")

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -20,6 +20,7 @@ from gopro_overlay_export import _read_process_updates
 from gopro_overlay_export import cancel_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job
 from gopro_overlay_export import create_gopro_overlay_job_from_paths
+from gopro_overlay_export import delete_gopro_overlay_job
 from models import Flight
 
 API_PREFIX = "/api"
@@ -658,6 +659,32 @@ def test_delete_gopro_overlay_video_rejects_running_job(client: TestClient):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Cannot delete video for an active overlay"
+
+
+def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(tmp_path):
+    job_id = "job-gopro-delete"
+    work_dir = tmp_path / ".gopro-overlay-work" / job_id
+    work_dir.mkdir(parents=True)
+    layout_path = work_dir / "layout.xml"
+    layout_path.write_text("<layout />")
+
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "failed",
+        "layout_path": str(layout_path),
+        "output_path": str(tmp_path / "final.mp4"),
+    }
+
+    try:
+        result = delete_gopro_overlay_job(job_id)
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+
+    assert result is not None
+    assert result["deleted"] is True
+    assert result["files_deleted"] == 1
+    assert not work_dir.exists()
+    assert gopro_overlay_export.get_gopro_overlay_job(job_id) is None
 
 
 def test_prepare_layout_file_injects_pip_id(tmp_path):

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -597,3 +597,50 @@ class TestVideoExportJobsEndpoint:
         assert response.status_code == 200
         assert response.json() == cleanup_payload
         cleanup.assert_called_once_with(manual_jobs + stream_jobs)
+
+    def test_delete_video_export_job_row_removes_overlay_job(self, client: TestClient):
+        delete_payload = {
+            "job_id": "job-overlay-failed",
+            "deleted": True,
+            "files_deleted": 2,
+            "dirs_deleted": 1,
+            "bytes_deleted": 10,
+            "paths_deleted": ["/tmp/overlay-work"],
+            "errors": [],
+        }
+
+        with patch("routes.delete_gopro_overlay_job", return_value=delete_payload):
+            response = client.delete(f"{API_PREFIX}/video-export-jobs/job-overlay-failed")
+
+        assert response.status_code == 200
+        assert response.json() == delete_payload
+
+    def test_delete_video_export_job_row_rejects_active_overlay(self, client: TestClient):
+        with patch(
+            "routes.delete_gopro_overlay_job",
+            return_value={"job_id": "job-overlay", "deleted": False, "error": "active"},
+        ):
+            response = client.delete(f"{API_PREFIX}/video-export-jobs/job-overlay")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Cannot delete an active job"
+
+    def test_delete_video_export_job_row_removes_manual_job(self, client: TestClient):
+        delete_payload = {
+            "job_id": "job-failed",
+            "deleted": True,
+            "files_deleted": 1,
+            "dirs_deleted": 1,
+            "bytes_deleted": 5,
+            "paths_deleted": ["/tmp/export-work"],
+            "errors": [],
+        }
+
+        with (
+            patch("routes.delete_gopro_overlay_job", return_value=None),
+            patch("routes.delete_video_export_manual_job", return_value=delete_payload),
+        ):
+            response = client.delete(f"{API_PREFIX}/video-export-jobs/job-failed")
+
+        assert response.status_code == 200
+        assert response.json() == delete_payload

--- a/apps/backend/video_export.py
+++ b/apps/backend/video_export.py
@@ -639,6 +639,16 @@ def cancel_video_export(job_id: str) -> bool:
     return True
 
 
+def delete_export_job(job_id: str) -> bool | None:
+    job = export_jobs.get(job_id)
+    if not job:
+        return None
+    if job.get("status") not in _TERMINAL_STATUSES:
+        return False
+    export_jobs.pop(job_id, None)
+    return True
+
+
 def list_exports(flight_id: str | None = None) -> list:
     """
     List all export jobs, optionally filtered by flight_id

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -706,6 +706,64 @@ def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, 
     }
 
 
+def cleanup_video_export_job_temp_files(job_id: str) -> dict[str, Any]:
+    """Delete temporary files for a single inactive video export job."""
+    candidates = [
+        (_job_temp_dir(_video_temp_images_dir(), job_id), _video_temp_images_dir()),
+        (_video_export_dir() / f"frames_{job_id}", _video_export_dir()),
+        (Path("/tmp") / f"playwright-debug-{job_id}.png", Path("/tmp")),
+        (Path("/tmp") / f"playwright-error-{job_id}.png", Path("/tmp")),
+    ]
+
+    deleted_paths: list[str] = []
+    errors: list[dict[str, str]] = []
+    files_deleted = 0
+    dirs_deleted = 0
+    bytes_deleted = 0
+
+    for path, allowed_root in candidates:
+        deletion = _delete_temp_path(path, allowed_root)
+        if deletion["deleted"]:
+            deleted_paths.append(str(deletion["path"]))
+            files_deleted += int(deletion["files_deleted"])
+            dirs_deleted += int(deletion["dirs_deleted"])
+            bytes_deleted += int(deletion["bytes_deleted"])
+        elif deletion["error"]:
+            errors.append({"path": str(deletion["path"]), "error": str(deletion["error"])})
+
+    return {
+        "files_deleted": files_deleted,
+        "dirs_deleted": dirs_deleted,
+        "bytes_deleted": bytes_deleted,
+        "paths_deleted": deleted_paths,
+        "errors": errors,
+    }
+
+
+def delete_video_export_job(job_id: str) -> dict[str, Any] | None:
+    """Delete an inactive video export row and its temporary files."""
+    job = _get_job(job_id)
+    snapshot = _snapshot_from_job(job) if job else _get_memory_snapshot(job_id)
+    if not snapshot:
+        return None
+    if _is_export_active(snapshot):
+        return {"job_id": job_id, "deleted": False, "error": "active"}
+
+    cleanup = cleanup_video_export_job_temp_files(job_id)
+    if job:
+        with SessionLocal() as db:
+            db_job = db.query(VideoExportJob).filter(VideoExportJob.id == job_id).first()
+            if db_job:
+                db.delete(db_job)
+                db.commit()
+
+    _set_memory_snapshot(job_id, None)
+    _clear_job_runtime(job_id)
+    _clear_job_cancel_requested(job_id)
+    _clear_job_auth_token(job_id)
+    return {"job_id": job_id, "deleted": True, **cleanup}
+
+
 def _prepare_export_dirs(export_root: Path, temp_dir: Path, frames_dir: Path) -> None:
     try:
         export_root.mkdir(parents=True, exist_ok=True)

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -8,7 +8,7 @@ import { VideoExportJobsPanel } from './VideoExportJobsPanel';
 const {
   cancelJob,
   cleanupTempFiles,
-  deleteOutput,
+  deleteJobRow,
   resumeJob,
   toastError,
   toastSuccess,
@@ -17,7 +17,7 @@ const {
 } = vi.hoisted(() => ({
   cancelJob: vi.fn(),
   cleanupTempFiles: vi.fn(),
-  deleteOutput: vi.fn(),
+  deleteJobRow: vi.fn(),
   resumeJob: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
@@ -108,8 +108,8 @@ vi.mock('../../hooks/flights/useVideoExportJobs', () => ({
     mutateAsync: resumeJob,
     isPending: false,
   }),
-  useDeleteVideoExportOutput: () => ({
-    mutateAsync: deleteOutput,
+  useDeleteVideoExportJobRow: () => ({
+    mutateAsync: deleteJobRow,
     isPending: false,
   }),
   useCleanupVideoExportTempFiles: () => ({
@@ -198,7 +198,7 @@ describe('VideoExportJobsPanel', () => {
       screen.getAllByRole('button', { name: 'Reprendre' }).length
     ).toBeGreaterThan(0);
     expect(
-      screen.getAllByRole('button', { name: 'Supprimer l’overlay' }).length
+      screen.getAllByRole('button', { name: 'Supprimer' }).length
     ).toBeGreaterThan(0);
   });
 
@@ -236,24 +236,30 @@ describe('VideoExportJobsPanel', () => {
     expect(toastSuccess).toHaveBeenCalledWith('Génération relancée');
   });
 
-  it('deletes a generated overlay after confirmation', async () => {
-    deleteOutput.mockResolvedValue(undefined);
+  it('filters jobs by type', () => {
+    render(<VideoExportJobsPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Overlay GoPro' }));
+
+    expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
+  });
+
+  it('deletes an inactive row after confirmation', async () => {
+    deleteJobRow.mockResolvedValue(undefined);
 
     render(<VideoExportJobsPanel />);
-    fireEvent.click(
-      screen.getAllByRole('button', { name: 'Supprimer l’overlay' })[0]!
-    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Supprimer' })[0]!);
     const deleteButtons = screen.getAllByRole('button', {
-      name: 'Supprimer l’overlay',
+      name: 'Supprimer',
     });
     fireEvent.click(deleteButtons[deleteButtons.length - 1]!);
 
     await waitFor(() =>
-      expect(deleteOutput).toHaveBeenCalledWith(
-        expect.objectContaining({ job_id: 'job-overlay-done' })
-      )
+      expect(deleteJobRow).toHaveBeenCalledWith(expect.any(String))
     );
-    expect(toastSuccess).toHaveBeenCalledWith('Overlay GoPro supprimé');
+    expect(toastSuccess).toHaveBeenCalledWith('Ligne supprimée');
   });
 
   it('cleans temporary files after confirmation', async () => {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -12,7 +12,7 @@ import {
   type VideoExportJob,
   useCancelVideoExportJob,
   useCleanupVideoExportTempFiles,
-  useDeleteVideoExportOutput,
+  useDeleteVideoExportJobRow,
   useResumeVideoExportJob,
   useVideoExportJobs,
 } from '../../hooks/flights/useVideoExportJobs';
@@ -50,6 +50,14 @@ const statusFilters = [
 ] as const;
 
 type StatusFilter = (typeof statusFilters)[number]['id'];
+
+const typeFilters = [
+  { id: 'all', label: 'Tous les types' },
+  { id: 'video', label: 'Exports vidéo' },
+  { id: 'gopro', label: 'Overlay GoPro' },
+] as const;
+
+type TypeFilter = (typeof typeFilters)[number]['id'];
 
 const columnHelper = createColumnHelper<VideoExportJob>();
 
@@ -151,8 +159,8 @@ function canDownloadJob(job: VideoExportJob) {
   return job.status === 'completed' && job.has_output_file !== false;
 }
 
-function canDeleteOutput(job: VideoExportJob) {
-  return !job.can_cancel && job.has_output_file !== false;
+function canDeleteJobRow(job: VideoExportJob) {
+  return !job.can_cancel;
 }
 
 function JobStatusBadge({ job }: { job: VideoExportJob }) {
@@ -206,18 +214,26 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   const [pendingConfirm, setPendingConfirm] =
     useState<PendingVideoConfirm | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'last_activity', desc: true },
   ]);
   const { data: jobs = [], isLoading, isError, refetch } = useVideoExportJobs();
   const cancelJob = useCancelVideoExportJob();
   const resumeJob = useResumeVideoExportJob();
-  const deleteOutput = useDeleteVideoExportOutput();
+  const deleteJobRow = useDeleteVideoExportJobRow();
   const cleanupTempFiles = useCleanupVideoExportTempFiles();
 
   const filteredJobs = useMemo(
-    () => jobs.filter((job) => isJobInFilter(job, statusFilter)),
-    [jobs, statusFilter]
+    () =>
+      jobs.filter((job) => {
+        const isInTypeFilter =
+          typeFilter === 'all' ||
+          (typeFilter === 'gopro' && isGoproOverlayJob(job)) ||
+          (typeFilter === 'video' && !isGoproOverlayJob(job));
+        return isInTypeFilter && isJobInFilter(job, statusFilter);
+      }),
+    [jobs, statusFilter, typeFilter]
   );
   const visibleJobs =
     typeof limit === 'number' ? filteredJobs.slice(0, limit) : filteredJobs;
@@ -290,47 +306,27 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     [t, toast]
   );
 
-  const handleDeleteOutput = useCallback(
+  const handleDeleteJobRow = useCallback(
     (job: VideoExportJob) => {
-      const isOverlay = isGoproOverlayJob(job);
       setPendingConfirm({
-        message: isOverlay
-          ? t(
-              'videoJobs.confirmDeleteOverlay',
-              'Supprimer la vidéo overlay GoPro générée ?'
-            )
-          : t(
-              'videoJobs.confirmDeleteVideo',
-              'Supprimer la vidéo générée pour ce traitement ?'
-            ),
-        confirmLabel: isOverlay
-          ? t('videoJobs.deleteOverlay', 'Supprimer l’overlay')
-          : t('videoJobs.deleteVideo', 'Supprimer la vidéo'),
+        message: t(
+          'videoJobs.confirmDeleteRow',
+          'Supprimer cette ligne et ses fichiers temporaires ?'
+        ),
+        confirmLabel: t('videoJobs.deleteRow', 'Supprimer'),
         onConfirm: async () => {
           try {
-            await deleteOutput.mutateAsync(job);
-            toast.success(
-              isOverlay
-                ? t('videoJobs.deleteOverlaySuccess', 'Overlay GoPro supprimé')
-                : t('videoJobs.deleteVideoSuccess', 'Vidéo générée supprimée')
-            );
+            await deleteJobRow.mutateAsync(job.job_id);
+            toast.success(t('videoJobs.deleteRowSuccess', 'Ligne supprimée'));
           } catch {
             toast.error(
-              isOverlay
-                ? t(
-                    'videoJobs.deleteOverlayError',
-                    'Impossible de supprimer l’overlay GoPro'
-                  )
-                : t(
-                    'videoJobs.deleteVideoError',
-                    'Impossible de supprimer la vidéo générée'
-                  )
+              t('videoJobs.deleteRowError', 'Impossible de supprimer la ligne')
             );
           }
         },
       });
     },
-    [deleteOutput, t, toast]
+    [deleteJobRow, t, toast]
   );
 
   const renderJobActions = useCallback(
@@ -374,31 +370,29 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
               : t('videoJobs.stop', 'Stopper')}
           </Button>
         )}
-        {canDeleteOutput(job) && (
+        {canDeleteJobRow(job) && (
           <Button
-            onClick={() => handleDeleteOutput(job)}
-            isDisabled={deleteOutput.isPending}
+            onClick={() => handleDeleteJobRow(job)}
+            isDisabled={deleteJobRow.isPending}
             className={`${actionButtonClassName} bg-gray-100 text-gray-800 hover:bg-gray-200 focus-visible:outline-gray-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600`}
           >
-            {isGoproOverlayJob(job)
-              ? t('videoJobs.deleteOverlay', 'Supprimer l’overlay')
-              : t('videoJobs.deleteVideo', 'Supprimer la vidéo')}
+            {t('videoJobs.deleteRow', 'Supprimer')}
           </Button>
         )}
         {!job.flight_id &&
           !canDownloadJob(job) &&
           !job.can_resume &&
           !job.can_cancel &&
-          !canDeleteOutput(job) && (
+          !canDeleteJobRow(job) && (
             <span className="text-xs text-gray-400 dark:text-gray-500">-</span>
           )}
       </div>
     ),
     [
       cancelJob.isPending,
-      deleteOutput.isPending,
+      deleteJobRow.isPending,
       handleCancel,
-      handleDeleteOutput,
+      handleDeleteJobRow,
       handleDownload,
       handleResume,
       resumeJob.isPending,
@@ -632,25 +626,47 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       )}
 
       {!isLoading && !isError && jobs.length > 0 && (
-        <div className="flex flex-wrap gap-2 border-t border-gray-100 p-3 dark:border-gray-700">
-          {statusFilters.map((filter) => {
-            const isSelected = statusFilter === filter.id;
-            return (
-              <button
-                key={filter.id}
-                type="button"
-                aria-pressed={isSelected}
-                className={`cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
-                  isSelected
-                    ? 'border-sky-600 bg-sky-600 text-white dark:border-sky-300 dark:bg-sky-300 dark:text-sky-950'
-                    : 'border-gray-200 bg-white text-gray-700 hover:border-sky-300 hover:bg-sky-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/40'
-                }`}
-                onClick={() => setStatusFilter(filter.id)}
-              >
-                {t(`videoJobs.filters.${filter.id}`, filter.label)}
-              </button>
-            );
-          })}
+        <div className="space-y-3 border-t border-gray-100 p-3 dark:border-gray-700">
+          <div className="flex flex-wrap gap-2">
+            {typeFilters.map((filter) => {
+              const isSelected = typeFilter === filter.id;
+              return (
+                <button
+                  key={filter.id}
+                  type="button"
+                  aria-pressed={isSelected}
+                  className={`cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+                    isSelected
+                      ? 'border-sky-600 bg-sky-600 text-white dark:border-sky-300 dark:bg-sky-300 dark:text-sky-950'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-sky-300 hover:bg-sky-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/40'
+                  }`}
+                  onClick={() => setTypeFilter(filter.id)}
+                >
+                  {t(`videoJobs.typeFilters.${filter.id}`, filter.label)}
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {statusFilters.map((filter) => {
+              const isSelected = statusFilter === filter.id;
+              return (
+                <button
+                  key={filter.id}
+                  type="button"
+                  aria-pressed={isSelected}
+                  className={`cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
+                    isSelected
+                      ? 'border-sky-600 bg-sky-600 text-white dark:border-sky-300 dark:bg-sky-300 dark:text-sky-950'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-sky-300 hover:bg-sky-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/40'
+                  }`}
+                  onClick={() => setStatusFilter(filter.id)}
+                >
+                  {t(`videoJobs.filters.${filter.id}`, filter.label)}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -90,16 +90,12 @@ export function useResumeVideoExportJob() {
   });
 }
 
-export function useDeleteVideoExportOutput() {
+export function useDeleteVideoExportJobRow() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (job: VideoExportJob) => {
-      const endpoint =
-        job.mode === 'gopro_overlay'
-          ? `gopro-overlays/jobs/${job.job_id}/video`
-          : `exports/${job.job_id}/video`;
-      await api.delete(endpoint).json();
+    mutationFn: async (jobId: string) => {
+      await api.delete(`video-export-jobs/${jobId}`).json();
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['video-export-jobs'] });

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -84,8 +84,24 @@
     "cleanupError": "Unable to delete temporary files",
     "loadError": "Unable to load video generations",
     "empty": "No video generation yet.",
+    "confirmDeleteRow": "Delete this row and its temporary files?",
+    "deleteRow": "Delete",
+    "deleteRowSuccess": "Row deleted",
+    "deleteRowError": "Unable to delete row",
     "mode": {
       "goproOverlay": "GoPro overlay"
+    },
+    "typeFilters": {
+      "all": "All types",
+      "video": "Video exports",
+      "gopro": "GoPro overlay"
+    },
+    "filters": {
+      "all": "All",
+      "active": "Running",
+      "completed": "Completed",
+      "failed": "Errors",
+      "cancelled": "Cancelled"
     },
     "status": {
       "queued": "Queued",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -84,8 +84,24 @@
     "cleanupError": "Impossible de supprimer les fichiers temporaires",
     "loadError": "Impossible de charger les générations vidéo",
     "empty": "Aucune génération vidéo pour le moment.",
+    "confirmDeleteRow": "Supprimer cette ligne et ses fichiers temporaires ?",
+    "deleteRow": "Supprimer",
+    "deleteRowSuccess": "Ligne supprimée",
+    "deleteRowError": "Impossible de supprimer la ligne",
     "mode": {
       "goproOverlay": "Overlay GoPro"
+    },
+    "typeFilters": {
+      "all": "Tous les types",
+      "video": "Exports vidéo",
+      "gopro": "Overlay GoPro"
+    },
+    "filters": {
+      "all": "Tous",
+      "active": "En cours",
+      "completed": "Terminés",
+      "failed": "Erreurs",
+      "cancelled": "Annulés"
     },
     "status": {
       "queued": "En attente",

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -564,6 +564,17 @@ export const videoExportHandlers = [
     return HttpResponse.json({ success: true });
   }),
 
+  http.delete('*/api/video-export-jobs/:jobId', ({ params }) => {
+    const index = mockVideoJobs.findIndex(
+      (item) => item.job_id === params.jobId
+    );
+    if (index !== -1) {
+      mockVideoJobs.splice(index, 1);
+    }
+
+    return HttpResponse.json({ success: true, deleted: true });
+  }),
+
   http.delete('*/api/exports/:jobId/video', ({ params }) => {
     const job = mockVideoJobs.find((item) => item.job_id === params.jobId);
     if (job) {


### PR DESCRIPTION
## Summary
- Mix GoPro overlay jobs into the Infrastructure video job list.
- Add filtering by job type and status, plus row deletion with temp-file cleanup.
- Update backend/frontend tests and storybook mocks for the combined list.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend --skip-nx-cache -- VideoExportJobsPanel.test.tsx`
- `../../.venv/bin/pytest tests/api/test_video_export_endpoints.py tests/api/test_gopro_overlay_endpoints.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delete completed, failed, or cancelled video export jobs directly from the jobs list
  * Filter jobs by type to view GoPro overlay exports, standard video exports, or all jobs
  * Inactive job rows now display a delete button for convenient cleanup

* **Documentation**
  * Updated UI labels and translations in English and French to support job deletion

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->