### PR TITLE
fix(frontend): require hour selection for future emagrams

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -70,12 +70,12 @@ const mockEmagramData = {
       ],
       par_source: {
         'meteo-parapente': [
-          "Courbe observee: temperature bien décroissante sous 2500 m | Comment la reconnaitre: courbe principale inclinée sans cassure nette | Interpretation: couche convective profonde | Consequence parapente: créneau favorable après 11h.",
-          "Courbe observee: point de rosée éloigné de la température | Comment la reconnaitre: grand espace entre les deux courbes | Interpretation: air assez sec | Consequence parapente: plafond correct mais nuages peu nombreux.",
+          'Courbe observee: temperature bien décroissante sous 2500 m | Comment la reconnaitre: courbe principale inclinée sans cassure nette | Interpretation: couche convective profonde | Consequence parapente: créneau favorable après 11h.',
+          'Courbe observee: point de rosée éloigné de la température | Comment la reconnaitre: grand espace entre les deux courbes | Interpretation: air assez sec | Consequence parapente: plafond correct mais nuages peu nombreux.',
         ],
         meteociel: [
-          "Courbe observee: inversion faible vers 2600 m | Comment la reconnaitre: la température devient presque verticale | Interpretation: frein en haut de convection | Consequence parapente: plafond exploitable mais transitions au-dessus plus limitées.",
-          "Courbe observee: vent en altitude modéré | Comment la reconnaitre: barbules plus longues au-dessus de 2000 m | Interpretation: dérive en hausse | Consequence parapente: surveiller le retour au terrain.",
+          'Courbe observee: inversion faible vers 2600 m | Comment la reconnaitre: la température devient presque verticale | Interpretation: frein en haut de convection | Consequence parapente: plafond exploitable mais transitions au-dessus plus limitées.',
+          'Courbe observee: vent en altitude modéré | Comment la reconnaitre: barbules plus longues au-dessus de 2000 m | Interpretation: dérive en hausse | Consequence parapente: surveiller le retour au terrain.',
         ],
       },
     },
@@ -218,6 +218,18 @@ export const DifferentDay = meta.story({
   args: { siteId: 'site-arguel', dayIndex: 2 },
   parameters: { msw: { handlers: defaultHandlers } },
 });
+
+DifferentDay.test(
+  'asks to choose an hour before analysis',
+  async ({ canvas }) => {
+    await canvas.findByText(/Choisissez une heure/);
+    await expect(canvas.getByText(/11h/)).toBeInTheDocument();
+    await expect(canvas.getByText(/14h/)).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('button', { name: /Afficher l'émagramme/ })
+    ).not.toBeInTheDocument();
+  }
+);
 
 export const NoSite = meta.story({
   name: 'No Site',

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -79,6 +79,7 @@ function HourSlider({
 }) {
   if (hours.length === 0) return null;
 
+  const hasSelectedHour = selectedHour !== null;
   const foundIndex = hours.findIndex((h) => h.hour === selectedHour);
   const currentIndex = foundIndex >= 0 ? foundIndex : 0;
   const effectiveHour = hours[currentIndex].hour;
@@ -94,7 +95,7 @@ function HourSlider({
         aria-label="Sélection de l'heure"
       >
         <SliderOutput className="text-xs text-purple-700 dark:text-purple-300 font-semibold mb-1 block text-center">
-          {effectiveHour}h
+          {hasSelectedHour ? `${effectiveHour}h` : 'Choisir une heure'}
         </SliderOutput>
         <SliderTrack className="relative w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full">
           {({ state }) => (
@@ -111,7 +112,7 @@ function HourSlider({
       </Slider>
       <div className="relative mt-1 h-7">
         {hours.map((h, idx) => {
-          const isActive = h.hour === effectiveHour;
+          const isActive = hasSelectedHour && h.hour === effectiveHour;
           const isFailed = h.status === 'failed';
           const isPending = h.status === 'pending';
           const errorText =
@@ -198,21 +199,18 @@ export default function EmagramWidget({
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [selectedHour, setSelectedHour] = useState<number | null>(null);
-  const [hasRequestedDisplay, setHasRequestedDisplay] = useState(
-    dayIndex === 0
-  );
 
   useEffect(() => {
     setSelectedHour(null);
-    setHasRequestedDisplay(dayIndex === 0);
   }, [dayIndex, siteId]);
 
-  const shouldFetchEmagram =
-    !!siteId && (dayIndex === 0 || hasRequestedDisplay);
-
-  const { data: hoursData } = useEmagramHours(siteId, dayIndex, {
-    enabled: shouldFetchEmagram,
-  });
+  const { data: hoursData, isLoading: isLoadingHours } = useEmagramHours(
+    siteId,
+    dayIndex,
+    {
+      enabled: !!siteId,
+    }
+  );
 
   const availableHours = useMemo(
     () => [...(hoursData?.hours ?? [])].sort((a, b) => a.hour - b.hour),
@@ -227,8 +225,8 @@ export default function EmagramWidget({
     ) {
       return selectedHour;
     }
-    if (!availableHours.length) return selectedHour;
-    const targetHour = dayIndex > 0 ? 14 : new Date().getHours();
+    if (!availableHours.length || dayIndex > 0) return selectedHour;
+    const targetHour = new Date().getHours();
     const hours = availableHours.map((h) => h.hour);
 
     if (hours.includes(targetHour)) return targetHour;
@@ -237,6 +235,9 @@ export default function EmagramWidget({
       Math.abs(curr - targetHour) < Math.abs(prev - targetHour) ? curr : prev
     );
   }, [selectedHour, availableHours, dayIndex]);
+
+  const shouldFetchEmagram =
+    !!siteId && (dayIndex === 0 || activeHour !== null);
 
   const {
     data: emagram,
@@ -314,17 +315,15 @@ export default function EmagramWidget({
         <div className="flex items-center justify-between mb-3">
           <EmagramHeaderTitle siteName={siteName} />
         </div>
+        {hourSlider}
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
-          Cliquez pour afficher l&apos;émagramme de ce jour.
-        </div>
-        <div className="flex justify-center">
-          <Button
-            onPress={() => setHasRequestedDisplay(true)}
-            isDisabled={!siteId}
-            className="px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:opacity-50"
-          >
-            Afficher l&apos;émagramme
-          </Button>
+          {!siteId
+            ? 'Aucun site selectionne'
+            : isLoadingHours
+              ? 'Chargement des heures...'
+              : hasHourlyData
+                ? 'Choisissez une heure pour lancer l’analyse.'
+                : 'Aucun créneau horaire disponible.'}
         </div>
       </div>
     );

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -318,7 +318,7 @@ export default function EmagramWidget({
         {hourSlider}
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
           {!siteId
-            ? 'Aucun site selectionne'
+            ? 'Aucun site sélectionné'
             : isLoadingHours
               ? 'Chargement des heures...'
               : hasHourlyData


### PR DESCRIPTION
## Summary
- show the hour slider directly for non-today emagrams
- start analysis only after the user picks an hour
- add a story test for the future-day flow

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e` ✅
- `CI=true NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e` ✅ Nx reported success, but the shell command hit the timeout because Vitest/Playwright processes stayed alive

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hour selection interface now prompts users to choose a time slot when switching between forecast days, with available hourly options clearly displayed
  * Enhanced UI feedback based on data loading states and availability

* **Tests**
  * Added test coverage for day-switching scenarios with hour selection workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->