### PR TITLE
feat(frontend): prototype mobile weather layouts

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.mobile-prototype.NOTES.md
+++ b/apps/frontend/src/pages/WeatherPage.mobile-prototype.NOTES.md
@@ -1,0 +1,13 @@
+# PROTOTYPE - Mobile weather expandable layouts
+
+Question: quelle structure mobile expandable rend la page météo la plus lisible pour décider vite si on vole ?
+
+Run: `pnpm nx serve frontend`
+
+URLs:
+
+- `/weather?variant=A` - Synthèse fixe + accordéons
+- `/weather?variant=B` - Timeline mobile
+- `/weather?variant=C` - Risques d'abord
+
+Verdict: à remplir après essai utilisateur, puis supprimer ce prototype ou absorber le choix dans `WeatherPage.tsx`.

--- a/apps/frontend/src/pages/WeatherPage.mobile-prototype.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile-prototype.tsx
@@ -1,0 +1,414 @@
+import { useEffect, type ReactNode } from 'react';
+import { ChevronLeft, ChevronRight, ShieldAlert, Wind } from 'lucide-react';
+import { weatherCardClassName } from '../components/weather/weatherUi';
+
+// PROTOTYPE - throwaway variants for mobile weather expandable layouts.
+// Three variants of /weather, switchable via ?variant=, to compare mobile information hierarchy.
+export type WeatherMobilePrototypeVariant = 'A' | 'B' | 'C';
+
+type WeatherMobilePrototypeProps = {
+  variant: WeatherMobilePrototypeVariant;
+  activeWeatherName?: string;
+  selectedDayLabel: string;
+  sourceLabel: string;
+  selectedSiteId?: string;
+  isSearchMode: boolean;
+  isAuthenticated: boolean;
+  selectionPanel: ReactNode;
+  searchResultPanel?: ReactNode;
+  emptyPanel?: ReactNode;
+  currentConditions?: ReactNode;
+  liveWindPanel?: ReactNode;
+  landingPanel?: ReactNode;
+  forecastPanel?: ReactNode;
+  emagramPanel?: ReactNode;
+  hourlyPanel?: ReactNode;
+  onVariantChange: (variant: WeatherMobilePrototypeVariant) => void;
+};
+
+const variants: {
+  id: WeatherMobilePrototypeVariant;
+  label: string;
+}[] = [
+  { id: 'A', label: 'Synthèse + accordéons' },
+  { id: 'B', label: 'Timeline mobile' },
+  { id: 'C', label: "Risques d'abord" },
+];
+
+const getVariantIndex = (variant: WeatherMobilePrototypeVariant) =>
+  variants.findIndex((item) => item.id === variant);
+
+const PrototypeDetails = ({
+  title,
+  summary,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  summary?: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) => (
+  <details
+    className={`${weatherCardClassName} group overflow-hidden`}
+    open={defaultOpen}
+  >
+    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-4 transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:hover:bg-slate-800/70">
+      <span className="min-w-0">
+        <span className="block text-sm font-black text-slate-950 dark:text-white">
+          {title}
+        </span>
+        {summary && (
+          <span className="mt-0.5 block truncate text-xs text-slate-500 dark:text-slate-400">
+            {summary}
+          </span>
+        )}
+      </span>
+      <ChevronRight
+        className="h-4 w-4 shrink-0 text-slate-500 transition-transform duration-200 group-open:rotate-90"
+        aria-hidden="true"
+      />
+    </summary>
+    <div className="border-t border-slate-100 p-3 dark:border-slate-800">
+      {children}
+    </div>
+  </details>
+);
+
+const PrototypeState = ({
+  variant,
+  activeWeatherName,
+  selectedDayLabel,
+  sourceLabel,
+  selectedSiteId,
+  isSearchMode,
+  isAuthenticated,
+}: Pick<
+  WeatherMobilePrototypeProps,
+  | 'variant'
+  | 'activeWeatherName'
+  | 'selectedDayLabel'
+  | 'sourceLabel'
+  | 'selectedSiteId'
+  | 'isSearchMode'
+  | 'isAuthenticated'
+>) => (
+  <section className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-3 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-950/70 dark:text-slate-300">
+    <p className="font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+      Etat prototype
+    </p>
+    <dl className="mt-2 grid grid-cols-2 gap-2">
+      <div>
+        <dt className="font-semibold">Variant</dt>
+        <dd>{variant}</dd>
+      </div>
+      <div>
+        <dt className="font-semibold">Jour</dt>
+        <dd>{selectedDayLabel}</dd>
+      </div>
+      <div>
+        <dt className="font-semibold">Source</dt>
+        <dd>{sourceLabel}</dd>
+      </div>
+      <div>
+        <dt className="font-semibold">Mode</dt>
+        <dd>{isSearchMode ? 'Recherche' : 'Favori'}</dd>
+      </div>
+      <div className="col-span-2">
+        <dt className="font-semibold">Météo active</dt>
+        <dd>{activeWeatherName ?? selectedSiteId ?? 'Aucune'}</dd>
+      </div>
+      <div className="col-span-2">
+        <dt className="font-semibold">Emagramme</dt>
+        <dd>{isAuthenticated ? 'Disponible' : 'Masqué'}</dd>
+      </div>
+    </dl>
+  </section>
+);
+
+const PrototypeHero = ({
+  activeWeatherName,
+  selectedDayLabel,
+  sourceLabel,
+  variantLabel,
+}: {
+  activeWeatherName?: string;
+  selectedDayLabel: string;
+  sourceLabel: string;
+  variantLabel: string;
+}) => (
+  <section className="overflow-hidden rounded-3xl border border-sky-900/20 bg-gradient-to-br from-slate-950 via-sky-900 to-cyan-800 p-4 text-white shadow-xl shadow-sky-950/20">
+    <div className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-sky-100">
+      <Wind className="h-3.5 w-3.5" aria-hidden="true" />
+      Prototype mobile
+    </div>
+    <h1 className="mt-3 text-2xl font-black tracking-tight">
+      {activeWeatherName ?? 'Prévisions météo'}
+    </h1>
+    <p className="mt-2 text-sm leading-6 text-sky-100">
+      {variantLabel}: lire l&apos;essentiel sans scroll long, ouvrir seulement
+      le détail utile.
+    </p>
+    <div className="mt-4 grid grid-cols-2 gap-2">
+      <div className="rounded-2xl border border-white/15 bg-white/10 px-3 py-2">
+        <span className="text-xs font-semibold text-sky-100">Jour</span>
+        <strong className="block text-sm">{selectedDayLabel}</strong>
+      </div>
+      <div className="rounded-2xl border border-white/15 bg-white/10 px-3 py-2">
+        <span className="text-xs font-semibold text-sky-100">Source</span>
+        <strong className="block truncate text-sm">{sourceLabel}</strong>
+      </div>
+    </div>
+  </section>
+);
+
+const PrototypeSwitcher = ({
+  variant,
+  onVariantChange,
+}: Pick<WeatherMobilePrototypeProps, 'variant' | 'onVariantChange'>) => {
+  const currentIndex = getVariantIndex(variant);
+  const current = variants[currentIndex] ?? variants[0];
+  const previous =
+    variants[(currentIndex + variants.length - 1) % variants.length];
+  const next = variants[(currentIndex + 1) % variants.length];
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.closest('input, textarea, select, [contenteditable="true"]')
+      ) {
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        onVariantChange(previous.id);
+      }
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        onVariantChange(next.id);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [next.id, onVariantChange, previous.id]);
+
+  if (import.meta.env.PROD) return null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-4 z-50 flex justify-center px-4">
+      <div className="flex items-center gap-2 rounded-full border border-slate-700 bg-slate-950 p-1 text-white shadow-2xl shadow-slate-950/30">
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+          onClick={() => onVariantChange(previous.id)}
+          aria-label={`Afficher ${previous.id}`}
+        >
+          <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+        </button>
+        <div className="min-w-44 px-2 text-center text-xs font-bold">
+          {current.id} - {current.label}
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+          onClick={() => onVariantChange(next.id)}
+          aria-label={`Afficher ${next.id}`}
+        >
+          <ChevronRight className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default function WeatherMobilePrototype({
+  variant,
+  activeWeatherName,
+  selectedDayLabel,
+  sourceLabel,
+  selectedSiteId,
+  isSearchMode,
+  isAuthenticated,
+  selectionPanel,
+  searchResultPanel,
+  emptyPanel,
+  currentConditions,
+  liveWindPanel,
+  landingPanel,
+  forecastPanel,
+  emagramPanel,
+  hourlyPanel,
+  onVariantChange,
+}: WeatherMobilePrototypeProps) {
+  const currentVariant = variants[getVariantIndex(variant)] ?? variants[0];
+  const state = (
+    <PrototypeState
+      variant={variant}
+      activeWeatherName={activeWeatherName}
+      selectedDayLabel={selectedDayLabel}
+      sourceLabel={sourceLabel}
+      selectedSiteId={selectedSiteId}
+      isSearchMode={isSearchMode}
+      isAuthenticated={isAuthenticated}
+    />
+  );
+  const hero = (
+    <PrototypeHero
+      activeWeatherName={activeWeatherName}
+      selectedDayLabel={selectedDayLabel}
+      sourceLabel={sourceLabel}
+      variantLabel={currentVariant.label}
+    />
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-3 pb-24 sm:max-w-lg lg:max-w-xl">
+      {hero}
+      {state}
+      {emptyPanel}
+
+      {variant === 'A' && (
+        <>
+          {currentConditions}
+          <PrototypeDetails
+            title="Choix du site"
+            summary="Changer de site ou chercher une ville"
+          >
+            {selectionPanel}
+          </PrototypeDetails>
+          {searchResultPanel}
+          <PrototypeDetails title="Vent live" summary="Source externe Spotair">
+            {liveWindPanel}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Prévision 7 jours"
+            summary="Comparer les jours"
+          >
+            {forecastPanel}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Détail heure par heure"
+            summary="Ouvrir seulement si besoin"
+            defaultOpen
+          >
+            {hourlyPanel}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Atterros et analyse avancée"
+            summary="Données secondaires"
+          >
+            <div className="space-y-3">
+              {landingPanel}
+              {emagramPanel}
+            </div>
+          </PrototypeDetails>
+        </>
+      )}
+
+      {variant === 'B' && (
+        <>
+          <PrototypeDetails
+            title="Timeline du créneau"
+            summary="Le quand d'abord"
+            defaultOpen
+          >
+            {hourlyPanel}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Décision actuelle"
+            summary="Indice, vent et résumé"
+            defaultOpen
+          >
+            {currentConditions}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Changer le contexte"
+            summary="Site, recherche, jour"
+          >
+            <div className="space-y-3">
+              {selectionPanel}
+              {searchResultPanel}
+              {forecastPanel}
+            </div>
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Compléments"
+            summary="Vent live, atterros, emagramme"
+          >
+            <div className="space-y-3">
+              {liveWindPanel}
+              {landingPanel}
+              {emagramPanel}
+            </div>
+          </PrototypeDetails>
+        </>
+      )}
+
+      {variant === 'C' && (
+        <>
+          <section className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-950 shadow-sm dark:border-amber-800/70 dark:bg-amber-950/30 dark:text-amber-100">
+            <div className="flex gap-3">
+              <ShieldAlert
+                className="mt-0.5 h-5 w-5 shrink-0"
+                aria-hidden="true"
+              />
+              <div>
+                <h2 className="text-sm font-black">Lecture sécurité</h2>
+                <p className="mt-1 text-sm leading-6">
+                  Cette variante force d&apos;abord la vérification des risques,
+                  puis laisse ouvrir les détails confort.
+                </p>
+              </div>
+            </div>
+          </section>
+          <PrototypeDetails
+            title="Risques immédiats"
+            summary="Vent, rafales, météo actuelle"
+            defaultOpen
+          >
+            <div className="space-y-3">
+              {liveWindPanel}
+              {currentConditions}
+            </div>
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Créneaux exploitables"
+            summary="Heures à surveiller"
+            defaultOpen
+          >
+            {hourlyPanel}
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Comparer avant de partir"
+            summary="7 jours et atterros"
+          >
+            <div className="space-y-3">
+              {forecastPanel}
+              {landingPanel}
+            </div>
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Configuration"
+            summary="Changer site ou cible"
+          >
+            <div className="space-y-3">
+              {selectionPanel}
+              {searchResultPanel}
+            </div>
+          </PrototypeDetails>
+          <PrototypeDetails
+            title="Analyse avancée"
+            summary="Pour confirmer la masse d'air"
+          >
+            {emagramPanel}
+          </PrototypeDetails>
+        </>
+      )}
+
+      <PrototypeSwitcher variant={variant} onVariantChange={onVariantChange} />
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -33,6 +33,9 @@ import {
   weatherCardClassName,
   weatherSectionTitleClassName,
 } from '../components/weather/weatherUi';
+import WeatherMobilePrototype, {
+  type WeatherMobilePrototypeVariant,
+} from './WeatherPage.mobile-prototype';
 
 const isSpotSearchTarget = (
   target: CityWeatherTarget | null
@@ -57,6 +60,7 @@ const getSearchDayLabel = (day: number, t: (key: string) => string) => {
 };
 
 type WeatherSearchParams = {
+  variant?: WeatherMobilePrototypeVariant;
   siteId?: string;
   day?: number;
   target?: 'city' | 'takeoff' | 'landing';
@@ -221,6 +225,326 @@ export default function WeatherPage() {
   const activeWeatherName = selectedSearchTarget
     ? selectedSearchTitle
     : selectedSite?.name;
+  const sourceLabel = selectedSearchTarget ? 'Recherche' : 'Site favori';
+
+  const prototypeSelectionPanel = (
+    <div className="space-y-4">
+      <section className={`${weatherCardClassName} overflow-visible`}>
+        <div className="border-b border-slate-100 bg-gradient-to-br from-sky-50 via-white to-white p-4 dark:border-slate-800 dark:from-sky-950/40 dark:via-slate-900 dark:to-slate-900 sm:p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <p className={weatherSectionTitleClassName}>Choix du site</p>
+              <h2 className="mt-1 text-xl font-black tracking-tight text-slate-950 dark:text-white">
+                Sélection météo
+              </h2>
+              <p className="mt-1 text-sm leading-5 text-slate-600 dark:text-slate-300">
+                Gardez vos favoris sous la main ou cherchez une ville, un déco
+                ou un atterro proche.
+              </p>
+            </div>
+            {activeWeatherName && (
+              <div className="min-w-0 rounded-2xl border border-sky-100 bg-white/80 px-3 py-2 text-sm shadow-sm dark:border-sky-900/60 dark:bg-slate-950/50">
+                <span className="block text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
+                  Actuel
+                </span>
+                <span className="block truncate font-bold text-sky-800 dark:text-sky-200">
+                  {activeWeatherName}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="p-3 sm:p-4">
+          <Tabs
+            selectedKey={selectionTab}
+            onSelectionChange={(key) => {
+              const nextTab = key as SelectionTab;
+              setSelectionTab(nextTab);
+              if (nextTab === 'favorites') {
+                void navigate({
+                  to: '/weather',
+                  search: {
+                    siteId: selectedSiteId || undefined,
+                    day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                    variant: search.variant,
+                  },
+                });
+              }
+            }}
+          >
+            <TabList className="grid-cols-2 gap-1 rounded-2xl bg-slate-100 p-1 shadow-none dark:bg-slate-950/70">
+              <Tab id="favorites">
+                <span className="inline-flex items-center gap-2">
+                  <MapPin className="h-4 w-4" aria-hidden="true" />
+                  Favoris
+                </span>
+              </Tab>
+              <Tab id="search">
+                <span className="inline-flex items-center gap-2">
+                  <Search className="h-4 w-4" aria-hidden="true" />
+                  Recherche
+                </span>
+              </Tab>
+            </TabList>
+            <TabPanel id="favorites">
+              {sites.length > 0 ? (
+                <SiteSelector
+                  selectedSiteId={selectedSearchTarget ? '' : selectedSiteId}
+                  onSelectSite={(siteId) => {
+                    setSelectionTab('favorites');
+                    void navigate({
+                      to: '/weather',
+                      search: {
+                        siteId,
+                        day:
+                          selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                        variant: search.variant,
+                      },
+                    });
+                  }}
+                  weatherData={weatherDataMap}
+                />
+              ) : (
+                <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
+                  <p className="font-semibold text-gray-900 dark:text-white">
+                    {t('dashboard.noSites')}
+                  </p>
+                  <p className="mt-1">{t('dashboard.noSitesDescription')}</p>
+                  <Button
+                    onPress={() => void navigate({ to: '/sites' })}
+                    className="mt-3 rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
+                  >
+                    {t('dashboard.addSite')}
+                  </Button>
+                </div>
+              )}
+            </TabPanel>
+            <TabPanel id="search">
+              <CityWeatherSearch
+                dayIndex={selectedDayIndex}
+                selectedTarget={selectedSearchTarget}
+                favoriteSites={sites}
+                isEmbedded
+                onSelectTarget={(target) => {
+                  setSelectionTab('search');
+                  void navigate({
+                    to: '/weather',
+                    search: {
+                      ...getSearchForTarget(target, selectedDayIndex),
+                      variant: search.variant,
+                    },
+                  });
+                }}
+                onFavoriteCreated={(siteId) => {
+                  setSelectionTab('favorites');
+                  void navigate({
+                    to: '/weather',
+                    search: {
+                      siteId,
+                      day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+                      variant: search.variant,
+                    },
+                  });
+                }}
+              />
+            </TabPanel>
+          </Tabs>
+        </div>
+      </section>
+
+      <BestSpotSuggestion
+        bestSpot={bestSpot ?? null}
+        hourlyBestSpots={hourlyBestSpots?.hours ?? []}
+        hourlyStartHour={hourlyBestSpots?.startHour}
+        onSelectSite={(siteId) => {
+          setSelectionTab('favorites');
+          void navigate({
+            to: '/weather',
+            search: {
+              siteId,
+              day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+              variant: search.variant,
+            },
+          });
+        }}
+        selectedDayIndex={selectedDayIndex}
+      />
+    </div>
+  );
+
+  const prototypeEmptyPanel =
+    !selectedSearchTarget && !selectedSiteId ? (
+      <section className={`${weatherCardClassName} p-6 text-center`}>
+        <h2 className="text-xl font-bold text-gray-950 dark:text-white">
+          Choisissez une météo
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          Ajoutez un site favori ou recherchez une ville pour afficher le détail
+          heure par heure.
+        </p>
+      </section>
+    ) : undefined;
+
+  const prototypeSearchResultPanel = selectedSearchTarget ? (
+    <section className={`${weatherCardClassName} p-4`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-sky-700 dark:text-sky-300">
+            Résultat de recherche sélectionné
+          </p>
+          <h2 className="text-xl font-bold text-gray-950 dark:text-white">
+            {selectedSearchTitle}
+          </h2>
+        </div>
+        <div
+          aria-label={t('weather.forecast7Days')}
+          className="flex flex-wrap gap-2"
+          role="tablist"
+        >
+          {Array.from({ length: 7 }, (_, day) => (
+            <button
+              key={day}
+              aria-selected={day === selectedDayIndex}
+              type="button"
+              onClick={() =>
+                void navigate({
+                  to: '/weather',
+                  search: {
+                    ...getSearchForTarget(selectedSearchTarget, day),
+                    variant: search.variant,
+                  },
+                })
+              }
+              role="tab"
+              className={`cursor-pointer rounded-xl px-3 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
+                day === selectedDayIndex
+                  ? 'bg-sky-600 text-white'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-700'
+              }`}
+            >
+              {getSearchDayLabel(day, t)}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  ) : undefined;
+
+  const prototypeCurrentConditions =
+    selectedSearchTarget || selectedSiteId ? (
+      <CurrentConditions
+        spotId={selectedSearchTarget ? undefined : selectedSiteId}
+        dayIndex={selectedDayIndex}
+        weatherData={selectedSearchWeatherData}
+        isLoading={selectedSearchTarget ? isSearchWeatherLoading : undefined}
+        isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+        siteOrientation={
+          isSpotSearchTarget(selectedSearchTarget)
+            ? selectedSearchTarget.spot.orientation
+            : undefined
+        }
+      />
+    ) : undefined;
+
+  const prototypeLiveWindPanel =
+    !selectedSearchTarget && selectedSiteId ? (
+      <section
+        className={`${weatherCardClassName} border-l-4 border-l-cyan-500 p-4 sm:p-5`}
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {t('weather.liveWindTitle')}
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {t('weather.liveWindExternalInfo')}
+            </p>
+          </div>
+          <a
+            href="https://www.spotair.mobi/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex cursor-pointer items-center justify-center rounded-xl bg-slate-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:bg-cyan-500 dark:text-slate-950 dark:hover:bg-cyan-400"
+          >
+            {t('weather.liveWindOpenSpotair')}
+          </a>
+        </div>
+      </section>
+    ) : undefined;
+
+  const prototypeLandingPanel =
+    !selectedSearchTarget && selectedSiteId ? (
+      <WeatherMultiLanding
+        spotId={selectedSiteId}
+        dayIndex={selectedDayIndex}
+      />
+    ) : undefined;
+
+  const prototypeForecastPanel =
+    !selectedSearchTarget && selectedSiteId ? (
+      <Forecast7Day
+        spotId={selectedSiteId}
+        selectedDayIndex={selectedDayIndex}
+        onSelectDay={(day) =>
+          void navigate({
+            to: '/weather',
+            search: {
+              ...weatherSearch,
+              day: day > 0 ? day : undefined,
+              variant: search.variant,
+            },
+          })
+        }
+      />
+    ) : undefined;
+
+  const prototypeEmagramPanel =
+    isAuthenticated && !selectedSearchTarget && selectedSiteId ? (
+      <EmagramWidget siteId={selectedSiteId} dayIndex={selectedDayIndex} />
+    ) : undefined;
+
+  const prototypeHourlyPanel =
+    selectedSearchTarget || selectedSiteId ? (
+      <HourlyForecast
+        spotId={selectedSearchTarget ? undefined : selectedSiteId}
+        dayIndex={selectedDayIndex}
+        weatherData={selectedSearchWeatherData}
+        isLoading={selectedSearchTarget ? isSearchWeatherLoading : undefined}
+        isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+      />
+    ) : undefined;
+
+  if (search.variant) {
+    return (
+      <WeatherMobilePrototype
+        variant={search.variant}
+        activeWeatherName={activeWeatherName}
+        selectedDayLabel={selectedDayLabel}
+        sourceLabel={sourceLabel}
+        selectedSiteId={selectedSiteId}
+        isSearchMode={Boolean(selectedSearchTarget)}
+        isAuthenticated={isAuthenticated}
+        selectionPanel={prototypeSelectionPanel}
+        searchResultPanel={prototypeSearchResultPanel}
+        emptyPanel={prototypeEmptyPanel}
+        currentConditions={prototypeCurrentConditions}
+        liveWindPanel={prototypeLiveWindPanel}
+        landingPanel={prototypeLandingPanel}
+        forecastPanel={prototypeForecastPanel}
+        emagramPanel={prototypeEmagramPanel}
+        hourlyPanel={prototypeHourlyPanel}
+        onVariantChange={(variant) =>
+          void navigate({
+            to: '/weather',
+            search: {
+              ...search,
+              variant,
+            },
+          })
+        }
+      />
+    );
+  }
 
   return (
     <div className="grid w-full min-w-0 gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">

--- a/apps/frontend/src/routes/weather.tsx
+++ b/apps/frontend/src/routes/weather.tsx
@@ -3,6 +3,7 @@ import { queryClient } from '../lib/queryClient';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
 
 type WeatherSearch = {
+  variant?: 'A' | 'B' | 'C';
   siteId?: string;
   day?: number;
   target?: 'city' | 'takeoff' | 'landing';
@@ -51,6 +52,12 @@ export const Route = createFileRoute('/weather')({
         : undefined;
 
     return {
+      variant:
+        search.variant === 'A' ||
+        search.variant === 'B' ||
+        search.variant === 'C'
+          ? search.variant
+          : undefined,
       siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
       day:
         Number.isInteger(parsedDay) && parsedDay >= 0 && parsedDay <= 6


### PR DESCRIPTION
## Summary
- Add a throwaway mobile weather prototype on `/weather` with three expandable layout variants selected via `?variant=`.
- Add a floating in-app switcher plus durable notes capturing the prototype question and candidate layouts.
- Keep the existing weather page behavior unchanged when no prototype variant is set.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --project=unit`

## Notes
- The full `nx test frontend` target also includes a Storybook browser project in this repo and was not used for the final pass here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a mobile weather prototype page with three layout variants for testing different content presentations
  * Users can switch between variants using arrow keys or the prototype switcher interface at the bottom of the page

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->