### PR TITLE
fix(backend): scope video export job tokens

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4461,7 +4461,6 @@ def start_flight_video_export(
                 fps=fps,
                 speed=speed,
                 frontend_url=frontend_url,
-                auth_token=_extract_bearer_token(request),
             )
         except Exception as e:
             fallback_mode = "manual" if selected_mode == "manual_fast" else "stream"
@@ -4480,7 +4479,6 @@ def start_flight_video_export(
                         fps=fps,
                         speed=speed,
                         frontend_url=frontend_url,
-                        auth_token=_extract_bearer_token(request),
                     )
                     effective_mode = "manual"
                 else:
@@ -4573,7 +4571,6 @@ def generate_flight_video(
             speed=1,
             frontend_url=frontend_url,
             update_db=True,
-            auth_token=_extract_bearer_token(request),
         )
         started_message = "Video generation started (Manual Fast Render)"
     except Exception as e:
@@ -4805,7 +4802,7 @@ def cancel_video_export(job_id: str):
 @router.post("/exports/{job_id}/resume")
 def resume_cancelled_video_export(request: Request, job_id: str):
     """Resume a cancelled or failed manual video export from preserved frames."""
-    success = resume_video_export(job_id, auth_token=_extract_bearer_token(request))
+    success = resume_video_export(job_id)
     if not success:
         raise HTTPException(
             status_code=400,

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -35,7 +35,7 @@ class TestVideoExportStartEndpoint:
         assert payload["mode"] == "manual"
         assert payload["message"] == "Video export started (manual render)"
         assert payload["status_url"] == "/api/exports/job-manual/status"
-        assert mock_start.call_args.kwargs["auth_token"] == "test-token"
+        assert "auth_token" not in mock_start.call_args.kwargs
 
     def test_start_video_export_accepts_manual_fast_mode(self, client: TestClient, sample_flight):
         """Fast manual mode should use the deterministic screenshot exporter."""
@@ -53,7 +53,7 @@ class TestVideoExportStartEndpoint:
         assert payload["job_id"] == "job-manual-fast"
         assert payload["mode"] == "manual_fast"
         assert payload["message"] == "Video export started (manual fast render)"
-        assert mock_start.call_args.kwargs["auth_token"] == "test-token"
+        assert "auth_token" not in mock_start.call_args.kwargs
 
     def test_start_video_export_manual_fast_falls_back_to_manual(
         self, client: TestClient, sample_flight
@@ -154,7 +154,7 @@ class TestGenerateVideoEndpoint:
         payload = response.json()
         assert payload["job_id"] == "job-manual-fast"
         assert payload["message"] == "Video generation started (Manual Fast Render)"
-        assert mock_start.call_args.kwargs["auth_token"] == "token-generate"
+        assert "auth_token" not in mock_start.call_args.kwargs
 
     def test_generate_video_falls_back_to_stream_on_manual_fast_error(
         self,
@@ -305,7 +305,7 @@ class TestExportStatusAndCancel:
             "message": "Export resume enqueued",
             "job_id": "job-cancelled",
         }
-        resume.assert_called_once_with("job-cancelled", auth_token="resume-token")
+        resume.assert_called_once_with("job-cancelled")
 
     def test_export_resume_returns_400_when_job_cannot_resume(self, client: TestClient):
         with patch("routes.resume_video_export", return_value=False):

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -7,6 +7,7 @@ from urllib.error import URLError
 
 import pytest
 
+from auth import create_access_token, create_job_token, decode_job_token
 from models import VideoExportJob
 
 import video_export
@@ -105,7 +106,8 @@ def test_build_playwright_init_script_sets_export_mode_and_token():
     script = video_export_manual._build_playwright_init_script("abc123")
 
     assert "window._exportMode = 'manual_render'" in script
-    assert "parapente-auth" in script
+    assert "window._exportToken" in script
+    assert "parapente-auth" not in script
     assert '"abc123"' in script
 
 
@@ -113,7 +115,7 @@ def test_build_playwright_init_script_without_token_still_sets_export_mode():
     script = video_export_manual._build_playwright_init_script(None)
 
     assert "window._exportMode = 'manual_render'" in script
-    assert "const token = null" in script
+    assert "window._exportToken = null" in script
 
 
 def test_job_auth_token_storage_roundtrip(test_db, monkeypatch):
@@ -325,6 +327,36 @@ def test_rq_job_id_does_not_use_forbidden_separator():
     assert ":" not in rq_job_id
 
 
+def test_resolve_video_export_job_token_replaces_access_token():
+    user_token = create_access_token("pilot@example.test")
+
+    job_token = video_export_manual._resolve_video_export_job_token(
+        "job-export",
+        "flight-test-001",
+        user_token,
+    )
+
+    assert job_token != user_token
+    payload = decode_job_token(job_token, purpose="video_export", job_id="job-export")
+    assert payload["flight_id"] == "flight-test-001"
+
+
+def test_resolve_video_export_job_token_keeps_matching_job_token():
+    existing_token = create_job_token(
+        purpose="video_export",
+        job_id="job-export",
+        flight_id="flight-test-001",
+    )
+
+    job_token = video_export_manual._resolve_video_export_job_token(
+        "job-export",
+        "flight-test-001",
+        existing_token,
+    )
+
+    assert job_token == existing_token
+
+
 def test_start_video_export_manual_enqueues_rq_job(test_db, monkeypatch):
     enqueued_job_ids: list[str] = []
     monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
@@ -340,7 +372,6 @@ def test_start_video_export_manual_enqueues_rq_job(test_db, monkeypatch):
     job_id = video_export_manual.start_video_export_manual(
         flight_id="flight-test-001",
         frontend_url="http://frontend.test",
-        auth_token="token-rq",
     )
 
     db_session = test_db()
@@ -349,7 +380,9 @@ def test_start_video_export_manual_enqueues_rq_job(test_db, monkeypatch):
 
     assert job_id == "job-rq"
     assert job.status == "queued"
-    assert job.auth_token == "token-rq"
+    assert job.auth_token is not None
+    payload = decode_job_token(job.auth_token, purpose="video_export", job_id=job_id)
+    assert payload["flight_id"] == "flight-test-001"
     assert enqueued_job_ids == ["job-rq"]
 
 
@@ -506,7 +539,9 @@ def test_resume_video_export_requeues_cancelled_job_with_frames(test_db, tmp_pat
     db_session = test_db()
     job = db_session.query(VideoExportJob).filter(VideoExportJob.id == job_id).one()
     assert job.status == "queued"
-    assert job.auth_token == "resume-token"
+    assert job.auth_token is not None
+    payload = decode_job_token(job.auth_token, purpose="video_export", job_id=job_id)
+    assert payload["flight_id"] == "flight-test-001"
     assert job.cancelled_at is None
     assert job.error is None
     assert job.video_path is None

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -23,7 +23,7 @@ from urllib.request import Request, urlopen
 from sqlalchemy.orm import Session
 
 import config
-from auth import create_job_token
+from auth import create_job_token, decode_job_token
 from database import SessionLocal
 from flight_storage import get_video_output_path
 from models import Flight, VideoExportJob
@@ -352,20 +352,28 @@ def _build_playwright_init_script(auth_token: str | None) -> str:
     return f"""
         (() => {{
             window._exportMode = 'manual_render';
-
-            const token = {token_literal};
-            if (token) {{
-                localStorage.setItem(
-                    'parapente-auth',
-                    JSON.stringify({{ state: {{ token }} }})
-                );
-            }}
+            window._exportToken = {token_literal};
         }})();
     """
 
 
 def _create_video_export_job_token(job_id: str, flight_id: str) -> str:
     return create_job_token(purpose="video_export", job_id=job_id, flight_id=flight_id)
+
+
+def _resolve_video_export_job_token(
+    job_id: str,
+    flight_id: str,
+    auth_token: str | None,
+) -> str:
+    if auth_token:
+        try:
+            payload = decode_job_token(auth_token, purpose="video_export", job_id=job_id)
+            if payload.get("flight_id") == flight_id:
+                return auth_token
+        except Exception:
+            return _create_video_export_job_token(job_id, flight_id)
+    return _create_video_export_job_token(job_id, flight_id)
 
 
 def _get_job(job_id: str, db: Session | None = None) -> VideoExportJob | None:
@@ -1069,7 +1077,7 @@ def _enqueue_video_export_job(
         _set_memory_snapshot(job_id, _snapshot_from_job(job))
         _set_job_runtime(job_id, phase=_STATUS_QUEUED)
 
-    _set_job_auth_token(job_id, auth_token or _create_video_export_job_token(job_id, flight_id))
+    _set_job_auth_token(job_id, _resolve_video_export_job_token(job_id, flight_id, auth_token))
 
     _enqueue_existing_video_export_job(job_id)
     return job_id
@@ -1721,7 +1729,7 @@ def resume_video_export(job_id: str, auth_token: str | None = None) -> bool:
         completed_at=None,
         cancelled_at=None,
     )
-    _set_job_auth_token(job_id, auth_token or _create_video_export_job_token(job_id, job.flight_id))
+    _set_job_auth_token(job_id, _resolve_video_export_job_token(job_id, job.flight_id, auth_token))
     _set_job_runtime(
         job_id,
         phase=_STATUS_QUEUED,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,16 @@ services:
     volumes:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'python -c "from job_queue import get_redis_connection; get_redis_connection().ping()"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     networks:
       - parapente-network
 


### PR DESCRIPTION
## Summary
- Stop forwarding user access tokens into the video export worker.
- Generate and persist scoped `video_export` job tokens for export/resume flows.
- Update backend tests to assert scoped job-token behavior.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend`
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py tests/api/test_video_export_endpoints.py -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced video export authentication by implementing job-scoped tokens instead of forwarding bearer tokens. The system now validates authentication against specific export jobs, improving security and reducing unnecessary token exposure throughout the pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->