### PR TITLE
feat(frontend): polish weather site selection ui

### DIFF
--- a/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
+++ b/apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import type { Site } from '../../types';
 import { WindIndicatorCompact } from '../common/WindIndicator';
 import { Button } from '@dashboard-parapente/design-system';
+import { Check, ChevronDown, Layers, MapPin, Mountain } from 'lucide-react';
 
 interface MultiOrientationSelectorProps {
   sites: Site[]; // All variants of this site (different orientations)
@@ -39,6 +40,7 @@ export function MultiOrientationSelector({
 
   // Find currently selected site
   const selectedSite = sites.find((site) => site.id === selectedSiteId);
+  const hasSelectedSite = Boolean(selectedSite);
 
   // Determine display name (use baseName prop or extract from first site)
   const displayName = baseName || extractBaseName(sites[0]?.name || '');
@@ -91,40 +93,62 @@ export function MultiOrientationSelector({
       {/* Main button */}
       <Button
         onClick={() => setIsOpen(!isOpen)}
-        className={`w-full h-full p-3 sm:p-2.5 rounded-lg font-medium transition-all ${
-          selectedSite
-            ? 'bg-blue-500 text-white hover:bg-blue-600'
-            : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+        className={`flex h-full w-full cursor-pointer flex-col items-start gap-2 rounded-xl border p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
+          hasSelectedSite
+            ? 'border-sky-500 bg-gradient-to-br from-sky-600 to-sky-800 text-white shadow-md shadow-sky-900/20'
+            : 'border-slate-200 bg-white text-slate-900 hover:border-sky-300 hover:bg-sky-50/70 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:border-sky-700 dark:hover:bg-sky-950/30'
         }`}
       >
-        <div className="flex items-center gap-2 justify-center">
-          <span>{displayName}</span>
-          {selectedSite && selectedSite.orientation && (
-            <span className="text-sm opacity-90">
-              ({selectedSite.orientation})
+        <div className="flex w-full items-start justify-between gap-2">
+          <div className="min-w-0">
+            <span className="line-clamp-2 text-sm font-bold leading-tight">
+              {displayName}
             </span>
-          )}
-          <svg
-            className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
+            <span
+              className={`mt-1 flex flex-wrap items-center gap-2 text-xs ${
+                hasSelectedSite
+                  ? 'text-sky-100'
+                  : 'text-slate-500 dark:text-slate-400'
+              }`}
+            >
+              <span className="inline-flex items-center gap-1">
+                <Layers className="h-3 w-3" aria-hidden="true" />
+                {sites.length} orientations
+              </span>
+              {selectedSite?.elevation_m && (
+                <span className="inline-flex items-center gap-1">
+                  <Mountain className="h-3 w-3" aria-hidden="true" />
+                  {selectedSite.elevation_m}m
+                </span>
+              )}
+            </span>
+          </div>
+          <ChevronDown
+            className={`h-4 w-4 shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            aria-hidden="true"
+          />
         </div>
+        {hasSelectedSite && (
+          <div className="flex w-full items-center justify-between gap-2">
+            {selectedSite?.orientation && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-xs font-bold ring-1 ring-white/20">
+                <MapPin className="h-3 w-3" aria-hidden="true" />
+                {selectedSite.orientation}
+              </span>
+            )}
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-xs font-bold ring-1 ring-white/20">
+              <Check className="h-3 w-3" aria-hidden="true" />
+              Actif
+            </span>
+          </div>
+        )}
       </Button>
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute top-full left-0 mt-2 w-full min-w-[200px] bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50">
+        <div className="absolute left-0 top-full z-50 mt-2 w-full min-w-[240px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-2xl shadow-slate-900/15 dark:border-slate-700 dark:bg-slate-900 dark:shadow-black/40">
           <div className="p-2">
-            <div className="text-xs text-gray-500 dark:text-gray-400 px-2 py-1 mb-1">
+            <div className="mb-1 px-2 py-1 text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
               Choisir un décollage
             </div>
 
@@ -137,21 +161,21 @@ export function MultiOrientationSelector({
                 <Button
                   key={site.id}
                   onClick={() => handleSelect(site.id)}
-                  className={`w-full flex items-center justify-between px-3 py-2 rounded-md transition-colors ${
+                  className={`flex w-full cursor-pointer items-center justify-between gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
                     isSelected
-                      ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-                      : 'hover:bg-gray-100 dark:hover:bg-gray-700'
+                      ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-500 dark:bg-sky-950/40 dark:text-sky-100'
+                      : 'border-transparent text-slate-900 hover:border-sky-200 hover:bg-sky-50/70 dark:text-slate-100 dark:hover:border-sky-800 dark:hover:bg-sky-950/30'
                   }`}
                 >
                   <div className="flex flex-col items-start">
-                    <span className="font-medium text-sm">{shortName}</span>
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      {site.orientation || 'N/A'}
-                      {site.elevation_m && ` • ${site.elevation_m}m`}
-                      {site.rating && ` • ${'⭐'.repeat(site.rating)}`}
+                    <span className="text-sm font-bold">{shortName}</span>
+                    <span className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                      <span>{site.orientation || 'N/A'}</span>
+                      {site.elevation_m && <span>{site.elevation_m}m</span>}
+                      {site.rating && <span>Note {site.rating}/5</span>}
                     </span>
                     {weather?.paraIndex !== undefined && (
-                      <span className="text-xs text-gray-600 dark:text-gray-400 mt-0.5">
+                      <span className="mt-1 text-xs font-semibold text-slate-600 dark:text-slate-300">
                         {t('weather.paraIndex')}: {weather.paraIndex}
                       </span>
                     )}
@@ -202,7 +226,7 @@ function extractBaseName(siteName: string): string {
 
   for (const orientation of orientations) {
     // Try to remove orientation from end of name
-    const regex = new RegExp(`\\s*${orientation}\\s*$`, 'i');
+    const regex = new RegExp(`\\s*${orientation}\\s*$`, 'iu');
     baseName = baseName.replace(regex, '');
   }
 

--- a/apps/frontend/src/components/dashboard/SiteSelector.tsx
+++ b/apps/frontend/src/components/dashboard/SiteSelector.tsx
@@ -8,6 +8,7 @@ import { createWeatherQueryFn } from '../../hooks/weather/useWeather';
 import type { Site } from '../../types';
 import { Button } from '@dashboard-parapente/design-system';
 import { useAppSettingsStore } from '../../stores/appSettingsStore';
+import { Check, MapPin, Mountain, Search } from 'lucide-react';
 
 interface SiteSelectorProps {
   selectedSiteId: string;
@@ -63,6 +64,27 @@ function getSiteMeta(site: Site): string {
   return [site.orientation, site.elevation_m ? `${site.elevation_m}m` : null]
     .filter(Boolean)
     .join(' · ');
+}
+
+function SiteMeta({ site, isActive }: { site: Site; isActive: boolean }) {
+  return (
+    <span
+      className={`mt-1 flex flex-wrap items-center gap-2 text-xs ${
+        isActive ? 'text-sky-100' : 'text-slate-500 dark:text-slate-400'
+      }`}
+    >
+      {site.orientation && (
+        <span className="inline-flex items-center gap-1">
+          <MapPin className="h-3 w-3" aria-hidden="true" />
+          {site.orientation}
+        </span>
+      )}
+      <span className="inline-flex items-center gap-1">
+        <Mountain className="h-3 w-3" aria-hidden="true" />
+        {site.elevation_m ? `${site.elevation_m}m` : 'Altitude N/A'}
+      </span>
+    </span>
+  );
 }
 
 function getSiteSearchText(site: Site): string {
@@ -122,24 +144,16 @@ export default function SiteSelector({
 
   if (isLoading) {
     return (
-      <div className="mb-4">
-        <div className="flex gap-2 flex-wrap bg-white dark:bg-gray-800 rounded-xl p-3 shadow-md">
-          <div className="flex-1 min-w-[120px] p-3 border-2 border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 cursor-not-allowed text-gray-400 dark:text-gray-400">
-            {t('common.loading')}
-          </div>
-        </div>
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-500 dark:border-slate-800 dark:bg-slate-950/60 dark:text-slate-400">
+        {t('common.loading')}
       </div>
     );
   }
 
   if (error || !sites) {
     return (
-      <div className="mb-4">
-        <div className="flex gap-2 flex-wrap bg-white dark:bg-gray-800 rounded-xl p-3 shadow-md">
-          <div className="flex-1 min-w-[120px] p-3 border-2 border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 cursor-not-allowed text-gray-400 dark:text-gray-400">
-            {t('common.loadingError')}
-          </div>
-        </div>
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+        {t('common.loadingError')}
       </div>
     );
   }
@@ -159,11 +173,12 @@ export default function SiteSelector({
       <div className="md:hidden">
         <Button
           onClick={() => setIsMobileSelectorOpen((isOpen) => !isOpen)}
-          className="flex w-full items-center justify-between gap-3 rounded-xl border border-sky-100 bg-white p-3 text-left shadow-sm dark:border-gray-700 dark:bg-gray-900"
+          className="flex w-full cursor-pointer items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-sky-50/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-sky-700 dark:hover:bg-sky-950/30"
         >
           <div className="min-w-0">
-            <span className="block text-xs font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
-              Site favori
+            <span className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">
+              <MapPin className="h-3 w-3" aria-hidden="true" />
+              Site sélectionné
             </span>
             <span className="block truncate text-base font-bold text-gray-950 dark:text-white">
               {selectedSite?.name ?? 'Choisir un site'}
@@ -174,17 +189,18 @@ export default function SiteSelector({
               </span>
             )}
           </div>
-          <span className="shrink-0 rounded-lg bg-sky-600 px-3 py-2 text-sm font-semibold text-white">
+          <span className="shrink-0 rounded-xl bg-sky-600 px-3 py-2 text-sm font-semibold text-white shadow-sm shadow-sky-900/20">
             Changer
           </span>
         </Button>
 
         {isMobileSelectorOpen && (
-          <div className="absolute left-0 right-0 top-full z-30 mt-2 rounded-2xl border border-gray-200 bg-white p-3 shadow-xl dark:border-gray-700 dark:bg-gray-800">
+          <div className="absolute left-0 right-0 top-full z-30 mt-2 rounded-2xl border border-slate-200 bg-white p-3 shadow-2xl shadow-slate-900/15 dark:border-slate-700 dark:bg-slate-900 dark:shadow-black/40">
             <label
               htmlFor={searchInputId}
-              className="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+              className="flex items-center gap-1.5 text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400"
             >
+              <Search className="h-3 w-3" aria-hidden="true" />
               Rechercher
             </label>
             <input
@@ -193,7 +209,7 @@ export default function SiteSelector({
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Nom, orientation, altitude..."
-              className="mt-1 w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-950 outline-none focus:border-sky-500 focus:ring-2 focus:ring-sky-200 dark:border-gray-600 dark:bg-gray-900 dark:text-white dark:focus:ring-sky-900"
+              className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-base text-slate-950 outline-none transition-colors placeholder:text-slate-400 focus:border-sky-500 focus:ring-2 focus:ring-sky-200 dark:border-slate-700 dark:bg-slate-950 dark:text-white dark:focus:ring-sky-900"
             />
 
             <div className="mt-3 max-h-[55vh] space-y-1 overflow-y-auto overscroll-contain pr-1">
@@ -207,24 +223,21 @@ export default function SiteSelector({
                       key={site.id}
                       onClick={() => handleMobileSelect(site.id)}
                       onMouseEnter={() => handleMouseEnter(site.id)}
-                      className={`flex w-full items-center justify-between gap-3 rounded-xl px-3 py-3 text-left transition-colors ${
+                      className={`flex w-full cursor-pointer items-center justify-between gap-3 rounded-xl border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
                         isActive
-                          ? 'bg-sky-50 text-sky-900 ring-2 ring-sky-200 dark:bg-sky-900/30 dark:text-sky-100 dark:ring-sky-700'
-                          : 'text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-900'
+                          ? 'border-sky-500 bg-sky-600 text-white shadow-sm shadow-sky-900/20 dark:border-sky-400 dark:bg-sky-600'
+                          : 'border-transparent text-slate-900 hover:border-sky-200 hover:bg-sky-50/70 dark:text-slate-100 dark:hover:border-sky-800 dark:hover:bg-sky-950/30'
                       }`}
                     >
                       <span className="min-w-0">
                         <span className="block truncate text-sm font-semibold">
                           {site.name}
                         </span>
-                        {meta && (
-                          <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
-                            {meta}
-                          </span>
-                        )}
+                        {meta && <SiteMeta site={site} isActive={isActive} />}
                       </span>
                       {isActive && (
-                        <span className="shrink-0 rounded-full bg-sky-600 px-2 py-0.5 text-xs font-bold text-white">
+                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-xs font-bold text-white ring-1 ring-white/20">
+                          <Check className="h-3 w-3" aria-hidden="true" />
                           Actif
                         </span>
                       )}
@@ -241,57 +254,65 @@ export default function SiteSelector({
         )}
       </div>
 
-      <div className="hidden gap-2 flex-wrap rounded-xl bg-white p-3 shadow-md dark:bg-gray-800 md:flex">
-        {Object.entries(siteGroups).map(([baseId, groupSites]) => {
-          // Single site -> regular button
-          if (groupSites.length === 1) {
-            const site = groupSites[0];
-            const isActive = selectedSiteId === site.id;
+      <div className="hidden md:block">
+        <div className="mb-2 flex items-center justify-between gap-3 px-1 text-xs text-slate-500 dark:text-slate-400">
+          <span>{visibleSites.length} sites disponibles</span>
+          {selectedSite && (
+            <span className="truncate font-semibold text-sky-700 dark:text-sky-300">
+              Actuel: {selectedSite.name}
+            </span>
+          )}
+        </div>
+        <div className="grid grid-cols-2 gap-2 rounded-2xl border border-slate-100 bg-slate-50/80 p-2 dark:border-slate-800 dark:bg-slate-950/40 lg:grid-cols-2">
+          {Object.entries(siteGroups).map(([baseId, groupSites]) => {
+            // Single site -> regular button
+            if (groupSites.length === 1) {
+              const site = groupSites[0];
+              const isActive = selectedSiteId === site.id;
 
-            return (
-              <Button
-                key={site.id}
-                className={`
-                  flex-1 min-w-[120px] sm:min-w-[100px] 
-                  p-3 sm:p-2.5 
-                  border-2 rounded-lg 
-                  transition-all 
-                  flex flex-col items-center gap-1
+              return (
+                <Button
+                  key={site.id}
+                  className={`
+                  min-w-0 rounded-xl border p-3 text-left transition-colors
+                  flex flex-col items-start gap-1 cursor-pointer
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500
                   ${
                     isActive
-                      ? 'border-sky-600 bg-gradient-to-br from-sky-600 to-sky-800 text-white'
-                      : 'border-gray-200 bg-white dark:bg-gray-700 dark:border-gray-600 hover:border-sky-600 hover:shadow-md hover:shadow-sky-100'
+                      ? 'border-sky-500 bg-gradient-to-br from-sky-600 to-sky-800 text-white shadow-md shadow-sky-900/20'
+                      : 'border-slate-200 bg-white text-slate-900 hover:border-sky-300 hover:bg-sky-50/70 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100 dark:hover:border-sky-700 dark:hover:bg-sky-950/30'
                   }
                 `}
-                onClick={() => onSelectSite(site.id)}
-                onMouseEnter={() => handleMouseEnter(site.id)}
-              >
-                <span
-                  className={`text-sm sm:text-xs font-semibold ${isActive ? '' : 'text-gray-900 dark:text-gray-100'}`}
+                  onClick={() => onSelectSite(site.id)}
+                  onMouseEnter={() => handleMouseEnter(site.id)}
                 >
-                  {site.name}
-                </span>
-                <span
-                  className={`text-xs sm:text-[11px] ${isActive ? 'opacity-90' : 'opacity-80 text-gray-600 dark:text-gray-400'}`}
-                >
-                  {site.elevation_m || '?'}m
-                </span>
-              </Button>
-            );
-          }
+                  <span className="line-clamp-2 text-sm font-bold leading-tight">
+                    {site.name}
+                  </span>
+                  <SiteMeta site={site} isActive={isActive} />
+                  {isActive && (
+                    <span className="mt-1 inline-flex items-center gap-1 rounded-full bg-white/15 px-2 py-0.5 text-xs font-bold text-white ring-1 ring-white/20">
+                      <Check className="h-3 w-3" aria-hidden="true" />
+                      Actif
+                    </span>
+                  )}
+                </Button>
+              );
+            }
 
-          // Multiple sites with same base -> dropdown selector
-          return (
-            <MultiOrientationSelector
-              key={baseId}
-              sites={groupSites}
-              selectedSiteId={selectedSiteId}
-              onSelectSite={onSelectSite}
-              weatherData={weatherData}
-              className="flex-1 min-w-[120px] sm:min-w-[100px]"
-            />
-          );
-        })}
+            // Multiple sites with same base -> dropdown selector
+            return (
+              <MultiOrientationSelector
+                key={baseId}
+                sites={groupSites}
+                selectedSiteId={selectedSiteId}
+                onSelectSite={onSelectSite}
+                weatherData={weatherData}
+                className="min-w-0"
+              />
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/weather/CityWeatherSearch.tsx
+++ b/apps/frontend/src/components/weather/CityWeatherSearch.tsx
@@ -340,11 +340,11 @@ export default function CityWeatherSearch({
       <div
         className={`flex items-start justify-between gap-3 ${isEmbedded ? '' : 'mb-4'}`}
       >
-        <div>
-          <p className="text-sm font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
+        <div className="min-w-0">
+          <p className="text-sm font-bold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">
             Recherche météo par ville
           </p>
-          <h2 className="text-xl font-bold text-gray-950 dark:text-white sm:text-2xl">
+          <h2 className="mt-1 text-xl font-black tracking-tight text-gray-950 dark:text-white sm:text-2xl">
             Choisir une ville, un déco ou un atterro proche
           </h2>
           {activeTargetLabel && (
@@ -355,16 +355,16 @@ export default function CityWeatherSearch({
         </div>
         <Button
           onPress={() => setIsExpanded((expanded) => !expanded)}
-          className="shrink-0 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900 sm:hidden"
+          className="shrink-0 cursor-pointer rounded-xl border border-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:border-sky-300 hover:bg-sky-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/30 sm:hidden"
         >
           {isExpanded ? 'Masquer' : 'Ouvrir'}
         </Button>
       </div>
 
       <div className={`${isExpanded ? 'block' : 'hidden'} sm:block`}>
-        <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
+        <div className="grid gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-950/40 lg:grid-cols-[1fr_auto_auto] lg:items-end">
           <TextField className="relative flex flex-col gap-1">
-            <Label className="text-sm font-medium text-gray-700 dark:text-gray-200">
+            <Label className="text-sm font-semibold text-slate-700 dark:text-slate-200">
               Ville
             </Label>
             <Input
@@ -396,14 +396,14 @@ export default function CityWeatherSearch({
               aria-controls={listboxId}
               aria-activedescendant={activeSuggestionId}
               placeholder="Ex: Besançon, Annecy, Grenoble..."
-              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 outline-none focus:ring-2 focus:ring-sky-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-950 outline-none transition-colors placeholder:text-slate-400 focus:border-sky-500 focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-white"
             />
             {isSuggestionsOpen && (
               <div
                 id={listboxId}
                 // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
                 role="listbox"
-                className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900"
+                className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-slate-700 dark:bg-slate-900"
               >
                 {locationSearch.isLoading ? (
                   <div className="p-3 text-sm text-gray-600 dark:text-gray-300">
@@ -420,7 +420,7 @@ export default function CityWeatherSearch({
                       aria-selected={index === activeSuggestionIndex}
                       onMouseEnter={() => setActiveSuggestionIndex(index)}
                       onClick={() => handleSelectLocation(location)}
-                      className={`block w-full border-b border-gray-100 px-3 py-2 text-left last:border-b-0 dark:border-gray-800 ${
+                      className={`block w-full cursor-pointer border-b border-slate-100 px-3 py-2 text-left transition-colors last:border-b-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-sky-500 dark:border-slate-800 ${
                         index === activeSuggestionIndex
                           ? 'bg-sky-100 dark:bg-sky-950/60'
                           : 'hover:bg-sky-50 dark:hover:bg-sky-950/40'
@@ -443,12 +443,12 @@ export default function CityWeatherSearch({
             )}
           </TextField>
 
-          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+          <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
             Rayon
             <select
               value={radiusKm}
               onChange={(event) => setRadiusKm(Number(event.target.value))}
-              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="cursor-pointer rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-950 outline-none transition-colors focus:border-sky-500 focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-white"
             >
               {radiusChoices.map((radius) => (
                 <option key={radius} value={radius}>
@@ -458,12 +458,12 @@ export default function CityWeatherSearch({
             </select>
           </label>
 
-          <label className="flex flex-col gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+          <label className="flex flex-col gap-1 text-sm font-semibold text-slate-700 dark:text-slate-200">
             Résultats
             <select
               value={limit}
               onChange={(event) => setLimit(Number(event.target.value))}
-              className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-950 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="cursor-pointer rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-950 outline-none transition-colors focus:border-sky-500 focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-white"
             >
               {limitChoices.map((choice) => (
                 <option key={choice} value={choice}>
@@ -487,7 +487,7 @@ export default function CityWeatherSearch({
               </div>
               <Button
                 onPress={() => handleSelectLocation(selectedLocation)}
-                className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
+                className="cursor-pointer rounded-xl bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
               >
                 Météo ville
               </Button>

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -227,13 +227,28 @@ export default function WeatherPage() {
       <aside className="min-w-0 space-y-4 xl:sticky xl:top-4 xl:self-start">
         <section className={`${weatherCardClassName} overflow-visible`}>
           <div className="border-b border-slate-100 bg-gradient-to-br from-sky-50 via-white to-white p-4 dark:border-slate-800 dark:from-sky-950/40 dark:via-slate-900 dark:to-slate-900 sm:p-5">
-            <p className={weatherSectionTitleClassName}>Choix du site</p>
-            <h2 className="mt-1 text-xl font-black tracking-tight text-slate-950 dark:text-white">
-              Sélection météo
-            </h2>
-            <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
-              Favoris, sites configurés ou recherche par ville.
-            </p>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <p className={weatherSectionTitleClassName}>Choix du site</p>
+                <h2 className="mt-1 text-xl font-black tracking-tight text-slate-950 dark:text-white">
+                  Sélection météo
+                </h2>
+                <p className="mt-1 text-sm leading-5 text-slate-600 dark:text-slate-300">
+                  Gardez vos favoris sous la main ou cherchez une ville, un déco
+                  ou un atterro proche.
+                </p>
+              </div>
+              {activeWeatherName && (
+                <div className="min-w-0 rounded-2xl border border-sky-100 bg-white/80 px-3 py-2 text-sm shadow-sm dark:border-sky-900/60 dark:bg-slate-950/50">
+                  <span className="block text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                    Actuel
+                  </span>
+                  <span className="block truncate font-bold text-sky-800 dark:text-sky-200">
+                    {activeWeatherName}
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
           <div className="p-3 sm:p-4">
             <Tabs
@@ -252,9 +267,19 @@ export default function WeatherPage() {
                 }
               }}
             >
-              <TabList className="grid-cols-2 bg-slate-100 shadow-none dark:bg-slate-950/70">
-                <Tab id="favorites">Favoris</Tab>
-                <Tab id="search">Recherche</Tab>
+              <TabList className="grid-cols-2 gap-1 rounded-2xl bg-slate-100 p-1 shadow-none dark:bg-slate-950/70">
+                <Tab id="favorites">
+                  <span className="inline-flex items-center gap-2">
+                    <MapPin className="h-4 w-4" aria-hidden="true" />
+                    Favoris
+                  </span>
+                </Tab>
+                <Tab id="search">
+                  <span className="inline-flex items-center gap-2">
+                    <Search className="h-4 w-4" aria-hidden="true" />
+                    Recherche
+                  </span>
+                </Tab>
               </TabList>
               <TabPanel id="favorites">
                 {sites.length > 0 ? (


### PR DESCRIPTION
## Summary
- Refined the weather site selector header, tabs, and site cards for clearer decision making.
- Modernized the mobile selector and multi-orientation dropdown while keeping the current behavior.
- Polished the city search controls to match the rest of the weather page.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm vitest run --config vitest.config.ts --project unit` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` timed out in this environment
- `vitest run --config vitest.config.ts --project storybook ...` timed out in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced site selector with improved visual indicators for active selections and integrated site metadata display (orientation, elevation).
  * Redesigned site selection layouts for better mobile and desktop navigation experience.
  * Updated weather search interface with improved styling and organization.
  * Added icon-based indicators throughout for clearer visual feedback on active selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->