### PR TITLE
Fix infrastructure tabs routing

### DIFF
--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useDeferredValue } from 'react';
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useTranslation } from 'react-i18next';
 import { Checkbox, Input, TextField } from 'react-aria-components';
@@ -32,6 +33,11 @@ import {
 } from '../hooks/admin/useStravaToken';
 import { VideoExportJobsPanel } from '../components/flights/VideoExportJobsPanel';
 import { useToastStore } from '../hooks/useToast';
+import {
+  normalizeInfrastructureTab,
+  type InfrastructureSearch,
+  type InfrastructureTab,
+} from '../routes/infrastructure';
 
 // --- Helpers ---
 
@@ -366,10 +372,18 @@ function StravaTokenSection() {
 // =============================================================================
 
 // oxlint-disable-next-line max-lines-per-function
-function CacheSection() {
+function CacheSection({
+  autoRefresh,
+  searchFilter,
+  onAutoRefreshChange,
+  onSearchFilterChange,
+}: {
+  autoRefresh: boolean;
+  searchFilter: string;
+  onAutoRefreshChange: (autoRefresh: boolean) => void;
+  onSearchFilterChange: (searchFilter: string) => void;
+}) {
   const { t } = useTranslation();
-  const [autoRefresh, setAutoRefresh] = useState(false);
-  const [searchFilter, setSearchFilter] = useState('');
   const deferredSearchFilter = useDeferredValue(searchFilter);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -495,7 +509,7 @@ function CacheSection() {
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md flex flex-col sm:flex-row sm:flex-wrap items-stretch sm:items-center gap-3">
         <Checkbox
           isSelected={autoRefresh}
-          onChange={setAutoRefresh}
+          onChange={onAutoRefreshChange}
           className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 group"
         >
           {({ isSelected }: { isSelected: boolean }) => (
@@ -535,7 +549,7 @@ function CacheSection() {
         </Button>
         <TextField
           value={searchFilter}
-          onChange={setSearchFilter}
+          onChange={onSearchFilterChange}
           aria-label={t('cache.searchPlaceholder')}
           className="flex-1 min-w-[200px]"
         >
@@ -803,9 +817,41 @@ function InfrastructureOverview() {
 
 export default function InfrastructurePage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const params = useParams({ strict: false }) as { tab?: string };
+  const search = useSearch({ strict: false }) as InfrastructureSearch;
   const { toasts, removeToast } = useToastStore();
   const { data: stravaStatus } = useStravaTokenStatus();
   const { data: cacheOverview } = useCacheOverview();
+  const activeTab = normalizeInfrastructureTab(params.tab);
+
+  const navigateToInfrastructure = (
+    tab: InfrastructureTab,
+    nextSearch: InfrastructureSearch = search
+  ) => {
+    void navigate({
+      to: '/infrastructure/$tab',
+      params: { tab },
+      search: {
+        cacheSearch: nextSearch.cacheSearch || undefined,
+        cacheAutoRefresh: nextSearch.cacheAutoRefresh ? true : undefined,
+      },
+    });
+  };
+
+  const updateCacheSearch = (cacheSearch: string) => {
+    navigateToInfrastructure(activeTab, {
+      ...search,
+      cacheSearch: cacheSearch || undefined,
+    });
+  };
+
+  const updateCacheAutoRefresh = (cacheAutoRefresh: boolean) => {
+    navigateToInfrastructure(activeTab, {
+      ...search,
+      cacheAutoRefresh: cacheAutoRefresh ? true : undefined,
+    });
+  };
 
   return (
     <div className="py-4 space-y-8">
@@ -813,7 +859,13 @@ export default function InfrastructurePage() {
 
       <InfrastructureOverview />
 
-      <Tabs className="space-y-4">
+      <Tabs
+        className="space-y-4"
+        selectedKey={activeTab}
+        onSelectionChange={(key) =>
+          navigateToInfrastructure(normalizeInfrastructureTab(key))
+        }
+      >
         <TabList className="grid-cols-1 sm:grid-cols-3">
           <Tab id="strava">
             <span className="flex items-center justify-center gap-2">
@@ -831,7 +883,7 @@ export default function InfrastructurePage() {
               </span>
             </span>
           </Tab>
-          <Tab id="videoExports">
+          <Tab id="video-exports">
             <span className="flex items-center justify-center gap-2">
               {t('infrastructure.tabs.videoExports')}
               <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
@@ -852,11 +904,16 @@ export default function InfrastructurePage() {
         <TabPanel id="strava" className="outline-none">
           <StravaTokenSection />
         </TabPanel>
-        <TabPanel id="videoExports" className="outline-none">
+        <TabPanel id="video-exports" className="outline-none">
           <VideoExportJobsPanel limit={null} />
         </TabPanel>
         <TabPanel id="cache" className="outline-none">
-          <CacheSection />
+          <CacheSection
+            autoRefresh={search.cacheAutoRefresh === true}
+            searchFilter={search.cacheSearch ?? ''}
+            onAutoRefreshChange={updateCacheAutoRefresh}
+            onSearchFilterChange={updateCacheSearch}
+          />
         </TabPanel>
       </Tabs>
     </div>

--- a/apps/frontend/src/routeTree.gen.ts
+++ b/apps/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as ExportViewerRouteImport } from './routes/export-viewer'
 import { Route as AnalyticsRouteImport } from './routes/analytics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ViewerFlightIdRouteImport } from './routes/viewer.$flightId'
+import { Route as InfrastructureTabRouteImport } from './routes/infrastructure.$tab'
 import { Route as FlightsFlightIdRouteImport } from './routes/flights.$flightId'
 
 const WeatherRoute = WeatherRouteImport.update({
@@ -87,6 +88,13 @@ const ViewerFlightIdRoute = ViewerFlightIdRouteImport.update({
 } as any).lazy(() =>
   import('./routes/viewer.$flightId.lazy').then((d) => d.Route),
 )
+const InfrastructureTabRoute = InfrastructureTabRouteImport.update({
+  id: '/$tab',
+  path: '/$tab',
+  getParentRoute: () => InfrastructureRoute,
+} as any).lazy(() =>
+  import('./routes/infrastructure.$tab.lazy').then((d) => d.Route),
+)
 const FlightsFlightIdRoute = FlightsFlightIdRouteImport.update({
   id: '/$flightId',
   path: '/$flightId',
@@ -101,13 +109,14 @@ export interface FileRoutesByFullPath {
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRouteWithChildren
   '/gopro-overlay': typeof GoproOverlayRoute
-  '/infrastructure': typeof InfrastructureRoute
+  '/infrastructure': typeof InfrastructureRouteWithChildren
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
   '/flights/$flightId': typeof FlightsFlightIdRoute
+  '/infrastructure/$tab': typeof InfrastructureTabRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRoutesByTo {
@@ -116,13 +125,14 @@ export interface FileRoutesByTo {
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRouteWithChildren
   '/gopro-overlay': typeof GoproOverlayRoute
-  '/infrastructure': typeof InfrastructureRoute
+  '/infrastructure': typeof InfrastructureRouteWithChildren
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
   '/flights/$flightId': typeof FlightsFlightIdRoute
+  '/infrastructure/$tab': typeof InfrastructureTabRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRoutesById {
@@ -132,13 +142,14 @@ export interface FileRoutesById {
   '/export-viewer': typeof ExportViewerRoute
   '/flights': typeof FlightsRouteWithChildren
   '/gopro-overlay': typeof GoproOverlayRoute
-  '/infrastructure': typeof InfrastructureRoute
+  '/infrastructure': typeof InfrastructureRouteWithChildren
   '/login': typeof LoginRoute
   '/settings': typeof SettingsRoute
   '/sites': typeof SitesRoute
   '/thermal': typeof ThermalRoute
   '/weather': typeof WeatherRoute
   '/flights/$flightId': typeof FlightsFlightIdRoute
+  '/infrastructure/$tab': typeof InfrastructureTabRoute
   '/viewer/$flightId': typeof ViewerFlightIdRoute
 }
 export interface FileRouteTypes {
@@ -156,6 +167,7 @@ export interface FileRouteTypes {
     | '/thermal'
     | '/weather'
     | '/flights/$flightId'
+    | '/infrastructure/$tab'
     | '/viewer/$flightId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -171,6 +183,7 @@ export interface FileRouteTypes {
     | '/thermal'
     | '/weather'
     | '/flights/$flightId'
+    | '/infrastructure/$tab'
     | '/viewer/$flightId'
   id:
     | '__root__'
@@ -186,6 +199,7 @@ export interface FileRouteTypes {
     | '/thermal'
     | '/weather'
     | '/flights/$flightId'
+    | '/infrastructure/$tab'
     | '/viewer/$flightId'
   fileRoutesById: FileRoutesById
 }
@@ -195,7 +209,7 @@ export interface RootRouteChildren {
   ExportViewerRoute: typeof ExportViewerRoute
   FlightsRoute: typeof FlightsRouteWithChildren
   GoproOverlayRoute: typeof GoproOverlayRoute
-  InfrastructureRoute: typeof InfrastructureRoute
+  InfrastructureRoute: typeof InfrastructureRouteWithChildren
   LoginRoute: typeof LoginRoute
   SettingsRoute: typeof SettingsRoute
   SitesRoute: typeof SitesRoute
@@ -290,6 +304,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ViewerFlightIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/infrastructure/$tab': {
+      id: '/infrastructure/$tab'
+      path: '/$tab'
+      fullPath: '/infrastructure/$tab'
+      preLoaderRoute: typeof InfrastructureTabRouteImport
+      parentRoute: typeof InfrastructureRoute
+    }
     '/flights/$flightId': {
       id: '/flights/$flightId'
       path: '/$flightId'
@@ -311,13 +332,25 @@ const FlightsRouteChildren: FlightsRouteChildren = {
 const FlightsRouteWithChildren =
   FlightsRoute._addFileChildren(FlightsRouteChildren)
 
+interface InfrastructureRouteChildren {
+  InfrastructureTabRoute: typeof InfrastructureTabRoute
+}
+
+const InfrastructureRouteChildren: InfrastructureRouteChildren = {
+  InfrastructureTabRoute: InfrastructureTabRoute,
+}
+
+const InfrastructureRouteWithChildren = InfrastructureRoute._addFileChildren(
+  InfrastructureRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AnalyticsRoute: AnalyticsRoute,
   ExportViewerRoute: ExportViewerRoute,
   FlightsRoute: FlightsRouteWithChildren,
   GoproOverlayRoute: GoproOverlayRoute,
-  InfrastructureRoute: InfrastructureRoute,
+  InfrastructureRoute: InfrastructureRouteWithChildren,
   LoginRoute: LoginRoute,
   SettingsRoute: SettingsRoute,
   SitesRoute: SitesRoute,

--- a/apps/frontend/src/routes/infrastructure.$tab.lazy.tsx
+++ b/apps/frontend/src/routes/infrastructure.$tab.lazy.tsx
@@ -1,0 +1,6 @@
+import { createLazyFileRoute } from '@tanstack/react-router';
+import InfrastructurePage from '../pages/InfrastructurePage';
+
+export const Route = createLazyFileRoute('/infrastructure/$tab')({
+  component: InfrastructurePage,
+});

--- a/apps/frontend/src/routes/infrastructure.$tab.tsx
+++ b/apps/frontend/src/routes/infrastructure.$tab.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { queryClient } from '../lib/queryClient';
+import { cacheOverviewQueryOptions } from '../hooks/admin/useCache';
+import { videoExportJobsQueryOptions } from '../hooks/flights/useVideoExportJobs';
+import { requireAuth } from '../lib/authGuard';
+import {
+  normalizeInfrastructureTab,
+  validateInfrastructureSearch,
+} from './infrastructure';
+
+export const Route = createFileRoute('/infrastructure/$tab')({
+  validateSearch: validateInfrastructureSearch,
+  beforeLoad: ({ params, search }) => {
+    requireAuth();
+    const tab = normalizeInfrastructureTab(params.tab);
+    if (tab !== params.tab) {
+      throw redirect({
+        to: '/infrastructure/$tab',
+        params: { tab },
+        search,
+      });
+    }
+  },
+  loader: () => {
+    void queryClient.prefetchQuery(cacheOverviewQueryOptions());
+    void queryClient.prefetchQuery(videoExportJobsQueryOptions());
+  },
+});

--- a/apps/frontend/src/routes/infrastructure.tsx
+++ b/apps/frontend/src/routes/infrastructure.tsx
@@ -4,7 +4,38 @@ import { cacheOverviewQueryOptions } from '../hooks/admin/useCache';
 import { videoExportJobsQueryOptions } from '../hooks/flights/useVideoExportJobs';
 import { requireAuth } from '../lib/authGuard';
 
+const infrastructureTabs = ['strava', 'video-exports', 'cache'] as const;
+
+export type InfrastructureTab = (typeof infrastructureTabs)[number];
+
+export type InfrastructureSearch = {
+  cacheSearch?: string;
+  cacheAutoRefresh?: boolean;
+};
+
+export function normalizeInfrastructureTab(tab: unknown): InfrastructureTab {
+  return infrastructureTabs.includes(tab as InfrastructureTab)
+    ? (tab as InfrastructureTab)
+    : 'strava';
+}
+
+export function validateInfrastructureSearch(
+  search: Record<string, unknown>
+): InfrastructureSearch {
+  return {
+    cacheSearch:
+      typeof search.cacheSearch === 'string' && search.cacheSearch.length > 0
+        ? search.cacheSearch
+        : undefined,
+    cacheAutoRefresh:
+      search.cacheAutoRefresh === true || search.cacheAutoRefresh === 'true'
+        ? true
+        : undefined,
+  };
+}
+
 export const Route = createFileRoute('/infrastructure')({
+  validateSearch: validateInfrastructureSearch,
   beforeLoad: requireAuth,
   loader: () => {
     void queryClient.prefetchQuery(cacheOverviewQueryOptions());


### PR DESCRIPTION
## Summary
- Make Infrastructure tabs navigable via real routes under `/infrastructure/$tab`.
- Persist cache search and auto-refresh state in query params.
- Keep `/infrastructure` working as the default tab entry.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend`