### PR TITLE
refactor(skills): separate shared invariants from skill commands

### DIFF
--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -23,6 +23,7 @@ Projects: `frontend` in `apps/frontend`, `backend` in `apps/backend`, `design-sy
 - Use `apply_patch` for manual edits; avoid shell-based file editing.
 - Never use destructive git commands.
 - Use `local-machine-stack` as the source of truth for pnpm paths, dependency readiness, command timeouts, and Nx validation commands.
+- Let specialized skills define their own project-specific commands, while `local-machine-stack` supplies shared machine invariants and generic validation commands.
 
 ## Analysis Source Of Truth
 

--- a/.agents/skills/implementation-worktree-strategy/SKILL.md
+++ b/.agents/skills/implementation-worktree-strategy/SKILL.md
@@ -33,11 +33,10 @@ After creating a worktree, launch the `worktree-bootstrap` subagent immediately 
 Subagent responsibility:
 
 - Work in the new worktree path.
-- Verify that local dependencies are usable before Nx commands run.
-- Check for `node_modules/.bin/nx` and representative required packages such as `typescript`.
-- Run `CI=true /home/capic/.local/share/pnpm/pnpm install --frozen-lockfile` only when dependencies are missing or unusable.
+- Verify dependency readiness using `local-machine-stack` as the source of truth for exact pnpm/Nx commands.
+- Install dependencies only when missing or unusable.
 - Do not rely on pnpm's global virtual store; each worktree must have a workspace-local dependency layout usable by Nx and Knip.
-- Run a lightweight readiness command after install/check, for example `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx --version`.
+- Run a lightweight readiness check after install/check.
 - Return a concise report with status, commands run, failures, and whether any files changed.
 
 The main agent remains responsible for interpreting blockers and making code changes. The `worktree-bootstrap` subagent must not edit source code or commit files.
@@ -86,14 +85,7 @@ Derive the worktree name from the user's implementation request, not from the fu
 
 Use this process:
 
-1. Extract a short task label from the main implementation intent.
-2. Keep 2 to 5 meaningful words.
-3. Convert to lowercase.
-4. Replace spaces with `-`.
-5. Remove accents, punctuation, and special characters.
-6. Prefix with `wt-`.
-
-Examples:
+Extract 2 to 5 meaningful words from the implementation intent, convert to lowercase, remove accents/punctuation/special characters, replace spaces with `-`, and prefix with `wt-`.
 
 - `implémenter le login Google` -> `wt-google-login`
 - `corriger le bug du dashboard` -> `wt-dashboard-bugfix`

--- a/.agents/skills/local-machine-stack/SKILL.md
+++ b/.agents/skills/local-machine-stack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-machine-stack
-description: Documents the local machine setup for this Nx monorepo, including the absolute pnpm binary path and validated commands for lint, tests, builds, and targeted Nx tasks. Use when working in this repository and the user asks to run local commands, lint/test/build the repo, diagnose command availability, or use pnpm/Nx on this machine.
+description: Documents local machine invariants for this Nx monorepo, including the absolute pnpm binary path, dependency readiness, Nx prefixes, timeouts, and generic validation commands. Use when working in this repository and the user asks to run local commands, lint/test/build the repo, diagnose command availability, or use pnpm/Nx on this machine.
 ---
 
 # Local Machine Stack
@@ -14,6 +14,8 @@ Run repository commands from the active checkout or worktree root. Use this pnpm
 ```
 
 Do not assume `pnpm`, `npm`, `npx`, `yarn`, or `corepack` are available in `PATH`.
+
+Use `NX_NO_CLOUD=true` for Nx commands unless a task explicitly requires Nx Cloud.
 
 Before Nx commands, verify local dependencies exist. If `node_modules/.bin/nx` or required packages such as `typescript` are missing, run:
 
