### PR TITLE
feat: extract flight cards into shared card component

### DIFF
--- a/apps/frontend/src/components/flights/Flight.stories.tsx
+++ b/apps/frontend/src/components/flights/Flight.stories.tsx
@@ -1,0 +1,95 @@
+import preview from '../../../.storybook/preview';
+import { Flight } from './Flight';
+import type { Flight as FlightRecord } from '../../types';
+
+const mockFlight: FlightRecord = {
+  id: 'flight-1',
+  flight_date: '2024-03-15',
+  site_name: 'Puy de Dome',
+  site_id: 'site-1',
+  title: 'Vol thermique Puy de Dome',
+  name: 'Vol thermique',
+  duration_minutes: 90,
+  distance_km: 12.5,
+  max_altitude_m: 1465,
+  departure_time: '2024-03-15T14:30:00',
+  gpx_file_path: '/uploads/flight-1.gpx',
+  video_file_path: '/exports/flight-1.mp4',
+  gopro_overlay_file_path: '/exports/final.mp4',
+  notes: null,
+};
+
+const meta = preview.meta({
+  title: 'Components/Flights/Flight',
+  component: Flight,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+});
+
+export const Default = meta.story({
+  name: 'Default',
+  render: () => (
+    <div className="max-w-sm">
+      <Flight
+        flight={mockFlight}
+        isActive={false}
+        isSelected={false}
+        selectionMode={false}
+        downloadingMedia={null}
+        onSelectFlight={() => undefined}
+        onDeleteFlight={() => undefined}
+        onDownloadGpx={() => undefined}
+        onDownloadVideo={() => undefined}
+        onDownloadOverlay={() => undefined}
+      />
+    </div>
+  ),
+});
+
+export const Active = meta.story({
+  name: 'Active',
+  render: () => (
+    <div className="max-w-sm">
+      <Flight
+        flight={mockFlight}
+        isActive
+        isSelected={false}
+        selectionMode={false}
+        downloadingMedia={null}
+        onSelectFlight={() => undefined}
+        onDeleteFlight={() => undefined}
+        onDownloadGpx={() => undefined}
+        onDownloadVideo={() => undefined}
+        onDownloadOverlay={() => undefined}
+      />
+    </div>
+  ),
+});
+
+export const Processing = meta.story({
+  name: 'Processing',
+  render: () => (
+    <div className="max-w-sm">
+      <Flight
+        flight={{
+          ...mockFlight,
+          id: 'flight-processing',
+          video_file_path: null,
+          video_export_status: 'running',
+          video_export_progress: 42,
+        }}
+        isActive={false}
+        isSelected={false}
+        selectionMode={false}
+        downloadingMedia={null}
+        onSelectFlight={() => undefined}
+        onDeleteFlight={() => undefined}
+        onDownloadGpx={() => undefined}
+        onDownloadVideo={() => undefined}
+        onDownloadOverlay={() => undefined}
+      />
+    </div>
+  ),
+});

