### PR TITLE
fix(backend): make rq video job ids valid

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -263,6 +263,13 @@ def test_job_frames_dir_uses_configured_temp_dir(tmp_path, monkeypatch):
     assert frames_dir == tmp_path / "temp-images" / "job-123" / "frames"
 
 
+def test_rq_job_id_does_not_use_forbidden_separator():
+    rq_job_id = video_export_manual._rq_job_id("job-rq")
+
+    assert rq_job_id == "video-export-job-rq"
+    assert ":" not in rq_job_id
+
+
 def test_start_video_export_manual_enqueues_rq_job(test_db, monkeypatch):
     enqueued_job_ids: list[str] = []
     monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
@@ -399,13 +406,23 @@ def test_job_resume_info_requires_terminal_status_and_frames(tmp_path, monkeypat
 
 def test_resume_video_export_requeues_cancelled_job_with_frames(test_db, tmp_path, monkeypatch):
     job_id = "job-resume"
+    enqueued_job_ids: list[str] = []
     temp_root = tmp_path / "temp-images"
     frames_dir = temp_root / job_id / "frames"
     frames_dir.mkdir(parents=True)
     (frames_dir / "frame00000.png").write_bytes(b"frame")
     monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
-    monkeypatch.setattr(video_export_manual, "start_video_export_worker", lambda: None)
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
+
+    def enqueue_rq_job(queued_job_id: str) -> None:
+        enqueued_job_ids.append(video_export_manual._rq_job_id(queued_job_id))
+
+    monkeypatch.setattr(
+        video_export_manual,
+        "_enqueue_video_export_job_in_rq",
+        enqueue_rq_job,
+    )
 
     db_session = test_db()
     db_session.add(
@@ -439,6 +456,7 @@ def test_resume_video_export_requeues_cancelled_job_with_frames(test_db, tmp_pat
     assert job.error is None
     assert job.video_path is None
     db_session.close()
+    assert enqueued_job_ids == ["video-export-job-resume"]
 
 
 def test_resume_video_export_waits_for_running_cancel_to_finish(test_db, tmp_path, monkeypatch):

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -455,7 +455,7 @@ def _queued_job_ids() -> list[str]:
 
 
 def _rq_job_id(job_id: str) -> str:
-    return f"video-export:{job_id}"
+    return f"video-export-{job_id}"
 
 
 def _enqueue_video_export_job_in_rq(job_id: str) -> None:


### PR DESCRIPTION
## Summary
- Replace the RQ job id separator so video export resume/relaunch jobs use a valid identifier.
- Add unit coverage for the RQ job id helper and the resume enqueue path.

## Validation
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5` (timed out after long-running suite activity)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed video export job identifier format to ensure proper compatibility with the job queue system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->