### PR TITLE
fix(backend): make export viewer reachable in production

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -22,7 +22,7 @@ def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
 
     resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
 
-    assert resolved == "http://localhost:8001"
+    assert resolved == "http://127.0.0.1:8001"
 
 
 def test_default_frontend_url_normalizes_configured_vite_url_in_production(monkeypatch):
@@ -35,7 +35,7 @@ def test_default_frontend_url_normalizes_configured_vite_url_in_production(monke
 
     resolved = video_export_manual._default_frontend_url()
 
-    assert resolved == "http://localhost:8001"
+    assert resolved == "http://127.0.0.1:8001"
 
 
 def test_resolve_frontend_url_keeps_dev_vite_url(monkeypatch):

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -120,7 +120,7 @@ def _default_frontend_url() -> str:
 
 
 def _backend_base_url() -> str:
-    host = "localhost" if config.API_HOST == "0.0.0.0" else config.API_HOST
+    host = "127.0.0.1" if config.API_HOST == "0.0.0.0" else config.API_HOST
     return f"http://{host}:{config.API_PORT}"
 
 

--- a/env.portainer
+++ b/env.portainer
@@ -77,7 +77,7 @@ BACKEND_TELEGRAM_BOT_TOKEN="<redacted: configured in Portainer>"
 BACKEND_TELEGRAM_CHAT_ID=
 
 # Frontend URL known by the backend currently configured in Portainer.
-BACKEND_FRONTEND_URL=http://localhost:5173
+BACKEND_FRONTEND_URL=http://127.0.0.1:8001
 
 # Frontend mock-service-worker toggle currently configured in Portainer.
 VITE_ENABLE_MSW=false


### PR DESCRIPTION
## Summary
- Use a container-local backend URL for the export viewer when serving the bundled frontend in production.
- Align the production Portainer env with the reachable export-viewer base URL.

## Validation
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved backend connectivity issues by updating URL resolution to use `127.0.0.1` instead of `localhost` in production and containerized environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->