--- a/apps/frontend/src/components/flights/Flight.tsx
+++ b/apps/frontend/src/components/flights/Flight.tsx
@@ -1,0 +1,297 @@
+import { useTranslation } from 'react-i18next';
+import { Button, Card } from '@dashboard-parapente/design-system';
+import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
+import {
+  Check,
+  Clock3,
+  Download,
+  FileText,
+  MapPin,
+  Mountain,
+  Ruler,
+  Trash2,
+  Video,
+  Wand2,
+} from 'lucide-react';
+import { formatMediaProgressLabel } from './mediaProgress';
+import type { Flight as FlightRecord } from '../../types';
+import {
+  formatAltitudeMeters,
+  formatDistanceKm,
+  useAppSettingsStore,
+} from '../../stores/appSettingsStore';
+
+export interface DownloadingMedia {
+  flightId: string;
+  type: 'gpx' | 'video' | 'overlay';
+}
+
+interface FlightProps {
+  flight: FlightRecord;
+  isActive: boolean;
+  isSelected: boolean;
+  selectionMode: boolean;
+  downloadingMedia: DownloadingMedia | null;
+  onSelectFlight: (flight: FlightRecord) => void;
+  onDeleteFlight: (flight: FlightRecord) => void;
+  onDownloadGpx: (flight: FlightRecord) => void;
+  onDownloadVideo: (flight: FlightRecord) => void;
+  onDownloadOverlay: (flight: FlightRecord) => void;
+}
+
+function formatFlightDate(date: string, language: string) {
+  const [year, month, day] = date.split('-');
+  const localDate = new Date(Number(year), Number(month) - 1, Number(day));
+
+  return localDate.toLocaleDateString(language, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function formatDepartureTime(date: string, language: string) {
+  return new Date(date).toLocaleTimeString(language, {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+// oxlint-disable-next-line max-lines-per-function
+export function Flight({
+  flight,
+  isActive,
+  isSelected,
+  selectionMode,
+  downloadingMedia,
+  onSelectFlight,
+  onDeleteFlight,
+  onDownloadGpx,
+  onDownloadVideo,
+  onDownloadOverlay,
+}: FlightProps) {
+  const { t, i18n } = useTranslation();
+  const units = useAppSettingsStore((state) => state.settings.units);
+  const isHighlighted = isActive || isSelected;
+  const hasGpx = Boolean(flight.gpx_file_path);
+  const hasVideo = Boolean(flight.video_file_path);
+  const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
+  const isGoproOverlayRunning =
+    flight.gopro_overlay_status === 'queued' ||
+    flight.gopro_overlay_status === 'running';
+  const isGoproOverlayFailed = flight.gopro_overlay_status === 'failed';
+  const canDownloadGoproOverlay =
+    hasPersistedGoproOverlay && !isGoproOverlayRunning && !isGoproOverlayFailed;
+  const isVideoExportRunning = Boolean(
+    flight.video_export_status &&
+    VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)
+  );
+  const isVideoExportFailed = flight.video_export_status === 'failed';
+  const videoProcessingLabel = formatMediaProgressLabel(
+    t('flights.videoProcessingBadge'),
+    flight.video_export_progress
+  );
+  const goproOverlayProcessingLabel = formatMediaProgressLabel(
+    t('flights.goproOverlayProcessingBadge'),
+    flight.gopro_overlay_progress
+  );
+  const selectFlight = () => {
+    if (!selectionMode) {
+      onSelectFlight(flight);
+    }
+  };
+  const titleColor = isHighlighted
+    ? 'text-sky-950 dark:text-white'
+    : 'text-gray-900 dark:text-white';
+  const metaColor = isHighlighted
+    ? 'text-sky-800 dark:text-sky-100'
+    : 'text-gray-500 dark:text-gray-400';
+  const statsColor = isHighlighted
+    ? 'text-sky-900 dark:text-sky-100'
+    : 'text-gray-600 dark:text-gray-300';
+  const hasMediaStatus =
+    hasGpx ||
+    hasVideo ||
+    isVideoExportRunning ||
+    isVideoExportFailed ||
+    hasPersistedGoproOverlay ||
+    isGoproOverlayRunning ||
+    isGoproOverlayFailed;
+
+  return (
+    <Card
+      // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
+      role="option"
+      aria-selected={isHighlighted}
+      tabIndex={0}
+      data-testid={`flight-row-${flight.id}`}
+      selected={isHighlighted}
+      interactive
+      padding="sm"
+      borderWidth="strong"
+      className="group"
+      onClick={selectFlight}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          selectFlight();
+        }
+      }}
+    >
+      {isHighlighted && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-2 left-0 w-1.5 rounded-r-full bg-sky-700 dark:bg-sky-300"
+        />
+      )}
+      {!selectionMode && (
+        <Button
+          size="icon"
+          variant="danger"
+          className="absolute top-2 right-2 w-10 h-10 sm:w-7 sm:h-7 flex items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30 text-red-500 dark:text-red-300 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-red-200 dark:hover:bg-red-900/50 hover:text-red-700 dark:hover:text-red-200 transition-all"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDeleteFlight(flight);
+          }}
+          aria-label={t('flights.deleteAriaLabel', {
+            title: flight.title || t('flights.untitledFlight'),
+          })}
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      )}
+      <div className="flex justify-between items-start mb-2 gap-2 pl-1.5">
+        <div className="min-w-0 flex-1">
+          {isHighlighted && (
+            <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-sky-700 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white dark:bg-sky-300 dark:text-sky-950">
+              <Check className="h-3 w-3" aria-hidden="true" />
+              {t('flights.activeFlight')}
+            </span>
+          )}
+          <h3 className={`truncate text-sm font-semibold ${titleColor}`}>
+            {flight.title || t('flights.untitledFlight')}
+          </h3>
+          {!selectionMode && hasMediaStatus && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {hasGpx && (
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDownloadGpx(flight);
+                  }}
+                  disabled={Boolean(downloadingMedia)}
+                  aria-label={t('flights.downloadGpx')}
+                >
+                  <FileText className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.gpxBadge')}
+                  <Download className="h-3 w-3" aria-hidden="true" />
+                </button>
+              )}
+              {hasVideo && (
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDownloadVideo(flight);
+                  }}
+                  disabled={Boolean(downloadingMedia)}
+                  aria-label={t('flights.viewer.downloadVideo')}
+                >
+                  <Video className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.videoBadge')}
+                  <Download className="h-3 w-3" aria-hidden="true" />
+                </button>
+              )}
+              {isVideoExportRunning && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
+                  {videoProcessingLabel}
+                </span>
+              )}
+              {isVideoExportFailed && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+                  {t('flights.videoErrorBadge')}
+                </span>
+              )}
+              {canDownloadGoproOverlay && (
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onDownloadOverlay(flight);
+                  }}
+                  disabled={Boolean(downloadingMedia)}
+                  aria-label={t('flights.goproOverlayDownload')}
+                >
+                  <Wand2 className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.goproOverlayBadge')}
+                  <Download className="h-3 w-3" aria-hidden="true" />
+                </button>
+              )}
+              {isGoproOverlayRunning && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
+                  {goproOverlayProcessingLabel}
+                </span>
+              )}
+              {isGoproOverlayFailed && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+                  {t('flights.goproOverlayErrorBadge')}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className={`mb-2 pl-1.5 text-xs ${metaColor}`}>
+        <span className="font-medium">
+          {formatFlightDate(flight.flight_date, i18n.language)}
+        </span>
+        {flight.departure_time && (
+          <span className="ml-2">
+            {t('flights.at', {
+              time: formatDepartureTime(flight.departure_time, i18n.language),
+            })}
+          </span>
+        )}
+      </div>
+
+      <div className={`flex flex-wrap gap-2 pl-1.5 text-xs ${statsColor}`}>
+        {flight.duration_minutes && (
+          <div className="flex items-center gap-1">
+            <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>
+              {Math.floor(flight.duration_minutes / 60)}h
+              {flight.duration_minutes % 60}m
+            </span>
+          </div>
+        )}
+        {flight.distance_km && (
+          <div className="flex items-center gap-1">
+            <Ruler className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{formatDistanceKm(flight.distance_km, units.distance)}</span>
+          </div>
+        )}
+        {flight.max_altitude_m && (
+          <div className="flex items-center gap-1">
+            <Mountain className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>
+              {formatAltitudeMeters(flight.max_altitude_m, units.altitude)}
+            </span>
+          </div>
+        )}
+      </div>
+      {flight.site_id && (
+        <div
+          className={`mt-2 flex items-center gap-1 pl-1.5 text-xs ${metaColor}`}
+        >
+          <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="truncate">{flight.site_name || flight.site_id}</span>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/flights/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/FlightsTable.tsx
@@ -2,47 +2,25 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Row, RowSelectionState, OnChangeFn } from '@tanstack/react-table';
 import type { Selection } from 'react-aria-components';
-import { DataList, Button } from '@dashboard-parapente/design-system';
-import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
-import {
-  Check,
-  Clock3,
-  Download,
-  FileText,
-  MapPin,
-  Mountain,
-  Ruler,
-  Trash2,
-  Video,
-  Wand2,
-} from 'lucide-react';
+import { DataList } from '@dashboard-parapente/design-system';
+import { Flight, type DownloadingMedia } from './Flight';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
-import { formatMediaProgressLabel } from './mediaProgress';
-import type { Flight } from '../../types';
-import {
-  formatAltitudeMeters,
-  formatDistanceKm,
-  useAppSettingsStore,
-} from '../../stores/appSettingsStore';
+import type { Flight as FlightRecord } from '../../types';
 
 interface FlightsTableProps {
-  flights: Flight[];
+  flights: FlightRecord[];
   selectedFlightId: string | null;
   selectionMode: boolean;
-  onSelectFlight: (flight: Flight) => void;
-  onDeleteFlight: (flight: Flight) => void;
-  onDownloadGpx: (flight: Flight) => void;
-  onDownloadVideo: (flight: Flight) => void;
-  onDownloadOverlay: (flight: Flight) => void;
-  downloadingMedia: {
-    flightId: string;
-    type: 'gpx' | 'video' | 'overlay';
-  } | null;
+  onSelectFlight: (flight: FlightRecord) => void;
+  onDeleteFlight: (flight: FlightRecord) => void;
+  onDownloadGpx: (flight: FlightRecord) => void;
+  onDownloadVideo: (flight: FlightRecord) => void;
+  onDownloadOverlay: (flight: FlightRecord) => void;
+  downloadingMedia: DownloadingMedia | null;
   rowSelection: RowSelectionState;
   onRowSelectionChange: OnChangeFn<RowSelectionState>;
 }
 
-// oxlint-disable-next-line max-lines-per-function
 export function FlightsTable({
   flights,
   selectedFlightId,
@@ -56,8 +34,7 @@ export function FlightsTable({
   rowSelection,
   onRowSelectionChange,
 }: FlightsTableProps) {
-  const { t, i18n } = useTranslation();
-  const units = useAppSettingsStore((state) => state.settings.units);
+  const { t } = useTranslation();
   const { table } = useFlightsTable({
     data: flights,
     selectionMode,
@@ -92,265 +69,22 @@ export function FlightsTable({
   );
 
   const renderFlightCard = useCallback(
-    // oxlint-disable-next-line max-lines-per-function
-    (row: Row<Flight>, { isSelected }: { isSelected: boolean }) => {
+    (row: Row<FlightRecord>, { isSelected }: { isSelected: boolean }) => {
       const flight = row.original;
-      const isActive = selectedFlightId === flight.id;
-      const hasGpx = Boolean(flight.gpx_file_path);
-      const hasVideo = Boolean(flight.video_file_path);
-      const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
-      const isGoproOverlayRunning =
-        flight.gopro_overlay_status === 'queued' ||
-        flight.gopro_overlay_status === 'running';
-      const isGoproOverlayFailed = flight.gopro_overlay_status === 'failed';
-      const canDownloadGoproOverlay =
-        hasPersistedGoproOverlay &&
-        !isGoproOverlayRunning &&
-        !isGoproOverlayFailed;
-      const isVideoExportRunning = Boolean(
-        flight.video_export_status &&
-        VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)
-      );
-      const isVideoExportFailed = flight.video_export_status === 'failed';
-      const videoProcessingLabel = formatMediaProgressLabel(
-        t('flights.videoProcessingBadge'),
-        flight.video_export_progress
-      );
-      const goproOverlayProcessingLabel = formatMediaProgressLabel(
-        t('flights.goproOverlayProcessingBadge'),
-        flight.gopro_overlay_progress
-      );
-      const selectFlight = () => {
-        if (!selectionMode) {
-          onSelectFlight(flight);
-        }
-      };
-
-      let surface = 'bg-white dark:bg-gray-800';
-      let color =
-        'border-gray-200 dark:border-gray-700 hover:border-sky-400 hover:shadow-md';
-      let titleColor = 'text-gray-900 dark:text-white';
-      let metaColor = 'text-gray-500 dark:text-gray-400';
-      let statsColor = 'text-gray-600 dark:text-gray-300';
-
-      if (isSelected) {
-        surface = 'bg-sky-100 dark:bg-sky-950/70';
-        color =
-          'border-sky-700 dark:border-sky-300 shadow-lg ring-2 ring-sky-500/40 dark:ring-sky-300/35';
-        titleColor = 'text-sky-950 dark:text-white';
-        metaColor = 'text-sky-800 dark:text-sky-100';
-        statsColor = 'text-sky-900 dark:text-sky-100';
-      } else if (isActive) {
-        surface = 'bg-sky-100 dark:bg-sky-950/70';
-        color =
-          'border-sky-700 dark:border-sky-300 shadow-lg ring-2 ring-sky-500/40 dark:ring-sky-300/35';
-        titleColor = 'text-sky-950 dark:text-white';
-        metaColor = 'text-sky-800 dark:text-sky-100';
-        statsColor = 'text-sky-900 dark:text-sky-100';
-      }
 
       return (
-        <div
-          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role
-          role="option"
-          aria-selected={isActive || isSelected}
-          tabIndex={0}
-          data-testid={`flight-row-${flight.id}`}
-          className={`group relative overflow-hidden rounded-lg p-3 shadow-sm border-2 transition-all duration-200 cursor-pointer ${surface} ${color}`}
-          onClick={selectFlight}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-              event.preventDefault();
-              selectFlight();
-            }
-          }}
-        >
-          {(isActive || isSelected) && (
-            <span
-              aria-hidden="true"
-              className="absolute inset-y-2 left-0 w-1.5 rounded-r-full bg-sky-700 dark:bg-sky-300"
-            />
-          )}
-          {/* Bouton supprimer au survol */}
-          {!selectionMode && (
-            <Button
-              size="icon"
-              variant="danger"
-              className="absolute top-2 right-2 w-10 h-10 sm:w-7 sm:h-7 flex items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30 text-red-500 dark:text-red-300 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 hover:bg-red-200 dark:hover:bg-red-900/50 hover:text-red-700 dark:hover:text-red-200 transition-all"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDeleteFlight(flight);
-              }}
-              aria-label={t('flights.deleteAriaLabel', {
-                title: flight.title || t('flights.untitledFlight'),
-              })}
-            >
-              <Trash2 className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          )}
-          <div className="flex justify-between items-start mb-2 gap-2 pl-1.5">
-            <div className="min-w-0 flex-1">
-              {(isActive || isSelected) && (
-                <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-sky-700 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white dark:bg-sky-300 dark:text-sky-950">
-                  <Check className="h-3 w-3" aria-hidden="true" />
-                  {t('flights.activeFlight')}
-                </span>
-              )}
-              <h3 className={`truncate text-sm font-semibold ${titleColor}`}>
-                {flight.title || t('flights.untitledFlight')}
-              </h3>
-              {!selectionMode &&
-                (hasGpx ||
-                  hasVideo ||
-                  isVideoExportRunning ||
-                  isVideoExportFailed ||
-                  hasPersistedGoproOverlay ||
-                  isGoproOverlayRunning ||
-                  isGoproOverlayFailed) && (
-                  <div className="mt-2 flex flex-wrap gap-1.5">
-                    {hasGpx && (
-                      <button
-                        type="button"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-green-800 transition-colors hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 dark:border-green-800 dark:bg-green-950/40 dark:text-green-200 dark:hover:bg-green-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onDownloadGpx(flight);
-                        }}
-                        disabled={Boolean(downloadingMedia)}
-                        aria-label={t('flights.downloadGpx')}
-                      >
-                        <FileText className="h-3 w-3" aria-hidden="true" />
-                        {t('flights.gpxBadge')}
-                        <Download className="h-3 w-3" aria-hidden="true" />
-                      </button>
-                    )}
-                    {hasVideo && (
-                      <button
-                        type="button"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-indigo-800 transition-colors hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onDownloadVideo(flight);
-                        }}
-                        disabled={Boolean(downloadingMedia)}
-                        aria-label={t('flights.viewer.downloadVideo')}
-                      >
-                        <Video className="h-3 w-3" aria-hidden="true" />
-                        {t('flights.videoBadge')}
-                        <Download className="h-3 w-3" aria-hidden="true" />
-                      </button>
-                    )}
-                    {isVideoExportRunning && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                        {videoProcessingLabel}
-                      </span>
-                    )}
-                    {isVideoExportFailed && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
-                        {t('flights.videoErrorBadge')}
-                      </span>
-                    )}
-                    {canDownloadGoproOverlay && (
-                      <button
-                        type="button"
-                        className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-cyan-800 transition-colors hover:bg-cyan-100 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200 dark:hover:bg-cyan-900/50 dark:focus:ring-offset-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onDownloadOverlay(flight);
-                        }}
-                        disabled={Boolean(downloadingMedia)}
-                        aria-label={t('flights.goproOverlayDownload')}
-                      >
-                        <Wand2 className="h-3 w-3" aria-hidden="true" />
-                        {t('flights.goproOverlayBadge')}
-                        <Download className="h-3 w-3" aria-hidden="true" />
-                      </button>
-                    )}
-                    {isGoproOverlayRunning && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-blue-800 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-200">
-                        {goproOverlayProcessingLabel}
-                      </span>
-                    )}
-                    {isGoproOverlayFailed && (
-                      <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
-                        {t('flights.goproOverlayErrorBadge')}
-                      </span>
-                    )}
-                  </div>
-                )}
-            </div>
-          </div>
-
-          {/* Date et heure */}
-          <div className={`mb-2 pl-1.5 text-xs ${metaColor}`}>
-            <span className="font-medium">
-              {(() => {
-                const [year, month, day] = flight.flight_date.split('-');
-                const localDate = new Date(
-                  Number(year),
-                  Number(month) - 1,
-                  Number(day)
-                );
-                return localDate.toLocaleDateString(i18n.language, {
-                  day: '2-digit',
-                  month: 'short',
-                  year: 'numeric',
-                });
-              })()}
-            </span>
-            {flight.departure_time && (
-              <span className="ml-2">
-                {t('flights.at', {
-                  time: new Date(flight.departure_time).toLocaleTimeString(
-                    i18n.language,
-                    {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    }
-                  ),
-                })}
-              </span>
-            )}
-          </div>
-
-          <div className={`flex flex-wrap gap-2 pl-1.5 text-xs ${statsColor}`}>
-            {flight.duration_minutes && (
-              <div className="flex items-center gap-1">
-                <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
-                <span>
-                  {Math.floor(flight.duration_minutes / 60)}h
-                  {flight.duration_minutes % 60}m
-                </span>
-              </div>
-            )}
-            {flight.distance_km && (
-              <div className="flex items-center gap-1">
-                <Ruler className="h-3.5 w-3.5" aria-hidden="true" />
-                <span>
-                  {formatDistanceKm(flight.distance_km, units.distance)}
-                </span>
-              </div>
-            )}
-            {flight.max_altitude_m && (
-              <div className="flex items-center gap-1">
-                <Mountain className="h-3.5 w-3.5" aria-hidden="true" />
-                <span>
-                  {formatAltitudeMeters(flight.max_altitude_m, units.altitude)}
-                </span>
-              </div>
-            )}
-          </div>
-          {flight.site_id && (
-            <div
-              className={`mt-2 flex items-center gap-1 pl-1.5 text-xs ${metaColor}`}
-            >
-              <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              <span className="truncate">
-                {flight.site_name || flight.site_id}
-              </span>
-            </div>
-          )}
-        </div>
+        <Flight
+          flight={flight}
+          isActive={selectedFlightId === flight.id}
+          isSelected={isSelected}
+          selectionMode={selectionMode}
+          downloadingMedia={downloadingMedia}
+          onSelectFlight={onSelectFlight}
+          onDeleteFlight={onDeleteFlight}
+          onDownloadGpx={onDownloadGpx}
+          onDownloadVideo={onDownloadVideo}
+          onDownloadOverlay={onDownloadOverlay}
+        />
       );
     },
     [
@@ -362,9 +96,6 @@ export function FlightsTable({
       onDownloadVideo,
       onDownloadOverlay,
       downloadingMedia,
-      t,
-      i18n,
-      units,
     ]
   );
 

--- a/libs/design-system/src/LoadingSkeleton.tsx
+++ b/libs/design-system/src/LoadingSkeleton.tsx
@@ -67,16 +67,11 @@ export default function LoadingSkeleton({
   };
 
   return (
-    <div
-      className="space-y-4"
-      role="status"
-      aria-busy="true"
-      aria-label={label}
-    >
+    <output className="space-y-4" aria-busy="true" aria-label={label}>
       <span className="sr-only">{label}</span>
       {Array.from({ length: count }).map((_, index) => (
         <div key={index}>{renderSkeleton()}</div>
       ))}
-    </div>
+    </output>
   );
 }

--- a/libs/design-system/src/components/Card/Card.stories.tsx
+++ b/libs/design-system/src/components/Card/Card.stories.tsx
@@ -1,0 +1,62 @@
+import preview from '../../../.storybook/preview';
+import { Card } from './Card';
+
+const meta = preview.meta({
+  title: 'Components/UI/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Reusable surface card with neutral, selected, and interactive states for compact dashboard content.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+});
+
+export const Default = meta.story({
+  name: 'Default',
+  render: () => (
+    <Card className="w-80">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        Vol thermique
+      </h3>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Surface neutre pour contenu compact.
+      </p>
+    </Card>
+  ),
+});
+
+export const Interactive = meta.story({
+  name: 'Interactive',
+  render: () => (
+    <Card interactive className="w-80" tabIndex={0}>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+        Carte cliquable
+      </h3>
+      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        Hover, focus clavier et curseur sont visibles.
+      </p>
+    </Card>
+  ),
+});
+
+export const Selected = meta.story({
+  name: 'Selected',
+  render: () => (
+    <Card selected interactive className="w-80" tabIndex={0}>
+      <span className="inline-flex rounded-full bg-sky-700 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white dark:bg-sky-300 dark:text-sky-950">
+        Actif
+      </span>
+      <h3 className="mt-2 text-sm font-semibold text-sky-950 dark:text-white">
+        Vol selectionne
+      </h3>
+      <p className="mt-1 text-xs text-sky-800 dark:text-sky-100">
+        Etat selectionne fort pour les listes de dashboard.
+      </p>
+    </Card>
+  ),
+});

--- a/libs/design-system/src/components/Card/Card.tsx
+++ b/libs/design-system/src/components/Card/Card.tsx
@@ -1,0 +1,70 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { tv, type VariantProps } from 'tailwind-variants';
+import { twMerge } from 'tailwind-merge';
+
+const cardStyles = tv({
+  base: 'relative overflow-hidden rounded-lg border bg-white shadow-sm transition-all duration-200 dark:bg-gray-800',
+  variants: {
+    tone: {
+      neutral: 'border-gray-200 dark:border-gray-700',
+      selected:
+        'border-sky-700 bg-sky-100 shadow-lg ring-2 ring-sky-500/40 dark:border-sky-300 dark:bg-sky-950/70 dark:ring-sky-300/35',
+    },
+    interactive: {
+      true: 'cursor-pointer hover:border-sky-400 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900',
+      false: '',
+    },
+    padding: {
+      none: '',
+      sm: 'p-3',
+      md: 'p-4',
+    },
+    borderWidth: {
+      default: 'border',
+      strong: 'border-2',
+    },
+  },
+  defaultVariants: {
+    tone: 'neutral',
+    interactive: false,
+    padding: 'md',
+    borderWidth: 'default',
+  },
+});
+
+type CardVariants = VariantProps<typeof cardStyles>;
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  selected?: boolean;
+  interactive?: boolean;
+  padding?: CardVariants['padding'];
+  borderWidth?: CardVariants['borderWidth'];
+}
+
+export function Card({
+  children,
+  className,
+  selected = false,
+  interactive = false,
+  padding,
+  borderWidth,
+  ...props
+}: CardProps) {
+  return (
+    <div
+      {...props}
+      className={twMerge(
+        cardStyles({
+          tone: selected ? 'selected' : 'neutral',
+          interactive,
+          padding,
+          borderWidth,
+        }),
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/libs/design-system/src/index.ts
+++ b/libs/design-system/src/index.ts
@@ -6,6 +6,8 @@ export { Modal } from './Modal';
 export { Toast, ToastContainer } from './Toast';
 export { Button } from './components/Button/Button';
 export type { ButtonProps } from './components/Button/Button';
+export { Card } from './components/Card/Card';
+export type { CardProps } from './components/Card/Card';
 export { Tab, TabList, TabPanel, Tabs } from './Tabs';
 export { DatePicker } from './components/DatePicker/DatePicker';
 export { Select } from './Select';


### PR DESCRIPTION
## Summary
- Add a reusable `Card` surface to the design system with selected and interactive states.
- Extract the flight list card into a dedicated frontend `Flight` component and wire `FlightsTable` to it.
- Fix a design-system lint issue needed for clean validation.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec nx affected -t lint,type-check,build --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec nx run frontend:test:unit`
- `/home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit` in `apps/frontend`
- `/home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit` in `libs/design-system`