### PR TITLE
Fix recovered video export jobs

### DIFF
--- a/apps/backend/job_queue.py
+++ b/apps/backend/job_queue.py
@@ -10,6 +10,8 @@ from rq.job import Job
 
 import config
 
+_PENDING_JOB_STATUSES = {"queued", "deferred", "scheduled"}
+
 
 def is_rq_enabled() -> bool:
     return config.JOB_QUEUE_BACKEND == "rq"
@@ -27,6 +29,13 @@ def get_queue(name: str | None = None) -> Queue:
     return Queue(name or config.JOB_QUEUE_NAME, connection=get_redis_connection())
 
 
+def _job_status_value(job: Job) -> str | None:
+    status = job.get_status(refresh=True)
+    if status is None:
+        return None
+    return str(getattr(status, "value", status)).lower()
+
+
 def enqueue_once(
     function_path: str,
     *args: Any,
@@ -38,7 +47,9 @@ def enqueue_once(
     queue = get_queue(queue_name)
     existing_job = queue.fetch_job(job_id)
     if existing_job is not None:
-        return existing_job
+        if _job_status_value(existing_job) in _PENDING_JOB_STATUSES:
+            return existing_job
+        existing_job.delete()
 
     return queue.enqueue(
         function_path,

--- a/apps/backend/tests/unit/test_job_queue.py
+++ b/apps/backend/tests/unit/test_job_queue.py
@@ -1,0 +1,76 @@
+"""Unit tests for RQ queue helpers."""
+
+import job_queue
+
+
+class FakeJob:
+    def __init__(self, status: str):
+        self.status = status
+        self.deleted = False
+
+    def get_status(self, refresh: bool = True) -> str:
+        return self.status
+
+    def delete(self) -> None:
+        self.deleted = True
+
+
+class FakeQueue:
+    def __init__(self, existing_job: FakeJob | None):
+        self.existing_job = existing_job
+        self.enqueued: list[dict[str, object]] = []
+
+    def fetch_job(self, job_id: str) -> FakeJob | None:
+        return self.existing_job
+
+    def enqueue(self, function_path: str, *args: object, **kwargs: object) -> dict[str, object]:
+        enqueued_job = {"function_path": function_path, "args": args, "kwargs": kwargs}
+        self.enqueued.append(enqueued_job)
+        return enqueued_job
+
+
+def test_enqueue_once_reuses_existing_pending_job(monkeypatch):
+    existing_job = FakeJob("queued")
+    queue = FakeQueue(existing_job)
+    monkeypatch.setattr(job_queue, "get_queue", lambda _name=None: queue)
+
+    result = job_queue.enqueue_once(
+        "video_export_manual.process_video_export_job",
+        "job-recovered",
+        job_id="video-export-job-recovered",
+    )
+
+    assert result is existing_job
+    assert existing_job.deleted is False
+    assert queue.enqueued == []
+
+
+def test_enqueue_once_replaces_stale_started_job(monkeypatch):
+    existing_job = FakeJob("started")
+    queue = FakeQueue(existing_job)
+    monkeypatch.setattr(job_queue, "get_queue", lambda _name=None: queue)
+
+    result = job_queue.enqueue_once(
+        "video_export_manual.process_video_export_job",
+        "job-recovered",
+        job_id="video-export-job-recovered",
+    )
+
+    assert existing_job.deleted is True
+    assert result == queue.enqueued[0]
+    assert queue.enqueued[0]["kwargs"]["job_id"] == "video-export-job-recovered"
+
+
+def test_enqueue_once_replaces_terminal_existing_job(monkeypatch):
+    existing_job = FakeJob("failed")
+    queue = FakeQueue(existing_job)
+    monkeypatch.setattr(job_queue, "get_queue", lambda _name=None: queue)
+
+    job_queue.enqueue_once(
+        "video_export_manual.process_video_export_job",
+        "job-recovered",
+        job_id="video-export-job-recovered",
+    )
+
+    assert existing_job.deleted is True
+    assert len(queue.enqueued) == 1


### PR DESCRIPTION
## Summary
- Keep recovered RQ video export jobs moving after restart by replacing stale non-pending queue entries.
- Add unit coverage for pending, stale-running, and terminal job queue cases.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend
- TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_job_queue.py tests/unit/test_video_export_manual.py -q --tb=short --no-header
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --base=origin/main --head=HEAD --exclude=e2e (no tasks were run)