### PR TITLE
feat(media): show export progress in flight badges

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -289,6 +289,31 @@ def _flight_gopro_overlay_status(flight: Flight) -> str | None:
     return str(job["status"]) if job else flight.gopro_overlay_status
 
 
+def _job_progress(job: dict[str, Any] | None) -> int | None:
+    if not job:
+        return None
+
+    progress = job.get("progress")
+    if not isinstance(progress, int | float) or not math.isfinite(progress):
+        return None
+    return max(0, min(100, round(progress)))
+
+
+def _flight_video_export_progress(flight: Flight) -> int | None:
+    if (
+        not flight.video_export_job_id
+        or flight.video_export_status not in _VIDEO_EXPORT_IN_PROGRESS_STATUSES
+    ):
+        return None
+    return _job_progress(_resolve_export_status(flight.video_export_job_id))
+
+
+def _flight_gopro_overlay_progress(flight: Flight) -> int | None:
+    if not flight.gopro_overlay_job_id or flight.gopro_overlay_status not in {"queued", "running"}:
+        return None
+    return _job_progress(get_gopro_overlay_job(flight.gopro_overlay_job_id))
+
+
 def _flight_gopro_overlay_file_exists(db: Session, flight: Flight) -> bool:
     overlay_path = _flight_gopro_overlay_file_path(db, flight)
     return bool(overlay_path)
