### PR TITLE
Fix deletable video export rows

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -135,6 +135,8 @@ _VIDEO_EXPORT_CANCELLABLE_STATUSES = {
     "encoding",
 }
 
+_VIDEO_EXPORT_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
 
 def _start_video_export_stream(
     flight_id: str, quality: str, fps: int, speed: int, frontend_url: str
@@ -386,7 +388,7 @@ def _video_export_sort_value(export: dict[str, Any]) -> str:
 
 def _video_export_public_status(export: dict[str, Any]) -> str:
     internal_status = export.get("internal_status")
-    if internal_status in {"completed", "failed", "cancelled"}:
+    if internal_status in _VIDEO_EXPORT_TERMINAL_STATUSES:
         return str(internal_status)
 
     status = export.get("status")
@@ -419,7 +421,7 @@ def _video_export_can_delete(export: dict[str, Any]) -> bool:
     if export.get("mode") in {"manual", "manual_fast"}:
         return True
 
-    return export.get("status") in {"completed", "failed", "cancelled"}
+    return export.get("status") in _VIDEO_EXPORT_TERMINAL_STATUSES
 
 
 def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
@@ -4846,7 +4848,7 @@ async def stream_video_export_status(job_id: str, request: Request) -> Streaming
                 yield serialize_sse_event("status", status)
                 last_serialized = serialized
 
-            if status.get("internal_status") in {"completed", "failed", "cancelled"}:
+            if status.get("internal_status") in _VIDEO_EXPORT_TERMINAL_STATUSES:
                 break
 
             try:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -412,6 +412,16 @@ def _video_export_can_cancel(export: dict[str, Any]) -> bool:
     } and bool(export.get("job_id"))
 
 
