### PR TITLE
fix(backend): allow stale video export resumes

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -557,6 +557,7 @@ def test_resume_video_export_waits_for_running_cancel_to_finish(test_db, tmp_pat
     (frames_dir / "frame00000.png").write_bytes(b"frame")
     monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "thread")
 
     db_session = test_db()
     db_session.add(
@@ -585,6 +586,60 @@ def test_resume_video_export_waits_for_running_cancel_to_finish(test_db, tmp_pat
         assert video_export_manual.resume_video_export(job_id, auth_token="resume-token") is False
     finally:
         video_export_manual._clear_job_cancel_requested(job_id)
+
+
+def test_resume_video_export_clears_stale_api_cancel_flag_for_finished_rq_job(
+    test_db, tmp_path, monkeypatch
+):
+    job_id = "job-stale-cancel-flag"
+    enqueued_job_ids: list[str] = []
+    temp_root = tmp_path / "temp-images"
+    frames_dir = temp_root / job_id / "frames"
+    frames_dir.mkdir(parents=True)
+    (frames_dir / "frame00000.png").write_bytes(b"frame")
+    monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(
+        video_export_manual, "_is_rq_video_export_job_started", lambda _job_id: False
+    )
+
+    def enqueue_rq_job(queued_job_id: str) -> None:
+        enqueued_job_ids.append(video_export_manual._rq_job_id(queued_job_id))
+
+    monkeypatch.setattr(
+        video_export_manual,
+        "_enqueue_video_export_job_in_rq",
+        enqueue_rq_job,
+    )
+
+    db_session = test_db()
+    db_session.add(
+        VideoExportJob(
+            id=job_id,
+            flight_id="flight-test-001",
+            status="cancelled",
+            mode="manual_fast",
+            quality="1080p",
+            fps=15,
+            speed=1,
+            progress=70,
+            total_frames=10,
+            message="cancelled",
+            frontend_url="http://backend:8001",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            cancelled_at=datetime.utcnow(),
+        )
+    )
+    db_session.commit()
+    db_session.close()
+
+    video_export_manual._set_job_cancel_requested(job_id)
+    assert video_export_manual.resume_video_export(job_id, auth_token="resume-token") is True
+
+    assert video_export_manual._is_job_cancel_requested(job_id) is False
+    assert enqueued_job_ids == ["video-export-job-stale-cancel-flag"]
 
 
 def test_cancel_queued_video_export_removes_rq_job(test_db, monkeypatch):

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -563,6 +563,20 @@ def _delete_rq_video_export_job(job_id: str) -> bool:
     return delete_job(_rq_job_id(job_id))
 
 
+def _is_rq_video_export_job_started(job_id: str) -> bool:
+    from job_queue import get_queue, is_rq_enabled
+
+    if not is_rq_enabled():
+        return False
+
+    job = get_queue().fetch_job(_rq_job_id(job_id))
+    if job is None:
+        return False
+
+    status = job.get_status(refresh=True)
+    return str(getattr(status, "value", status)).lower() == "started"
+
+
 def enqueue_pending_video_export_jobs() -> int:
     """Enqueue queued DB jobs into RQ after an API or worker restart."""
     from job_queue import is_rq_enabled
@@ -1720,7 +1734,9 @@ def resume_video_export(job_id: str, auth_token: str | None = None) -> bool:
         return False
 
     if _is_job_cancel_requested(job_id):
-        return False
+        if config.JOB_QUEUE_BACKEND != "rq" or _is_rq_video_export_job_started(job_id):
+            return False
+        _clear_job_cancel_requested(job_id)
 
     resume_info = _job_resume_info(job)
     if not resume_info["can_resume"]:


### PR DESCRIPTION
## Summary
- Allow video export resume to recover from a stale API-side cancel flag when the RQ job is no longer started.
- Keep the existing guard for genuinely running exports.
- Add backend tests covering the production resume case.

## Validation
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py tests/api/test_video_export_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (timed out after 15m while unrelated scraper tests were still running)