### PR TITLE
fix: prefer flight name in export list

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -436,7 +436,7 @@ def _build_video_export_jobs_payload(
             job["has_output_file"] = bool(video_path and Path(str(video_path)).exists())
         if flight:
             job["flight_name"] = flight.name or flight.title
-            job["flight_title"] = flight.title or flight.name
+            job["flight_title"] = flight.name or flight.title
         jobs.append(job)
 
     return sorted(jobs, key=_video_export_sort_value, reverse=True)

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -458,8 +458,11 @@ class TestVideoExportJobsEndpoint:
     """Tests for GET /video-export-jobs."""
 
     def test_video_export_jobs_lists_jobs_with_cancel_state(
-        self, client: TestClient, sample_flight
+        self, client: TestClient, db_session, sample_flight
     ):
+        sample_flight.title = "Legacy flight title"
+        db_session.commit()
+
         manual_jobs = [
             {
                 "job_id": "job-running",
@@ -513,6 +516,7 @@ class TestVideoExportJobsEndpoint:
         assert jobs[1]["status"] == "processing"
         assert jobs[1]["can_cancel"] is True
         assert jobs[1]["flight_name"] == sample_flight.name
+        assert jobs[1]["flight_title"] == sample_flight.name
         assert jobs[2]["job_id"] == "job-cancelled"
         assert jobs[2]["status"] == "cancelled"
         assert jobs[2]["can_cancel"] is False

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -25,6 +25,7 @@ const {
   jobs: [
     {
       job_id: 'job-active',
+      flight_name: 'Nom du vol test',
       flight_title: 'Vol test',
       status: 'processing',
       internal_status: 'capturing',
@@ -132,6 +133,7 @@ describe('VideoExportJobsPanel', () => {
       jobs.length,
       {
         job_id: 'job-active',
+        flight_name: 'Nom du vol test',
         flight_title: 'Vol test',
         status: 'processing',
         internal_status: 'capturing',
@@ -187,7 +189,8 @@ describe('VideoExportJobsPanel', () => {
     render(<VideoExportJobsPanel />);
 
     expect(screen.getByText('Générations vidéo')).toBeInTheDocument();
-    expect(screen.getAllByText('Vol test').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nom du vol test').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
@@ -215,7 +218,7 @@ describe('VideoExportJobsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /Terminés/u }));
 
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nom du vol test')).not.toBeInTheDocument();
     expect(screen.queryByText('vol-overlay.mp4')).not.toBeInTheDocument();
   });
 
@@ -250,7 +253,7 @@ describe('VideoExportJobsPanel', () => {
 
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
-    expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nom du vol test')).not.toBeInTheDocument();
   });
 
   it('resets active filters', () => {
@@ -261,7 +264,7 @@ describe('VideoExportJobsPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Réinitialiser' }));
 
-    expect(screen.getAllByText('Vol test').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nom du vol test').length).toBeGreaterThan(0);
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
   });
 

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -118,7 +118,7 @@ function getProgress(job: VideoExportJob) {
 }
 
 function getFlightLabel(job: VideoExportJob) {
-  return job.flight_title || job.flight_name || job.flight_id || job.job_id;
+  return job.flight_name || job.flight_title || job.flight_id || job.job_id;
 }
 
 function getLastActivityTime(job: VideoExportJob) {


### PR DESCRIPTION
## Summary
- Prefer the flight name over the legacy title in the video exports list.
- Normalize the backend `/video-export-jobs` payload so the displayed flight label matches the flight name.
- Cover the mismatch case in frontend and backend tests.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel`
- `/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend` (fails in this worktree because Nx falls back to `ruff` instead of the repo venv)
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e` (times out after reaching backend/test environment issues)