### PR TITLE
fix(frontend): refresh flight tags after media updates

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -148,6 +148,16 @@ export function FlightDetails({
     setNotesText(flight.notes ?? '');
   }, [flight.notes]);
 
+  useEffect(() => {
+    if (
+      streamedGoproOverlayJob?.status === 'completed' ||
+      streamedGoproOverlayJob?.status === 'failed' ||
+      streamedGoproOverlayJob?.status === 'cancelled'
+    ) {
+      void queryClient.invalidateQueries({ queryKey: ['flights'] });
+    }
+  }, [queryClient, streamedGoproOverlayJob?.status]);
+
   const handleSubmitEdit = async (values: FlightFormData) => {
     await updateFlight.mutateAsync(values);
     toast.success(t('flights.updateSuccess'));
@@ -213,6 +223,7 @@ export function FlightDetails({
       if (activeFlightIdRef.current !== requestedFlightId) return;
       setGoproOverlayJobId(job.job_id);
       setGoproOverlayJobToken(job.job_token ?? null);
+      void queryClient.invalidateQueries({ queryKey: ['flights'] });
       toast.success(t('flights.goproOverlayStarted'));
     } catch (error) {
       toast.error(

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -144,7 +144,7 @@ export function FlightVideoExportControls({
       exportStatus.internal_status === 'failed' ||
       exportStatus.internal_status === 'cancelled'
     ) {
-      queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+      queryClient.invalidateQueries({ queryKey: ['flights'] });
     }
   }, [exportStatus?.internal_status, flight.id, queryClient]);
 
@@ -159,7 +159,7 @@ export function FlightVideoExportControls({
         })
         .json<{ job_token?: string | null }>();
       setVideoExportJobToken(payload.job_token ?? null);
-      await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+      await queryClient.invalidateQueries({ queryKey: ['flights'] });
     } finally {
       setIsStartingVideoExport(false);
     }
@@ -174,16 +174,11 @@ export function FlightVideoExportControls({
         .post(`exports/${flight.video_export_job_id}/resume`)
         .json<{ job_token?: string | null }>();
       setVideoExportJobToken(payload.job_token ?? null);
-      await queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+      await queryClient.invalidateQueries({ queryKey: ['flights'] });
     } finally {
       setIsStartingVideoExport(false);
     }
-  }, [
-    flight.id,
-    flight.video_export_job_id,
-    isStartingVideoExport,
-    queryClient,
-  ]);
+  }, [flight.video_export_job_id, isStartingVideoExport, queryClient]);
 
   const handlePrimaryAction = async () => {
     if (hasActiveVideoExport(flight)) return;
@@ -215,7 +210,7 @@ export function FlightVideoExportControls({
 
     try {
       await api.delete(`exports/${flight.video_export_job_id}/cancel`);
-      queryClient.invalidateQueries({ queryKey: ['flights', flight.id] });
+      queryClient.invalidateQueries({ queryKey: ['flights'] });
     } catch (error) {
       if (error instanceof HTTPError) {
         const detail = await getHttpErrorDetail(error);


### PR DESCRIPTION
## Summary
- Refresh the flights list when video export or GoPro overlay states change.
- Keep list badges/tags in sync without requiring a full page reload.

## Validation
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightVideoExportControls.test.tsx`
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `oxlint -c .oxlintrc.json apps/frontend/src/components/flights/FlightDetails.tsx apps/frontend/src/components/flights/FlightVideoExportControls.tsx`