### PR TITLE
fix(backend): harden export viewer startup

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -662,6 +662,49 @@ app.include_router(public_router)
 app.include_router(router)
 app.include_router(webhooks_router)
 
+# Database
+DB_PATH = Path(__file__).parent / "db" / "dashboard.db"
+
+
+@app.get("/health")
+def health_check():
+    """
+    Health check endpoint for monitoring and e2e tests.
+
+    Returns a simple status response to verify the API server is running
+    and ready to accept requests. Used by:
+    - Playwright webServer configuration to wait for backend startup
+    - Monitoring and load balancers for health checks
+    - CI/CD pipelines to verify deployment success
+
+    Returns:
+        dict: A dictionary containing the status key with value "ok"
+
+    Example:
+        >>> response = client.get("/health")
+        >>> response.json()
+        {"status": "ok"}
+    """
+    return {"status": "ok"}
+
+
+@app.get("/")
+def read_root():
+    return {
+        "status": "ok",
+        "message": "Dashboard Parapente API v0.2.0",
+        "features": [
+            "Multi-source weather aggregation (5 sources)",
+            "Para-Index scoring (0-100)",
+            "Hourly scheduler (every hour)",
+            "Strava webhook integration",
+            "Telegram notifications",
+        ],
+        "db_path": str(DB_PATH),
+        "db_exists": DB_PATH.exists(),
+    }
+
+
 # ============================================
 # Serve Static Files (Frontend React SPA)
 # ============================================
@@ -706,48 +749,6 @@ if STATIC_DIR.exists():
 else:
     logger.warning(f"⚠️  Static directory not found: {STATIC_DIR}")
     logger.warning("Frontend will not be served. Build frontend: cd frontend && npm run build")
-
-# Database
-DB_PATH = Path(__file__).parent / "db" / "dashboard.db"
-
-
-@app.get("/health")
-def health_check():
-    """
-    Health check endpoint for monitoring and e2e tests.
-
-    Returns a simple status response to verify the API server is running
-    and ready to accept requests. Used by:
-    - Playwright webServer configuration to wait for backend startup
-    - Monitoring and load balancers for health checks
-    - CI/CD pipelines to verify deployment success
-
-    Returns:
-        dict: A dictionary containing the status key with value "ok"
-
-    Example:
-        >>> response = client.get("/health")
-        >>> response.json()
-        {"status": "ok"}
-    """
-    return {"status": "ok"}
-
-
-@app.get("/")
-def read_root():
-    return {
-        "status": "ok",
-        "message": "Dashboard Parapente API v0.2.0",
-        "features": [
-            "Multi-source weather aggregation (5 sources)",
-            "Para-Index scoring (0-100)",
-            "Hourly scheduler (every hour)",
-            "Strava webhook integration",
-            "Telegram notifications",
-        ],
-        "db_path": str(DB_PATH),
-        "db_exists": DB_PATH.exists(),
-    }
 
 
 if __name__ == "__main__":