@@ -60,6 +62,8 @@ NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run-many -t test --all
 ```
 
 Use direct project targets such as `nx affected -t lint frontend` or `nx affected -t test backend` only as follow-up diagnostics after an affected run identifies a failing project, or when explicitly requested.
+
+Specialized skills may define their own project-specific Nx targets, such as Storybook or code generation. They should still use this skill for the pnpm path, dependency readiness, Nx prefixes, and timeouts.
 
 For direct Oxlint checks on frontend/design-system:
 

--- a/.agents/skills/storybook-visual-preview/SKILL.md
+++ b/.agents/skills/storybook-visual-preview/SKILL.md
@@ -19,24 +19,22 @@ The workflow is:
 4. Try reading the PNG so clients that support inline images can display it.
 5. Always provide the PNG path and a Markdown image link for users with workspace access.
 6. If the user is chat-only, provide a short visual diagnosis and explain that a viewable image requires an attachment-capable client or upload target.
-7. Add a short visual assessment with any obvious issues.
-
 ## Project Defaults
 
-- Frontend Storybook: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook frontend`, port `6006`.
-- Design system Storybook: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook design-system`, port `6007`.
+- Frontend Storybook target: `nx storybook frontend`, port `6006`.
+- Design system Storybook target: `nx storybook design-system`, port `6007`.
 - Screenshot script: `.agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs`.
 - Default output directory: `.codenomad/storybook-previews` when the user should open the file, or `/tmp/opencode/storybook-visual-preview` for disposable captures.
 - Browser fallback: if Playwright browsers are missing, the script tries `/usr/bin/chromium`.
 
-If a worktree has no `node_modules`, follow `local-machine-stack` and run `CI=true /home/capic/.local/share/pnpm/pnpm install` before capturing.
+Use `local-machine-stack` for the pnpm path, `NX_NO_CLOUD` prefix, dependency readiness, and command timeouts. If dependencies are missing, follow its readiness workflow before capturing.
 
 ## Quick Start
 
 Start Storybook as a background process:
 
 ```bash
-NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx storybook frontend
+NX_NO_CLOUD=true <pnpm-from-local-machine-stack> nx storybook frontend
 ```
 
 Capture a story by id:
@@ -48,7 +46,7 @@ node .agents/skills/storybook-visual-preview/scripts/capture-storybook.mjs \
   --output .codenomad/storybook-previews/button-primary.png
 ```
 
-Then use the Read tool on the PNG path and include this fallback in the response:
+Then use the Read tool on the PNG path and include this fallback:
 
 ```md
 Preview: `.codenomad/storybook-previews/button-primary.png`
@@ -86,19 +84,10 @@ Keep the user-facing report concise:
 
 - Mention which story and viewport were captured.
 - Include the preview file path and Markdown image link.
-- If the image did not render inline, explicitly say the client may not support image attachments from tool output.
-- If the user has no workspace access, do not rely on local paths. Ask for an upload target or suggest creating a PR/check artifact if GitHub is available.
+- If the image did not render inline, say the client may not support image attachments from tool output.
+- If the user has no workspace access, ask for an upload target or suggest creating a PR/check artifact.
 - State obvious visual issues only if visible: clipped content, overlap, empty state, unreadable text, broken spacing, missing assets, horizontal scroll.
 - If capture fails, report the Storybook URL, command, and the first actionable error.
-
-## Chat-Only Users
-
-If the user cannot access the project/workspace and the chat client does not render tool images:
-
-- Be explicit: `I can capture the screenshot, but this client is not rendering image attachments and you cannot open local files, so I cannot directly show the PNG here.`
-- Give a visual text summary from the captured image.
-- Offer one concrete next step: upload to a destination the user can access, attach through a compatible client, or publish as a GitHub PR artifact/comment if allowed.
-- Do not paste large base64 image blobs into the conversation unless the user explicitly asks for that format.
 
 ## Guardrails
 
@@ -106,3 +95,5 @@ If the user cannot access the project/workspace and the chat client does not ren
 - Do not expose secrets from query params, local storage, logs, or environment output.
 - Do not modify stories just to make a screenshot pass unless the user asked for a fix.
 - If the story depends on backend services and renders broken data, report that dependency instead of faking state.
+- For chat-only users who cannot open local files, give a visual text summary and offer one accessible delivery channel.
+- Do not paste large base64 image blobs unless the user explicitly asks for that format.


### PR DESCRIPTION
## Summary
- Clarify `local-machine-stack` as the source of truth for shared pnpm/Nx invariants.
- Keep Storybook targets in the Storybook skill while removing duplicated install/path details.
- Simplify the worktree strategy skill to reference shared readiness instead of repeating commands.

## Validation
- `git diff --check`
- Verified all edited `SKILL.md` files stay under 100 lines
- Confirmed command duplication is reduced to the intended locations

## Notes
- Commit: `38dbff65`