### PR TITLE
fix(frontend): add export type column

### DIFF
--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -194,6 +194,8 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('Vol terminé').length).toBeGreaterThan(0);
     expect(screen.getAllByText('vol-overlay.mp4').length).toBeGreaterThan(0);
     expect(screen.getAllByText('final.mp4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Video').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('GoPro overlay').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Overlay GoPro').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
     expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -109,6 +109,14 @@ function getModeLabelParts(mode: string) {
   return { key: `videoJobs.mode.${mode}`, fallback: mode };
 }
 
+function getJobTypeLabelParts(job: VideoExportJob) {
+  if (isGoproOverlayJob(job)) {
+    return { key: 'videoJobs.type.goproOverlay', fallback: 'GoPro overlay' };
+  }
+
+  return { key: 'videoJobs.type.video', fallback: 'Video' };
+}
+
 function getProgress(job: VideoExportJob) {
   if (typeof job.progress !== 'number' || !Number.isFinite(job.progress)) {
     return 0;
@@ -283,6 +291,17 @@ function JobModeBadge({ mode }: { mode: string }) {
   return (
     <span className="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-200">
       {t(modeLabel.key, modeLabel.fallback)}
+    </span>
+  );
+}
+
+function JobTypeBadge({ job }: { job: VideoExportJob }) {
+  const { t } = useTranslation();
+  const typeLabel = getJobTypeLabelParts(job);
+
+  return (
+    <span className="inline-flex rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-semibold text-indigo-700 dark:bg-indigo-950/50 dark:text-indigo-200">
+      {t(typeLabel.key, typeLabel.fallback)}
     </span>
   );
 }
@@ -529,6 +548,12 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
             )}
           </div>
         ),
+        sortingFn: 'alphanumeric',
+      }),
+      columnHelper.accessor((job) => getJobTypeLabelParts(job).fallback, {
+        id: 'type',
+        header: t('videoJobs.table.type', 'Type'),
+        cell: ({ row }) => <JobTypeBadge job={row.original} />,
         sortingFn: 'alphanumeric',
       }),
       columnHelper.accessor('mode', {
@@ -806,6 +831,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <JobStatusBadge job={job} />
+                        <JobTypeBadge job={job} />
                         {modeLabel && (
                           <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-200">
                             {t(modeLabel.key, modeLabel.fallback)}


### PR DESCRIPTION
## Summary\n- add a Type column to video exports\n- label rows as Video or GoPro overlay\n- keep mobile cards in sync and update tests\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend