### PR TITLE
fix(frontend): make hourly weather timeline responsive

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.chromatic.stories.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.chromatic.stories.tsx
@@ -14,6 +14,7 @@ import {
   CompactNoWind,
   CompactNullData,
   HourlyTimeline,
+  HourlyTimelineSidebarWidth,
   Today,
   Tomorrow,
   Day3,
@@ -74,6 +75,9 @@ export const BestSpotSuggestionChromatic = meta.story({
       </FigureWrapper>
       <FigureWrapper title={HourlyTimeline.composed.name}>
         <HourlyTimeline.Component />
+      </FigureWrapper>
+      <FigureWrapper title={HourlyTimelineSidebarWidth.composed.name}>
+        <HourlyTimelineSidebarWidth.Component />
       </FigureWrapper>
       <FigureWrapper title={Today.composed.name}>
         <Today.Component />

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.stories.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.stories.tsx
@@ -243,6 +243,19 @@ export const HourlyTimeline = meta.story({
   ),
 });
 
+export const HourlyTimelineSidebarWidth = meta.story({
+  name: 'Hourly Timeline Sidebar Width',
+  render: () => (
+    <div className="w-[420px] max-w-full">
+      <BestSpotSuggestion
+        bestSpot={mockBestSpotExcellent}
+        hourlyBestSpots={mockHourlyBestSpots}
+        onSelectSite={fn()}
+      />
+    </div>
+  ),
+});
+
 // Null data (renders nothing)
 export const NullData = meta.story({
   name: 'Null Data',

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -413,7 +413,7 @@ export const BestSpotSuggestion = ({
         </p>
 
         {hourlyBestSpots.length > 0 && (
-          <div className="mb-4 min-w-0 border-t border-slate-100 pt-3 dark:border-slate-700">
+          <div className="@container/best-spot-timeline mb-4 min-w-0 border-t border-slate-100 pt-3 dark:border-slate-700">
             <div className="flex items-center justify-between gap-2 mb-2">
               <span className="text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                 {t('weather.bestSpotTimeline')}
@@ -422,7 +422,7 @@ export const BestSpotSuggestion = ({
                 {t('weather.byHour')}
               </span>
             </div>
-            <div className="flex max-w-full min-w-0 gap-2 overflow-x-auto overscroll-x-contain pb-1 lg:hidden">
+            <div className="flex max-w-full min-w-0 gap-2 overflow-x-auto overscroll-x-contain pb-1 @min-[760px]/best-spot-timeline:hidden">
               {hourlyRows.map((row) => {
                 const rowSite = row.spot.site;
                 const content = (
@@ -490,7 +490,7 @@ export const BestSpotSuggestion = ({
               })}
             </div>
 
-            <div className="hidden overflow-x-auto overscroll-x-contain rounded-2xl border border-slate-200 bg-white p-2 shadow-sm dark:border-slate-700 dark:bg-slate-950/60 lg:block">
+            <div className="hidden overflow-x-auto overscroll-x-contain rounded-2xl border border-slate-200 bg-white p-2 shadow-sm @min-[760px]/best-spot-timeline:block dark:border-slate-700 dark:bg-slate-950/60">
               <table className="w-full min-w-[760px] table-auto border-separate border-spacing-y-1 text-left text-sm">
                 <thead>
                   <tr className="text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
## Summary
- Switch the hourly best-spot timeline to a container-width breakpoint so it stays readable in the weather sidebar.
- Add a narrow-sidebar story to cover the real weather-page layout.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend --skip-nx-cache` ⚠️ hangs after Vitest start in this environment
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e` ⚠️ backend task fails because `pytest` is missing in the backend venv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new Storybook story scenario for testing hourly timeline component behavior within fixed-width container layouts

* **Refactor**
  * Updated hourly timeline responsive layout to use container-based responsive design instead of viewport-based breakpoints, improving layout adaptation to varying container sizes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->