### PR TITLE
feat(flights): add direct media tag downloads

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -248,16 +248,20 @@ def _gopro_overlay_flight_directory(db: Session, flight: Flight, *, create: bool
     return directory
 
 
-def _flight_gopro_overlay_path(db: Session, flight: Flight) -> Path | None:
+def _flight_gopro_overlay_path(
+    db: Session, flight: Flight, *, suppress_config_error: bool = False
+) -> Path | None:
     try:
         output_path = _gopro_overlay_flight_directory(db, flight, create=False) / "final.mp4"
     except HTTPException:
+        if not suppress_config_error:
+            raise
         return None
     return output_path if output_path.exists() else None
 
 
 def _flight_gopro_overlay_file_path(db: Session, flight: Flight) -> str | None:
-    output_path = _flight_gopro_overlay_path(db, flight)
+    output_path = _flight_gopro_overlay_path(db, flight, suppress_config_error=True)
     return str(output_path) if output_path else None
 
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -233,7 +233,7 @@ def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
     return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
-def _gopro_overlay_flight_directory(db: Session, flight: Flight) -> Path:
+def _gopro_overlay_flight_directory(db: Session, flight: Flight, *, create: bool = True) -> Path:
     root = config.GOPRO_OVERLAY_PARAGLIDING_ROOT.strip()
     if not root:
         raise HTTPException(
@@ -243,8 +243,22 @@ def _gopro_overlay_flight_directory(db: Session, flight: Flight) -> Path:
     date_dir = flight.flight_date.strftime("%Y%m%d")
     sequence = flight_sequence_number(db, flight)
     directory = Path(root).expanduser().resolve() / date_dir / f"{sequence:02d}"
-    directory.mkdir(parents=True, exist_ok=True)
+    if create:
+        directory.mkdir(parents=True, exist_ok=True)
     return directory
+
+
+def _flight_gopro_overlay_path(db: Session, flight: Flight) -> Path | None:
+    try:
+        output_path = _gopro_overlay_flight_directory(db, flight, create=False) / "final.mp4"
+    except HTTPException:
+        return None
+    return output_path if output_path.exists() else None
+
+
+def _flight_gopro_overlay_file_path(db: Session, flight: Flight) -> str | None:
+    output_path = _flight_gopro_overlay_path(db, flight)
+    return str(output_path) if output_path else None
 
 
 def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
@@ -3004,6 +3018,7 @@ def get_flights(
             "video_export_job_id": flight.video_export_job_id,
             "video_export_status": flight.video_export_status,
             "video_file_path": flight.video_file_path,
+            "gopro_overlay_file_path": _flight_gopro_overlay_file_path(db, flight),
             "external_url": flight.external_url,
             "created_at": flight.created_at.isoformat() if flight.created_at else None,
             "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
@@ -3193,6 +3208,7 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
         "video_export_job_id": flight.video_export_job_id,
         "video_export_status": flight.video_export_status,
         "video_file_path": flight.video_file_path,
+        "gopro_overlay_file_path": _flight_gopro_overlay_file_path(db, flight),
         "created_at": flight.created_at.isoformat() if flight.created_at else None,
         "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
     }
@@ -3363,6 +3379,36 @@ def download_flight_gpx(flight_id: str, db: Session = Depends(get_db)):
         f"{flight.title.replace(' ', '_') if flight.title else 'flight'}_{flight.flight_date}.gpx"
     )
     return FileResponse(path=gpx_path, media_type="application/gpx+xml", filename=filename)
+
+
+@router.get("/flights/{flight_id}/video")
+def download_flight_video(flight_id: str, db: Session = Depends(get_db)) -> FileResponse:
+    """Download generated video for a flight."""
+    flight = db.query(Flight).filter(Flight.id == flight_id).first()
+    if not flight:
+        raise HTTPException(status_code=404, detail="Flight not found")
+
+    video_path = _resolve_flight_file_path(flight.video_file_path)
+    if not video_path:
+        raise HTTPException(status_code=404, detail="No video file available for this flight")
+    if not video_path.exists():
+        raise HTTPException(status_code=404, detail="Video file not found on disk")
+
+    return FileResponse(path=video_path, media_type="video/mp4", filename=video_path.name)
+
+
+@router.get("/flights/{flight_id}/gopro-overlay")
+def download_flight_gopro_overlay(flight_id: str, db: Session = Depends(get_db)) -> FileResponse:
+    """Download generated GoPro overlay video for a flight."""
+    flight = db.query(Flight).filter(Flight.id == flight_id).first()
+    if not flight:
+        raise HTTPException(status_code=404, detail="Flight not found")
+
+    overlay_path = _flight_gopro_overlay_path(db, flight)
+    if not overlay_path:
+        raise HTTPException(status_code=404, detail="No GoPro overlay available for this flight")
+
+    return FileResponse(path=overlay_path, media_type="video/mp4", filename=overlay_path.name)
 
 
 @router.post("/flights")

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -259,6 +259,7 @@ class Flight(FlightBase):
     video_export_job_id: str | None = None
     video_export_status: str | None = None  # "processing", "completed", "failed"
     video_file_path: str | None = None
+    gopro_overlay_file_path: str | None = None
     created_at: datetime
     updated_at: datetime
     site: SiteInFlight | None = None  # Include site details with orientation

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -64,7 +64,9 @@ class TestFlightsListEndpoint:
         response = client.get(f"{API_PREFIX}/flights")
 
         assert response.status_code == 200
-        returned = response.json()["flights"][0]
+        returned = next(
+            flight for flight in response.json()["flights"] if flight["id"] == "flight-with-video"
+        )
         assert returned["gpx_file_path"] == "db/gpx/flight-with-video.gpx"
         assert returned["video_file_path"] == "/exports/flight-with-video.mp4"
         assert returned["video_export_job_id"] == "job-video"
@@ -92,7 +94,9 @@ class TestFlightsListEndpoint:
         response = client.get(f"{API_PREFIX}/flights")
 
         assert response.status_code == 200
-        returned = response.json()["flights"][0]
+        returned = next(
+            flight for flight in response.json()["flights"] if flight["id"] == "flight-with-overlay"
+        )
         assert returned["gopro_overlay_file_path"] == str(overlay_path)
 
     def test_download_flight_video(self, client, db_session, tmp_path):
@@ -152,6 +156,25 @@ class TestFlightsListEndpoint:
         assert response.status_code == 200
         assert response.content == b"overlay"
         assert response.headers["content-type"] == "video/mp4"
+
+    def test_download_flight_gopro_overlay_reports_missing_config(
+        self, client, db_session, monkeypatch
+    ):
+        """GET /flights/{id}/gopro-overlay reports configuration errors separately."""
+        monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", "")
+        flight = Flight(
+            id="flight-overlay-missing-config",
+            name="Flight overlay missing config",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/gopro-overlay")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "GoPro overlay paragliding root is not configured"
 
     def test_get_flights_filter_by_site(self, client, db_session, arguel_site, chalais_site):
         """GET /flights?site_id=X filters by site"""

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -8,6 +8,7 @@ Coverage: GET, POST, PATCH, DELETE for flights.
 from datetime import date, timedelta
 from pathlib import Path
 
+import config
 from models import Flight
 
 # API prefix for all routes
@@ -68,6 +69,89 @@ class TestFlightsListEndpoint:
         assert returned["video_file_path"] == "/exports/flight-with-video.mp4"
         assert returned["video_export_job_id"] == "job-video"
         assert returned["video_export_status"] == "completed"
+        assert returned["gopro_overlay_file_path"] is None
+
+    def test_get_flights_includes_available_gopro_overlay_path(
+        self, client, db_session, monkeypatch, tmp_path
+    ):
+        """GET /flights includes derived GoPro overlay path when final.mp4 exists."""
+        monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+        overlay_dir = tmp_path / "20260315" / "01"
+        overlay_dir.mkdir(parents=True)
+        overlay_path = overlay_dir / "final.mp4"
+        overlay_path.write_bytes(b"overlay")
+        flight = Flight(
+            id="flight-with-overlay",
+            name="Flight with overlay",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = response.json()["flights"][0]
+        assert returned["gopro_overlay_file_path"] == str(overlay_path)
+
+    def test_download_flight_video(self, client, db_session, tmp_path):
+        """GET /flights/{id}/video downloads the generated flight video."""
+        video_path = tmp_path / "flight.mp4"
+        video_path.write_bytes(b"video")
+        flight = Flight(
+            id="flight-video-download",
+            name="Flight video download",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            video_file_path=str(video_path),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/video")
+
+        assert response.status_code == 200
+        assert response.content == b"video"
+        assert response.headers["content-type"] == "video/mp4"
+
+    def test_download_flight_video_returns_404_without_video(self, client, db_session):
+        """GET /flights/{id}/video rejects flights without video file."""
+        flight = Flight(
+            id="flight-no-video",
+            name="Flight no video",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/video")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No video file available for this flight"
+
+    def test_download_flight_gopro_overlay(self, client, db_session, monkeypatch, tmp_path):
+        """GET /flights/{id}/gopro-overlay downloads the generated overlay."""
+        monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+        overlay_dir = tmp_path / "20260315" / "01"
+        overlay_dir.mkdir(parents=True)
+        overlay_path = overlay_dir / "final.mp4"
+        overlay_path.write_bytes(b"overlay")
+        flight = Flight(
+            id="flight-overlay-download",
+            name="Flight overlay download",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/gopro-overlay")
+
+        assert response.status_code == 200
+        assert response.content == b"overlay"
+        assert response.headers["content-type"] == "video/mp4"
 
     def test_get_flights_filter_by_site(self, client, db_session, arguel_site, chalais_site):
         """GET /flights?site_id=X filters by site"""

--- a/apps/frontend/src/components/flights/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.stories.tsx
@@ -51,6 +51,8 @@ const fullFlight: Flight = {
   site_name: 'Arguel',
   notes: 'Superbe vol thermique, base cumulus 1800m',
   gpx_file_path: '/data/flights/arguel-001.gpx',
+  video_file_path: '/data/flights/arguel-001.mp4',
+  gopro_overlay_file_path: '/data/flights/final.mp4',
 };
 
 const flightWithoutGpx: Flight = {
@@ -100,6 +102,16 @@ const defaultHandlers = [
   http.get('*/api/flights/:id/gpx', () =>
     HttpResponse.text('<gpx></gpx>', {
       headers: { 'Content-Type': 'application/gpx+xml' },
+    })
+  ),
+  http.get('*/api/flights/:id/video', () =>
+    HttpResponse.arrayBuffer(new ArrayBuffer(8), {
+      headers: { 'Content-Type': 'video/mp4' },
+    })
+  ),
+  http.get('*/api/flights/:id/gopro-overlay', () =>
+    HttpResponse.arrayBuffer(new ArrayBuffer(8), {
+      headers: { 'Content-Type': 'video/mp4' },
     })
   ),
   http.get('*/api/flights/:id', () => HttpResponse.json(fullFlight)),

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -143,6 +143,7 @@ export function FlightDetails({
   const isGoproOverlayCompleted = goproOverlayJob?.status === 'completed';
   const isGoproOverlayFailed = goproOverlayJob?.status === 'failed';
   const goproOverlayProgress = clampProgress(goproOverlayJob?.progress ?? 0);
+  const isDownloadingAnyMedia = downloadingMedia !== null;
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
     normalizedTitle ||
@@ -312,7 +313,7 @@ export function FlightDetails({
     filename: string,
     media: DownloadableFlightMedia
   ) => {
-    if (downloadingMedia) return;
+    if (isDownloadingAnyMedia) return;
 
     setDownloadingMedia(media);
     try {
@@ -626,7 +627,7 @@ export function FlightDetails({
                       type="button"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                       onClick={() => void handleDownloadGpx()}
-                      disabled={downloadingMedia === 'gpx'}
+                      disabled={isDownloadingAnyMedia}
                       aria-label={t('flights.downloadGpx')}
                     >
                       <FileText className="h-3 w-3" aria-hidden="true" />
@@ -639,7 +640,7 @@ export function FlightDetails({
                       type="button"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                       onClick={() => void handleDownloadVideo()}
-                      disabled={downloadingMedia === 'video'}
+                      disabled={isDownloadingAnyMedia}
                       aria-label={t('flights.viewer.downloadVideo')}
                     >
                       <Video className="h-3 w-3" aria-hidden="true" />
@@ -674,7 +675,7 @@ export function FlightDetails({
                       type="button"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
                       onClick={() => void handleDownloadPersistedGoproOverlay()}
-                      disabled={downloadingMedia === 'overlay'}
+                      disabled={isDownloadingAnyMedia}
                       aria-label={t('flights.goproOverlayDownload')}
                     >
                       <Wand2 className="h-3 w-3" aria-hidden="true" />

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -57,6 +57,7 @@ interface FlightDetailsProps {
 }
 
 type FlightDetailsTab = 'infos' | 'replay';
+type DownloadableFlightMedia = 'gpx' | 'video' | 'overlay';
 type GoproOverlayFieldId =
   | 'videoPath'
   | 'gpxPath'
@@ -119,10 +120,13 @@ export function FlightDetails({
     useState('');
   const [editingGoproOverlayField, setEditingGoproOverlayField] =
     useState<GoproOverlayFieldId | null>(null);
+  const [downloadingMedia, setDownloadingMedia] =
+    useState<DownloadableFlightMedia | null>(null);
   const goproOverlayEditInputRef = useRef<HTMLInputElement>(null);
 
   const hasGpx = Boolean(flight.gpx_file_path);
   const hasVideo = Boolean(flight.video_file_path);
+  const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
   const { job: streamedGoproOverlayJob } = useGoproOverlayJobStream(
     goproOverlayJobId,
     goproOverlayJobToken
@@ -165,6 +169,7 @@ export function FlightDetails({
     setGoproOverlayOutputDir('');
     setGoproOverlayOutputFilename('');
     setEditingGoproOverlayField(null);
+    setDownloadingMedia(null);
     resetGoproOverlayJob();
   }, [flight.id, resetGoproOverlayJob]);
 
@@ -299,6 +304,78 @@ export function FlightDetails({
       toast.success(t('flights.goproOverlayCancelled'));
     } catch {
       toast.error(t('flights.goproOverlayCancelError'));
+    }
+  };
+
+  const downloadBlob = async (
+    path: string,
+    filename: string,
+    media: DownloadableFlightMedia
+  ) => {
+    if (downloadingMedia) return;
+
+    setDownloadingMedia(media);
+    try {
+      const blob = await api.get(path, { timeout: false }).blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setDownloadingMedia(null);
+    }
+  };
+
+  const flightFilename = (extension: string) => {
+    const filename = flightTitle.replace(/[^a-zA-Z0-9._-]+/gu, '_');
+    return `${filename || flight.id}.${extension}`;
+  };
+
+  const handleDownloadGpx = async () => {
+    if (!hasGpx) return;
+
+    try {
+      await downloadBlob(
+        `flights/${flight.id}/gpx`,
+        flightFilename('gpx'),
+        'gpx'
+      );
+    } catch {
+      toast.error(t('flights.gpxDownloadError'));
+    }
+  };
+
+  const handleDownloadVideo = async () => {
+    if (!hasVideo) return;
+
+    try {
+      await downloadBlob(
+        `flights/${flight.id}/video`,
+        flightFilename('mp4'),
+        'video'
+      );
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(error, t('flights.viewer.videoDownloadError'))
+      );
+    }
+  };
+
+  const handleDownloadPersistedGoproOverlay = async () => {
+    if (!hasPersistedGoproOverlay) return;
+
+    try {
+      await downloadBlob(
+        `flights/${flight.id}/gopro-overlay`,
+        flightFilename('mp4'),
+        'overlay'
+      );
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(error, t('flights.goproOverlayDownloadError'))
+      );
     }
   };
 
@@ -541,19 +618,34 @@ export function FlightDetails({
                 hasVideo ||
                 isVideoExportRunning ||
                 isVideoExportFailed ||
-                goproOverlayJob) && (
+                goproOverlayJob ||
+                hasPersistedGoproOverlay) && (
                 <div className="mt-2 flex flex-wrap gap-1.5">
                   {hasGpx && (
-                    <span className="inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200">
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => void handleDownloadGpx()}
+                      disabled={downloadingMedia === 'gpx'}
+                      aria-label={t('flights.downloadGpx')}
+                    >
                       <FileText className="h-3 w-3" aria-hidden="true" />
                       {t('flights.gpxBadge')}
-                    </span>
+                      <Download className="h-3 w-3" aria-hidden="true" />
+                    </button>
                   )}
                   {hasVideo && (
-                    <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => void handleDownloadVideo()}
+                      disabled={downloadingMedia === 'video'}
+                      aria-label={t('flights.viewer.downloadVideo')}
+                    >
                       <Video className="h-3 w-3" aria-hidden="true" />
                       {t('flights.videoBadge')}
-                    </span>
+                      <Download className="h-3 w-3" aria-hidden="true" />
+                    </button>
                   )}
                   {isVideoExportRunning && (
                     <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
@@ -570,6 +662,19 @@ export function FlightDetails({
                       type="button"
                       className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800"
                       onClick={() => void handleDownloadGoproOverlay()}
+                      aria-label={t('flights.goproOverlayDownload')}
+                    >
+                      <Wand2 className="h-3 w-3" aria-hidden="true" />
+                      {t('flights.goproOverlayBadge')}
+                      <Download className="h-3 w-3" aria-hidden="true" />
+                    </button>
+                  )}
+                  {!isGoproOverlayCompleted && hasPersistedGoproOverlay && (
+                    <button
+                      type="button"
+                      className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      onClick={() => void handleDownloadPersistedGoproOverlay()}
+                      disabled={downloadingMedia === 'overlay'}
                       aria-label={t('flights.goproOverlayDownload')}
                     >
                       <Wand2 className="h-3 w-3" aria-hidden="true" />

--- a/apps/frontend/src/components/flights/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.stories.tsx
@@ -23,6 +23,7 @@ const mockFlights: Flight[] = [
     video_export_job_id: 'job-flight-1',
     video_export_status: 'completed',
     video_file_path: '/exports/flight-1.mp4',
+    gopro_overlay_file_path: '/exports/final.mp4',
     notes: 'Super conditions thermiques',
   },
   {
@@ -110,6 +111,7 @@ function FlightsTableWrapper({
         onDeleteFlight={fn()}
         onDownloadGpx={fn()}
         onDownloadVideo={fn()}
+        onDownloadOverlay={fn()}
         downloadingMedia={null}
         rowSelection={rowSelection}
         onRowSelectionChange={setRowSelection}

--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -34,6 +34,7 @@ const flights: Flight[] = [
     video_export_job_id: 'job-flight-1',
     video_export_status: 'completed',
     video_file_path: '/exports/flight-1.mp4',
+    gopro_overlay_file_path: '/exports/final.mp4',
     notes: null,
   },
   {
@@ -55,9 +56,11 @@ const flights: Flight[] = [
 function FlightsTableHarness({
   onDownloadGpx = () => undefined,
   onDownloadVideo = () => undefined,
+  onDownloadOverlay = () => undefined,
 }: {
   onDownloadGpx?: (flight: Flight) => void;
   onDownloadVideo?: (flight: Flight) => void;
+  onDownloadOverlay?: (flight: Flight) => void;
 }) {
   const [selectedFlightId, setSelectedFlightId] = useState<string | null>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -71,6 +74,7 @@ function FlightsTableHarness({
       onDeleteFlight={() => undefined}
       onDownloadGpx={onDownloadGpx}
       onDownloadVideo={onDownloadVideo}
+      onDownloadOverlay={onDownloadOverlay}
       downloadingMedia={null}
       rowSelection={rowSelection}
       onRowSelectionChange={setRowSelection}
@@ -89,15 +93,32 @@ test('applies the active style when a flight is selected', () => {
   expect(flightRow).toHaveAttribute('aria-selected', 'true');
 });
 
-test('shows media badges without download actions', () => {
-  render(<FlightsTableHarness />);
+test('downloads media from badges without selecting the flight', () => {
+  const onDownloadGpx = vi.fn();
+  const onDownloadVideo = vi.fn();
+  const onDownloadOverlay = vi.fn();
+  render(
+    <FlightsTableHarness
+      onDownloadGpx={onDownloadGpx}
+      onDownloadVideo={onDownloadVideo}
+      onDownloadOverlay={onDownloadOverlay}
+    />
+  );
 
   const flightRow = screen.getByTestId('flight-row-flight-1');
 
   expect(screen.getByText('flights.gpxBadge')).toBeInTheDocument();
-  expect(
-    screen.queryByRole('button', { name: 'flights.downloadGpx' })
-  ).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'flights.downloadGpx' }));
+  fireEvent.click(
+    screen.getByRole('button', { name: 'flights.viewer.downloadVideo' })
+  );
+  fireEvent.click(
+    screen.getByRole('button', { name: 'flights.goproOverlayDownload' })
+  );
+
+  expect(onDownloadGpx).toHaveBeenCalledWith(flights[0]);
+  expect(onDownloadVideo).toHaveBeenCalledWith(flights[0]);
+  expect(onDownloadOverlay).toHaveBeenCalledWith(flights[0]);
   expect(flightRow).not.toHaveClass('border-sky-700');
   expect(flightRow).toHaveAttribute('aria-selected', 'false');
 });

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -186,10 +186,7 @@ export function FlightsTable({
                           event.stopPropagation();
                           onDownloadGpx(flight);
                         }}
-                        disabled={
-                          downloadingMedia?.flightId === flight.id &&
-                          downloadingMedia.type === 'gpx'
-                        }
+                        disabled={Boolean(downloadingMedia)}
                         aria-label={t('flights.downloadGpx')}
                       >
                         <FileText className="h-3 w-3" aria-hidden="true" />
@@ -204,10 +201,7 @@ export function FlightsTable({
                           event.stopPropagation();
                           onDownloadVideo(flight);
                         }}
-                        disabled={
-                          downloadingMedia?.flightId === flight.id &&
-                          downloadingMedia.type === 'video'
-                        }
+                        disabled={Boolean(downloadingMedia)}
                         aria-label={t('flights.viewer.downloadVideo')}
                       >
                         <Video className="h-3 w-3" aria-hidden="true" />
@@ -222,10 +216,7 @@ export function FlightsTable({
                           event.stopPropagation();
                           onDownloadOverlay(flight);
                         }}
-                        disabled={
-                          downloadingMedia?.flightId === flight.id &&
-                          downloadingMedia.type === 'overlay'
-                        }
+                        disabled={Boolean(downloadingMedia)}
                         aria-label={t('flights.goproOverlayDownload')}
                       >
                         <Wand2 className="h-3 w-3" aria-hidden="true" />

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -13,6 +13,7 @@ import {
   Ruler,
   Trash2,
   Video,
+  Wand2,
 } from 'lucide-react';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
 import type { Flight } from '../../types';
@@ -30,7 +31,11 @@ interface FlightsTableProps {
   onDeleteFlight: (flight: Flight) => void;
   onDownloadGpx: (flight: Flight) => void;
   onDownloadVideo: (flight: Flight) => void;
-  downloadingMedia: { flightId: string; type: 'gpx' | 'video' } | null;
+  onDownloadOverlay: (flight: Flight) => void;
+  downloadingMedia: {
+    flightId: string;
+    type: 'gpx' | 'video' | 'overlay';
+  } | null;
   rowSelection: RowSelectionState;
   onRowSelectionChange: OnChangeFn<RowSelectionState>;
 }
@@ -42,6 +47,10 @@ export function FlightsTable({
   selectionMode,
   onSelectFlight,
   onDeleteFlight,
+  onDownloadGpx,
+  onDownloadVideo,
+  onDownloadOverlay,
+  downloadingMedia,
   rowSelection,
   onRowSelectionChange,
 }: FlightsTableProps) {
@@ -165,19 +174,63 @@ export function FlightsTable({
                 {flight.title || t('flights.untitledFlight')}
               </h3>
               {!selectionMode &&
-                (flight.gpx_file_path || flight.video_file_path) && (
+                (flight.gpx_file_path ||
+                  flight.video_file_path ||
+                  flight.gopro_overlay_file_path) && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {flight.gpx_file_path && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200">
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDownloadGpx(flight);
+                        }}
+                        disabled={
+                          downloadingMedia?.flightId === flight.id &&
+                          downloadingMedia.type === 'gpx'
+                        }
+                        aria-label={t('flights.downloadGpx')}
+                      >
                         <FileText className="h-3 w-3" aria-hidden="true" />
                         {t('flights.gpxBadge')}
-                      </span>
+                      </button>
                     )}
                     {flight.video_file_path && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDownloadVideo(flight);
+                        }}
+                        disabled={
+                          downloadingMedia?.flightId === flight.id &&
+                          downloadingMedia.type === 'video'
+                        }
+                        aria-label={t('flights.viewer.downloadVideo')}
+                      >
                         <Video className="h-3 w-3" aria-hidden="true" />
                         {t('flights.videoBadge')}
-                      </span>
+                      </button>
+                    )}
+                    {flight.gopro_overlay_file_path && (
+                      <button
+                        type="button"
+                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onDownloadOverlay(flight);
+                        }}
+                        disabled={
+                          downloadingMedia?.flightId === flight.id &&
+                          downloadingMedia.type === 'overlay'
+                        }
+                        aria-label={t('flights.goproOverlayDownload')}
+                      >
+                        <Wand2 className="h-3 w-3" aria-hidden="true" />
+                        {t('flights.goproOverlayBadge')}
+                      </button>
                     )}
                   </div>
                 )}
@@ -269,6 +322,10 @@ export function FlightsTable({
       selectedFlightId,
       onSelectFlight,
       onDeleteFlight,
+      onDownloadGpx,
+      onDownloadVideo,
+      onDownloadOverlay,
+      downloadingMedia,
       t,
       i18n,
       units,

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -32,7 +32,7 @@ import { useIsMobile } from '../hooks/useIsMobile';
 
 type DownloadingFlightMedia = {
   flightId: string;
-  type: 'gpx' | 'video';
+  type: 'gpx' | 'video' | 'overlay';
 };
 
 function getFlightDownloadName(flight: Flight, extension: string) {
@@ -262,18 +262,14 @@ export default function FlightHistory() {
 
   const handleDownloadFlightVideo = useCallback(
     async (flight: Flight) => {
-      if (
-        !flight.video_file_path ||
-        !flight.video_export_job_id ||
-        downloadingFlightMedia
-      ) {
+      if (!flight.video_file_path || downloadingFlightMedia) {
         return;
       }
 
       setDownloadingFlightMedia({ flightId: flight.id, type: 'video' });
       try {
         const blob = await api
-          .get(`exports/${flight.video_export_job_id}/download`, {
+          .get(`flights/${flight.id}/video`, {
             timeout: false,
           })
           .blob();
@@ -288,6 +284,37 @@ export default function FlightHistory() {
           await getApiErrorMessage(
             error,
             t('flights.viewer.videoDownloadError')
+          )
+        );
+      } finally {
+        setDownloadingFlightMedia(null);
+      }
+    },
+    [downloadingFlightMedia, t, toast]
+  );
+
+  const handleDownloadFlightOverlay = useCallback(
+    async (flight: Flight) => {
+      if (!flight.gopro_overlay_file_path || downloadingFlightMedia) return;
+
+      setDownloadingFlightMedia({ flightId: flight.id, type: 'overlay' });
+      try {
+        const blob = await api
+          .get(`flights/${flight.id}/gopro-overlay`, {
+            timeout: false,
+          })
+          .blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = getFlightDownloadName(flight, 'mp4');
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        toast.error(
+          await getApiErrorMessage(
+            error,
+            t('flights.goproOverlayDownloadError')
           )
         );
       } finally {
@@ -439,6 +466,7 @@ export default function FlightHistory() {
               onDeleteFlight={setFlightToDelete}
               onDownloadGpx={handleDownloadFlightGpx}
               onDownloadVideo={handleDownloadFlightVideo}
+              onDownloadOverlay={handleDownloadFlightOverlay}
               downloadingMedia={downloadingFlightMedia}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -96,6 +96,7 @@ export const FlightSchema = z.object({
     ])
     .nullish(),
   video_file_path: z.string().nullish(),
+  gopro_overlay_file_path: z.string().nullish(),
   site: SiteSchema.optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),


### PR DESCRIPTION
## Summary
- Make GPX, video, and GoPro overlay tags downloadable from flight list and flight details.
- Add backend download endpoints for flight video and GoPro overlay, plus shared flight metadata for the overlay path.
- Cover the new download flows with targeted frontend and backend tests.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint shared-types`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check shared-types`
- `.venv/bin/pytest apps/backend/tests/api/test_routes_flights.py apps/backend/tests/api/test_gopro_overlay_endpoints.py -q`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`

## Notes
- Full `nx test backend` was attempted but exceeded the available time window after starting the suite; the targeted backend tests covering the changed routes passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Flight videos and GoPro overlays are now downloadable directly from the app
  * Flight listings and details display whether a GoPro overlay is available
  * Added interactive download buttons for overlays in flight cards and flight details
  * Improved media download experience with progress indicators for concurrent operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->