+def _video_export_can_delete(export: dict[str, Any]) -> bool:
+    if not export.get("job_id"):
+        return False
+
+    if export.get("mode") in {"manual", "manual_fast"}:
+        return True
+
+    return export.get("status") in {"completed", "failed", "cancelled"}
+
+
 def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
     output_path = job.get("output_path")
     return {
@@ -469,6 +479,7 @@ def _build_video_export_jobs_payload(
         job = dict(export)
         job["status"] = _video_export_public_status(job)
         job["can_cancel"] = _video_export_can_cancel(job)
+        job["can_delete"] = _video_export_can_delete(job)
         if "has_output_file" not in job:
             video_path = job.get("video_path")
             job["has_output_file"] = bool(video_path and Path(str(video_path)).exists())

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -513,17 +513,20 @@ class TestVideoExportJobsEndpoint:
         assert jobs[0]["status"] == "running"
         assert jobs[0]["mode"] == "gopro_overlay"
         assert jobs[0]["can_cancel"] is True
+        assert jobs[0]["can_delete"] is False
         assert jobs[0]["flight_id"] == sample_flight.id
         assert jobs[0]["flight_name"] == sample_flight.name
         assert jobs[0]["flight_title"] == sample_flight.name
         assert jobs[1]["job_id"] == "job-running"
         assert jobs[1]["status"] == "processing"
         assert jobs[1]["can_cancel"] is True
+        assert jobs[1]["can_delete"] is True
         assert jobs[1]["flight_name"] == sample_flight.name
         assert jobs[1]["flight_title"] == sample_flight.name
         assert jobs[2]["job_id"] == "job-cancelled"
         assert jobs[2]["status"] == "cancelled"
         assert jobs[2]["can_cancel"] is False
+        assert jobs[2]["can_delete"] is True
 
     def test_video_export_jobs_can_filter_active_jobs(self, client: TestClient):
         with (
@@ -580,6 +583,31 @@ class TestVideoExportJobsEndpoint:
             "job-overlay-running",
         }
         assert all(job["can_cancel"] is True for job in jobs)
+
+    def test_video_export_jobs_marks_terminal_stream_and_overlay_deletable(
+        self, client: TestClient
+    ):
+        with (
+            patch("routes.list_exports_manual", return_value=[]),
+            patch(
+                "routes.list_exports_stream",
+                return_value=[{"job_id": "job-stream-done", "status": "completed"}],
+            ),
+            patch(
+                "routes.list_gopro_overlay_jobs",
+                return_value=[
+                    {"job_id": "job-overlay-running", "status": "running"},
+                    {"job_id": "job-overlay-failed", "status": "failed"},
+                ],
+            ),
+        ):
+            response = client.get(f"{API_PREFIX}/video-export-jobs")
+
+        assert response.status_code == 200
+        jobs = {job["job_id"]: job for job in response.json()["jobs"]}
+        assert jobs["job-stream-done"]["can_delete"] is True
+        assert jobs["job-overlay-running"]["can_delete"] is False
+        assert jobs["job-overlay-failed"]["can_delete"] is True
 
     def test_video_export_jobs_temp_files_endpoint_cleans_known_exports(self, client: TestClient):
         manual_jobs = [{"job_id": "job-failed", "internal_status": "failed"}]

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.test.tsx
@@ -33,6 +33,7 @@ const {
       message: 'Capturing frames',
       mode: 'manual_fast',
       can_cancel: true,
+      can_delete: true,
     },
     {
       job_id: 'job-done',
@@ -42,6 +43,7 @@ const {
       progress: 100,
       has_output_file: true,
       can_cancel: false,
+      can_delete: true,
     },
     {
       job_id: 'job-overlay',
@@ -53,6 +55,7 @@ const {
       message: 'Rendering overlay',
       mode: 'gopro_overlay',
       can_cancel: true,
+      can_delete: false,
     },
     {
       job_id: 'job-resumable',
@@ -62,6 +65,7 @@ const {
       internal_status: 'cancelled',
       progress: 30,
       can_cancel: false,
+      can_delete: true,
       can_resume: true,
     },
     {
@@ -75,6 +79,7 @@ const {
       mode: 'gopro_overlay',
       has_output_file: true,
       can_cancel: false,
+      can_delete: true,
     },
   ],
 }));
@@ -143,6 +148,7 @@ describe('VideoExportJobsPanel', () => {
         message: 'Capturing frames',
         mode: 'manual_fast',
         can_cancel: true,
+        can_delete: true,
       },
       {
         job_id: 'job-done',
@@ -152,6 +158,7 @@ describe('VideoExportJobsPanel', () => {
         progress: 100,
         has_output_file: true,
         can_cancel: false,
+        can_delete: true,
       },
       {
         job_id: 'job-overlay',
@@ -163,6 +170,7 @@ describe('VideoExportJobsPanel', () => {
         message: 'Rendering overlay',
         mode: 'gopro_overlay',
         can_cancel: true,
+        can_delete: false,
       },
       {
         job_id: 'job-resumable',
@@ -172,6 +180,7 @@ describe('VideoExportJobsPanel', () => {
         internal_status: 'cancelled',
         progress: 30,
         can_cancel: false,
+        can_delete: true,
         can_resume: true,
       },
       {
@@ -185,6 +194,7 @@ describe('VideoExportJobsPanel', () => {
         mode: 'gopro_overlay',
         has_output_file: true,
         can_cancel: false,
+        can_delete: true,
       }
     );
   });
@@ -292,6 +302,34 @@ describe('VideoExportJobsPanel', () => {
       expect(deleteJobRow).toHaveBeenCalledWith(expect.any(String))
     );
     expect(toastSuccess).toHaveBeenCalledWith('Ligne supprimée');
+  });
+
+  it('uses the API delete permission instead of inferring from cancel state', async () => {
+    deleteJobRow.mockResolvedValue(undefined);
+    jobs.splice(0, jobs.length, {
+      job_id: 'job-running-manual',
+      flight_name: 'Export manuel en cours',
+      flight_title: 'Export manuel en cours',
+      status: 'processing',
+      internal_status: 'capturing',
+      progress: 12,
+      message: 'Capturing frames',
+      mode: 'manual_fast',
+      can_cancel: true,
+      can_delete: true,
+    });
+
+    render(<VideoExportJobsPanel />);
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'Supprimer',
+    });
+    fireEvent.click(deleteButtons[0]!);
+    const confirmButtons = screen.getAllByRole('button', { name: 'Supprimer' });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]!);
+
+    await waitFor(() =>
+      expect(deleteJobRow).toHaveBeenCalledWith('job-running-manual')
+    );
   });
 
   it('cleans temporary files after confirmation', async () => {

--- a/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/VideoExportJobsPanel.tsx
@@ -247,7 +247,7 @@ function canDownloadJob(job: VideoExportJob) {
 }
 
 function canDeleteJobRow(job: VideoExportJob) {
-  return !job.can_cancel;
+  return job.can_delete;
 }
 
 function JobStatusBadge({ job }: { job: VideoExportJob }) {

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -29,6 +29,7 @@ export type VideoExportJob = {
   layout_label?: string | null;
   has_output_file?: boolean;
   can_cancel: boolean;
+  can_delete: boolean;
 };
 
 type VideoExportJobsResponse = {

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -210,6 +210,7 @@ const initialMockVideoJobs: VideoExportJob[] = [
     started_at: '2026-01-15T09:15:00Z',
     updated_at: '2026-01-15T10:05:00Z',
     can_cancel: true,
+    can_delete: true,
   },
   {
     job_id: 'job-chalais-completed',
@@ -225,6 +226,7 @@ const initialMockVideoJobs: VideoExportJob[] = [
     has_output_file: true,
     output_filename: 'chalais-export.mp4',
     can_cancel: false,
+    can_delete: true,
   },
   {
     job_id: 'job-gopro-completed',
@@ -242,6 +244,7 @@ const initialMockVideoJobs: VideoExportJob[] = [
     layout_label: 'Overlay GoPro',
     has_output_file: true,
     can_cancel: false,
+    can_delete: true,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add an explicit `can_delete` contract for video export rows in the backend API.
- Update the frontend to rely on `can_delete` instead of inferring deleteability from cancel state.
- Cover the new behavior with backend and frontend tests.

## Validation
- `pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- VideoExportJobsPanel.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video export job deletion permissions are now determined by explicit backend permissions rather than being inferred from job cancellation state.
  * Overlay export jobs cannot be deleted while running or processing.
  * Terminal job states (completed, failed, cancelled) are now properly marked as deletable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->