### PR TITLE
fix(backend): restore flight export filename prefix

### DIFF
--- a/apps/backend/flight_storage.py
+++ b/apps/backend/flight_storage.py
@@ -53,7 +53,7 @@ def get_video_output_path(flight_id: str, timestamp: str) -> Path:
         with SessionLocal() as db:
             flight = db.query(Flight).filter(Flight.id == flight_id).first()
             if flight:
-                return ensure_flight_directory(db, flight) / f"history-{timestamp}.mp4"
+                return ensure_flight_directory(db, flight) / f"flight-{timestamp}.mp4"
     except Exception as exc:
         print(f"⚠️ Could not resolve flight storage directory: {exc}")
 

--- a/apps/backend/tests/unit/test_flight_storage.py
+++ b/apps/backend/tests/unit/test_flight_storage.py
@@ -152,7 +152,7 @@ def test_get_video_output_path_uses_flight_directory(db_session, monkeypatch, tm
 
     output_path = get_video_output_path("flight-video", "20260517-120000")
 
-    assert output_path == tmp_path / "20260517" / "01" / "history-20260517-120000.mp4"
+    assert output_path == tmp_path / "20260517" / "01" / "flight-20260517-120000.mp4"
 
 
 def test_get_video_output_path_falls_back_to_export_root(monkeypatch, tmp_path, test_db):


### PR DESCRIPTION
## Summary
- Restore flight export filenames to use a `flight-` prefix in flight storage.
- Lock the naming behavior with a unit test.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend` ✅
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/unit/test_flight_storage.py -q --tb=short --no-header` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5` was attempted but Nx expanded to multiple projects and exceeded the shell timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated video file naming convention to use `flight-` prefix instead of `history-` prefix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->