### PR TITLE
fix(video-export): resolve worker restart conflict

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -610,6 +610,48 @@ def test_trigger_auto_export_uses_manual_fast(db_session, sample_flight, monkeyp
     assert job_id == "job-manual-fast"
 
 
+def test_start_video_export_worker_restarts_when_previous_worker_is_stopping(monkeypatch):
+    class StoppingThread:
+        joined = False
+
+        def is_alive(self):
+            return True
+
+        def join(self, timeout=None):
+            self.joined = True
+
+    class StartedThread:
+        def __init__(self, target, name, daemon):
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+            self.started = False
+
+        def start(self):
+            self.started = True
+
+        def is_alive(self):
+            return self.started
+
+    previous_thread = StoppingThread()
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "thread")
+    monkeypatch.setattr(video_export_manual, "_WORKER_THREAD", previous_thread)
+    monkeypatch.setattr(video_export_manual, "_mark_stale_jobs_as_queued", lambda: None)
+    monkeypatch.setattr(video_export_manual.threading, "Thread", StartedThread)
+    video_export_manual._WORKER_STOP.set()
+
+    try:
+        video_export_manual.start_video_export_worker()
+
+        assert previous_thread.joined is True
+        assert video_export_manual._WORKER_STOP.is_set() is False
+        assert isinstance(video_export_manual._WORKER_THREAD, StartedThread)
+        assert video_export_manual._WORKER_THREAD.started is True
+    finally:
+        video_export_manual._WORKER_THREAD = None
+        video_export_manual._WORKER_STOP.clear()
+
+
 def test_cleanup_temp_dir_removes_nested_files(tmp_path):
     temp_dir = tmp_path / "temp-images" / "job-123"
     frames_dir = temp_dir / "frames"

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -1005,8 +1005,11 @@ def start_video_export_worker():
 
     global _WORKER_THREAD
     with _WORKER_LOCK:
-        if _WORKER_THREAD and _WORKER_THREAD.is_alive():
+        if _WORKER_THREAD and _WORKER_THREAD.is_alive() and not _WORKER_STOP.is_set():
             return
+
+        if _WORKER_THREAD and _WORKER_THREAD.is_alive():
+            _WORKER_THREAD.join(timeout=5)
 
         _WORKER_STOP.clear()
         _mark_stale_jobs_as_queued()
@@ -1021,9 +1024,12 @@ def start_video_export_worker():
 
 def stop_video_export_worker():
     """Stop the manual export worker (used during shutdown)."""
+    global _WORKER_THREAD
     _WORKER_STOP.set()
     if _WORKER_THREAD and _WORKER_THREAD.is_alive():
         _WORKER_THREAD.join(timeout=5)
+    if _WORKER_THREAD and not _WORKER_THREAD.is_alive():
+        _WORKER_THREAD = None
 
 
 def _enqueue_video_export_job(


### PR DESCRIPTION
## Summary
- Keep the RQ-backed manual export flow from main.
- Allow the manual worker to restart cleanly when a previous thread is stopping.
- Add a regression test for the worker restart path.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend -- tests/unit/test_video_export_manual.py`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export worker reliability by enhancing the background worker restart mechanism. Better thread lifecycle management ensures proper and stable operation during stop and restart sequences.

* **Tests**
  * Added comprehensive unit testing for video export worker restart behavior, validating system stability and reliability when stopping and restarting the worker in manual mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->