### PR TITLE
fix(frontend): remove flight generation progress UI

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -69,18 +69,6 @@ const labelClass = 'text-xs text-gray-600 dark:text-gray-300';
 const valueClass =
   'block text-sm font-medium text-gray-900 dark:text-white mt-1';
 
-function clampProgress(progress: number) {
-  return Math.max(0, Math.min(Math.round(progress), 100));
-}
-
-function goproOverlayProgressClass(status: string) {
-  if (status === 'completed') return 'accent-emerald-500';
-  if (status === 'failed') return 'accent-red-500';
-  if (status === 'cancelled') return 'accent-slate-500';
-  if (status === 'queued') return 'accent-amber-500';
-  return 'accent-cyan-500';
-}
-
 export function FlightDetails({
   flight,
   sites,
@@ -142,7 +130,6 @@ export function FlightDetails({
   const isVideoExportFailed = flight.video_export_status === 'failed';
   const isGoproOverlayCompleted = goproOverlayJob?.status === 'completed';
   const isGoproOverlayFailed = goproOverlayJob?.status === 'failed';
-  const goproOverlayProgress = clampProgress(goproOverlayJob?.progress ?? 0);
   const isDownloadingAnyMedia = downloadingMedia !== null;
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
@@ -773,20 +760,6 @@ export function FlightDetails({
                   {t(`flights.goproOverlayStatus.${goproOverlayJob.status}`)}
                 </span>
               </div>
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
-                  {goproOverlayJob.message}
-                </span>
-                <span className="font-mono text-sm font-bold text-slate-950 dark:text-white">
-                  {goproOverlayProgress}%
-                </span>
-              </div>
-              <progress
-                className={`h-2.5 w-full overflow-hidden rounded-full bg-slate-200 ring-1 ring-slate-300 transition-[accent-color] duration-300 motion-reduce:transition-none dark:bg-slate-800 dark:ring-slate-700 ${goproOverlayProgressClass(goproOverlayJob.status)}`}
-                value={goproOverlayProgress}
-                max={100}
-                aria-label={t('flights.goproOverlayJobTitle')}
-              />
               {goproOverlayJob.status === 'completed' && (
                 <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 dark:border-emerald-800 dark:bg-emerald-950/30">
                   <span className="text-xs font-semibold text-emerald-900 dark:text-emerald-100">

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
@@ -45,7 +45,6 @@ vi.mock('react-i18next', () => ({
         'flights.viewer.resumeVideo': 'Resume generation',
         'flights.viewer.videoResumeHint': 'frames preserved',
         'flights.viewer.videoGenerating': 'Generating video',
-        'flights.viewer.videoProgress': 'Progress',
         'flights.viewer.cancelGeneration': 'Cancel generation',
         'flights.viewer.regenerateVideo': 'Restart generation',
       })[key] ?? key,
@@ -57,7 +56,6 @@ vi.mock('../../hooks/flights/useFlight', () => ({
 }));
 
 vi.mock('../../hooks/flights/useVideoExportStatus', () => ({
-  formatEta: () => null,
   useVideoExportStatus: () => ({ status: exportStatusMock.current }),
 }));
 

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -7,10 +7,7 @@ import {
   VIDEO_EXPORT_IN_PROGRESS_STATUSES,
   type Flight,
 } from '@dashboard-parapente/shared-types';
-import {
-  formatEta,
-  useVideoExportStatus,
-} from '../../hooks/flights/useVideoExportStatus';
+import { useVideoExportStatus } from '../../hooks/flights/useVideoExportStatus';
 import { useFlight } from '../../hooks/flights/useFlight';
 import { useToast } from '../../hooks/useToast';
 import { api } from '../../lib/api';
@@ -93,11 +90,6 @@ export function FlightVideoExportControls({
     shouldReadExportStatus,
     videoExportJobToken
   );
-  const exportProgress = Math.min(
-    100,
-    Math.max(0, Math.round(exportStatus?.progress ?? 0))
-  );
-  const exportEta = formatEta(exportStatus?.eta_seconds);
   const canResumeVideoExport = Boolean(
     flight.video_export_job_id && exportStatus?.can_resume
   );
@@ -303,33 +295,6 @@ export function FlightVideoExportControls({
             count: exportStatus?.frames_captured ?? 0,
           })}
         </p>
-      )}
-
-      {hasActiveVideoExport(flight) && (
-        <div
-          className={`mt-2 rounded-lg border border-blue-200 bg-blue-50 p-2 dark:border-blue-700 dark:bg-blue-900/20 ${
-            compact ? 'basis-full sm:min-w-72' : ''
-          }`}
-        >
-          <div className="mb-1 flex items-center justify-between text-xs font-medium text-blue-900 dark:text-blue-100">
-            <span>{t('flights.viewer.videoProgress')}</span>
-            <span>{exportProgress}%</span>
-          </div>
-          <div className="h-2 w-full overflow-hidden rounded bg-blue-100 dark:bg-blue-950/40">
-            <div
-              className="h-full rounded bg-blue-600 transition-all duration-500"
-              style={{ width: `${exportProgress}%` }}
-            />
-          </div>
-          <p className="mt-2 text-xs text-blue-900 dark:text-blue-100">
-            {exportStatus?.message || t('flights.viewer.videoGenerating')}
-          </p>
-          {exportEta && (
-            <p className="mt-1 text-xs text-blue-900 dark:text-blue-100">
-              {t('flights.viewer.videoEta', { time: exportEta })}
-            </p>
-          )}
-        </div>
       )}
 
       {hasActiveVideoExport(flight) && (


### PR DESCRIPTION
## Summary
- Remove flight generation progress details from the flights page UI.
- Keep the generation, resume, cancel, and download actions intact.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/FlightVideoExportControls.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Removed video export progress percentage display and estimated time remaining information from export controls
- Simplified GoPro overlay job status interface by removing progress indicators, progress bars, and detailed job status messages
- Export and generation functionality remains operational

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->