### PR TITLE
fix(frontend): persist weather search targets in URL

### DIFF
--- a/apps/frontend/src/components/weather/CityWeatherSearch.tsx
+++ b/apps/frontend/src/components/weather/CityWeatherSearch.tsx
@@ -213,7 +213,8 @@ export default function CityWeatherSearch({
   const weatherTitle = getOptionName(selectedOption);
   const activeTargetLabel = getOptionName(selectedTarget);
   const suggestions = locationSearch.data?.locations ?? [];
-  const isSuggestionsOpen = debouncedQuery.length >= 3 && !selectedLocation;
+  const isSuggestionsOpen =
+    debouncedQuery.length >= 3 && !selectedLocation && !selectedOption;
   const activeSuggestion = suggestions[activeSuggestionIndex];
   const activeSuggestionId = activeSuggestion
     ? `${listboxId}-${activeSuggestion.id}`
@@ -311,6 +312,20 @@ export default function CityWeatherSearch({
   useEffect(() => {
     if (!selectedTarget) {
       setSelectedOption(null);
+      setSelectedLocation(null);
+      return;
+    }
+
+    setSelectedOption(selectedTarget);
+    setIsExpanded(true);
+    setFavoriteError(null);
+
+    if (selectedTarget.type === 'city') {
+      setSelectedLocation(selectedTarget.location);
+      setQuery(selectedTarget.location.name);
+    } else {
+      setSelectedLocation(null);
+      setQuery(selectedTarget.spot.name);
     }
   }, [selectedTarget]);
 

--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -642,6 +642,27 @@ const weatherRouteConfig = {
           typeof rawDay === 'string' || typeof rawDay === 'number'
             ? Number(rawDay)
             : Number.NaN;
+        const parseNumber = (value: unknown) => {
+          const parsed =
+            typeof value === 'string' || typeof value === 'number'
+              ? Number(value)
+              : Number.NaN;
+          return Number.isFinite(parsed) ? parsed : undefined;
+        };
+        const parseString = (value: unknown) =>
+          typeof value === 'string' && value.length > 0 ? value : undefined;
+        const target =
+          search.target === 'city' ||
+          search.target === 'takeoff' ||
+          search.target === 'landing'
+            ? search.target
+            : undefined;
+        const spotType =
+          search.spotType === 'takeoff' ||
+          search.spotType === 'landing' ||
+          search.spotType === 'both'
+            ? search.spotType
+            : undefined;
 
         return {
           siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
@@ -649,6 +670,18 @@ const weatherRouteConfig = {
             Number.isInteger(parsedDay) && parsedDay >= 0 && parsedDay <= 6
               ? parsedDay
               : undefined,
+          target,
+          city: parseString(search.city),
+          displayName: parseString(search.displayName),
+          spotId: parseString(search.spotId),
+          spotName: parseString(search.spotName),
+          spotType,
+          lat: parseNumber(search.lat),
+          lon: parseNumber(search.lon),
+          elevation: parseNumber(search.elevation),
+          orientation: parseString(search.orientation),
+          country: parseString(search.country),
+          source: parseString(search.source),
         };
       },
     },
@@ -698,6 +731,50 @@ WithSelectedSite.test(
     await canvas.findAllByText('Chalais');
     await canvas.findAllByText('Arguel');
     await canvas.findByText(/Best spot for|Meilleur spot pour/);
+  }
+);
+
+export const WithCityQueryParam = meta.story({
+  name: 'With City Query Param',
+  parameters: {
+    router: {
+      ...weatherRouteConfig,
+      initialPath:
+        '/weather?target=city&city=Besan%C3%A7on&displayName=Besan%C3%A7on%2C%20Doubs&lat=47.238&lon=6.024&country=FR',
+    },
+    msw: { handlers: defaultHandlers },
+  },
+});
+
+WithCityQueryParam.test(
+  'renders city weather from query params',
+  async ({ canvas }) => {
+    await canvas.findByText('Résultat de recherche sélectionné');
+    await canvas.findAllByText('Besançon');
+    await canvas.findByText('Météo sélectionnée');
+    await canvas.findByText('Prévisions Horaires');
+  }
+);
+
+export const WithSpotQueryParam = meta.story({
+  name: 'With Spot Query Param',
+  parameters: {
+    router: {
+      ...weatherRouteConfig,
+      initialPath:
+        '/weather?target=takeoff&spotId=merged-takeoff-arguel&spotName=Arguel%20d%C3%A9co&spotType=takeoff&lat=47.205&lon=6.005&elevation=427&orientation=SW&country=FR&source=merged',
+    },
+    msw: { handlers: defaultHandlers },
+  },
+});
+
+WithSpotQueryParam.test(
+  'renders searched spot weather from query params',
+  async ({ canvas }) => {
+    await canvas.findByText('Résultat de recherche sélectionné');
+    await canvas.findAllByText('Arguel déco');
+    await canvas.findByText('Météo sélectionnée');
+    await canvas.findByRole('button', { name: /Ajouter aux favoris/u });
   }
 );
 

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
@@ -56,6 +56,104 @@ const getSearchDayLabel = (day: number, t: (key: string) => string) => {
   return `J+${day}`;
 };
 
+type WeatherSearchParams = {
+  siteId?: string;
+  day?: number;
+  target?: 'city' | 'takeoff' | 'landing';
+  city?: string;
+  displayName?: string;
+  spotId?: string;
+  spotName?: string;
+  spotType?: 'takeoff' | 'landing' | 'both';
+  lat?: number;
+  lon?: number;
+  elevation?: number;
+  orientation?: string;
+  country?: string;
+  source?: string;
+};
+
+const hasCoordinates = (
+  search: WeatherSearchParams
+): search is WeatherSearchParams & { lat: number; lon: number } =>
+  typeof search.lat === 'number' && typeof search.lon === 'number';
+
+const getTargetFromSearch = (
+  search: WeatherSearchParams
+): CityWeatherTarget | null => {
+  if (search.target === 'city' && search.city && hasCoordinates(search)) {
+    return {
+      type: 'city',
+      location: {
+        id: `query-city-${search.lat}-${search.lon}`,
+        name: search.city,
+        display_name: search.displayName ?? search.city,
+        latitude: search.lat,
+        longitude: search.lon,
+        country: search.country ?? 'FR',
+      },
+    };
+  }
+
+  if (
+    (search.target === 'takeoff' || search.target === 'landing') &&
+    search.spotId &&
+    search.spotName &&
+    hasCoordinates(search)
+  ) {
+    return {
+      type: search.target,
+      spot: {
+        id: search.spotId,
+        name: search.spotName,
+        type: search.spotType ?? search.target,
+        latitude: search.lat,
+        longitude: search.lon,
+        elevation_m: search.elevation,
+        orientation: search.orientation,
+        rating: undefined,
+        country: search.country ?? 'FR',
+        source: search.source ?? 'query',
+        distance_km: undefined,
+      },
+    };
+  }
+
+  return null;
+};
+
+const getSearchForTarget = (target: CityWeatherTarget | null, day: number) => {
+  const daySearch = day > 0 ? day : undefined;
+
+  if (!target) return { day: daySearch };
+
+  if (target.type === 'city') {
+    return {
+      target: 'city' as const,
+      city: target.location.name,
+      displayName: target.location.display_name,
+      lat: target.location.latitude,
+      lon: target.location.longitude,
+      country: target.location.country,
+      day: daySearch,
+    };
+  }
+
+  return {
+    target: target.type,
+    spotId: target.spot.id,
+    spotName: target.spot.name,
+    spotType: target.spot.type,
+    lat: target.spot.latitude,
+    lon: target.spot.longitude,
+    elevation: target.spot.elevation_m ?? undefined,
+    orientation: target.spot.orientation ?? undefined,
+    country: target.spot.country,
+    source: target.spot.source,
+    day: daySearch,
+  };
+};
+
 type SelectionTab = 'favorites' | 'search';
 
 export default function WeatherPage() {
@@ -68,11 +166,12 @@ export default function WeatherPage() {
   const search = useSearch({ from: '/weather' });
   const routeSiteId = search ? search.siteId : '';
   const selectedDayIndex = search.day ?? 0;
+  const selectedSearchTarget = getTargetFromSearch(search);
   const { data: bestSpot } = useBestSpotAPI(selectedDayIndex);
   const { data: hourlyBestSpots } = useHourlyBestSpotsAPI(selectedDayIndex);
-  const [selectedSearchTarget, setSelectedSearchTarget] =
-    useState<CityWeatherTarget | null>(null);
-  const [selectionTab, setSelectionTab] = useState<SelectionTab>('favorites');
+  const [selectionTab, setSelectionTab] = useState<SelectionTab>(
+    selectedSearchTarget ? 'search' : 'favorites'
+  );
   const favoriteSites = useMemo(() => {
     if (favoriteSiteIds.length === 0) return sites;
 
@@ -142,7 +241,15 @@ export default function WeatherPage() {
               onSelectionChange={(key) => {
                 const nextTab = key as SelectionTab;
                 setSelectionTab(nextTab);
-                if (nextTab === 'favorites') setSelectedSearchTarget(null);
+                if (nextTab === 'favorites') {
+                  void navigate({
+                    to: '/weather',
+                    search: {
+                      siteId: selectedSiteId || undefined,
+                      day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                    },
+                  });
+                }
               }}
             >
               <TabList className="grid-cols-2 bg-slate-100 shadow-none dark:bg-slate-950/70">
@@ -154,7 +261,6 @@ export default function WeatherPage() {
                   <SiteSelector
                     selectedSiteId={selectedSearchTarget ? '' : selectedSiteId}
                     onSelectSite={(siteId) => {
-                      setSelectedSearchTarget(null);
                       setSelectionTab('favorites');
                       void navigate({
                         to: '/weather',
@@ -189,11 +295,13 @@ export default function WeatherPage() {
                   favoriteSites={sites}
                   isEmbedded
                   onSelectTarget={(target) => {
-                    setSelectedSearchTarget(target);
                     setSelectionTab('search');
+                    void navigate({
+                      to: '/weather',
+                      search: getSearchForTarget(target, selectedDayIndex),
+                    });
                   }}
                   onFavoriteCreated={(siteId) => {
-                    setSelectedSearchTarget(null);
                     setSelectionTab('favorites');
                     void navigate({
                       to: '/weather',
@@ -215,7 +323,6 @@ export default function WeatherPage() {
           hourlyBestSpots={hourlyBestSpots?.hours ?? []}
           hourlyStartHour={hourlyBestSpots?.startHour}
           onSelectSite={(siteId) => {
-            setSelectedSearchTarget(null);
             setSelectionTab('favorites');
             void navigate({
               to: '/weather',
@@ -308,10 +415,7 @@ export default function WeatherPage() {
                     onClick={() =>
                       void navigate({
                         to: '/weather',
-                        search: {
-                          siteId: selectedSiteId || undefined,
-                          day: day > 0 ? day : undefined,
-                        },
+                        search: getSearchForTarget(selectedSearchTarget, day),
                       })
                     }
                     role="tab"

--- a/apps/frontend/src/routes/weather.tsx
+++ b/apps/frontend/src/routes/weather.tsx
@@ -5,7 +5,30 @@ import { sitesQueryOptions } from '../hooks/sites/useSites';
 type WeatherSearch = {
   siteId?: string;
   day?: number;
+  target?: 'city' | 'takeoff' | 'landing';
+  city?: string;
+  displayName?: string;
+  spotId?: string;
+  spotName?: string;
+  spotType?: 'takeoff' | 'landing' | 'both';
+  lat?: number;
+  lon?: number;
+  elevation?: number;
+  orientation?: string;
+  country?: string;
+  source?: string;
 };
+
+const parseOptionalNumber = (value: unknown) => {
+  const parsed =
+    typeof value === 'string' || typeof value === 'number'
+      ? Number(value)
+      : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const parseString = (value: unknown) =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
 
 export const Route = createFileRoute('/weather')({
   validateSearch: (search: Record<string, unknown>): WeatherSearch => {
@@ -14,6 +37,18 @@ export const Route = createFileRoute('/weather')({
       typeof rawDay === 'string' || typeof rawDay === 'number'
         ? Number(rawDay)
         : Number.NaN;
+    const target =
+      search.target === 'city' ||
+      search.target === 'takeoff' ||
+      search.target === 'landing'
+        ? search.target
+        : undefined;
+    const spotType =
+      search.spotType === 'takeoff' ||
+      search.spotType === 'landing' ||
+      search.spotType === 'both'
+        ? search.spotType
+        : undefined;
 
     return {
       siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
@@ -21,6 +56,18 @@ export const Route = createFileRoute('/weather')({
         Number.isInteger(parsedDay) && parsedDay >= 0 && parsedDay <= 6
           ? parsedDay
           : undefined,
+      target,
+      city: parseString(search.city),
+      displayName: parseString(search.displayName),
+      spotId: parseString(search.spotId),
+      spotName: parseString(search.spotName),
+      spotType,
+      lat: parseOptionalNumber(search.lat),
+      lon: parseOptionalNumber(search.lon),
+      elevation: parseOptionalNumber(search.elevation),
+      orientation: parseString(search.orientation),
+      country: parseString(search.country),
+      source: parseString(search.source),
     };
   },
   loader: () => {


### PR DESCRIPTION
## Summary
- Persist weather city and spot searches in weather page query params
- Restore the active search target from the URL on reload
- Add story coverage for city and spot query-param entrypoints

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5