--- a/apps/backend/tests/unit/test_main.py
+++ b/apps/backend/tests/unit/test_main.py
@@ -7,6 +7,20 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+def test_health_check_route_is_not_intercepted_by_spa_catch_all(client):
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_root_route_is_not_intercepted_by_spa_catch_all(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
 def test_schedule_strava_token_refresh_job_forces_refresh():
     """Strava refresh job should be registered in forced mode."""
 

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -3,6 +3,7 @@
 import os
 import time
 from datetime import datetime
+from urllib.error import URLError
 
 import pytest
 
@@ -20,6 +21,19 @@ def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
     monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
 
     resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
+
+    assert resolved == "http://localhost:8001"
+
+
+def test_default_frontend_url_normalizes_configured_vite_url_in_production(monkeypatch):
+    """Production defaults should not point browser workers to absent local Vite."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "FRONTEND_URL", "http://localhost:5173")
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual._default_frontend_url()
 
     assert resolved == "http://localhost:8001"
 
@@ -44,6 +58,19 @@ def test_resolve_frontend_url_strips_export_viewer_suffix(monkeypatch):
     )
 
     assert resolved == "http://frontend.example"
+
+
+def test_check_url_reachable_reports_connection_failure(monkeypatch):
+    def fail_urlopen(_request, timeout):
+        assert timeout == 5.0
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(video_export_manual, "urlopen", fail_urlopen)
+
+    with pytest.raises(RuntimeError, match="Export viewer is unreachable"):
+        video_export_manual._check_url_reachable(
+            "http://localhost:8001/export-viewer?flightId=flight-1"
+        )
 
 
 def test_build_playwright_init_script_sets_export_mode_and_token():

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -16,7 +16,9 @@ import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from sqlalchemy.orm import Session
 
@@ -108,7 +110,7 @@ def _to_iso(value: datetime | None) -> str | None:
 
 def _default_frontend_url() -> str:
     if config.FRONTEND_URL:
-        return config.FRONTEND_URL.rstrip("/")
+        return _normalize_frontend_url(config.FRONTEND_URL)
 
     static_index = Path(__file__).parent / "static" / "index.html"
     if static_index.exists():
@@ -156,6 +158,30 @@ def _normalize_frontend_url(frontend_url: str) -> str:
         return _backend_base_url()
 
     return candidate.rstrip("/")
+
+
+def _check_url_reachable(url: str, timeout_seconds: float = 5.0) -> None:
+    request = Request(url, headers={"User-Agent": "dashboard-parapente-video-export"})
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            status = response.status
+    except HTTPError as exc:
+        if exc.code >= 500:
+            raise RuntimeError(f"Export viewer returned HTTP {exc.code}: {url}") from exc
+        return
+    except URLError as exc:
+        raise RuntimeError(f"Export viewer is unreachable: {url} ({exc.reason})") from exc
+    except TimeoutError as exc:
+        raise RuntimeError(
+            f"Export viewer did not respond within {timeout_seconds:g}s: {url}"
+        ) from exc
+
+    if status >= 500:
+        raise RuntimeError(f"Export viewer returned HTTP {status}: {url}")
+
+
+async def _ensure_export_viewer_reachable(url: str, timeout_seconds: float = 5.0) -> None:
+    await asyncio.to_thread(_check_url_reachable, url, timeout_seconds)
 
 
 def _snapshot_from_job(job: VideoExportJob) -> dict[str, Any]:
@@ -1066,12 +1092,20 @@ async def _export_video_manual_render(job_id: str):
     temp_root = _video_temp_images_dir()
     temp_dir: Path | None = None
     frames_dir: Path | None = None
+    auth_token = job.auth_token
+    url = f"{frontend_url}/export-viewer?flightId={flight_id}&jobId={job_id}"
+    preflight_url = url
+    log_url = url
+    if auth_token:
+        url = f"{url}&exportToken={auth_token}"
+        log_url = f"{log_url}&exportToken=<redacted>"
 
     try:
         from playwright.async_api import async_playwright
 
         _update_job(job_id, status=_STATUS_INITIALIZING, message="Setting up manual render")
         _set_job_runtime(job_id, phase=_STATUS_INITIALIZING)
+        await _ensure_export_viewer_reachable(preflight_url)
 
         # Resolution mapping
         resolutions = {"720p": (1280, 720), "1080p": (1920, 1080), "4K": (3840, 2160)}
@@ -1106,17 +1140,11 @@ async def _export_video_manual_render(job_id: str):
             )
             page = await context.new_page()
 
-            auth_token = job.auth_token
             await page.add_init_script(_build_playwright_init_script(auth_token))
 
             page.on("console", lambda msg: print(f"🖥️  [{msg.type}]: {msg.text}"))
             page.on("pageerror", lambda err: print(f"❌ Browser error: {err}"))
 
-            url = f"{frontend_url}/export-viewer?flightId={flight_id}&jobId={job_id}"
-            log_url = url
-            if auth_token:
-                url = f"{url}&exportToken={auth_token}"
-                log_url = f"{log_url}&exportToken=<redacted>"
             print(f"📺 Opening {log_url}")
 
             _update_job(job_id, message="Loading export viewer")


### PR DESCRIPTION
## Summary
- Normalize export viewer URLs to the backend-served SPA in production and fail fast when the viewer is unreachable.
- Move `/health` and `/` ahead of the SPA catch-all so backend readiness checks remain valid.
- Add targeted backend tests for URL resolution and route handling.

## Validation
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py tests/unit/test_main.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend --skip-nx-cache`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend --skip-nx-cache` (timed out after progressing to scrapers; targeted unit coverage passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify health check and root endpoints function correctly.
  * Added tests for export viewer reachability validation and URL normalization.

* **Bug Fixes**
  * Added preflight reachability check before video export rendering, providing improved error handling for unreachable export viewers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->