### PR TITLE
fix(frontend): sync GoPro overlay badges with video statuses

### DIFF
--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -54,10 +54,12 @@ const flights: Flight[] = [
 ];
 
 function FlightsTableHarness({
+  tableFlights = flights,
   onDownloadGpx = () => undefined,
   onDownloadVideo = () => undefined,
   onDownloadOverlay = () => undefined,
 }: {
+  tableFlights?: Flight[];
   onDownloadGpx?: (flight: Flight) => void;
   onDownloadVideo?: (flight: Flight) => void;
   onDownloadOverlay?: (flight: Flight) => void;
@@ -67,7 +69,7 @@ function FlightsTableHarness({
 
   return (
     <FlightsTable
-      flights={flights}
+      flights={tableFlights}
       selectedFlightId={selectedFlightId}
       selectionMode={false}
       onSelectFlight={(flight) => setSelectedFlightId(flight.id)}
@@ -121,4 +123,38 @@ test('downloads media from badges without selecting the flight', () => {
   expect(onDownloadOverlay).toHaveBeenCalledWith(flights[0]);
   expect(flightRow).not.toHaveClass('border-sky-700');
   expect(flightRow).toHaveAttribute('aria-selected', 'false');
+});
+
+test('shows GoPro overlay status badges like video badges', () => {
+  const { rerender } = render(
+    <FlightsTableHarness
+      tableFlights={[
+        {
+          ...flights[1],
+          id: 'flight-overlay-running',
+          gopro_overlay_status: 'running',
+        },
+      ]}
+    />
+  );
+
+  expect(
+    screen.getByText('flights.goproOverlayProcessingBadge')
+  ).toBeInTheDocument();
+
+  rerender(
+    <FlightsTableHarness
+      tableFlights={[
+        {
+          ...flights[1],
+          id: 'flight-overlay-failed',
+          gopro_overlay_status: 'failed',
+        },
+      ]}
+    />
+  );
+
+  expect(
+    screen.getByText('flights.goproOverlayErrorBadge')
+  ).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -98,6 +98,10 @@ export function FlightsTable({
       const hasGpx = Boolean(flight.gpx_file_path);
       const hasVideo = Boolean(flight.video_file_path);
       const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
+      const isGoproOverlayRunning =
+        flight.gopro_overlay_status === 'queued' ||
+        flight.gopro_overlay_status === 'running';
+      const isGoproOverlayFailed = flight.gopro_overlay_status === 'failed';
       const isVideoExportRunning = Boolean(
         flight.video_export_status &&
         VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)
@@ -187,7 +191,9 @@ export function FlightsTable({
                   hasVideo ||
                   isVideoExportRunning ||
                   isVideoExportFailed ||
-                  hasPersistedGoproOverlay) && (
+                  hasPersistedGoproOverlay ||
+                  isGoproOverlayRunning ||
+                  isGoproOverlayFailed) && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {hasGpx && (
                       <button
@@ -246,6 +252,16 @@ export function FlightsTable({
                         {t('flights.goproOverlayBadge')}
                         <Download className="h-3 w-3" aria-hidden="true" />
                       </button>
+                    )}
+                    {isGoproOverlayRunning && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
+                        {t('flights.goproOverlayProcessingBadge')}
+                      </span>
+                    )}
+                    {isGoproOverlayFailed && (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+                        {t('flights.goproOverlayErrorBadge')}
+                      </span>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Add GoPro overlay running/failed badges to the flight list.
- Keep the overlay tag status behavior aligned with the video tag.
- Add a unit test for the overlay status badges.

## Validation
- `vitest run --config vitest.config.ts src/components/flights/FlightsTable.test.tsx --reporter=verbose`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual status indicators to the flights table for GoPro overlay exports, displaying "processing" and "error" states alongside the existing download status badge, enabling users to monitor overlay export progress and quickly identify any issues encountered during the export process.

* **Tests**
  * Enhanced test coverage to verify GoPro overlay status badge rendering behavior across different processing states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->