### PR TITLE
fix(backend): warm Redis cache on startup

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -506,26 +506,31 @@ else:
     logger.info("🧪 Testing mode: Skipping database initialization and migrations")
 
 
-async def initial_cache_warmup():
+async def initial_cache_warmup() -> None:
     """
-    Warm up Redis cache on startup
-    Fetches today's data for all sites (non-blocking)
+    Warm up Redis cache on startup.
+
+    Fetches weather data for the configured default sites and forecast days.
     """
     from scheduler import scheduled_weather_fetch
 
     try:
-        # Wait 3 seconds for app to fully start
-        await asyncio.sleep(3)
-
         logger.info("🔥 Starting cache warmup...")
         await scheduled_weather_fetch()
         logger.info("✅ Cache warmup complete!")
 
-    except Exception as e:
-        logger.error(f"❌ Cache warmup failed: {e}")
+    except Exception:
+        logger.warning("❌ Cache warmup failed", exc_info=True)
         logger.info(
             "⚠️ App will continue, cache will populate on first request or next hourly poll"
         )
+
+
+def trigger_initial_cache_warmup() -> None:
+    """Start the Redis cache warmup without blocking startup."""
+
+    logger.info("🔥 Triggering initial cache warmup...")
+    asyncio.create_task(initial_cache_warmup())
 
 
 def schedule_strava_token_refresh_job():
@@ -609,9 +614,7 @@ async def lifespan(app: FastAPI):
         logger.info("🔑 Strava token refresh scheduled (every 4h)")
         trigger_initial_strava_token_refresh()
 
-        # Initial cache warmup (non-blocking)
-        logger.info("🔥 Triggering initial cache warmup...")
-        asyncio.create_task(initial_cache_warmup())
+        trigger_initial_cache_warmup()
     else:
         logger.info("📅 Scheduler disabled, skipping cache warmup")
 

--- a/apps/backend/tests/unit/test_main.py
+++ b/apps/backend/tests/unit/test_main.py
@@ -24,6 +24,36 @@ def test_schedule_strava_token_refresh_job_forces_refresh():
 
 
 @pytest.mark.asyncio
+async def test_initial_cache_warmup_runs_scheduled_fetch():
+    """Startup cache warmup should populate Redis through the scheduler fetch."""
+
+    with patch("scheduler.scheduled_weather_fetch", new=AsyncMock()) as mock_fetch:
+        from main import initial_cache_warmup
+
+        await initial_cache_warmup()
+
+    mock_fetch.assert_awaited_once()
+
+
+def test_trigger_initial_cache_warmup_starts_background_task():
+    """Cache warmup should be scheduled without blocking application startup."""
+
+    created_tasks = []
+
+    def fake_create_task(coro):
+        created_tasks.append(coro)
+        coro.close()
+        return object()
+
+    with patch("main.asyncio.create_task", side_effect=fake_create_task):
+        from main import trigger_initial_cache_warmup
+
+        trigger_initial_cache_warmup()
+
+    assert len(created_tasks) == 1
+
+
+@pytest.mark.asyncio
 async def test_initial_strava_token_refresh_forces_refresh():
     """Initial startup refresh should force a token exchange immediately."""
 
@@ -43,13 +73,6 @@ async def test_lifespan_starts_strava_job_when_scheduler_enabled():
         def close(self):
             return None
 
-    created_tasks = []
-
-    def fake_create_task(coro):
-        created_tasks.append(coro)
-        coro.close()
-        return object()
-
     with (
         patch("main.config.SCHEDULER_ENABLED", True),
         patch("app_settings.reload_cache") as mock_reload_cache,
@@ -59,11 +82,11 @@ async def test_lifespan_starts_strava_job_when_scheduler_enabled():
         patch("main.start_video_export_worker"),
         patch("main.stop_video_export_worker") as mock_stop_video_export_worker,
         patch("main.schedule_strava_token_refresh_job") as mock_schedule_strava,
+        patch("main.trigger_initial_cache_warmup") as mock_trigger_cache_warmup,
         patch("main.trigger_initial_strava_token_refresh") as mock_trigger_initial_strava,
         patch("cache.close_redis", new=AsyncMock()) as mock_close_redis,
         patch("emagram_scheduler.emagram_scheduler.setup_emagram_scheduler") as mock_setup_emagram,
         patch("emagram_scheduler.emagram_scheduler.start_scheduler") as mock_start_emagram,
-        patch("main.asyncio.create_task", side_effect=fake_create_task),
     ):
         mock_session_local.return_value = DummyDb()
         mock_setup_emagram.return_value = object()
@@ -73,12 +96,12 @@ async def test_lifespan_starts_strava_job_when_scheduler_enabled():
         await cm.__aenter__()
 
         assert mock_schedule_strava.call_count == 1
+        mock_trigger_cache_warmup.assert_called_once()
         mock_trigger_initial_strava.assert_called_once()
         mock_reload_cache.assert_called_once()
         mock_start_weather_scheduler.assert_called_once()
         mock_setup_emagram.assert_called_once_with(app)
         mock_start_emagram.assert_called_once_with(mock_setup_emagram.return_value)
-        assert len(created_tasks) == 1
 
         await cm.__aexit__(None, None, None)
 


### PR DESCRIPTION
## Summary
- Trigger Redis cache warmup immediately during backend startup.
- Add unit coverage for the warmup path and startup task scheduling.

## Validation
- `TESTING=true ENVIRONMENT=test ../../.venv/bin/pytest tests/unit/test_main.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true ENVIRONMENT=test NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend`

## Notes
- `nx affected -t test --parallel=5 --exclude=e2e` also ran, but unrelated frontend/design-system test tasks failed due existing port contention/timeouts.