### PR TITLE
fix(backend): always merge uploaded GPX with OSV

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5054,7 +5054,23 @@ async def create_flight_gopro_overlay_job(
             resolved_gpx_path or auto_gpx_path or _resolve_flight_file_path(flight.gpx_file_path)
         )
         fallback_pip_path = resolved_pip_path or auto_pip_path or generated_video_path
-        if fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
+        gpx_file_for_job = gpx_file
+        if gpx_file and gpx_file.filename and auto_osv_paths:
+            uploaded_gpx_path = await save_uploaded_file(
+                gpx_file,
+                input_dir
+                / ".gopro-overlay-work"
+                / f"uploaded-{uuid.uuid4()}{Path(gpx_file.filename).suffix.lower()}",
+                {".gpx", ".fit"},
+            )
+            fallback_gpx_path = await asyncio.to_thread(
+                _merge_osv_files_with_gpx,
+                auto_osv_paths,
+                uploaded_gpx_path,
+                input_dir,
+            )
+            gpx_file_for_job = None
+        elif fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
             fallback_gpx_path = await asyncio.to_thread(
                 _merge_osv_files_with_gpx,
                 auto_osv_paths,
@@ -5100,7 +5116,7 @@ async def create_flight_gopro_overlay_job(
 
         job = await create_gopro_overlay_job(
             video_file=video_file,
-            gpx_file=gpx_file,
+            gpx_file=gpx_file_for_job,
             fallback_gpx_path=fallback_gpx_path,
             fallback_pip_path=fallback_pip_path,
             pip_file=osv_video_file,

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -444,6 +444,67 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     assert create_job.call_args.kwargs["gpx_path"] == merged_gpx_path
 
 
+def test_create_flight_gopro_overlay_job_uses_merged_uploaded_gpx_when_osv_exists(
+    client: TestClient,
+    db_session,
+    sample_flight,
+    tmp_path,
+    monkeypatch,
+):
+    paragliding_root = tmp_path / "gopro-root"
+    input_dir = paragliding_root / "20260315" / "01"
+    input_dir.mkdir(parents=True)
+    pip_path = input_dir / "flight-pip.mp4"
+    osv_path = input_dir / "flight.osv"
+    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    pip_path.write_bytes(b"pip")
+    osv_path.write_bytes(b"osv")
+    sample_flight.gpx_file_path = None
+    sample_flight.video_file_path = str(pip_path)
+    db_session.commit()
+    merged_gpx_path.parent.mkdir(parents=True)
+    merged_gpx_path.write_text("<gpx>merged</gpx>")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
+
+    expected = {
+        "job_id": "job-flight-gopro-uploaded-osv",
+        "status": "queued",
+        "progress": 0,
+        "message": "queued",
+        "layout_id": "parapente-1080",
+        "layout_label": "Parapente 1920x1080",
+        "output_filename": "final.mp4",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    with (
+        patch(
+            "routes.check_gopro_overlay_dependencies",
+            return_value={"gopro_dashboard": True, "ffmpeg": True, "ffprobe": True},
+        ),
+        patch("routes._merge_osv_files_with_gpx", return_value=merged_gpx_path) as merge_osv,
+        patch("routes.create_gopro_overlay_job", AsyncMock(return_value=expected)) as create_job,
+    ):
+        response = client.post(
+            f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay",
+            files={
+                "video_file": ("camera.mp4", b"camera", "video/mp4"),
+                "gpx_file": ("uploaded.gpx", b"<gpx>uploaded</gpx>", "application/gpx+xml"),
+            },
+        )
+
+    assert response.status_code == 200
+    uploaded_gpx_path = merge_osv.call_args.args[1]
+    assert merge_osv.call_args.args[0] == [osv_path]
+    assert uploaded_gpx_path.parent == input_dir / ".gopro-overlay-work"
+    assert uploaded_gpx_path.name.startswith("uploaded-")
+    assert uploaded_gpx_path.read_text() == "<gpx>uploaded</gpx>"
+    assert merge_osv.call_args.args[2] == input_dir
+    assert create_job.call_args.kwargs["gpx_file"] is None
+    assert create_job.call_args.kwargs["fallback_gpx_path"] == merged_gpx_path
+
+
 def test_create_flight_gopro_overlay_job_rejects_paths_outside_paragliding_root(
     client: TestClient,
     db_session,


### PR DESCRIPTION
## Summary
- Ensure the GoPro overlay flow feeds the GPX produced by `osv_merge` when OSV samples are present.
- Preserve the uploaded GPX by saving it to the work dir before merging, then pass the merged GPX to the render job.
- Add a regression test covering uploaded GPX + OSV files.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header`

## Notes
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` ran but exceeded the execution timeout while still in the long scraper portion.