### PR TITLE
fix backend root to serve frontend SPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ EXPOSE 8001
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8001/ || exit 1
+    CMD curl -f http://localhost:8001/health || exit 1
 
 # Lancer application avec migration automatique
 CMD ["./entrypoint.sh"]

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -690,6 +690,10 @@ def health_check():
 
 @app.get("/")
 def read_root():
+    index_path = STATIC_DIR / "index.html"
+    if index_path.exists():
+        return FileResponse(index_path)
+
     return {
         "status": "ok",
         "message": "Dashboard Parapente API v0.2.0",

--- a/apps/backend/tests/unit/test_main.py
+++ b/apps/backend/tests/unit/test_main.py
@@ -14,11 +14,28 @@ def test_health_check_route_is_not_intercepted_by_spa_catch_all(client):
     assert response.json() == {"status": "ok"}
 
 
-def test_root_route_is_not_intercepted_by_spa_catch_all(client):
+def test_root_route_returns_api_status_when_frontend_is_missing(client, tmp_path, monkeypatch):
+    import main
+
+    monkeypatch.setattr(main, "STATIC_DIR", tmp_path)
+
     response = client.get("/")
 
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
+
+
+def test_root_route_serves_frontend_index_when_built(client, tmp_path, monkeypatch):
+    import main
+
+    (tmp_path / "index.html").write_text("<html><body>frontend</body></html>")
+    monkeypatch.setattr(main, "STATIC_DIR", tmp_path)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "frontend" in response.text
 
 
 def test_schedule_strava_token_refresh_job_forces_refresh():


### PR DESCRIPTION
## Summary
- Serve the built frontend `index.html` at `/` when static assets are present.
- Keep the API JSON fallback when the frontend is not built.
- Move the Docker healthcheck to `/health`.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_main.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (full suite started but hit the shell timeout while running scraper tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend can now serve a built frontend, falling back to the JSON API when not available
  * Container health checks now use the dedicated health endpoint

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->