### PR TITLE
fix(frontend): improve video export filters

### DIFF
--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -78,10 +78,16 @@ const {
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback: string, values?: Record<string, unknown>) =>
-      values?.count
-        ? fallback.replace('{{count}}', String(values.count))
-        : fallback,
+    t: (_key: string, fallback: string, values?: Record<string, unknown>) => {
+      if (!values) {
+        return fallback;
+      }
+
+      return Object.entries(values).reduce(
+        (label, [key, value]) => label.replace(`{{${key}}}`, String(value)),
+        fallback
+      );
+    },
   }),
   withTranslation: () => (Component: React.ComponentType) => Component,
 }));
@@ -206,7 +212,7 @@ describe('VideoExportJobsPanel', () => {
   it('filters jobs by status', () => {
     render(<VideoExportJobsPanel />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Terminés' }));
+    fireEvent.click(screen.getByRole('button', { name: /Terminés/u }));
 
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
     expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
@@ -240,11 +246,23 @@ describe('VideoExportJobsPanel', () => {
   it('filters jobs by type', () => {
     render(<VideoExportJobsPanel />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Overlay GoPro' }));
+    fireEvent.click(screen.getByRole('button', { name: /Overlay GoPro/u }));
 
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
     expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
+  });
+
+  it('resets active filters', () => {
+    render(<VideoExportJobsPanel />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Overlay GoPro/u }));
+    expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Réinitialiser' }));
+
+    expect(screen.getAllByText('Vol test').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
   });
 
   it('deletes an inactive row after confirmation', async () => {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -59,6 +59,12 @@ const typeFilters = [
 
 type TypeFilter = (typeof typeFilters)[number]['id'];
 
+type FilterOption<T extends string> = {
+  id: T;
+  label: string;
+  count: number;
+};
+
 const activeStatusLabels = new Set([
   'running',
   'initializing',
@@ -84,11 +90,14 @@ function getJobPhase(job: VideoExportJob) {
 
 function getStatusLabelParts(job: VideoExportJob) {
   const phase = getJobPhase(job);
-  const status = activeStatusLabels.has(phase)
-    ? 'processing'
-    : statusLabelFallbacks[phase]
-      ? phase
-      : job.status;
+  let status = job.status;
+
+  if (activeStatusLabels.has(phase)) {
+    status = 'processing';
+  } else if (statusLabelFallbacks[phase]) {
+    status = phase;
+  }
+
   const fallback = statusLabelFallbacks[status] || status;
   return { key: `videoJobs.status.${status}`, fallback };
 }
@@ -167,6 +176,64 @@ function isGoproOverlayJob(job: VideoExportJob) {
   return job.mode === 'gopro_overlay';
 }
 
+function isJobInTypeFilter(job: VideoExportJob, filter: TypeFilter) {
+  return (
+    filter === 'all' ||
+    (filter === 'gopro' && isGoproOverlayJob(job)) ||
+    (filter === 'video' && !isGoproOverlayJob(job))
+  );
+}
+
+function SegmentedFilter<T extends string>({
+  label,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: FilterOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="min-w-0 flex-1 space-y-2">
+      <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </div>
+      <div className="grid overflow-hidden rounded-xl border border-gray-200 bg-gray-50 p-1 dark:border-gray-700 dark:bg-gray-900/50 sm:flex">
+        {options.map((option) => {
+          const isSelected = value === option.id;
+
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={isSelected}
+              className={`flex min-h-10 cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 sm:flex-1 sm:justify-center ${
+                isSelected
+                  ? 'bg-white text-sky-700 shadow-sm ring-1 ring-sky-200 dark:bg-sky-950/70 dark:text-sky-200 dark:ring-sky-800'
+                  : 'text-gray-600 hover:bg-white/80 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white'
+              }`}
+              onClick={() => onChange(option.id)}
+            >
+              <span className="truncate">{option.label}</span>
+              <span
+                className={`rounded-md px-1.5 py-0.5 text-xs font-semibold ${
+                  isSelected
+                    ? 'bg-sky-100 text-sky-700 dark:bg-sky-900 dark:text-sky-200'
+                    : 'bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
+                }`}
+              >
+                {option.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function canDownloadJob(job: VideoExportJob) {
   return job.status === 'completed' && job.has_output_file !== false;
 }
@@ -239,16 +306,15 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   const filteredJobs = useMemo(
     () =>
       jobs.filter((job) => {
-        const isInTypeFilter =
-          typeFilter === 'all' ||
-          (typeFilter === 'gopro' && isGoproOverlayJob(job)) ||
-          (typeFilter === 'video' && !isGoproOverlayJob(job));
-        return isInTypeFilter && isJobInFilter(job, statusFilter);
+        return (
+          isJobInTypeFilter(job, typeFilter) && isJobInFilter(job, statusFilter)
+        );
       }),
     [jobs, statusFilter, typeFilter]
   );
   const visibleJobs =
     typeof limit === 'number' ? filteredJobs.slice(0, limit) : filteredJobs;
+  const isFiltering = statusFilter !== 'all' || typeFilter !== 'all';
 
   const activeCount = jobs.filter((job) => job.can_cancel).length;
   const completedCount = jobs.filter(
@@ -258,6 +324,29 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   const cancelledCount = jobs.filter(
     (job) => job.status === 'cancelled'
   ).length;
+  const jobsInSelectedType = useMemo(
+    () => jobs.filter((job) => isJobInTypeFilter(job, typeFilter)),
+    [jobs, typeFilter]
+  );
+  const typeFilterOptions = useMemo<FilterOption<TypeFilter>[]>(
+    () =>
+      typeFilters.map((filter) => ({
+        id: filter.id,
+        label: t(`videoJobs.typeFilters.${filter.id}`, filter.label),
+        count: jobs.filter((job) => isJobInTypeFilter(job, filter.id)).length,
+      })),
+    [jobs, t]
+  );
+  const statusFilterOptions = useMemo<FilterOption<StatusFilter>[]>(
+    () =>
+      statusFilters.map((filter) => ({
+        id: filter.id,
+        label: t(`videoJobs.filters.${filter.id}`, filter.label),
+        count: jobsInSelectedType.filter((job) => isJobInFilter(job, filter.id))
+          .length,
+      })),
+    [jobsInSelectedType, t]
+  );
 
   const handleCancel = useCallback(
     (job: VideoExportJob) => {
@@ -638,46 +727,46 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       )}
 
       {!isLoading && !isError && jobs.length > 0 && (
-        <div className="space-y-3 border-t border-gray-100 p-3 dark:border-gray-700">
-          <div className="flex flex-wrap gap-2">
-            {typeFilters.map((filter) => {
-              const isSelected = typeFilter === filter.id;
-              return (
-                <button
-                  key={filter.id}
-                  type="button"
-                  aria-pressed={isSelected}
-                  className={`cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
-                    isSelected
-                      ? 'border-sky-600 bg-sky-600 text-white dark:border-sky-300 dark:bg-sky-300 dark:text-sky-950'
-                      : 'border-gray-200 bg-white text-gray-700 hover:border-sky-300 hover:bg-sky-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/40'
-                  }`}
-                  onClick={() => setTypeFilter(filter.id)}
-                >
-                  {t(`videoJobs.typeFilters.${filter.id}`, filter.label)}
-                </button>
-              );
-            })}
+        <div className="space-y-4 border-t border-gray-100 bg-gray-50/70 p-4 dark:border-gray-700 dark:bg-gray-900/20">
+          <div className="flex flex-col gap-4 xl:flex-row">
+            <SegmentedFilter
+              label={t('videoJobs.filterLabels.type', 'Type')}
+              options={typeFilterOptions}
+              value={typeFilter}
+              onChange={setTypeFilter}
+            />
+            <SegmentedFilter
+              label={t('videoJobs.filterLabels.status', 'Statut')}
+              options={statusFilterOptions}
+              value={statusFilter}
+              onChange={setStatusFilter}
+            />
           </div>
-          <div className="flex flex-wrap gap-2">
-            {statusFilters.map((filter) => {
-              const isSelected = statusFilter === filter.id;
-              return (
-                <button
-                  key={filter.id}
-                  type="button"
-                  aria-pressed={isSelected}
-                  className={`cursor-pointer rounded-full border px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${
-                    isSelected
-                      ? 'border-sky-600 bg-sky-600 text-white dark:border-sky-300 dark:bg-sky-300 dark:text-sky-950'
-                      : 'border-gray-200 bg-white text-gray-700 hover:border-sky-300 hover:bg-sky-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:border-sky-700 dark:hover:bg-sky-950/40'
-                  }`}
-                  onClick={() => setStatusFilter(filter.id)}
-                >
-                  {t(`videoJobs.filters.${filter.id}`, filter.label)}
-                </button>
-              );
-            })}
+          <div className="flex flex-col gap-2 text-sm text-gray-600 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
+            <span>
+              {isFiltering || visibleJobs.length !== jobs.length
+                ? t(
+                    'videoJobs.filteredSummary',
+                    '{{visible}} génération(s) affichée(s) sur {{total}}',
+                    { visible: visibleJobs.length, total: jobs.length }
+                  )
+                : t(
+                    'videoJobs.visibleSummary',
+                    '{{visible}} génération(s) affichée(s)',
+                    { visible: visibleJobs.length }
+                  )}
+            </span>
+            {isFiltering && (
+              <Button
+                onClick={() => {
+                  setTypeFilter('all');
+                  setStatusFilter('all');
+                }}
+                className="cursor-pointer self-start rounded-lg px-3 py-1.5 text-sm font-semibold text-sky-700 transition-colors hover:bg-sky-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-sky-300 dark:hover:bg-sky-950/40 sm:self-auto"
+              >
+                {t('videoJobs.resetFilters', 'Réinitialiser')}
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -88,6 +88,13 @@
     "deleteRow": "Delete",
     "deleteRowSuccess": "Row deleted",
     "deleteRowError": "Unable to delete row",
+    "resetFilters": "Reset",
+    "visibleSummary": "{{visible}} generation(s) shown",
+    "filteredSummary": "{{visible}} generation(s) shown out of {{total}}",
+    "filterLabels": {
+      "type": "Type",
+      "status": "Status"
+    },
     "mode": {
       "goproOverlay": "GoPro overlay"
     },

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -88,6 +88,13 @@
     "deleteRow": "Supprimer",
     "deleteRowSuccess": "Ligne supprimée",
     "deleteRowError": "Impossible de supprimer la ligne",
+    "resetFilters": "Réinitialiser",
+    "visibleSummary": "{{visible}} génération(s) affichée(s)",
+    "filteredSummary": "{{visible}} génération(s) affichée(s) sur {{total}}",
+    "filterLabels": {
+      "type": "Type",
+      "status": "Statut"
+    },
     "mode": {
       "goproOverlay": "Overlay GoPro"
     },


### PR DESCRIPTION
## Summary
- Replace the video export filter chips with segmented controls.
- Add per-filter counters, a visible summary, and a reset action.
- Update translations and tests for the new filter UI.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Reset Filters" button for video export jobs to quickly clear all active filters
  * Introduced dynamic filter counts showing how many jobs match each filter option
  * Added summary text displaying the count of filtered versus visible jobs

* **UI Improvements**
  * Replaced filter selection interface with an improved segmented control design for better usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->