### PR TITLE
fix: display flight names for overlay jobs

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -412,10 +412,23 @@ def _build_video_export_jobs_payload(
     exports: list[dict[str, Any]], db: Session
 ) -> list[dict[str, Any]]:
     flight_ids = {export.get("flight_id") for export in exports if export.get("flight_id")}
+    overlay_job_ids = {
+        export.get("job_id")
+        for export in exports
+        if export.get("mode") == "gopro_overlay" and export.get("job_id")
+    }
     flights_by_id = {}
     if flight_ids:
         flights_by_id = {
             flight.id: flight for flight in db.query(Flight).filter(Flight.id.in_(flight_ids)).all()
+        }
+    overlay_flights_by_job_id = {}
+    if overlay_job_ids:
+        overlay_flights_by_job_id = {
+            flight.gopro_overlay_job_id: flight
+            for flight in db.query(Flight)
+            .filter(Flight.gopro_overlay_job_id.in_(overlay_job_ids))
+            .all()
         }
 
     jobs: list[dict[str, Any]] = []
@@ -427,7 +440,7 @@ def _build_video_export_jobs_payload(
         if job_id:
             seen_job_ids.add(job_id)
 
-        flight = flights_by_id.get(export.get("flight_id"))
+        flight = flights_by_id.get(export.get("flight_id")) or overlay_flights_by_job_id.get(job_id)
         job = dict(export)
         job["status"] = _video_export_public_status(job)
         job["can_cancel"] = _video_export_can_cancel(job)
@@ -435,6 +448,7 @@ def _build_video_export_jobs_payload(
             video_path = job.get("video_path")
             job["has_output_file"] = bool(video_path and Path(str(video_path)).exists())
         if flight:
+            job["flight_id"] = flight.id
             job["flight_name"] = flight.name or flight.title
             job["flight_title"] = flight.name or flight.title
         jobs.append(job)

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -461,6 +461,7 @@ class TestVideoExportJobsEndpoint:
         self, client: TestClient, db_session, sample_flight
     ):
         sample_flight.title = "Legacy flight title"
+        sample_flight.gopro_overlay_job_id = "job-overlay"
         db_session.commit()
 
         manual_jobs = [
@@ -512,6 +513,9 @@ class TestVideoExportJobsEndpoint:
         assert jobs[0]["status"] == "running"
         assert jobs[0]["mode"] == "gopro_overlay"
         assert jobs[0]["can_cancel"] is True
+        assert jobs[0]["flight_id"] == sample_flight.id
+        assert jobs[0]["flight_name"] == sample_flight.name
+        assert jobs[0]["flight_title"] == sample_flight.name
         assert jobs[1]["job_id"] == "job-running"
         assert jobs[1]["status"] == "processing"
         assert jobs[1]["can_cancel"] is True

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -45,6 +45,7 @@ const {
     },
     {
       job_id: 'job-overlay',
+      flight_name: 'Nom du vol overlay',
       flight_title: 'vol-overlay.mp4',
       status: 'running',
       internal_status: 'running',
@@ -65,6 +66,7 @@ const {
     },
     {
       job_id: 'job-overlay-done',
+      flight_name: 'Nom du vol overlay terminé',
       flight_title: 'final.mp4',
       status: 'completed',
       internal_status: 'completed',
@@ -153,6 +155,7 @@ describe('VideoExportJobsPanel', () => {
       },
       {
         job_id: 'job-overlay',
+        flight_name: 'Nom du vol overlay',
         flight_title: 'vol-overlay.mp4',
         status: 'running',
         internal_status: 'running',
@@ -173,6 +176,7 @@ describe('VideoExportJobsPanel', () => {
       },
       {
         job_id: 'job-overlay-done',
+        flight_name: 'Nom du vol overlay terminé',
         flight_title: 'final.mp4',
         status: 'completed',
         internal_status: 'completed',
@@ -192,8 +196,12 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('Nom du vol test').length).toBeGreaterThan(0);
     expect(screen.queryByText('Vol test')).not.toBeInTheDocument();
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nom du vol overlay').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Nom du vol overlay terminé').length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText('vol-overlay.mp4')).not.toBeInTheDocument();
+    expect(screen.queryByText('final.mp4')).not.toBeInTheDocument();
     expect(screen.getAllByText('Overlay GoPro').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
     expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);
@@ -219,7 +227,7 @@ describe('VideoExportJobsPanel', () => {
 
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
     expect(screen.queryByText('Nom du vol test')).not.toBeInTheDocument();
-    expect(screen.queryByText('vol-overlay.mp4')).not.toBeInTheDocument();
+    expect(screen.queryByText('Nom du vol overlay')).not.toBeInTheDocument();
   });
 
   it('cancels a running job after confirmation', async () => {
@@ -251,8 +259,10 @@ describe('VideoExportJobsPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Overlay GoPro/u }));
 
-    expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nom du vol overlay').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Nom du vol overlay terminé').length
+    ).toBeGreaterThan(0);
     expect(screen.queryByText('Nom du vol test')).not.toBeInTheDocument();
   });
 
@@ -265,7 +275,7 @@ describe('VideoExportJobsPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Réinitialiser' }));
 
     expect(screen.getAllByText('Nom du vol test').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Nom du vol overlay').length).toBeGreaterThan(0);
   });
 
   it('deletes an inactive row after confirmation', async () => {

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -228,6 +228,8 @@ const initialMockVideoJobs: VideoExportJob[] = [
   },
   {
     job_id: 'job-gopro-completed',
+    flight_id: 'flight-chalais',
+    flight_name: 'Chalais - thermique bleu',
     flight_title: 'final.mp4',
     status: 'completed',
     internal_status: 'completed',


### PR DESCRIPTION
## Summary
- Resolve video export jobs to the linked flight for GoPro overlay rows so the flight name is shown consistently.
- Update tests and story mocks to cover overlay jobs using flight names instead of filenames.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GoPro overlay export jobs to properly display associated flight information across all export views, even when flight IDs are not directly embedded in the export data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->