### PR TITLE
Fix hourly best spot desktop presentation

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -233,6 +233,33 @@ export const BestSpotSuggestion = ({
   );
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
+  const hourlyRows = hourlyBestSpots.map((hourlySpot) => {
+    const hourlyScore = Math.min(
+      100,
+      Math.max(0, Math.round(hourlySpot.score ?? hourlySpot.paraIndex))
+    );
+    const roundedWindSpeed =
+      typeof hourlySpot.windSpeed === 'number'
+        ? Math.round(hourlySpot.windSpeed)
+        : null;
+
+    return {
+      spot: hourlySpot,
+      key: `${hourlySpot.hour}-${hourlySpot.site?.id ?? 'none'}`,
+      hourLabel:
+        selectedDayIndex === 0 && hourlySpot.hour === hourlyStartHour
+          ? t('common.now')
+          : `${hourlySpot.hour}h`,
+      score: hourlyScore,
+      scoreColor: getScoreColor(hourlyScore),
+      verdict: getVerdict(hourlyScore, hourlySpot.verdict ?? undefined),
+      windLabel:
+        hourlySpot.windDirection && roundedWindSpeed != null
+          ? `${hourlySpot.windDirection} ${roundedWindSpeed} km/h`
+          : '—',
+      orientationLabel: hourlySpot.site?.orientation ?? '—',
+    };
+  });
 
   return (
     <div
@@ -395,88 +422,143 @@ export const BestSpotSuggestion = ({
                 {t('weather.byHour')}
               </span>
             </div>
-            <div className="flex max-w-full min-w-0 gap-2 overflow-x-auto overscroll-x-contain pb-1">
-              {hourlyBestSpots.map((hourlySpot) => {
-                const hourlyScore = Math.min(
-                  100,
-                  Math.max(
-                    0,
-                    Math.round(hourlySpot.score ?? hourlySpot.paraIndex)
-                  )
-                );
-                const hourlyScoreColor = getScoreColor(hourlyScore);
-                const hourlyVerdict = getVerdict(
-                  hourlyScore,
-                  hourlySpot.verdict ?? undefined
-                );
-                const hourLabel =
-                  selectedDayIndex === 0 && hourlySpot.hour === hourlyStartHour
-                    ? t('common.now')
-                    : `${hourlySpot.hour}h`;
-                const roundedWindSpeed =
-                  typeof hourlySpot.windSpeed === 'number'
-                    ? Math.round(hourlySpot.windSpeed)
-                    : null;
-                const windLabel =
-                  hourlySpot.windDirection && roundedWindSpeed != null
-                    ? `${t('common.wind')} ${hourlySpot.windDirection} ${roundedWindSpeed} km/h`
-                    : '—';
-                const orientationLabel = hourlySpot.site?.orientation
-                  ? `${t('sites.orientation')} ${hourlySpot.site.orientation}`
-                  : null;
-
-                return (
-                  <Button
-                    key={`${hourlySpot.hour}-${hourlySpot.site?.id ?? 'none'}`}
-                    onPress={() => {
-                      if (hourlySpot.site) {
-                        onSelectSite(hourlySpot.site.id);
-                      }
-                    }}
-                    className="min-w-[176px] cursor-pointer flex-col items-stretch justify-start gap-0 whitespace-normal rounded-2xl border border-slate-200 bg-white px-3.5 py-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-950/60 dark:hover:border-sky-800 dark:hover:bg-slate-950"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <span className="text-sm font-extrabold text-slate-950 dark:text-white">
-                        {hourLabel}
-                      </span>
-                      <div className="text-right">
-                        <span
-                          className={`block text-xl font-black leading-none ${hourlyScoreColor.text}`}
-                        >
-                          {hourlyScore}
-                        </span>
-                        <span className="text-[10px] font-semibold text-slate-400 dark:text-slate-500">
-                          /100
-                        </span>
-                      </div>
-                    </div>
-                    <div className="mt-2 h-1.5 rounded-full bg-slate-100 dark:bg-slate-800">
-                      <div
-                        className={`h-full rounded-full ${hourlyScoreColor.bg}`}
-                        style={{ width: `${hourlyScore}%` }}
-                      />
-                    </div>
-                    <div className="mt-2 truncate text-base font-black text-slate-950 dark:text-gray-50">
-                      {hourlySpot.site?.name ?? '—'}
-                    </div>
-                    <div className="mt-2 flex items-center justify-between gap-2">
+            <div className="flex max-w-full min-w-0 gap-2 overflow-x-auto overscroll-x-contain pb-1 lg:hidden">
+              {hourlyRows.map((row) => (
+                <Button
+                  key={row.key}
+                  onPress={() => {
+                    if (row.spot.site) {
+                      onSelectSite(row.spot.site.id);
+                    }
+                  }}
+                  className="min-w-[176px] cursor-pointer flex-col items-stretch justify-start gap-0 whitespace-normal rounded-2xl border border-slate-200 bg-white px-3.5 py-3 text-left shadow-sm transition-colors hover:border-sky-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-950/60 dark:hover:border-sky-800 dark:hover:bg-slate-950"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <span className="text-sm font-extrabold text-slate-950 dark:text-white">
+                      {row.hourLabel}
+                    </span>
+                    <div className="text-right">
                       <span
-                        className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${hourlyVerdict.className}`}
+                        className={`block text-xl font-black leading-none ${row.scoreColor.text}`}
                       >
-                        {hourlyVerdict.label}
+                        {row.score}
                       </span>
-                      {orientationLabel && (
-                        <span className="truncate text-xs font-semibold text-slate-500 dark:text-slate-400">
-                          {orientationLabel}
+                      <span className="text-[10px] font-semibold text-slate-400 dark:text-slate-500">
+                        /100
+                      </span>
+                    </div>
+                  </div>
+                  <div className="mt-2 h-1.5 rounded-full bg-slate-100 dark:bg-slate-800">
+                    <div
+                      className={`h-full rounded-full ${row.scoreColor.bg}`}
+                      style={{ width: `${row.score}%` }}
+                    />
+                  </div>
+                  <div className="mt-2 truncate text-base font-black text-slate-950 dark:text-gray-50">
+                    {row.spot.site?.name ?? '—'}
+                  </div>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${row.verdict.className}`}
+                    >
+                      {row.verdict.label}
+                    </span>
+                    <span className="truncate text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      {row.orientationLabel}
+                    </span>
+                  </div>
+                  <div className="mt-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
+                    {t('common.wind')} {row.windLabel}
+                  </div>
+                </Button>
+              ))}
+            </div>
+
+            <div className="hidden overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-950/60 lg:block">
+              <table className="w-full table-fixed text-left text-sm">
+                <thead className="border-b border-slate-200 bg-slate-50 text-xs font-bold uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+                  <tr>
+                    <th scope="col" className="w-20 px-3 py-2.5">
+                      {t('common.time')}
+                    </th>
+                    <th scope="col" className="px-3 py-2.5">
+                      {t('common.site')}
+                    </th>
+                    <th scope="col" className="w-28 px-3 py-2.5">
+                      {t('weather.score')}
+                    </th>
+                    <th scope="col" className="w-28 px-3 py-2.5">
+                      {t('common.conditions')}
+                    </th>
+                    <th scope="col" className="w-32 px-3 py-2.5">
+                      {t('common.wind')}
+                    </th>
+                    <th scope="col" className="w-28 px-3 py-2.5">
+                      {t('sites.orientation', 'Orientation')}
+                    </th>
+                    <th scope="col" className="w-28 px-3 py-2.5 text-right">
+                      <span className="sr-only">
+                        {t('weather.viewForecast')}
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {hourlyRows.map((row) => (
+                    <tr
+                      key={row.key}
+                      className="transition-colors hover:bg-sky-50/70 dark:hover:bg-slate-900"
+                    >
+                      <td className="px-3 py-2.5 font-extrabold text-slate-950 dark:text-white">
+                        {row.hourLabel}
+                      </td>
+                      <td className="min-w-0 px-3 py-2.5">
+                        <div className="truncate font-bold text-slate-950 dark:text-white">
+                          {row.spot.site?.name ?? '—'}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <div className="flex items-center gap-2">
+                          <span className={`font-black ${row.scoreColor.text}`}>
+                            {row.score}
+                          </span>
+                          <div className="h-1.5 w-14 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+                            <div
+                              className={`h-full rounded-full ${row.scoreColor.bg}`}
+                              style={{ width: `${row.score}%` }}
+                            />
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5">
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${row.verdict.className}`}
+                        >
+                          {row.verdict.label}
                         </span>
-                      )}
-                    </div>
-                    <div className="mt-2 text-xs font-semibold text-slate-600 dark:text-slate-300">
-                      {windLabel}
-                    </div>
-                  </Button>
-                );
-              })}
+                      </td>
+                      <td className="px-3 py-2.5 font-semibold text-slate-600 dark:text-slate-300">
+                        {row.windLabel}
+                      </td>
+                      <td className="px-3 py-2.5 font-semibold text-slate-600 dark:text-slate-300">
+                        {row.orientationLabel}
+                      </td>
+                      <td className="px-3 py-2.5 text-right">
+                        <Button
+                          onPress={() => {
+                            if (row.spot.site) {
+                              onSelectSite(row.spot.site.id);
+                            }
+                          }}
+                          className="cursor-pointer rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-700 shadow-sm transition-colors hover:border-sky-300 hover:bg-sky-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-sky-800 dark:hover:bg-slate-800"
+                        >
+                          {t('weather.viewForecast')}
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           </div>
         )}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -51,6 +51,7 @@
     "never": "Never",
     "justNow": "Just now",
     "now": "Now",
+    "time": "Time",
     "minutesAgo": "{{count}}min ago",
     "hoursAgo": "{{count}}h ago",
     "daysAgo": "{{count}}d ago",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -51,6 +51,7 @@
     "never": "Jamais",
     "justNow": "À l'instant",
     "now": "Maintenant",
+    "time": "Heure",
     "minutesAgo": "Il y a {{count}}min",
     "hoursAgo": "Il y a {{count}}h",
     "daysAgo": "Il y a {{count}}j",


### PR DESCRIPTION
## Summary
- Render the hourly best spot section as a dense desktop table while keeping the compact mobile card view.
- Add localized table labels for common time in FR/EN.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend` ⚠️ Nx reported success, but the process did not exit cleanly before timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced responsive hourly weather recommendations display with dedicated mobile and desktop layouts. Mobile users see a scrollable card view, while desktop users benefit from an optimized table layout, both showing consistent hourly metrics including scores, verdicts, wind conditions, and site orientation.

* **Localization**
  * Added "Time" label translations for English and French.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->