### PR TITLE
fix(deploy): default export viewer URL to backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,8 @@ services:
       - BACKEND_ADMIN_PASSWORD=${BACKEND_ADMIN_PASSWORD:?required}
 
       # Backend - Frontend URL
-      - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
+      # Video export runs in a separate worker container; use Docker DNS by default.
+      - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL:-http://backend:8001}
 
       # Backend - GoPro overlay toolchain
       - BACKEND_GOPRO_OVERLAY_ROOT=/app/gopro-overlay
@@ -146,7 +147,8 @@ services:
       - BACKEND_WEATHERAPI_KEY=${BACKEND_WEATHERAPI_KEY}
       - BACKEND_METEOBLUE_API_KEY=${BACKEND_METEOBLUE_API_KEY}
       - BACKEND_STRAVA_VERIFY_TOKEN=${BACKEND_STRAVA_VERIFY_TOKEN:-PARAPENTE_2025}
-      - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL}
+      # localhost inside this container is not the API container.
+      - BACKEND_FRONTEND_URL=${BACKEND_FRONTEND_URL:-http://backend:8001}
       - BACKEND_GOPRO_OVERLAY_ROOT=/app/gopro-overlay
       - BACKEND_GOPRO_OVERLAY_BIN=/app/gopro-overlay/venv/bin/gopro-dashboard.py
       - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay


### PR DESCRIPTION
## Summary
- Default video export viewer URLs to the backend service DNS name in Docker production.
- Prevent workers from using `localhost:8001`, which resolves to the worker container itself.

## Validation
- `docker compose config --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker Compose configuration by providing a default value for the backend service URL, eliminating the need for manual environment variable setup during deployment.

* **Documentation**
  * Added inline clarifications on Docker service networking conventions for improved setup clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->