### PR TITLE
fix(frontend): remove duplicate Cesium replay track line

### DIFF
--- a/apps/frontend/src/components/flights/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.tsx
@@ -342,7 +342,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const gpxStartTimeRef = useRef<number>(0);
 
   const trackEntityRef = useRef<Entity | null>(null);
-  const trackFallbackEntityRef = useRef<Entity | null>(null);
   const trackCurtainEntityRef = useRef<Entity | null>(null);
   const trackPositionCountRef = useRef(0);
   const cursorEntityRef = useRef<Entity | null>(null);
@@ -411,7 +410,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const removeTrackEntity = useCallback((viewer: CesiumViewer) => {
     if (!getViewerScene(viewer)) {
       trackEntityRef.current = null;
-      trackFallbackEntityRef.current = null;
       trackCurtainEntityRef.current = null;
       trackPositionCountRef.current = 0;
       return;
@@ -424,19 +422,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       viewer.entities.remove(trackEntityRef.current);
     }
     if (
-      trackFallbackEntityRef.current &&
-      viewer.entities.contains(trackFallbackEntityRef.current)
-    ) {
-      viewer.entities.remove(trackFallbackEntityRef.current);
-    }
-    if (
       trackCurtainEntityRef.current &&
       viewer.entities.contains(trackCurtainEntityRef.current)
     ) {
       viewer.entities.remove(trackCurtainEntityRef.current);
     }
     trackEntityRef.current = null;
-    trackFallbackEntityRef.current = null;
     trackCurtainEntityRef.current = null;
     trackPositionCountRef.current = 0;
   }, []);
@@ -455,8 +446,8 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       }
 
       if (
-        !trackFallbackEntityRef.current ||
-        !viewer.entities.contains(trackFallbackEntityRef.current)
+        !trackCurtainEntityRef.current ||
+        !viewer.entities.contains(trackCurtainEntityRef.current)
       ) {
         const curtainImage = createReplayTrackCurtainImage();
 
@@ -485,22 +476,6 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
                   transparent: true,
                 })
               : Color.fromCssColorString('#ff5a1f').withAlpha(0.16),
-            shadows: ShadowMode.DISABLED,
-          },
-        });
-        trackFallbackEntityRef.current = viewer.entities.add({
-          polyline: {
-            positions: new CallbackProperty(
-              () =>
-                isActiveViewer(viewer)
-                  ? getRenderableTrackPositions(visiblePositionsRef.current)
-                  : [],
-              false
-            ),
-            width: 3,
-            material: Color.fromCssColorString('#ff5a1f').withAlpha(0.95),
-            depthFailMaterial:
-              Color.fromCssColorString('#ff5a1f').withAlpha(0.5),
             shadows: ShadowMode.DISABLED,
           },
         });

--- a/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/FlightViewer3D.video-export.test.tsx
@@ -372,6 +372,34 @@ describe('FlightViewer3D video export mode', () => {
     expect(viewer.render).toHaveBeenCalled();
   });
 
+  it('draws the replay track only as a volume plus curtain', async () => {
+    window._exportMode = 'manual_render';
+
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(window._setExportFrame).toBeTypeOf('function');
+    });
+
+    window._setExportFrame?.(1, 2);
+
+    expect(
+      entityOptions.some((options) =>
+        Boolean((options as { polyline?: unknown }).polyline)
+      )
+    ).toBe(false);
+    expect(
+      entityOptions.some((options) =>
+        Boolean((options as { polylineVolume?: unknown }).polylineVolume)
+      )
+    ).toBe(true);
+    expect(
+      entityOptions.some((options) =>
+        Boolean((options as { wall?: unknown }).wall)
+      )
+    ).toBe(true);
+  });
+
   it('ignores stale track callbacks after switching flights', async () => {
     window._exportMode = 'manual_render';
 


### PR DESCRIPTION
## Summary
- Remove the duplicate Cesium polyline fallback that was rendering alongside the replay tube.
- Keep the curtain wall and add a regression test to ensure the track renders as volume + curtain only.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --base=origin/main --parallel=5 --exclude=e2e
- /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit src/components/flights/FlightViewer3D.video-export.test.tsx
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --base=origin/main --parallel=5 --exclude=e2e