### PR TITLE
feat(frontend): show active site name in weather cards

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -32,6 +32,22 @@ import {
 interface EmagramWidgetProps {
   siteId: string;
   dayIndex?: number;
+  siteName?: string;
+}
+
+function EmagramHeaderTitle({ siteName }: { siteName?: string }) {
+  return (
+    <div className="min-w-0">
+      <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
+        🌡️ Analyse Thermique (Émagramme)
+      </h2>
+      {siteName && (
+        <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
+          {siteName}
+        </p>
+      )}
+    </div>
+  );
 }
 
 const getStabilityEmoji = (stabilite: string | null): string => {
@@ -176,6 +192,7 @@ function HourSlider({
 export default function EmagramWidget({
   siteId,
   dayIndex = 0,
+  siteName,
 }: EmagramWidgetProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
@@ -295,9 +312,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-            🌡️ Analyse Thermique (Émagramme)
-          </h2>
+          <EmagramHeaderTitle siteName={siteName} />
         </div>
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
           Cliquez pour afficher l&apos;émagramme de ce jour.
@@ -318,9 +333,9 @@ export default function EmagramWidget({
   if (isLoading) {
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3.5 font-semibold">
-          🌡️ Analyse Thermique (Émagramme)
-        </h2>
+        <div className="mb-3.5">
+          <EmagramHeaderTitle siteName={siteName} />
+        </div>
         {hourSlider}
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
           Chargement...
@@ -333,9 +348,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-red-500">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-            🌡️ Analyse Thermique (Émagramme)
-          </h2>
+          <EmagramHeaderTitle siteName={siteName} />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing || !siteId}
@@ -363,9 +376,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-            🌡️ Analyse Thermique (Émagramme)
-          </h2>
+          <EmagramHeaderTitle siteName={siteName} />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing || !siteId}
@@ -400,9 +411,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-orange-500">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-            🌡️ Analyse Thermique (Émagramme)
-          </h2>
+          <EmagramHeaderTitle siteName={siteName} />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing}
@@ -472,9 +481,7 @@ export default function EmagramWidget({
     <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600 flex-1 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
-          🌡️ Analyse Thermique (Émagramme)
-        </h2>
+        <EmagramHeaderTitle siteName={siteName} />
         <div className="flex items-center gap-2">
           <EmagramExplanationTooltip emagram={emagram} compact />
           <Button

--- a/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
@@ -133,7 +133,9 @@ describe('HourlyForecast tooltip behavior', () => {
   });
 
   it('shows para-index tooltip content on hover', () => {
-    render(<HourlyForecast spotId="site-1" dayIndex={0} />);
+    render(<HourlyForecast spotId="site-1" dayIndex={0} siteName="Arguel" />);
+
+    expect(screen.getByText('Site : Arguel')).toBeTruthy();
 
     fireEvent.mouseOver(
       screen.getByRole('button', { name: 'Para-Index 10:00' })

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -30,6 +30,7 @@ interface HourlyForecastProps {
   weatherData?: WeatherData;
   isLoading?: boolean;
   isError?: boolean;
+  siteName?: string;
 }
 
 // ============================================================================
@@ -564,6 +565,7 @@ export default function HourlyForecast({
   weatherData,
   isLoading: isOverrideLoading,
   isError: isOverrideError,
+  siteName,
 }: HourlyForecastProps) {
   const { t } = useTranslation();
   const {
@@ -624,9 +626,16 @@ export default function HourlyForecast({
   if (isLoading) {
     return (
       <div className={`${weatherCardClassName} p-4`} aria-live="polite">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
-          Prévisions Horaires
-        </h2>
+        <div className="mb-3">
+          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
+            Prévisions Horaires
+          </h2>
+          {siteName && (
+            <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
+              Site : {siteName}
+            </p>
+          )}
+        </div>
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
           Chargement...
         </div>
@@ -637,9 +646,16 @@ export default function HourlyForecast({
   if (hasError || !weather || !weather.hourly_forecast) {
     return (
       <div className={`${weatherCardClassName} p-4`} role="alert">
-        <h2 className="text-sm text-gray-600 dark:text-gray-300 mb-3 font-semibold">
-          Prévisions Horaires
-        </h2>
+        <div className="mb-3">
+          <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
+            Prévisions Horaires
+          </h2>
+          {siteName && (
+            <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
+              Site : {siteName}
+            </p>
+          )}
+        </div>
         <div className="py-5 text-center text-red-500 dark:text-red-400 text-sm">
           Données non disponibles
         </div>
@@ -782,6 +798,11 @@ export default function HourlyForecast({
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
           <h2 className={weatherSectionTitleClassName}>Prévisions Horaires</h2>
+          {siteName && (
+            <p className="mt-1 truncate text-sm font-bold text-slate-950 dark:text-white">
+              Site : {siteName}
+            </p>
+          )}
           <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
             Créneaux de vol, consensus des sources et points de vigilance.
           </p>

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -59,7 +59,6 @@ const getSearchDayLabel = (day: number, t: (key: string) => string) => {
 };
 
 type WeatherSearchParams = {
-  variant?: WeatherMobilePrototypeVariant;
   siteId?: string;
   day?: number;
   target?: 'city' | 'takeoff' | 'landing';
@@ -493,7 +492,11 @@ export default function WeatherPage() {
 
   const mobileEmagramPanel =
     isAuthenticated && !selectedSearchTarget && selectedSiteId ? (
-      <EmagramWidget siteId={selectedSiteId} dayIndex={selectedDayIndex} />
+      <EmagramWidget
+        siteId={selectedSiteId}
+        dayIndex={selectedDayIndex}
+        siteName={selectedSite?.name}
+      />
     ) : undefined;
 
   const mobileHourlyPanel =
@@ -504,6 +507,7 @@ export default function WeatherPage() {
         weatherData={selectedSearchWeatherData}
         isLoading={selectedSearchTarget ? isSearchWeatherLoading : undefined}
         isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+        siteName={activeWeatherName}
       />
     ) : undefined;
 
@@ -834,7 +838,11 @@ export default function WeatherPage() {
 
         {/* Emagram Analysis (authenticated only) */}
         {isAuthenticated && !selectedSearchTarget && selectedSiteId && (
-          <EmagramWidget siteId={selectedSiteId} dayIndex={selectedDayIndex} />
+          <EmagramWidget
+            siteId={selectedSiteId}
+            dayIndex={selectedDayIndex}
+            siteName={selectedSite?.name}
+          />
         )}
 
         {/* Hourly Forecast */}
@@ -847,6 +855,7 @@ export default function WeatherPage() {
               selectedSearchTarget ? isSearchWeatherLoading : undefined
             }
             isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+            siteName={activeWeatherName}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Show the active site name in the thermal analysis and hourly forecast cards.
- Propagate the selected site label from the weather page into both desktop and mobile layouts.
- Add a small regression test for the hourly forecast header.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- HourlyForecast.behavior.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Weather analysis (thermique) and hourly forecast widgets now display the selected site name alongside forecast data, providing clearer context about which location's weather information is currently being shown across all interface states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->