### PR TITLE
fix backend GoPro overlay job visibility

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import OperationalError
 logger = logging.getLogger(__name__)
 
 _STATUS_QUEUED = "queued"
+_STATUS_PREPARING = "preparing"
 _STATUS_RUNNING = "running"
 _STATUS_COMPLETED = "completed"
 _STATUS_FAILED = "failed"
@@ -399,8 +400,12 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         return job
 
     try:
-        current_job = _update_job(job_id, message="Preparing overlay files")
-        if current_job.get("status") != _STATUS_QUEUED:
+        current_job = _update_job(
+            job_id,
+            status=_STATUS_PREPARING,
+            message="Preparing overlay files",
+        )
+        if not current_job or current_job.get("status") != _STATUS_PREPARING:
             return None
         work_dir = Path(str(job["layout_path"])).parent
         video_path = Path(str(job["video_path"]))
@@ -443,8 +448,9 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             has_pip=pip_path is not None,
         )
 
-        return _update_job(
+        prepared_job = _update_job(
             job_id,
+            status=_STATUS_QUEUED,
             video_path=str(video_path),
             gpx_path=str(gpx_path),
             pip_path=str(pip_path) if pip_path else None,
@@ -456,6 +462,9 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             command_json=None,
             message="Overlay queued",
         )
+        if not prepared_job or prepared_job.get("status") != _STATUS_QUEUED:
+            return None
+        return prepared_job
     except Exception as exc:
         logger.exception("Failed to prepare GoPro overlay job %s", job_id)
         _finish_job(
@@ -790,7 +799,7 @@ def _run_job(job_id: str) -> None:
     if not job:
         return
     job = _prepare_queued_job(job_id, job)
-    if not job:
+    if not job or job.get("status") != _STATUS_QUEUED:
         return
 
     command = [

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -185,6 +185,14 @@ def _copy_job_input(source: Path, destination: Path, allowed_extensions: set[str
     return destination
 
 
+def _job_preparation_metadata(pin_inputs: bool, requested_layout_id: str | None) -> dict[str, Any]:
+    return {
+        "prepare_overlay_inputs": True,
+        "pin_inputs": pin_inputs,
+        "requested_layout_id": requested_layout_id,
+    }
+
+
 def _job_to_payload(job: GoproOverlayJob, include_command: bool = False) -> dict[str, Any]:
     payload = {
         "job_id": job.id,
@@ -383,6 +391,82 @@ def _transition_job_to_running(job_id: str, command: list[str]) -> dict[str, Any
             updated_at=_utc_now(),
         )
         return job.copy()
+
+
+def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = job.get("command")
+    if not isinstance(metadata, dict) or not metadata.get("prepare_overlay_inputs"):
+        return job
+
+    try:
+        current_job = _update_job(job_id, message="Preparing overlay files")
+        if current_job.get("status") != _STATUS_QUEUED:
+            return None
+        work_dir = Path(str(job["layout_path"])).parent
+        video_path = Path(str(job["video_path"]))
+        gpx_path = Path(str(job["gpx_path"]))
+        pip_path = Path(str(job["pip_path"])) if job.get("pip_path") else None
+
+        if metadata.get("pin_inputs"):
+            video_path = _copy_job_input(
+                video_path,
+                work_dir / f"input{video_path.suffix.lower()}",
+                _VIDEO_EXTENSIONS,
+            )
+            gpx_path = _copy_job_input(
+                gpx_path,
+                work_dir / f"track{gpx_path.suffix.lower()}",
+                _GPX_EXTENSIONS,
+            )
+            if pip_path:
+                pip_path = _copy_job_input(
+                    pip_path,
+                    work_dir / f"pip{pip_path.suffix.lower()}",
+                    _VIDEO_EXTENSIONS,
+                )
+
+        width, height = probe_video_resolution(video_path)
+        requested_layout_id = metadata.get("requested_layout_id")
+        selected_layout = (
+            _find_layout(str(requested_layout_id))
+            if requested_layout_id
+            else _nearest_layout(width, height)
+        )
+        if not selected_layout:
+            raise ValueError("Unknown layout")
+        source_layout_path = _layout_path(selected_layout)
+        if not source_layout_path.exists():
+            raise ValueError(f"Layout file not found: {source_layout_path}")
+        layout_path = _prepare_layout_file(
+            source_layout_path,
+            work_dir / source_layout_path.name,
+            has_pip=pip_path is not None,
+        )
+
+        return _update_job(
+            job_id,
+            video_path=str(video_path),
+            gpx_path=str(gpx_path),
+            pip_path=str(pip_path) if pip_path else None,
+            layout_id=selected_layout.id,
+            layout_label=selected_layout.label,
+            layout_path=str(layout_path),
+            video_width=width,
+            video_height=height,
+            command_json=None,
+            message="Overlay queued",
+        )
+    except Exception as exc:
+        logger.exception("Failed to prepare GoPro overlay job %s", job_id)
+        _finish_job(
+            job_id,
+            status=_STATUS_FAILED,
+            progress=100,
+            message="Overlay preparation failed",
+            error=str(exc) or exc.__class__.__name__,
+            completed_at=_utc_now(),
+        )
+        return None
 
 
 def _finish_job(job_id: str, **changes: Any) -> dict[str, Any]:
@@ -590,40 +674,21 @@ def _create_gopro_overlay_job_from_paths(
         output_name = f"{Path(output_name).stem}.mp4"
     output_path = _output_path_for_dir(output_dir, video_path, output_name)
 
-    if pin_inputs:
-        video_path = _copy_job_input(
-            video_path,
-            work_dir / f"input{video_path.suffix.lower()}",
-            _VIDEO_EXTENSIONS,
-        )
-        gpx_path = _copy_job_input(
-            gpx_path,
-            work_dir / f"track{gpx_path.suffix.lower()}",
-            _GPX_EXTENSIONS,
-        )
-        if pip_path:
-            pip_path = _copy_job_input(
-                pip_path,
-                work_dir / f"pip{pip_path.suffix.lower()}",
-                _VIDEO_EXTENSIONS,
-            )
-
-    width, height = probe_video_resolution(video_path)
-    selected_layout = _find_layout(layout_id) if layout_id else _nearest_layout(width, height)
+    selected_layout = _find_layout(layout_id) if layout_id else _LAYOUTS[0]
     if not selected_layout:
         raise ValueError("Unknown layout")
     source_layout_path = _layout_path(selected_layout)
     if not source_layout_path.exists():
         raise ValueError(f"Layout file not found: {source_layout_path}")
-    layout_path = _prepare_layout_file(
-        source_layout_path,
-        work_dir / source_layout_path.name,
-        has_pip=pip_path is not None,
-    )
+    layout_path = work_dir / source_layout_path.name
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_output_path = _temp_output_path(output_path, job_id)
     log_path = work_dir / "overlay.log"
+    preparation_metadata = _job_preparation_metadata(
+        pin_inputs=pin_inputs,
+        requested_layout_id=layout_id,
+    )
 
     now = _utc_now_dt()
     db_job: GoproOverlayJob | None = None
@@ -645,8 +710,9 @@ def _create_gopro_overlay_job_from_paths(
                 temp_output_path=str(temp_output_path),
                 output_filename=output_path.name,
                 log_path=str(log_path),
-                video_width=width,
-                video_height=height,
+                command_json=json.dumps(preparation_metadata),
+                video_width=None,
+                video_height=None,
                 created_at=now,
                 updated_at=now,
             )
@@ -675,12 +741,12 @@ def _create_gopro_overlay_job_from_paths(
             "temp_output_path": str(temp_output_path),
             "output_filename": output_path.name,
             "log_path": str(log_path),
-            "video_width": width,
-            "video_height": height,
+            "video_width": None,
+            "video_height": None,
             "created_at": _utc_now(),
             "updated_at": _utc_now(),
             "completed_at": None,
-            "command": None,
+            "command": preparation_metadata,
         }
 
     legacy_job = {
@@ -699,12 +765,12 @@ def _create_gopro_overlay_job_from_paths(
         "temp_output_path": str(temp_output_path),
         "output_filename": output_path.name,
         "log_path": str(log_path),
-        "video_width": width,
-        "video_height": height,
+        "video_width": None,
+        "video_height": None,
         "created_at": _utc_now(),
         "updated_at": _utc_now(),
         "completed_at": None,
-        "command": None,
+        "command": preparation_metadata,
     }
     with _LOCK:
         _JOBS[job_id] = legacy_job
@@ -720,7 +786,10 @@ def _create_gopro_overlay_job_from_paths(
 
 
 def _run_job(job_id: str) -> None:
-    job = get_gopro_overlay_job(job_id)
+    job = get_gopro_overlay_job(job_id, include_command=True)
+    if not job:
+        return
+    job = _prepare_queued_job(job_id, job)
     if not job:
         return
 

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -31,7 +31,7 @@ class GoproOverlayProbeResponse(GoproOverlayLayoutsResponse):
 
 class GoproOverlayJob(BaseModel):
     job_id: str
-    status: Literal["queued", "running", "completed", "failed", "cancelled"]
+    status: Literal["queued", "preparing", "running", "completed", "failed", "cancelled"]
     progress: int
     message: str
     error: str | None = None

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -965,6 +965,58 @@ def test_create_gopro_overlay_job_from_paths_defers_input_copy_to_worker_prepara
     assert prepared["video_height"] == 1080
 
 
+def test_run_job_prepares_inputs_before_starting_process(
+    tmp_path,
+    monkeypatch,
+    test_db,
+):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_BIN", "gopro-dashboard.py")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(tmp_path / "runner-root"))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    monkeypatch.setattr(gopro_overlay_export, "_verify_video_output", lambda _: (True, None))
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=None,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
+
+    class FakeProcess:
+        def __init__(self, command: list[str]):
+            self.command = command
+            self.stdout = None
+
+        def wait(self) -> int:
+            Path(self.command[-1]).write_bytes(b"video")
+            return 0
+
+    with patch(
+        "gopro_overlay_export.subprocess.Popen",
+        side_effect=lambda command, **kwargs: FakeProcess(command),
+    ) as popen:
+        gopro_overlay_export._run_job(job["job_id"])
+
+    assert popen.called
+    command = popen.call_args.args[0]
+    assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
+    assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
+    assert Path(command[-2]).parent == work_dir
+    assert Path(command[-1]) == Path(job["temp_output_path"])
+    assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
+
+
 def test_create_gopro_overlay_job_from_paths_sanitizes_output_filename_in_source_dir(
     tmp_path,
     monkeypatch,

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -916,7 +916,7 @@ def test_create_gopro_overlay_job_from_paths_rejects_unsupported_input_before_wo
     assert not work_root.exists()
 
 
-def test_create_gopro_overlay_job_from_paths_copies_inputs_into_job_dir(
+def test_create_gopro_overlay_job_from_paths_defers_input_copy_to_worker_preparation(
     tmp_path,
     monkeypatch,
     test_db,
@@ -929,7 +929,11 @@ def test_create_gopro_overlay_job_from_paths_copies_inputs_into_job_dir(
     video_path.write_bytes(b"video")
     gpx_path.write_text("<gpx />")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
-    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_resolution",
+        lambda _: pytest.fail("video probing should be deferred to worker preparation"),
+    )
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
 
     job = create_gopro_overlay_job_from_paths(
@@ -941,11 +945,24 @@ def test_create_gopro_overlay_job_from_paths_copies_inputs_into_job_dir(
     )
 
     work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
-    assert Path(job["video_path"]).parent == work_dir
-    assert Path(job["gpx_path"]).parent == work_dir
-    assert Path(job["video_path"]).read_bytes() == b"video"
-    assert Path(job["gpx_path"]).read_text() == "<gpx />"
+    assert Path(job["video_path"]) == video_path
+    assert Path(job["gpx_path"]) == gpx_path
     assert Path(job["output_path"]) == tmp_path / "overlay.mp4"
+
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
+    assert queued_job is not None
+
+    prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
+
+    assert prepared is not None
+    assert prepared["status"] == "queued"
+    assert Path(prepared["video_path"]).parent == work_dir
+    assert Path(prepared["gpx_path"]).parent == work_dir
+    assert Path(prepared["video_path"]).read_bytes() == b"video"
+    assert Path(prepared["gpx_path"]).read_text() == "<gpx />"
+    assert prepared["video_width"] == 1920
+    assert prepared["video_height"] == 1080
 
 
 def test_create_gopro_overlay_job_from_paths_sanitizes_output_filename_in_source_dir(

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -4,7 +4,13 @@ import { api } from '../../lib/api';
 
 export type GoproOverlayJob = {
   job_id: string;
-  status: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+  status:
+    | 'queued'
+    | 'preparing'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'cancelled';
   progress: number;
   message: string;
   error?: string | null;

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -100,7 +100,14 @@ export const FlightSchema = z.object({
   gopro_camera_file_exists: z.boolean().nullish(),
   gopro_overlay_job_id: z.string().nullish(),
   gopro_overlay_status: z
-    .enum(['queued', 'running', 'completed', 'failed', 'cancelled'])
+    .enum([
+      'queued',
+      'preparing',
+      'running',
+      'completed',
+      'failed',
+      'cancelled',
+    ])
     .nullish(),
   gopro_overlay_file_path: z.string().nullish(),
   gopro_overlay_file_exists: z.boolean().nullish(),


### PR DESCRIPTION
## Summary
- Create GoPro overlay jobs immediately in `queued` state so the UI can show them without waiting on file preparation.
- Move overlay input copying and layout preparation into the worker path.
- Add backend coverage for deferred preparation.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (timed out after 6 minutes while running the broader suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Job creation is now faster; input file preparation is performed during job execution rather than at creation time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->