### PR TITLE
fix(frontend): align flight list media tags

### DIFF
--- a/apps/frontend/src/components/flights/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.stories.tsx
@@ -55,6 +55,7 @@ const mockFlights: Flight[] = [
     max_speed_kmh: 55,
     departure_time: '2024-03-05T12:15:00',
     gpx_file_path: '/uploads/flight-3.gpx',
+    video_export_status: 'processing',
     notes: 'Premier cross de la saison',
   },
   {
@@ -68,6 +69,7 @@ const mockFlights: Flight[] = [
     distance_km: null,
     max_altitude_m: null,
     gpx_file_path: null,
+    video_export_status: 'failed',
     notes: null,
   },
   {

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from 'react-i18next';
 import type { Row, RowSelectionState, OnChangeFn } from '@tanstack/react-table';
 import type { Selection } from 'react-aria-components';
 import { DataList, Button } from '@dashboard-parapente/design-system';
+import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
 import {
   Check,
   Clock3,
+  Download,
   FileText,
   MapPin,
   Mountain,
-  Paperclip,
   Ruler,
   Trash2,
   Video,
@@ -94,6 +95,14 @@ export function FlightsTable({
     (row: Row<Flight>, { isSelected }: { isSelected: boolean }) => {
       const flight = row.original;
       const isActive = selectedFlightId === flight.id;
+      const hasGpx = Boolean(flight.gpx_file_path);
+      const hasVideo = Boolean(flight.video_file_path);
+      const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
+      const isVideoExportRunning = Boolean(
+        flight.video_export_status &&
+        VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)
+      );
+      const isVideoExportFailed = flight.video_export_status === 'failed';
       const selectFlight = () => {
         if (!selectionMode) {
           onSelectFlight(flight);
@@ -174,11 +183,13 @@ export function FlightsTable({
                 {flight.title || t('flights.untitledFlight')}
               </h3>
               {!selectionMode &&
-                (flight.gpx_file_path ||
-                  flight.video_file_path ||
-                  flight.gopro_overlay_file_path) && (
+                (hasGpx ||
+                  hasVideo ||
+                  isVideoExportRunning ||
+                  isVideoExportFailed ||
+                  hasPersistedGoproOverlay) && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
-                    {flight.gpx_file_path && (
+                    {hasGpx && (
                       <button
                         type="button"
                         className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
@@ -191,9 +202,10 @@ export function FlightsTable({
                       >
                         <FileText className="h-3 w-3" aria-hidden="true" />
                         {t('flights.gpxBadge')}
+                        <Download className="h-3 w-3" aria-hidden="true" />
                       </button>
                     )}
-                    {flight.video_file_path && (
+                    {hasVideo && (
                       <button
                         type="button"
                         className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
@@ -206,9 +218,20 @@ export function FlightsTable({
                       >
                         <Video className="h-3 w-3" aria-hidden="true" />
                         {t('flights.videoBadge')}
+                        <Download className="h-3 w-3" aria-hidden="true" />
                       </button>
                     )}
-                    {flight.gopro_overlay_file_path && (
+                    {isVideoExportRunning && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
+                        {t('flights.videoProcessingBadge')}
+                      </span>
+                    )}
+                    {isVideoExportFailed && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+                        {t('flights.videoErrorBadge')}
+                      </span>
+                    )}
+                    {hasPersistedGoproOverlay && (
                       <button
                         type="button"
                         className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
@@ -221,19 +244,12 @@ export function FlightsTable({
                       >
                         <Wand2 className="h-3 w-3" aria-hidden="true" />
                         {t('flights.goproOverlayBadge')}
+                        <Download className="h-3 w-3" aria-hidden="true" />
                       </button>
                     )}
                   </div>
                 )}
             </div>
-
-            {/* Badge GPX manquant */}
-            {!flight.gpx_file_path && !selectionMode && (
-              <span className="ml-2 inline-flex shrink-0 items-center gap-1 rounded-full bg-orange-100 px-2 py-0.5 text-xs text-orange-700 dark:bg-orange-900/20 dark:text-orange-400">
-                <Paperclip className="h-3 w-3" aria-hidden="true" />
-                {t('flights.gpxMissing')}
-              </span>
-            )}
           </div>
 
           {/* Date et heure */}


### PR DESCRIPTION
## Summary
- Align flight list media tags with the flight detail view.
- Remove the divergent "GPX missing" badge from the list.
- Add story coverage for video processing and failed states.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` reported success, but the shell hit the timeout after Nx completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flight videos now display real-time export status indicators, including active processing and error states, providing clearer feedback.
* **Style**
  * Updated download button icons across the flights table for improved visual clarity.
* **Bug Fixes**
  * Refined logic for determining when media badges display on flight records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->