### PR TITLE
fix(frontend): make flight media actions state-aware

### DIFF
--- a/apps/frontend/src/components/flights/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Flight, Site } from '../../types';
+
+const {
+  apiDelete,
+  confirmMock,
+  createOverlayMock,
+  mockFlight,
+  overlayJobStreamMock,
+  resetOverlayMock,
+} = vi.hoisted(() => ({
+  apiDelete: vi.fn(),
+  confirmMock: vi.fn(),
+  createOverlayMock: vi.fn(),
+  resetOverlayMock: vi.fn(),
+  overlayJobStreamMock: { current: null as unknown },
+  mockFlight: {
+    id: 'flight-1',
+    flight_date: '2026-03-15',
+    title: 'Test flight',
+    gpx_file_path: 'sample.gpx',
+    video_file_path: '/exports/flight.mp4',
+    video_file_exists: true,
+    gopro_camera_file_exists: true,
+    gopro_overlay_job_id: null,
+    gopro_overlay_status: null,
+    gopro_overlay_file_path: null,
+    gopro_overlay_file_exists: undefined,
+    duration_minutes: 12,
+    max_altitude_m: 1000,
+    max_speed_kmh: 42,
+    distance_km: 3.5,
+    elevation_gain_m: 250,
+    notes: null,
+  } as Flight,
+}));
+
+vi.mock('@dashboard-parapente/design-system', () => ({
+  Button: ({
+    children,
+    isDisabled,
+    onPress,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isDisabled?: boolean;
+    onPress?: () => void;
+  }) => (
+    <button type="button" disabled={isDisabled} onClick={onPress} {...props}>
+      {children}
+    </button>
+  ),
+  Tab: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabPanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-aria-components', () => ({
+  TextArea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea {...props} />
+  ),
+  TextField: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en' },
+    t: (key: string) =>
+      ({
+        'flights.goproOverlayCancel': 'Cancel overlay',
+        'flights.goproOverlayCancelShort': 'Cancel overlay',
+        'flights.goproOverlayConfirmCancel': 'Confirm cancel overlay',
+        'flights.goproOverlayRegenerate': 'Regenerate overlay',
+        'flights.goproOverlayRegenerateShort': 'Regenerate overlay',
+        'flights.goproOverlayGenerate': 'Generate overlay',
+        'flights.goproOverlayGenerateShort': 'Generate overlay',
+        'flights.goproOverlayStarted': 'Overlay started',
+        'flights.goproOverlayCancelled': 'Overlay cancelled',
+        'flights.goproOverlayStartError': 'Overlay start error',
+        'flights.goproOverlayCancelError': 'Overlay cancel error',
+        'flights.goproOverlayNeedsVideo': 'Needs video',
+        'flights.goproOverlayNeedsCameraVideo': 'Needs camera video',
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../../hooks/flights/useFlights', () => ({
+  useUpdateFlight: () => ({ mutateAsync: vi.fn() }),
+  useUploadGPXToFlight: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock('../../hooks/gopro/useGoproOverlay', () => ({
+  useCreateFlightGoproOverlayJob: () => ({
+    data: null,
+    isPending: false,
+    mutateAsync: createOverlayMock,
+    reset: resetOverlayMock,
+  }),
+  useGoproOverlayJobStream: () => ({ job: overlayJobStreamMock.current }),
+}));
+
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ error: vi.fn(), success: vi.fn() }),
+}));
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    delete: apiDelete,
+  },
+  getApiErrorMessage: async (_error: unknown, fallback: string) => fallback,
+}));
+
+vi.mock('../../stores/appSettingsStore', () => ({
+  formatAltitudeMeters: (value: number) => `${value} m`,
+  formatDistanceKm: (value: number) => `${value} km`,
+  formatSpeedKmh: (value: number) => `${value} km/h`,
+  useAppSettingsStore: () => ({
+    altitude: 'metric',
+    distance: 'metric',
+    speed: 'metric',
+  }),
+}));
+
+vi.mock('./FlightVideoExportControls', () => ({
+  FlightVideoExportControls: () => <button type="button">Video action</button>,
+}));
+
+import { FlightDetails } from './FlightDetails';
+
+const sites: Site[] = [];
+
+describe('FlightDetails GoPro overlay action', () => {
+  beforeEach(() => {
+    apiDelete.mockReset();
+    createOverlayMock.mockReset();
+    createOverlayMock.mockResolvedValue({ job_id: 'job-new', job_token: null });
+    confirmMock.mockReset();
+    confirmMock.mockReturnValue(true);
+    vi.stubGlobal('confirm', confirmMock);
+    overlayJobStreamMock.current = null;
+    mockFlight.gopro_overlay_job_id = null;
+    mockFlight.gopro_overlay_status = null;
+    mockFlight.gopro_overlay_file_path = null;
+    mockFlight.gopro_overlay_file_exists = undefined;
+  });
+
+  it('turns the overlay button into cancel while generation is running', async () => {
+    mockFlight.gopro_overlay_job_id = 'job-overlay';
+    mockFlight.gopro_overlay_status = 'running';
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel overlay/u }));
+
+    await waitFor(() => {
+      expect(apiDelete).toHaveBeenCalledWith(
+        'gopro-overlays/jobs/job-overlay/cancel',
+        { searchParams: undefined }
+      );
+    });
+  });
+
+  it('regenerates overlay after cancellation', async () => {
+    mockFlight.gopro_overlay_job_id = 'job-overlay';
+    mockFlight.gopro_overlay_status = 'cancelled';
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Regenerate overlay/u })
+    );
+
+    await waitFor(() => {
+      expect(createOverlayMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/src/components/flights/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/FlightDetails.tsx
@@ -91,6 +91,8 @@ export function FlightDetails({
   const [goproOverlayJobToken, setGoproOverlayJobToken] = useState<
     string | null
   >(null);
+  const [isCancellingGoproOverlay, setIsCancellingGoproOverlay] =
+    useState(false);
   const [downloadingMedia, setDownloadingMedia] =
     useState<DownloadableFlightMedia | null>(null);
 
@@ -121,6 +123,9 @@ export function FlightDetails({
   const isGoproOverlayCompleted =
     goproOverlayStatus === 'completed' && hasPersistedGoproOverlay;
   const isGoproOverlayFailed = goproOverlayStatus === 'failed';
+  const isGoproOverlayCancelled = goproOverlayStatus === 'cancelled';
+  const canRegenerateGoproOverlay =
+    hasPersistedGoproOverlay || isGoproOverlayCancelled;
   const isDownloadingAnyMedia = downloadingMedia !== null;
   const videoProcessingLabel = formatMediaProgressLabel(
     t('flights.videoProcessingBadge'),
@@ -149,6 +154,7 @@ export function FlightDetails({
     setEditingNotes(false);
     setGoproOverlayJobId(null);
     setGoproOverlayJobToken(null);
+    setIsCancellingGoproOverlay(false);
     setDownloadingMedia(null);
     resetGoproOverlayJob();
   }, [flight.id, resetGoproOverlayJob]);
@@ -188,6 +194,35 @@ export function FlightDetails({
       setEditingNotes(false);
     } catch (err) {
       console.error('Failed to update notes:', err);
+    }
+  };
+
+  const handleCancelGoproOverlay = async () => {
+    if (
+      !effectiveGoproOverlayJobId ||
+      !confirm(t('flights.goproOverlayConfirmCancel'))
+    ) {
+      return;
+    }
+
+    setIsCancellingGoproOverlay(true);
+    try {
+      const cancelPath = goproOverlayJobToken
+        ? `job-access/gopro-overlays/jobs/${effectiveGoproOverlayJobId}/cancel`
+        : `gopro-overlays/jobs/${effectiveGoproOverlayJobId}/cancel`;
+      await api.delete(cancelPath, {
+        searchParams: goproOverlayJobToken
+          ? { access_token: goproOverlayJobToken }
+          : undefined,
+      });
+      void queryClient.invalidateQueries({ queryKey: ['flights'] });
+      toast.success(t('flights.goproOverlayCancelled'));
+    } catch (error) {
+      toast.error(
+        await getApiErrorMessage(error, t('flights.goproOverlayCancelError'))
+      );
+    } finally {
+      setIsCancellingGoproOverlay(false);
     }
   };
 
@@ -339,27 +374,35 @@ export function FlightDetails({
     }
   };
 
-  const goproOverlayAction = handleStartGoproOverlay;
+  const goproOverlayAction = isGoproOverlayRunning
+    ? handleCancelGoproOverlay
+    : handleStartGoproOverlay;
   let goproOverlayLabel = t('flights.goproOverlayGenerate');
   let goproOverlayCompactLabel = t('flights.goproOverlayGenerateShort');
-  if (isGoproOverlayRunning || createGoproOverlayJob.isPending) {
+  if (isGoproOverlayRunning) {
+    goproOverlayLabel = t('flights.goproOverlayCancel');
+    goproOverlayCompactLabel = t('flights.goproOverlayCancelShort');
+  } else if (createGoproOverlayJob.isPending) {
     goproOverlayLabel = t('flights.goproOverlayInProgress');
     goproOverlayCompactLabel = t('flights.goproOverlayInProgressShort');
-  } else if (isGoproOverlayCompleted) {
+  } else if (canRegenerateGoproOverlay) {
     goproOverlayLabel = t('flights.goproOverlayRegenerate');
     goproOverlayCompactLabel = t('flights.goproOverlayRegenerateShort');
   }
 
-  let goproOverlayTitle = isGoproOverlayCompleted
+  let goproOverlayTitle = canRegenerateGoproOverlay
     ? t('flights.goproOverlayRegenerate')
     : t('flights.goproOverlayGenerateTitle');
-  if (!hasGoproCameraVideo) {
+  if (isGoproOverlayRunning) {
+    goproOverlayTitle = t('flights.goproOverlayCancel');
+  } else if (!hasGoproCameraVideo) {
     goproOverlayTitle = t('flights.goproOverlayNeedsCameraVideo');
   } else if (!hasVideo) {
     goproOverlayTitle = t('flights.goproOverlayNeedsVideo');
   }
   const canUseGoproOverlayAction =
-    hasGoproCameraVideo && hasVideo && !isGoproOverlayRunning;
+    (isGoproOverlayRunning && Boolean(effectiveGoproOverlayJobId)) ||
+    (hasGoproCameraVideo && hasVideo && !isGoproOverlayRunning);
 
   const infoCard = (
     <div className="rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
@@ -499,11 +542,23 @@ export function FlightDetails({
                   </Button>
                 )}
                 <Button
-                  variant="outline"
-                  className="min-h-10 w-full rounded-lg border-cyan-200 px-3 py-2 text-sm text-cyan-800 transition-colors hover:bg-cyan-50 dark:border-cyan-800 dark:text-cyan-200 dark:hover:bg-cyan-950/40"
+                  variant={
+                    isGoproOverlayRunning
+                      ? 'danger'
+                      : canRegenerateGoproOverlay
+                        ? 'warning'
+                        : 'outline'
+                  }
+                  className={`min-h-10 w-full rounded-lg px-3 py-2 text-sm ${
+                    isGoproOverlayRunning || canRegenerateGoproOverlay
+                      ? ''
+                      : 'border-cyan-200 text-cyan-800 transition-colors hover:bg-cyan-50 dark:border-cyan-800 dark:text-cyan-200 dark:hover:bg-cyan-950/40'
+                  }`}
                   onPress={goproOverlayAction}
                   isDisabled={
-                    !canUseGoproOverlayAction || createGoproOverlayJob.isPending
+                    !canUseGoproOverlayAction ||
+                    createGoproOverlayJob.isPending ||
+                    isCancellingGoproOverlay
                   }
                   title={goproOverlayTitle}
                   aria-label={goproOverlayLabel}

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.test.tsx
@@ -3,20 +3,22 @@ import type React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Flight } from '@dashboard-parapente/shared-types';
 
-const { apiDelete, apiPost, exportStatusMock, mockFlight } = vi.hoisted(() => ({
-  apiDelete: vi.fn(),
-  apiPost: vi.fn(),
-  exportStatusMock: { current: null as unknown },
-  mockFlight: {
-    id: 'flight-1',
-    flight_date: '2026-03-15',
-    title: 'Test flight',
-    gpx_file_path: 'sample.gpx',
-    video_export_status: null as string | null,
-    video_export_job_id: null as string | null,
-    video_file_path: null as string | null,
-  } as Flight,
-}));
+const { apiDelete, apiPost, confirmMock, exportStatusMock, mockFlight } =
+  vi.hoisted(() => ({
+    apiDelete: vi.fn(),
+    apiPost: vi.fn(),
+    confirmMock: vi.fn(),
+    exportStatusMock: { current: null as unknown },
+    mockFlight: {
+      id: 'flight-1',
+      flight_date: '2026-03-15',
+      title: 'Test flight',
+      gpx_file_path: 'sample.gpx',
+      video_export_status: null as string | null,
+      video_export_job_id: null as string | null,
+      video_file_path: null as string | null,
+    } as Flight,
+  }));
 
 vi.mock('@dashboard-parapente/design-system', () => ({
   Button: ({
@@ -86,6 +88,9 @@ describe('FlightVideoExportControls', () => {
     apiDelete.mockReset();
     apiPost.mockReset();
     apiPost.mockReturnValue({ json: vi.fn().mockResolvedValue({}) });
+    confirmMock.mockReset();
+    confirmMock.mockReturnValue(true);
+    vi.stubGlobal('confirm', confirmMock);
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
@@ -123,7 +128,7 @@ describe('FlightVideoExportControls', () => {
     });
   });
 
-  it('resumes a cancelled export when preserved frames are available', async () => {
+  it('regenerates a cancelled export even when preserved frames are available', async () => {
     mockFlight.video_export_status = 'cancelled';
     mockFlight.video_export_job_id = 'job-cancelled';
     exportStatusMock.current = {
@@ -137,12 +142,29 @@ describe('FlightVideoExportControls', () => {
 
     render(<FlightVideoExportControls flight={mockFlight} />);
 
-    expect(screen.getByText('frames preserved')).toBeInTheDocument();
+    expect(screen.queryByText('frames preserved')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /Resume generation/u }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /Restart generation/u })
+    );
 
     await waitFor(() => {
-      expect(apiPost).toHaveBeenCalledWith('exports/job-cancelled/resume');
+      expect(apiPost).toHaveBeenCalledWith('flights/flight-1/export-video', {
+        searchParams: { mode: 'manual_fast' },
+      });
+    });
+  });
+
+  it('turns the primary button into cancel while export is active', async () => {
+    mockFlight.video_export_status = 'running';
+    mockFlight.video_export_job_id = 'job-running';
+
+    render(<FlightVideoExportControls flight={mockFlight} compact />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel generation/u }));
+
+    await waitFor(() => {
+      expect(apiDelete).toHaveBeenCalledWith('exports/job-running/cancel');
     });
   });
 
@@ -157,6 +179,19 @@ describe('FlightVideoExportControls', () => {
     expect(
       screen.queryByRole('button', { name: /Download video/u })
     ).not.toBeInTheDocument();
+  });
+
+  it('shows regenerate when a video already exists', () => {
+    mockFlight.video_export_status = 'completed';
+    mockFlight.video_export_job_id = 'job-video';
+    mockFlight.video_file_path = '/exports/job-video.mp4';
+    mockFlight.video_file_exists = true;
+
+    render(<FlightVideoExportControls flight={mockFlight} compact />);
+
+    expect(
+      screen.getByRole('button', { name: /Regenerate video/u })
+    ).toBeEnabled();
   });
 
   it('generates again when database references a missing completed video file', () => {

--- a/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/FlightVideoExportControls.tsx
@@ -69,6 +69,9 @@ const hasActiveVideoExport = (
 const needsVideoExportRecovery = (status?: string | null) =>
   status === 'failed' || status === 'cancelled';
 
+const isCancelledVideoExport = (status?: string | null) =>
+  status === 'cancelled';
+
 const getHttpErrorDetail = async (error: HTTPError): Promise<string | null> => {
   try {
     const body = (await error.response.json()) as {
@@ -102,7 +105,6 @@ export function FlightVideoExportControls({
   buttonClassName = '',
   compact = false,
   showModeSelector = true,
-  showCancelAction = true,
 }: FlightVideoExportControlsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -132,6 +134,9 @@ export function FlightVideoExportControls({
   );
   const canResumeVideoExport = Boolean(
     flight.video_export_job_id && exportStatus?.can_resume
+  );
+  const canResumeFailedVideoExport = Boolean(
+    flight.video_export_status === 'failed' && canResumeVideoExport
   );
 
   useEffect(() => {
@@ -181,10 +186,21 @@ export function FlightVideoExportControls({
   }, [flight.video_export_job_id, isStartingVideoExport, queryClient]);
 
   const handlePrimaryAction = async () => {
-    if (hasActiveVideoExport(flight)) return;
+    if (hasActiveVideoExport(flight)) {
+      await handleCancelVideoExport();
+      return;
+    }
+
+    if (
+      hasGeneratedVideo ||
+      isCancelledVideoExport(flight.video_export_status)
+    ) {
+      await handleRegenerateVideo();
+      return;
+    }
 
     try {
-      if (canResumeVideoExport) {
+      if (canResumeFailedVideoExport) {
         await resumeVideoExport();
       } else {
         await startVideoExport();
@@ -240,11 +256,15 @@ export function FlightVideoExportControls({
 
   const getPrimaryButtonTitle = () => {
     if (hasActiveVideoExport(flight)) {
-      return t('flights.viewer.videoGeneratingTitle');
+      return t('flights.viewer.cancelGenerationTitle');
+    }
+
+    if (isCancelledVideoExport(flight.video_export_status)) {
+      return t('flights.viewer.videoRegenerateTitle');
     }
 
     if (needsVideoExportRecovery(flight.video_export_status)) {
-      return canResumeVideoExport
+      return canResumeFailedVideoExport
         ? t('flights.viewer.videoResumeTitle')
         : t('flights.viewer.videoRegenerateTitle');
     }
@@ -263,11 +283,17 @@ export function FlightVideoExportControls({
   const primaryButtonLabel = (() => {
     if (hasActiveVideoExport(flight)) {
       return compact
-        ? t('flights.viewer.videoGeneratingShort')
-        : t('flights.viewer.videoGenerating');
+        ? t('flights.viewer.cancelGenerationShort')
+        : t('flights.viewer.cancelGeneration');
     }
+    if (isCancelledVideoExport(flight.video_export_status)) {
+      return compact
+        ? t('flights.viewer.regenerateVideoShort')
+        : t('flights.viewer.regenerateVideo');
+    }
+
     if (needsVideoExportRecovery(flight.video_export_status)) {
-      if (canResumeVideoExport) {
+      if (canResumeFailedVideoExport) {
         return compact
           ? t('flights.viewer.resumeVideoShort')
           : t('flights.viewer.resumeVideo');
@@ -295,7 +321,7 @@ export function FlightVideoExportControls({
     }
 
     if (needsVideoExportRecovery(flight.video_export_status)) {
-      return canResumeVideoExport ? Play : RotateCcw;
+      return canResumeFailedVideoExport ? Play : RotateCcw;
     }
 
     if (hasGeneratedVideo) {
@@ -382,24 +408,25 @@ export function FlightVideoExportControls({
           </div>
         )}
 
-      {!hasGeneratedVideo && (
-        <Button
-          onClick={handlePrimaryAction}
-          isDisabled={isStartingVideoExport || hasActiveVideoExport(flight)}
-          variant={
-            needsVideoExportRecovery(flight.video_export_status)
+      <Button
+        onClick={handlePrimaryAction}
+        isDisabled={isStartingVideoExport}
+        variant={
+          hasActiveVideoExport(flight)
+            ? 'danger'
+            : needsVideoExportRecovery(flight.video_export_status) ||
+                hasGeneratedVideo
               ? 'warning'
               : 'primary'
-          }
-          className={primaryButtonClassName}
-          title={getPrimaryButtonTitle()}
-        >
-          <PrimaryButtonIcon className="h-4 w-4" aria-hidden="true" />
-          {primaryButtonLabel}
-        </Button>
-      )}
+        }
+        className={primaryButtonClassName}
+        title={getPrimaryButtonTitle()}
+      >
+        <PrimaryButtonIcon className="h-4 w-4" aria-hidden="true" />
+        {primaryButtonLabel}
+      </Button>
 
-      {canResumeVideoExport && !isExportActive && (
+      {canResumeFailedVideoExport && !isExportActive && (
         <p
           className={`mt-2 text-xs text-blue-700 dark:text-blue-300 ${
             compact ? 'basis-full text-right' : ''
@@ -409,39 +436,6 @@ export function FlightVideoExportControls({
             count: exportStatus?.frames_captured ?? 0,
           })}
         </p>
-      )}
-
-      {showCancelAction && hasActiveVideoExport(flight) && (
-        <Button
-          onClick={handleCancelVideoExport}
-          variant="danger"
-          className={`mt-2 rounded-lg px-3 py-2 text-xs font-semibold ${
-            compact ? 'basis-full sm:w-auto' : 'w-full'
-          }`}
-          title={t('flights.viewer.cancelGenerationTitle')}
-        >
-          <Square className="h-3.5 w-3.5" aria-hidden="true" />
-          {compact
-            ? t('flights.viewer.cancelGenerationShort')
-            : t('flights.viewer.cancelGeneration')}
-        </Button>
-      )}
-
-      {hasGeneratedVideo && (
-        <Button
-          onClick={handleRegenerateVideo}
-          isDisabled={isStartingVideoExport}
-          variant="warning"
-          className={`mt-2 rounded-lg px-3 py-2 text-xs font-semibold ${
-            compact ? 'basis-full sm:w-auto' : 'w-full'
-          }`}
-          title={t('flights.viewer.regenerateTitle')}
-        >
-          <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
-          {compact
-            ? t('flights.viewer.regenerateVideoShort')
-            : t('flights.viewer.regenerateVideo')}
-        </Button>
       )}
     </div>
   );

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -666,6 +666,7 @@
     "goproOverlayNeedsOutputFilename": "Enter the output file name",
     "goproOverlayStarted": "GoPro overlay generation started",
     "goproOverlayStartError": "Unable to start GoPro overlay",
+    "goproOverlayConfirmCancel": "Are you sure you want to cancel this overlay generation?",
     "goproOverlayCancelled": "GoPro overlay generation cancelled",
     "goproOverlayCancelError": "Unable to cancel GoPro overlay",
     "goproOverlayDownloadError": "Unable to download GoPro overlay",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -670,6 +670,7 @@
     "goproOverlayNeedsOutputFilename": "Renseignez le nom du fichier de sortie",
     "goproOverlayStarted": "Génération overlay GoPro lancée",
     "goproOverlayStartError": "Impossible de lancer l'overlay GoPro",
+    "goproOverlayConfirmCancel": "Êtes-vous sûr de vouloir annuler cette génération d'overlay ?",
     "goproOverlayCancelled": "Génération overlay GoPro annulée",
     "goproOverlayCancelError": "Impossible d'annuler l'overlay GoPro",
     "goproOverlayDownloadError": "Impossible de télécharger l'overlay GoPro",


### PR DESCRIPTION
## Summary
- Make the flight video button context-aware: cancel while generation is active, regenerate when a video exists or a generation was cancelled.
- Apply the same cancel/regenerate behavior to the GoPro overlay action, using the existing cancel endpoint.
- Add targeted frontend tests for the video and overlay action states.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/FlightVideoExportControls.test.tsx src/components/flights/FlightDetails.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5` (hit an unrelated backend pytest environment issue in the repo-wide affected run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now cancel in-progress GoPro overlay generation and video exports
  * Cancelled exports can be regenerated with a single click and appropriate confirmation prompts
  * Improved button states and labels dynamically reflect export status (running, cancelled, or completed)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->