### PR TITLE
fix(frontend): label active video jobs in progress

### DIFF
--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -187,6 +187,7 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Overlay GoPro').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);
     expect(screen.getAllByRole('button', { name: 'Stopper' })).toHaveLength(4);
     expect(
       screen.getAllByRole('link', { name: 'Voir le vol' })[0]

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -59,6 +59,14 @@ const typeFilters = [
 
 type TypeFilter = (typeof typeFilters)[number]['id'];
 
+const activeStatusLabels = new Set([
+  'running',
+  'initializing',
+  'capturing',
+  'encoding',
+  'processing',
+]);
+
 const columnHelper = createColumnHelper<VideoExportJob>();
 
 const actionButtonClassName =
@@ -76,7 +84,11 @@ function getJobPhase(job: VideoExportJob) {
 
 function getStatusLabelParts(job: VideoExportJob) {
   const phase = getJobPhase(job);
-  const status = statusLabelFallbacks[phase] ? phase : job.status;
+  const status = activeStatusLabels.has(phase)
+    ? 'processing'
+    : statusLabelFallbacks[phase]
+      ? phase
+      : job.status;
   const fallback = statusLabelFallbacks[status] || status;
   return { key: `videoJobs.status.${status}`, fallback };
 }


### PR DESCRIPTION
## Summary
- Show active video export jobs with the `En cours` badge in the jobs panel
- Keep the underlying phase detail visible in the table
- Add a regression test for the active-job label

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`