@@ -3102,11 +3127,13 @@ def get_flights(
             "gpx_file_path": flight.gpx_file_path,
             "video_export_job_id": flight.video_export_job_id,
             "video_export_status": flight.video_export_status,
+            "video_export_progress": _flight_video_export_progress(flight),
             "video_file_path": flight.video_file_path,
             "video_file_exists": _flight_video_file_exists(flight),
             "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
             "gopro_overlay_job_id": flight.gopro_overlay_job_id,
             "gopro_overlay_status": _flight_gopro_overlay_status(flight),
+            "gopro_overlay_progress": _flight_gopro_overlay_progress(flight),
             "gopro_overlay_file_path": gopro_overlay_file_path,
             "gopro_overlay_file_exists": bool(gopro_overlay_file_path),
             "external_url": flight.external_url,
@@ -3299,11 +3326,13 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
         "external_url": flight.external_url,
         "video_export_job_id": flight.video_export_job_id,
         "video_export_status": flight.video_export_status,
+        "video_export_progress": _flight_video_export_progress(flight),
         "video_file_path": flight.video_file_path,
         "video_file_exists": _flight_video_file_exists(flight),
         "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
         "gopro_overlay_job_id": flight.gopro_overlay_job_id,
         "gopro_overlay_status": _flight_gopro_overlay_status(flight),
+        "gopro_overlay_progress": _flight_gopro_overlay_progress(flight),
         "gopro_overlay_file_path": gopro_overlay_file_path,
         "gopro_overlay_file_exists": bool(gopro_overlay_file_path),
         "created_at": flight.created_at.isoformat() if flight.created_at else None,

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -258,11 +258,13 @@ class Flight(FlightBase):
     external_url: str | None = None
     video_export_job_id: str | None = None
     video_export_status: str | None = None  # "processing", "completed", "failed"
+    video_export_progress: int | None = None
     video_file_path: str | None = None
     video_file_exists: bool = False
     gopro_camera_file_exists: bool = False
     gopro_overlay_job_id: str | None = None
     gopro_overlay_status: str | None = None
+    gopro_overlay_progress: int | None = None
     gopro_overlay_file_path: str | None = None
     gopro_overlay_file_exists: bool = False
     created_at: datetime

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -7,6 +7,7 @@ Coverage: GET, POST, PATCH, DELETE for flights.
 
 from datetime import date, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 import config
 from models import Flight
@@ -77,6 +78,43 @@ class TestFlightsListEndpoint:
         assert returned["gopro_overlay_status"] is None
         assert returned["gopro_overlay_file_path"] is None
         assert returned["gopro_overlay_file_exists"] is False
+
+    def test_get_flights_includes_media_export_progress(self, client, db_session, arguel_site):
+        """GET /flights includes active video and GoPro overlay progress."""
+        flight = Flight(
+            id="flight-with-progress",
+            name="Flight with progress",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            video_export_job_id="job-video-progress",
+            video_export_status="running",
+            gopro_overlay_job_id="job-overlay-progress",
+            gopro_overlay_status="running",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with (
+            patch(
+                "routes.get_export_status_manual",
+                return_value={"status": "running", "progress": 42.4},
+            ),
+            patch("routes.get_export_status_stream", return_value=None),
+            patch(
+                "routes.get_gopro_overlay_job",
+                return_value={"status": "running", "progress": 55.1},
+            ),
+        ):
+            response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = next(
+            flight
+            for flight in response.json()["flights"]
+            if flight["id"] == "flight-with-progress"
+        )
+        assert returned["video_export_progress"] == 42
+        assert returned["gopro_overlay_progress"] == 55
 
     def test_get_flights_includes_available_gopro_overlay_path(
         self, client, db_session, monkeypatch, tmp_path

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -32,6 +32,7 @@ import { useToast } from '../../hooks/useToast';
 import { api, getApiErrorMessage } from '../../lib/api';
 import type { Flight, FlightFormData, Site } from '../../types';
 import { FlightEditForm } from './FlightEditForm';
+import { formatMediaProgressLabel } from './mediaProgress';
 import {
   formatAltitudeMeters,
   formatDistanceKm,
@@ -121,6 +122,14 @@ export function FlightDetails({
     goproOverlayStatus === 'completed' && hasPersistedGoproOverlay;
   const isGoproOverlayFailed = goproOverlayStatus === 'failed';
   const isDownloadingAnyMedia = downloadingMedia !== null;
+  const videoProcessingLabel = formatMediaProgressLabel(
+    t('flights.videoProcessingBadge'),
+    flight.video_export_progress
+  );
+  const goproOverlayProcessingLabel = formatMediaProgressLabel(
+    t('flights.goproOverlayProcessingBadge'),
+    goproOverlayJob?.progress ?? flight.gopro_overlay_progress
+  );
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
     normalizedTitle ||
@@ -404,7 +413,7 @@ export function FlightDetails({
                   )}
                   {isVideoExportRunning && (
                     <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                      {t('flights.videoProcessingBadge')}
+                      {videoProcessingLabel}
                     </span>
                   )}
                   {isVideoExportFailed && (
@@ -444,7 +453,7 @@ export function FlightDetails({
                     )}
                   {isGoproOverlayRunning && (
                     <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                      {t('flights.goproOverlayProcessingBadge')}
+                      {goproOverlayProcessingLabel}
                     </span>
                   )}
                   {isGoproOverlayFailed && (

--- a/apps/frontend/src/components/flights/FlightsTable.test.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.test.tsx
@@ -134,13 +134,14 @@ test('shows GoPro overlay status badges like video badges', () => {
           id: 'flight-overlay-running',
           gopro_overlay_file_path: '/exports/final.mp4',
           gopro_overlay_status: 'running',
+          gopro_overlay_progress: 55,
         },
       ]}
     />
   );
 
   expect(
-    screen.getByText('flights.goproOverlayProcessingBadge')
+    screen.getByText('flights.goproOverlayProcessingBadge 55%')
   ).toBeInTheDocument();
   expect(
     screen.queryByRole('button', { name: 'flights.goproOverlayDownload' })
@@ -165,4 +166,23 @@ test('shows GoPro overlay status badges like video badges', () => {
   expect(
     screen.queryByRole('button', { name: 'flights.goproOverlayDownload' })
   ).not.toBeInTheDocument();
+});
+
+test('shows video progress in processing badge', () => {
+  render(
+    <FlightsTableHarness
+      tableFlights={[
+        {
+          ...flights[1],
+          id: 'flight-video-running',
+          video_export_status: 'running',
+          video_export_progress: 42,
+        },
+      ]}
+    />
+  );
+
+  expect(
+    screen.getByText('flights.videoProcessingBadge 42%')
+  ).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -17,6 +17,7 @@ import {
   Wand2,
 } from 'lucide-react';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
+import { formatMediaProgressLabel } from './mediaProgress';
 import type { Flight } from '../../types';
 import {
   formatAltitudeMeters,
@@ -111,6 +112,14 @@ export function FlightsTable({
         VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)
       );
       const isVideoExportFailed = flight.video_export_status === 'failed';
+      const videoProcessingLabel = formatMediaProgressLabel(
+        t('flights.videoProcessingBadge'),
+        flight.video_export_progress
+      );
+      const goproOverlayProcessingLabel = formatMediaProgressLabel(
+        t('flights.goproOverlayProcessingBadge'),
+        flight.gopro_overlay_progress
+      );
       const selectFlight = () => {
         if (!selectionMode) {
           onSelectFlight(flight);
@@ -233,7 +242,7 @@ export function FlightsTable({
                     )}
                     {isVideoExportRunning && (
                       <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                        {t('flights.videoProcessingBadge')}
+                        {videoProcessingLabel}
                       </span>
                     )}
                     {isVideoExportFailed && (
@@ -259,7 +268,7 @@ export function FlightsTable({
                     )}
                     {isGoproOverlayRunning && (
                       <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                        {t('flights.goproOverlayProcessingBadge')}
+                        {goproOverlayProcessingLabel}
                       </span>
                     )}
                     {isGoproOverlayFailed && (

--- a/apps/frontend/src/components/flights/mediaProgress.ts
+++ b/apps/frontend/src/components/flights/mediaProgress.ts
@@ -1,0 +1,11 @@
+export function formatMediaProgressLabel(
+  label: string,
+  progress?: number | null
+): string {
+  if (typeof progress !== 'number' || !Number.isFinite(progress)) {
+    return label;
+  }
+
+  const roundedProgress = Math.min(100, Math.max(0, Math.round(progress)));
+  return `${label} ${roundedProgress}%`;
+}

--- a/apps/frontend/src/hooks/flights/useFlight.ts
+++ b/apps/frontend/src/hooks/flights/useFlight.ts
@@ -9,6 +9,9 @@ import {
 const isExportInProgress = (status?: string | null) =>
   status ? VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status) : false;
 
+const isOverlayInProgress = (status?: string | null) =>
+  status === 'queued' || status === 'running';
+
 type ExportViewerAccess = {
   exportJobId?: string | null;
   exportToken?: string | null;
@@ -41,11 +44,13 @@ export const useFlight = (
       return await api.get(`flights/${flightId}`).json();
     },
     enabled: !!flightId,
-    staleTime: getStaleTime(1000 * 10), // 10 seconds - refresh frequently to check video status
+    staleTime: getStaleTime(1000 * 10), // 10 seconds - refresh frequently to check media status
     refetchInterval: (query) => {
-      // Auto-refresh every 10 seconds if video is processing
       const data = query.state.data as Flight | undefined;
-      return isExportInProgress(data?.video_export_status) ? 10000 : false;
+      return isExportInProgress(data?.video_export_status) ||
+        isOverlayInProgress(data?.gopro_overlay_status)
+        ? 10000
+        : false;
     },
   });
 };

--- a/apps/frontend/src/hooks/flights/useFlights.ts
+++ b/apps/frontend/src/hooks/flights/useFlights.ts
@@ -20,9 +20,18 @@ import {
   FlightsApiResponseSchema,
   FlightSchema,
   FlightStatsSchema,
+  VIDEO_EXPORT_IN_PROGRESS_STATUSES,
 } from '@dashboard-parapente/shared-types';
 import { isHTTPError } from 'ky';
 import { getStaleTime } from '../../lib/cacheConfig';
+
+const isMediaExportInProgress = (flight: Flight) =>
+  Boolean(
+    (flight.video_export_status &&
+      VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)) ||
+    flight.gopro_overlay_status === 'queued' ||
+    flight.gopro_overlay_status === 'running'
+  );
 
 export const flightsQueryOptions = (filters: FlightFilters = {}) => {
   const searchParams = Object.entries(filters).reduce(
@@ -46,6 +55,10 @@ export const flightsQueryOptions = (filters: FlightFilters = {}) => {
       return validation.data.flights;
     },
     staleTime: getStaleTime(1000 * 60 * 10),
+    refetchInterval: (query) => {
+      const data = query.state.data as Flight[] | undefined;
+      return data?.some(isMediaExportInProgress) ? 10000 : false;
+    },
   });
 };
 

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -95,6 +95,7 @@ export const FlightSchema = z.object({
       'cancelled',
     ])
     .nullish(),
+  video_export_progress: z.number().nullish(),
   video_file_path: z.string().nullish(),
   video_file_exists: z.boolean().nullish(),
   gopro_camera_file_exists: z.boolean().nullish(),
@@ -102,6 +103,7 @@ export const FlightSchema = z.object({
   gopro_overlay_status: z
     .enum(['queued', 'running', 'completed', 'failed', 'cancelled'])
     .nullish(),
+  gopro_overlay_progress: z.number().nullish(),
   gopro_overlay_file_path: z.string().nullish(),
   gopro_overlay_file_exists: z.boolean().nullish(),
   site: SiteSchema.optional(),


### PR DESCRIPTION
## Summary
- Add video and GoPro overlay progress fields to flight payloads.
- Show live percentages in processing badges and refresh while media exports run.
- Cover the new behavior with backend and frontend tests.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run FlightsTable.test.tsx`
- `../../.venv/bin/pytest tests/api/test_routes_flights.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video export progress now displays a completion percentage (0–100%) during export instead of a generic "in progress" status.
  * GoPro overlay processing progress now displays a completion percentage (0–100%) during processing.
  * Flight data automatically refreshes in real-time while media processing is active, ensuring progress updates are current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->