### PR TITLE
Remove flight download buttons

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.stories.tsx
@@ -190,16 +190,6 @@ Default.test('The GPX can be replaced', async ({ canvas, step }) => {
   });
 });
 
-Default.test('The GPX can be downloaded', async ({ canvas, step }) => {
-  await step('show the download GPX button', async () => {
-    await expect(
-      await canvas.findByRole('button', {
-        name: i18n.t('flights.downloadGpx'),
-      })
-    ).toBeInTheDocument();
-  });
-});
-
 Default.test(
   'The GoPro overlay settings use edit in place fields',
   async ({ canvas, userEvent, step }) => {

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -103,8 +103,6 @@ export function FlightDetails({
   const [notesText, setNotesText] = useState(flight.notes ?? '');
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
   const [hasOpenedReplay, setHasOpenedReplay] = useState(false);
-  const [isDownloadingGpx, setIsDownloadingGpx] = useState(false);
-  const [isDownloadingVideo, setIsDownloadingVideo] = useState(false);
   const [goproOverlayJobId, setGoproOverlayJobId] = useState<string | null>(
     null
   );
@@ -213,57 +211,6 @@ export function FlightDetails({
 
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
-    }
-  };
-
-  const handleGPXDownload = async () => {
-    if (!hasGpx || isDownloadingGpx) return;
-
-    setIsDownloadingGpx(true);
-    try {
-      const blob = await api.get(`flights/${flight.id}/gpx`).blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/gu, '_');
-
-      a.href = url;
-      a.download = `${filename || flight.id}.gpx`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Failed to download GPX:', error);
-      toast.error(t('flights.gpxDownloadError'));
-    } finally {
-      setIsDownloadingGpx(false);
-    }
-  };
-
-  const handleVideoDownload = async () => {
-    if (!hasVideo || !flight.video_export_job_id || isDownloadingVideo) {
-      return;
-    }
-
-    setIsDownloadingVideo(true);
-    try {
-      const blob = await api
-        .get(`exports/${flight.video_export_job_id}/download`, {
-          timeout: false,
-        })
-        .blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/gu, '_');
-
-      a.href = url;
-      a.download = `${filename || flight.id}.mp4`;
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      toast.error(
-        await getApiErrorMessage(error, t('flights.viewer.videoDownloadError'))
-      );
-    } finally {
-      setIsDownloadingVideo(false);
     }
   };
 
@@ -585,44 +532,16 @@ export function FlightDetails({
               {(hasGpx || hasVideo) && (
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {hasGpx && (
-                    <button
-                      type="button"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800"
-                      onClick={() => void handleGPXDownload()}
-                      disabled={isDownloadingGpx}
-                      aria-label={t('flights.downloadGpx')}
-                    >
+                    <span className="inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200">
                       <FileText className="h-3 w-3" aria-hidden="true" />
-                      {isDownloadingGpx ? (
-                        t('flights.gpxDownloadInProgress')
-                      ) : (
-                        <>
-                          {t('flights.gpxBadge')}
-                          <Download className="h-3 w-3" aria-hidden="true" />
-                        </>
-                      )}
-                    </button>
+                      {t('flights.gpxBadge')}
+                    </span>
                   )}
                   {hasVideo && (
-                    <button
-                      type="button"
-                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800"
-                      onClick={() => void handleVideoDownload()}
-                      disabled={
-                        isDownloadingVideo || !flight.video_export_job_id
-                      }
-                      aria-label={t('flights.viewer.downloadVideo')}
-                    >
+                    <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
                       <Video className="h-3 w-3" aria-hidden="true" />
-                      {isDownloadingVideo ? (
-                        t('flights.gpxDownloadInProgress')
-                      ) : (
-                        <>
-                          {t('flights.videoBadge')}
-                          <Download className="h-3 w-3" aria-hidden="true" />
-                        </>
-                      )}
-                    </button>
+                      {t('flights.videoBadge')}
+                    </span>
                   )}
                 </div>
               )}
@@ -664,19 +583,6 @@ export function FlightDetails({
               <Edit3 className="h-4 w-4" aria-hidden="true" />
               {t('flights.editButton')}
             </Button>
-            {hasGpx && (
-              <Button
-                variant="ghost"
-                className="min-h-10 rounded-lg px-3 py-2 text-sm"
-                onPress={handleGPXDownload}
-                isDisabled={isDownloadingGpx}
-              >
-                <Download className="h-4 w-4" aria-hidden="true" />
-                {isDownloadingGpx
-                  ? t('flights.gpxDownloadInProgress')
-                  : t('flights.downloadGpx')}
-              </Button>
-            )}
             <Button
               variant="ghost"
               className="min-h-10 rounded-lg px-3 py-2 text-sm"

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
@@ -3,23 +3,20 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Flight } from '@dashboard-parapente/shared-types';
 
-const { apiDelete, apiGet, apiPost, exportStatusMock, mockFlight } = vi.hoisted(
-  () => ({
-    apiDelete: vi.fn(),
-    apiGet: vi.fn(),
-    apiPost: vi.fn(),
-    exportStatusMock: { current: null as unknown },
-    mockFlight: {
-      id: 'flight-1',
-      flight_date: '2026-03-15',
-      title: 'Test flight',
-      gpx_file_path: 'sample.gpx',
-      video_export_status: null as string | null,
-      video_export_job_id: null as string | null,
-      video_file_path: null as string | null,
-    } as Flight,
-  })
-);
+const { apiDelete, apiPost, exportStatusMock, mockFlight } = vi.hoisted(() => ({
+  apiDelete: vi.fn(),
+  apiPost: vi.fn(),
+  exportStatusMock: { current: null as unknown },
+  mockFlight: {
+    id: 'flight-1',
+    flight_date: '2026-03-15',
+    title: 'Test flight',
+    gpx_file_path: 'sample.gpx',
+    video_export_status: null as string | null,
+    video_export_job_id: null as string | null,
+    video_file_path: null as string | null,
+  } as Flight,
+}));
 
 vi.mock('@dashboard-parapente/design-system', () => ({
   Button: ({
@@ -45,7 +42,6 @@ vi.mock('react-i18next', () => ({
         'flights.viewer.videoModeManualFastHint': 'Fast hint',
         'flights.viewer.videoModeManualHint': 'Manual hint',
         'flights.viewer.generateVideo': 'Generate video',
-        'flights.viewer.downloadVideo': 'Download video',
         'flights.viewer.resumeVideo': 'Resume generation',
         'flights.viewer.videoResumeHint': 'frames preserved',
         'flights.viewer.videoGenerating': 'Generating video',
@@ -68,7 +64,6 @@ vi.mock('../../hooks/flights/useVideoExportStatus', () => ({
 vi.mock('../../lib/api', () => ({
   api: {
     delete: apiDelete,
-    get: apiGet,
     post: apiPost,
   },
 }));
@@ -86,7 +81,6 @@ import { FlightVideoExportControls } from './FlightVideoExportControls';
 describe('FlightVideoExportControls', () => {
   beforeEach(() => {
     apiDelete.mockReset();
-    apiGet.mockReset();
     apiPost.mockReset();
     apiPost.mockResolvedValue(undefined);
     mockFlight.video_export_status = null;
@@ -150,30 +144,15 @@ describe('FlightVideoExportControls', () => {
     });
   });
 
-  it('downloads generated videos without applying the API request timeout', async () => {
+  it('does not show the download button for completed videos', () => {
     mockFlight.video_export_status = 'completed';
     mockFlight.video_export_job_id = 'job-video';
     mockFlight.video_file_path = '/exports/job-video.mp4';
-    const blob = vi.fn().mockResolvedValue(new Blob(['video']));
-    apiGet.mockReturnValue({ blob });
-    Object.defineProperty(URL, 'createObjectURL', {
-      configurable: true,
-      value: vi.fn(() => 'blob:video'),
-    });
-    Object.defineProperty(URL, 'revokeObjectURL', {
-      configurable: true,
-      value: vi.fn(),
-    });
 
     render(<FlightVideoExportControls flight={mockFlight} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Download video/u }));
-
-    await waitFor(() => {
-      expect(apiGet).toHaveBeenCalledWith('exports/job-video/download', {
-        timeout: false,
-      });
-      expect(blob).toHaveBeenCalled();
-    });
+    expect(
+      screen.queryByRole('button', { name: /Download video/u })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -154,33 +154,6 @@ export function FlightVideoExportControls({
   ]);
 
   const handlePrimaryAction = async () => {
-    if (flight.video_export_status === 'completed' && flight.video_file_path) {
-      try {
-        const blob = await api
-          .get(`exports/${flight.video_export_job_id}/download`, {
-            timeout: false,
-          })
-          .blob();
-
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `flight-${flight.id}.mp4`;
-        a.click();
-        URL.revokeObjectURL(url);
-      } catch (error) {
-        if (error instanceof HTTPError) {
-          const detail = await getHttpErrorDetail(error);
-          toast.error(detail || t('flights.viewer.videoDownloadError'));
-          return;
-        }
-
-        console.error('Failed to download video:', error);
-        toast.error(t('flights.viewer.videoDownloadError'));
-      }
-      return;
-    }
-
     if (hasActiveVideoExport(flight)) return;
 
     try {
@@ -243,21 +216,16 @@ export function FlightVideoExportControls({
 
   const primaryButtonTitle = hasActiveVideoExport(flight)
     ? t('flights.viewer.videoGeneratingTitle')
-    : flight.video_export_status === 'completed'
-      ? t('flights.viewer.videoDownloadTitle')
-      : flight.video_export_status === 'failed' ||
-          flight.video_export_status === 'cancelled'
-        ? canResumeVideoExport
-          ? t('flights.viewer.videoResumeTitle')
-          : t('flights.viewer.videoRegenerateTitle')
-        : t('flights.viewer.videoGenerateTitle');
+    : flight.video_export_status === 'failed' ||
+        flight.video_export_status === 'cancelled'
+      ? canResumeVideoExport
+        ? t('flights.viewer.videoResumeTitle')
+        : t('flights.viewer.videoRegenerateTitle')
+      : t('flights.viewer.videoGenerateTitle');
 
   const primaryButtonLabel = (() => {
     if (hasActiveVideoExport(flight))
       return t('flights.viewer.videoGenerating');
-    if (flight.video_export_status === 'completed') {
-      return t('flights.viewer.downloadVideo');
-    }
     if (
       flight.video_export_status === 'failed' ||
       flight.video_export_status === 'cancelled'
@@ -272,11 +240,9 @@ export function FlightVideoExportControls({
   const primaryButtonClassName = [
     'cursor-pointer rounded-md text-sm font-semibold text-white transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400',
     compact ? 'px-3.5 py-2' : 'px-4 py-2.5',
-    flight.video_export_status === 'completed'
-      ? 'bg-green-600 hover:bg-green-700'
-      : isStartingVideoExport || hasActiveVideoExport(flight)
-        ? 'bg-gray-400'
-        : 'bg-blue-600 hover:bg-blue-700',
+    isStartingVideoExport || hasActiveVideoExport(flight)
+      ? 'bg-gray-400'
+      : 'bg-blue-600 hover:bg-blue-700',
     buttonClassName,
   ]
     .filter(Boolean)
@@ -316,14 +282,16 @@ export function FlightVideoExportControls({
           </div>
         )}
 
-      <Button
-        onClick={handlePrimaryAction}
-        isDisabled={isStartingVideoExport || hasActiveVideoExport(flight)}
-        className={primaryButtonClassName}
-        title={primaryButtonTitle}
-      >
-        {primaryButtonLabel}
-      </Button>
+      {flight.video_export_status !== 'completed' && (
+        <Button
+          onClick={handlePrimaryAction}
+          isDisabled={isStartingVideoExport || hasActiveVideoExport(flight)}
+          className={primaryButtonClassName}
+          title={primaryButtonTitle}
+        >
+          {primaryButtonLabel}
+        </Button>
+      )}
 
       {canResumeVideoExport && !isExportActive && (
         <p

--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -89,15 +89,15 @@ test('applies the active style when a flight is selected', () => {
   expect(flightRow).toHaveAttribute('aria-selected', 'true');
 });
 
-test('downloads media from badges without selecting the flight', () => {
-  const onDownloadGpx = vi.fn();
-  render(<FlightsTableHarness onDownloadGpx={onDownloadGpx} />);
+test('shows media badges without download actions', () => {
+  render(<FlightsTableHarness />);
 
   const flightRow = screen.getByTestId('flight-row-flight-1');
 
-  fireEvent.click(screen.getByRole('button', { name: 'flights.downloadGpx' }));
-
-  expect(onDownloadGpx).toHaveBeenCalledWith(flights[0]);
+  expect(screen.getByText('flights.gpxBadge')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'flights.downloadGpx' })
+  ).not.toBeInTheDocument();
   expect(flightRow).not.toHaveClass('border-sky-700');
   expect(flightRow).toHaveAttribute('aria-selected', 'false');
 });

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -6,7 +6,6 @@ import { DataList, Button } from '@dashboard-parapente/design-system';
 import {
   Check,
   Clock3,
-  Download,
   FileText,
   MapPin,
   Mountain,
@@ -43,9 +42,6 @@ export function FlightsTable({
   selectionMode,
   onSelectFlight,
   onDeleteFlight,
-  onDownloadGpx,
-  onDownloadVideo,
-  downloadingMedia,
   rowSelection,
   onRowSelectionChange,
 }: FlightsTableProps) {
@@ -89,12 +85,6 @@ export function FlightsTable({
     (row: Row<Flight>, { isSelected }: { isSelected: boolean }) => {
       const flight = row.original;
       const isActive = selectedFlightId === flight.id;
-      const isDownloadingGpx =
-        downloadingMedia?.flightId === flight.id &&
-        downloadingMedia.type === 'gpx';
-      const isDownloadingVideo =
-        downloadingMedia?.flightId === flight.id &&
-        downloadingMedia.type === 'video';
       const selectFlight = () => {
         if (!selectionMode) {
           onSelectFlight(flight);
@@ -178,52 +168,16 @@ export function FlightsTable({
                 (flight.gpx_file_path || flight.video_file_path) && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {flight.gpx_file_path && (
-                      <button
-                        type="button"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onDownloadGpx(flight);
-                        }}
-                        onKeyDown={(event) => event.stopPropagation()}
-                        disabled={Boolean(downloadingMedia)}
-                        aria-label={t('flights.downloadGpx')}
-                      >
+                      <span className="inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200">
                         <FileText className="h-3 w-3" aria-hidden="true" />
-                        {isDownloadingGpx ? (
-                          t('flights.gpxDownloadInProgress')
-                        ) : (
-                          <>
-                            {t('flights.gpxBadge')}
-                            <Download className="h-3 w-3" aria-hidden="true" />
-                          </>
-                        )}
-                      </button>
+                        {t('flights.gpxBadge')}
+                      </span>
                     )}
                     {flight.video_file_path && (
-                      <button
-                        type="button"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onDownloadVideo(flight);
-                        }}
-                        onKeyDown={(event) => event.stopPropagation()}
-                        disabled={Boolean(
-                          downloadingMedia || !flight.video_export_job_id
-                        )}
-                        aria-label={t('flights.viewer.downloadVideo')}
-                      >
+                      <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
                         <Video className="h-3 w-3" aria-hidden="true" />
-                        {isDownloadingVideo ? (
-                          t('flights.gpxDownloadInProgress')
-                        ) : (
-                          <>
-                            {t('flights.videoBadge')}
-                            <Download className="h-3 w-3" aria-hidden="true" />
-                          </>
-                        )}
-                      </button>
+                        {t('flights.videoBadge')}
+                      </span>
                     )}
                   </div>
                 )}
@@ -315,9 +269,6 @@ export function FlightsTable({
       selectedFlightId,
       onSelectFlight,
       onDeleteFlight,
-      onDownloadGpx,
-      onDownloadVideo,
-      downloadingMedia,
       t,
       i18n,
       units,


### PR DESCRIPTION
## Summary
- Remove GPX and video download buttons from flight details and flight table badges.
- Hide the completed video download action in the 3D flight controls.
- Update the affected flight component tests and story checks.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e --uncommitted`
- Targeted vitest: `FlightsTable.test.tsx`, `FlightVideoExportControls.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed direct download functionality for GPX and video files. Media availability is now displayed as static indicators rather than clickable download buttons.
  * Updated video export controls to reflect new download behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->