### PR TITLE
Make responsive tables CSS-driven

### DIFF
--- a/apps/frontend/src/components/analytics/SiteStats.tsx
+++ b/apps/frontend/src/components/analytics/SiteStats.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from 'react';
-import { useIsMobile } from '../../hooks/useIsMobile';
 import {
   PieChart,
   Pie,
@@ -69,11 +68,13 @@ const columns = [
   }),
   columnHelper.accessor('avgAltitude', {
     header: 'Alt. moy.',
+    meta: { className: 'hidden sm:table-cell' },
     cell: (info) => `${info.getValue()} m`,
   }),
   columnHelper.display({
     id: 'totalTime',
     header: 'Temps total',
+    meta: { className: 'hidden sm:table-cell' },
     cell: (info) => {
       const row = info.row.original;
       return `${row.totalHours}h${row.totalMinutes}m`;
@@ -88,7 +89,6 @@ const columns = [
 ];
 
 export default function SiteStats({ flights }: SiteStatsProps) {
-  const isMobile = useIsMobile();
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'count', desc: true },
   ]);
@@ -148,14 +148,10 @@ export default function SiteStats({ flights }: SiteStatsProps) {
     return { siteData: pieData, siteDetails: details };
   }, [flights]);
 
-  const columnVisibility: Record<string, boolean> = isMobile
-    ? { avgAltitude: false, totalTime: false }
-    : {};
-
   const table = useReactTable({
     data: siteDetails,
     columns,
-    state: { sorting, columnVisibility },
+    state: { sorting },
     onSortingChange: setSorting,
     getRowId: (row) => row.siteId,
     getCoreRowModel: getCoreRowModel(),

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useCallback, useDeferredValue } from 'react';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
-import { useIsMobile } from '../hooks/useIsMobile';
 import { useTranslation } from 'react-i18next';
 import { Checkbox, Input, TextField } from 'react-aria-components';
 import {
@@ -946,12 +945,7 @@ function GroupSection({
   isPending: boolean;
 }) {
   const { t } = useTranslation();
-  const isMobile = useIsMobile();
   const [sorting, setSorting] = useState<SortingState>([]);
-
-  const columnVisibility: Record<string, boolean> = isMobile
-    ? { ttl: false, size: false }
-    : {};
 
   const columns = useMemo(
     () => [
@@ -973,6 +967,7 @@ function GroupSection({
       }),
       columnHelper.accessor('ttl', {
         header: t('cache.ttl'),
+        meta: { className: 'hidden sm:table-cell' },
         cell: (info) => (
           <span className="text-xs text-gray-600 dark:text-gray-400">
             {formatTtl(info.getValue())}
@@ -981,6 +976,7 @@ function GroupSection({
       }),
       columnHelper.accessor('size', {
         header: t('cache.size'),
+        meta: { className: 'hidden sm:table-cell' },
         cell: (info) => (
           <span className="text-xs text-gray-600 dark:text-gray-400">
             {formatSize(info.getValue())}
@@ -1015,7 +1011,7 @@ function GroupSection({
   const table = useReactTable({
     data: group.keys,
     columns,
-    state: { sorting, columnVisibility },
+    state: { sorting },
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -4,7 +4,6 @@
 
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useIsMobile } from '../hooks/useIsMobile';
 import {
   useReactTable,
   getCoreRowModel,
@@ -41,7 +40,6 @@ function formatSourceName(source: string): string {
 
 function ThermalHistoryTable({ history }: { history: EmagramListItem[] }) {
   const { t } = useTranslation();
-  const isMobile = useIsMobile();
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'created_at', desc: true },
   ]);
@@ -89,6 +87,7 @@ function ThermalHistoryTable({ history }: { history: EmagramListItem[] }) {
       }),
       historyColumnHelper.accessor('force_thermique_ms', {
         header: t('thermal.tableStrength'),
+        meta: { className: 'hidden sm:table-cell' },
         cell: (info) => {
           const val = info.getValue();
           return val == null ? '-' : `${val.toFixed(1)} m/s`;
@@ -101,6 +100,7 @@ function ThermalHistoryTable({ history }: { history: EmagramListItem[] }) {
       }),
       historyColumnHelper.accessor('analysis_method', {
         header: t('thermal.tableMethod'),
+        meta: { className: 'hidden sm:table-cell' },
         cell: (info) => (
           <span className="text-xs text-gray-500 dark:text-gray-400">
             {info.getValue() === 'llm_vision'
@@ -113,14 +113,10 @@ function ThermalHistoryTable({ history }: { history: EmagramListItem[] }) {
     [t]
   );
 
-  const columnVisibility: Record<string, boolean> = isMobile
-    ? { force_thermique_ms: false, analysis_method: false }
-    : {};
-
   const table = useReactTable({
     data: history,
     columns: historyColumns,
-    state: { sorting, columnVisibility },
+    state: { sorting },
     onSortingChange: setSorting,
     getRowId: (row) => row.id,
     getCoreRowModel: getCoreRowModel(),
@@ -357,7 +353,8 @@ export default function ThermalAnalysis() {
                       alt={image.alt}
                       className="h-52 w-full object-cover object-top transition group-hover:scale-[1.02]"
                       onError={(e) => {
-                        (e.target as HTMLImageElement).src = skewtUnavailableSvg;
+                        (e.target as HTMLImageElement).src =
+                          skewtUnavailableSvg;
                       }}
                     />
                     <span className="flex items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200">

--- a/libs/design-system/src/LoadingSkeleton.tsx
+++ b/libs/design-system/src/LoadingSkeleton.tsx
@@ -67,16 +67,11 @@ export default function LoadingSkeleton({
   };
 
   return (
-    <div
-      className="space-y-4"
-      role="status"
-      aria-busy="true"
-      aria-label={label}
-    >
+    <output className="space-y-4" aria-busy="true" aria-label={label}>
       <span className="sr-only">{label}</span>
       {Array.from({ length: count }).map((_, index) => (
         <div key={index}>{renderSkeleton()}</div>
       ))}
-    </div>
+    </output>
   );
 }

--- a/libs/design-system/src/components/DataTable/DataTable.tsx
+++ b/libs/design-system/src/components/DataTable/DataTable.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { flexRender, type Table } from '@tanstack/react-table';
+import { flexRender, type RowData, type Table } from '@tanstack/react-table';
 import { useTranslation } from 'react-i18next';
 import { tv } from 'tailwind-variants';
 
@@ -28,6 +28,18 @@ const dataTable = tv({
     hoverable: true,
   },
 });
+
+declare module '@tanstack/react-table' {
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+    headerClassName?: string;
+    cellClassName?: string;
+  }
+}
+
+function classNames(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(' ');
+}
 
 interface DataTableProps<TData> {
   table: Table<TData>;
@@ -96,6 +108,7 @@ export function DataTable<TData>({
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sorted = header.column.getIsSorted();
+                  const meta = header.column.columnDef.meta;
                   const headerContent = flexRender(
                     header.column.columnDef.header,
                     header.getContext()
@@ -105,7 +118,11 @@ export function DataTable<TData>({
                     <th
                       key={header.id}
                       colSpan={header.colSpan}
-                      className={dataTable({ sortable: canSort }).headerCell()}
+                      className={classNames(
+                        dataTable({ sortable: canSort }).headerCell(),
+                        meta?.className,
+                        meta?.headerClassName
+                      )}
                       aria-sort={getAriaSort(sorted, canSort)}
                     >
                       {!header.isPlaceholder && canSort && (
@@ -131,16 +148,27 @@ export function DataTable<TData>({
                 key={tableRow.id}
                 className={dataTable({ hoverable: true }).row()}
               >
-                {tableRow.getVisibleCells().map((cell) => (
-                  <td key={cell.id} className="py-2 px-2">
-                    {cell.column.columnDef.cell
-                      ? flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )
-                      : (cell.getValue() as ReactNode)}
-                  </td>
-                ))}
+                {tableRow.getVisibleCells().map((cell) => {
+                  const meta = cell.column.columnDef.meta;
+
+                  return (
+                    <td
+                      key={cell.id}
+                      className={classNames(
+                        'py-2 px-2',
+                        meta?.className,
+                        meta?.cellClassName
+                      )}
+                    >
+                      {cell.column.columnDef.cell
+                        ? flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )
+                        : (cell.getValue() as ReactNode)}
+                    </td>
+                  );
+                })}
               </tr>
             ))}
             {rows.length === 0 && (


### PR DESCRIPTION
## Summary
- Move mobile column visibility from `isMobile` state to Tailwind classes via `DataTable` column metadata.
- Remove the mobile table visibility hook from the affected frontend pages.
- Fix a design-system accessibility lint issue uncovered during validation.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:lint`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:test:unit`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run design-system:lint`
- `CI=true /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit` (design-system)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Optimized table column visibility and responsiveness across analytics and infrastructure pages
  * Enhanced data table component with improved styling capabilities and column-level metadata support
  * Refined loading state indicator for better semantic HTML structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->