### PR TITLE
fix(backend): improve export viewer readiness checks

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -17,12 +17,13 @@ def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
     """Production should avoid localhost:5173 when static frontend is bundled."""
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
     monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
     monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
     monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
 
     resolved = video_export_manual.resolve_frontend_url("http://localhost:5173")
 
-    assert resolved == "http://127.0.0.1:8001"
+    assert resolved == "http://backend:8001"
 
 
 def test_default_frontend_url_normalizes_configured_vite_url_in_production(monkeypatch):
@@ -30,10 +31,37 @@ def test_default_frontend_url_normalizes_configured_vite_url_in_production(monke
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
     monkeypatch.setattr(video_export_manual.config, "FRONTEND_URL", "http://localhost:5173")
     monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
     monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
     monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
 
     resolved = video_export_manual._default_frontend_url()
+
+    assert resolved == "http://backend:8001"
+
+
+def test_resolve_frontend_url_rewrites_local_backend_url_for_rq_worker(monkeypatch):
+    """The worker container must reach the API through Docker DNS, not loopback."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual.resolve_frontend_url("http://127.0.0.1:8001")
+
+    assert resolved == "http://backend:8001"
+
+
+def test_resolve_frontend_url_keeps_local_backend_url_without_rq(monkeypatch):
+    """Thread mode runs in the API process, where loopback remains valid."""
+    monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)
+    monkeypatch.setattr(video_export_manual.config, "ENVIRONMENT", "production")
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "thread")
+    monkeypatch.setattr(video_export_manual.config, "API_HOST", "0.0.0.0")
+    monkeypatch.setattr(video_export_manual.config, "API_PORT", 8001)
+
+    resolved = video_export_manual.resolve_frontend_url("http://127.0.0.1:8001")
 
     assert resolved == "http://127.0.0.1:8001"
 

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -120,6 +120,9 @@ def _default_frontend_url() -> str:
 
 
 def _backend_base_url() -> str:
+    if config.ENVIRONMENT == "production" and config.JOB_QUEUE_BACKEND == "rq":
+        return f"http://backend:{config.API_PORT}"
+
     host = "127.0.0.1" if config.API_HOST == "0.0.0.0" else config.API_HOST
     return f"http://{host}:{config.API_PORT}"
 
@@ -128,6 +131,12 @@ def _is_local_vite_url(candidate: str) -> bool:
     parsed = urlparse(candidate)
     hostname = (parsed.hostname or "").lower()
     return hostname in {"localhost", "127.0.0.1", "::1"} and parsed.port == 5173
+
+
+def _is_local_backend_url(candidate: str) -> bool:
+    parsed = urlparse(candidate)
+    hostname = (parsed.hostname or "").lower()
+    return hostname in {"localhost", "127.0.0.1", "::1"} and parsed.port == config.API_PORT
 
 
 def resolve_frontend_url(frontend_url: str | None = None) -> str:
@@ -153,7 +162,7 @@ def _normalize_frontend_url(frontend_url: str) -> str:
     if (
         static_index.exists()
         and config.ENVIRONMENT == "production"
-        and _is_local_vite_url(candidate)
+        and (_is_local_vite_url(candidate) or _is_local_backend_url(candidate))
     ):
         return _backend_base_url()
 

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -70,10 +70,44 @@ _JOB_RUNTIME: dict[str, dict[str, Any]] = {}
 _JOB_CANCEL_REQUESTS: set[str] = set()
 
 _CANCEL_CHECK_INTERVAL = 10
+_EXPORT_VIEWER_READY_TIMEOUT_SECONDS = 180
 _FFMPEG_STALL_TIMEOUT_SECONDS = 10 * 60
 _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS = 30
 _EXPORT_FRAME_TERRAIN_TIMEOUT_SECONDS = 10.0
 _EXPORT_FRAME_TERRAIN_POLL_SECONDS = 0.1
+
+_EXPORT_VIEWER_STATE_SCRIPT = """
+    () => {
+        const hasCanvas = Boolean(document.querySelector('.cesium-viewer canvas, canvas'));
+        const isLoginPage =
+            window.location.pathname === '/login' ||
+            Boolean(document.querySelector('input[type="password"]'));
+        const errorText = document.body?.innerText || '';
+        const hasCesiumError =
+            errorText.includes("Erreur d'initialisation Cesium") ||
+            errorText.includes('Cesium initialization error') ||
+            errorText.includes('VITE_CESIUM_ION_TOKEN is required') ||
+            errorText.includes('Container has zero dimensions') ||
+            errorText.includes('Cesium scene could not be initialized');
+
+        return {
+            hasCanvas,
+            isLoginPage,
+            path: window.location.pathname,
+            hasCesiumError,
+            missingIonToken: errorText.includes('VITE_CESIUM_ION_TOKEN is required'),
+            missingFlightId: errorText.includes('No flight ID provided'),
+            bodyText: errorText.slice(0, 1000),
+        };
+    }
+"""
+
+_EXPORT_VIEWER_READY_SCRIPT = f"""
+    () => {{
+        const state = ({_EXPORT_VIEWER_STATE_SCRIPT})();
+        return state.hasCanvas || state.isLoginPage || state.hasCesiumError || state.missingFlightId;
+    }}
+"""
 
 
 def check_dependencies():
@@ -1110,6 +1144,7 @@ async def _export_video_manual_render(job_id: str):
         log_url = f"{log_url}&exportToken=<redacted>"
 
     try:
+        from playwright.async_api import TimeoutError as PlaywrightTimeoutError
         from playwright.async_api import async_playwright
 
         _update_job(job_id, status=_STATUS_INITIALIZING, message="Setting up manual render")
@@ -1163,44 +1198,25 @@ async def _export_video_manual_render(job_id: str):
 
             _update_job(job_id, message="Waiting for Cesium viewer")
             await page.wait_for_load_state("domcontentloaded")
-            await page.wait_for_function(
-                """
-                () => {
-                    const hasCanvas = Boolean(document.querySelector('.cesium-viewer canvas, canvas'));
-                    const isLoginPage =
-                        window.location.pathname === '/login' ||
-                        Boolean(document.querySelector('input[type="password"]'));
+            try:
+                await page.wait_for_function(
+                    _EXPORT_VIEWER_READY_SCRIPT,
+                    timeout=_EXPORT_VIEWER_READY_TIMEOUT_SECONDS * 1000,
+                )
+            except PlaywrightTimeoutError as exc:
+                viewer_state = await page.evaluate(_EXPORT_VIEWER_STATE_SCRIPT)
+                body_text = str(viewer_state.get("bodyText") or "").strip()
+                raise Exception(
+                    "Export viewer did not become ready within "
+                    f"{_EXPORT_VIEWER_READY_TIMEOUT_SECONDS}s "
+                    f"(path={viewer_state.get('path', 'unknown')}, "
+                    f"hasCanvas={viewer_state.get('hasCanvas')}, "
+                    f"hasCesiumError={viewer_state.get('hasCesiumError')}, "
+                    f"isLoginPage={viewer_state.get('isLoginPage')}, "
+                    f"body={body_text[:300]!r})"
+                ) from exc
 
-                    const errorText = document.body?.innerText || '';
-                    const hasViewerError =
-                        errorText.includes("Erreur d'initialisation Cesium") ||
-                        errorText.includes('VITE_CESIUM_ION_TOKEN is required') ||
-                        errorText.includes('No flight ID provided');
-
-                    return hasCanvas || isLoginPage || hasViewerError;
-                }
-                """,
-                timeout=60000,
-            )
-
-            viewer_state = await page.evaluate("""
-                () => {
-                    const hasCanvas = Boolean(document.querySelector('.cesium-viewer canvas, canvas'));
-                    const isLoginPage =
-                        window.location.pathname === '/login' ||
-                        Boolean(document.querySelector('input[type="password"]'));
-                    const errorText = document.body?.innerText || '';
-
-                    return {
-                        hasCanvas,
-                        isLoginPage,
-                        path: window.location.pathname,
-                        hasViewerError: errorText.includes("Erreur d'initialisation Cesium"),
-                        missingIonToken: errorText.includes('VITE_CESIUM_ION_TOKEN is required'),
-                        missingFlightId: errorText.includes('No flight ID provided'),
-                    };
-                }
-                """)
+            viewer_state = await page.evaluate(_EXPORT_VIEWER_STATE_SCRIPT)
 
             if viewer_state.get("isLoginPage"):
                 raise Exception(
@@ -1214,8 +1230,10 @@ async def _export_video_manual_render(job_id: str):
                 raise Exception("Export viewer opened without flightId")
 
             if not viewer_state.get("hasCanvas"):
+                body_text = str(viewer_state.get("bodyText") or "").strip()
                 raise Exception(
                     f"Cesium canvas not available (path={viewer_state.get('path', 'unknown')})"
+                    f": {body_text[:300]}"
                 )
 
             await asyncio.sleep(3)


### PR DESCRIPTION
## Summary
- Extend export-viewer readiness detection so Playwright reports the real page state instead of timing out blindly.
- Include more Cesium failure cases in the readiness probe and surface the page body excerpt on failure.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_video_export_manual.py -q --tb=short --no-header`