### PR TITLE
fix(backend): route export viewer through docker dns

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -17,12 +17,13 @@ def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
     """Production should avoid localhost:5173 when static frontend is bundled."""
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
     monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
     monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
     monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
 
     resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
 
-    assert resolved == "http://127.0.0.1:8001"
+    assert resolved == "http://backend:8001"
 
 
 def test_default_frontend_url_normalizes_configured_vite_url_in_production(monkeypatch):
@@ -30,10 +31,37 @@ def test_default_frontend_url_normalizes_configured_vite_url_in_production(monke
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
     monkeypatch.setattr(video_export_manual.config, "FRONTEND_URL", "http://localhost:5173")
     monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
     monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
     monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
 
     resolved = video_export_manual._default_frontend_url()
+
+    assert resolved == "http://backend:8001"
+
+
+def test_resolve_frontend_url_rewrites_local_backend_url_for_rq_worker(monkeypatch):
+    """The worker container must reach the API through Docker DNS, not loopback."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual.resolve_frontend_url("http://127.0.0.1:8001")
+
+    assert resolved == "http://backend:8001"
+
+
+def test_resolve_frontend_url_keeps_local_backend_url_without_rq(monkeypatch):
+    """Thread mode runs in the API process, where loopback remains valid."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "thread")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual.resolve_frontend_url("http://127.0.0.1:8001")
 
     assert resolved == "http://127.0.0.1:8001"
 

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -120,6 +120,9 @@ def _default_frontend_url() -> str:
 
 
 def _backend_base_url() -> str:
+    if config.ENVIRONMENT == "production" and config.JOB_QUEUE_BACKEND == "rq":
+        return f"http://backend:{config.API_PORT}"
+
     host = "127.0.0.1" if config.API_HOST == "0.0.0.0" else config.API_HOST
     return f"http://{host}:{config.API_PORT}"
 
@@ -128,6 +131,12 @@ def _is_local_vite_url(candidate: str) -> bool:
     parsed = urlparse(candidate)
     hostname = (parsed.hostname or "").lower()
     return hostname in {"localhost", "127.0.0.1", "::1"} and parsed.port == 5173
+
+
+def _is_local_backend_url(candidate: str) -> bool:
+    parsed = urlparse(candidate)
+    hostname = (parsed.hostname or "").lower()
+    return hostname in {"localhost", "127.0.0.1", "::1"} and parsed.port == config.API_PORT
 
 
 def resolve_frontend_url(frontend_url: str | None = None) -> str:
@@ -153,7 +162,7 @@ def _normalize_frontend_url(frontend_url: str) -> str:
     if (
         static_index.exists()
         and config.ENVIRONMENT == "production"
-        and _is_local_vite_url(candidate)
+        and (_is_local_vite_url(candidate) or _is_local_backend_url(candidate))
     ):
         return _backend_base_url()
 


### PR DESCRIPTION
## Summary
- Route production export-viewer checks through Docker DNS when the video queue runs in RQ mode.
- Add regression tests for production worker URL normalization.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_video_export_manual.py -q --tb=short --no-header`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video export URL resolution in production deployments to correctly route requests through the service backend instead of localhost connections.
  * Improved backend URL detection and handling for production environments to ensure reliable communication during video exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->