### PR TITLE
Fix emagram explanation on mobile

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.test.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EmagramExplanationTooltip } from './EmagramExplanationTooltip';
+import type { EmagramAnalysis } from '../../types/emagram';
+
+const emagram: EmagramAnalysis = {
+  id: 'emagram-test',
+  analysis_date: '2026-03-24',
+  analysis_time: '12:00',
+  analysis_datetime: '2026-03-24T12:00:00Z',
+  station_code: 'site-arguel',
+  station_name: 'Arguel',
+  station_latitude: 47.2,
+  station_longitude: 6.0,
+  distance_km: 0,
+  data_source: 'test',
+  sounding_time: '12Z',
+  llm_provider: 'google',
+  llm_model: 'gemini-2.5-flash',
+  llm_tokens_used: null,
+  llm_cost_usd: null,
+  analysis_method: 'llm_vision',
+  plafond_thermique_m: 2500,
+  force_thermique_ms: 2.5,
+  cape_jkg: null,
+  stabilite_atmospherique: 'instable',
+  cisaillement_vent: 'faible',
+  heure_debut_thermiques: '11:00',
+  heure_fin_thermiques: '17:00',
+  heures_volables_total: 6,
+  risque_orage: 'faible',
+  score_volabilite: 75,
+  resume_conditions: 'Bonnes conditions thermiques.',
+  conseils_vol: 'Thermiques exploitables dès 11h.',
+  alertes_securite: null,
+  lcl_m: null,
+  lfc_m: null,
+  el_m: null,
+  lifted_index: null,
+  k_index: null,
+  total_totals: null,
+  showalter_index: null,
+  wind_shear_0_3km_ms: null,
+  wind_shear_0_6km_ms: null,
+  skewt_image_path: null,
+  raw_sounding_data: null,
+  ai_raw_response: JSON.stringify({
+    explication_analyse: {
+      resume: 'Le score est bon grâce aux thermiques établis.',
+      indices: ['Plafond correct au-dessus du relief.'],
+      par_source: {
+        'meteo-parapente': ['Courbe de température bien décroissante.'],
+      },
+    },
+  }),
+  analysis_status: 'completed',
+  error_message: null,
+  is_from_llm: true,
+  has_thermal_data: true,
+  flyable_hours_formatted: '6h',
+  screenshot_paths: JSON.stringify({
+    'meteo-parapente': '/tmp/test-mp.png',
+  }),
+  sources_count: 1,
+  sources_agreement: 'high',
+  created_at: '2026-03-24T12:00:00Z',
+  updated_at: '2026-03-24T12:00:00Z',
+};
+
+describe('EmagramExplanationTooltip', () => {
+  it('opens explanation content on click', async () => {
+    render(<EmagramExplanationTooltip emagram={emagram} compact />);
+
+    fireEvent.click(screen.getByLabelText("Comment l'IA a analysé ?"));
+
+    await expect(
+      screen.findByText('Lecture par émagramme')
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.getByText('Le score est bon grâce aux thermiques établis.')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramExplanationTooltip.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, TooltipTrigger } from 'react-aria-components';
+import { Button, Dialog, DialogTrigger, Popover } from 'react-aria-components';
 import { parseAnalysisExplanation } from '../../types/emagram';
 import type {
   EmagramAnalysis,
@@ -15,7 +15,7 @@ const SOURCE_READING_HINTS: Record<string, string> = {
   'meteo-parapente':
     "Sur Météo-Parapente, commence par comparer la courbe de température et celle du point de rosée, puis vérifie le plafond et le vent avec l'altitude.",
   meteociel:
-    "Sur Meteociel, les profils type Skew-T se lisent surtout avec la courbe température, la courbe point de rosée et les barbules de vent à droite.",
+    'Sur Meteociel, les profils type Skew-T se lisent surtout avec la courbe température, la courbe point de rosée et les barbules de vent à droite.',
 };
 
 const CURVE_READING_GUIDE = [
@@ -131,8 +131,94 @@ export function EmagramExplanationTooltip({
   );
   const label = "Comment l'IA a analysé ?";
 
+  const content = (
+    <div className="space-y-3">
+      <div className="font-semibold text-purple-800 dark:text-purple-200">
+        {label}
+      </div>
+      {explanationContent.resume && <p>{explanationContent.resume}</p>}
+      {sources.length > 0 && (
+        <div className="space-y-3 border-t border-gray-100 pt-2 dark:border-gray-700">
+          <div className="font-semibold text-gray-900 dark:text-gray-100">
+            Lecture par émagramme
+          </div>
+          {sources.map((source) => {
+            const observations = explanationContent.par_source[source] ?? [];
+            return (
+              <div
+                key={source}
+                className="rounded-md border border-gray-100 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800/60"
+              >
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <div className="font-semibold text-gray-900 dark:text-gray-100">
+                    {getSourceLabel(source)}
+                  </div>
+                  {screenshotSources.includes(source) && (
+                    <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-medium text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
+                      image capturée
+                    </span>
+                  )}
+                </div>
+                <p className="mb-2 text-[11px] text-gray-600 dark:text-gray-300">
+                  {SOURCE_READING_HINTS[source] ??
+                    "Lis cette image en comparant d'abord température, point de rosée, plafond et vent avec l'altitude."}
+                </p>
+                <div className="space-y-1.5">
+                  {CURVE_READING_GUIDE.map((item) => (
+                    <div key={item.label}>
+                      <span className="font-medium text-gray-800 dark:text-gray-100">
+                        {item.label}
+                      </span>{' '}
+                      <span className="text-gray-500 dark:text-gray-400">
+                        Repère : {item.recognize} Sens : {item.meaning}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                {observations.length > 0 && (
+                  <div className="mt-2 border-t border-gray-200 pt-2 dark:border-gray-700">
+                    <div className="mb-1 font-medium text-gray-800 dark:text-gray-100">
+                      Ce que l’IA observe sur cette image
+                    </div>
+                    <ul className="space-y-1 pl-4">
+                      {observations.map((observation) => (
+                        <li key={observation} className="list-disc">
+                          {observation}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {explanationContent.indices.length > 0 && (
+        <div className="border-t border-gray-100 pt-2 dark:border-gray-700">
+          <div className="mb-1 font-semibold text-gray-900 dark:text-gray-100">
+            Indices globaux
+          </div>
+          <ul className="space-y-1 pl-4">
+            {explanationContent.indices.map((indice) => (
+              <li key={indice} className="list-disc">
+                {indice}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="border-t border-gray-100 pt-2 text-[11px] text-gray-500 dark:border-gray-700 dark:text-gray-400">
+        {emagram.llm_model ? `Modèle : ${emagram.llm_model}` : 'Analyse IA'}
+        {emagram.sources_agreement
+          ? ` • Consensus : ${emagram.sources_agreement}`
+          : ''}
+      </div>
+    </div>
+  );
+
   return (
-    <TooltipTrigger>
+    <DialogTrigger>
       <Button
         className={`inline-flex items-center gap-1 rounded-full border border-purple-200 bg-purple-50 text-purple-700 hover:bg-purple-100 dark:border-purple-700 dark:bg-purple-900/30 dark:text-purple-200 dark:hover:bg-purple-900/50 transition-colors cursor-pointer ${
           compact ? 'px-2 py-1 text-[11px]' : 'px-3 py-1.5 text-xs'
@@ -142,91 +228,14 @@ export function EmagramExplanationTooltip({
         <span aria-hidden="true">?</span>
         {!compact && <span>{label}</span>}
       </Button>
-      <Tooltip className="max-h-[80vh] w-[calc(100vw-2rem)] max-w-2xl overflow-y-auto rounded-lg border border-purple-200 bg-white p-3 text-xs text-gray-700 shadow-xl dark:border-purple-700 dark:bg-gray-900 dark:text-gray-200">
-        <div className="space-y-3">
-          <div className="font-semibold text-purple-800 dark:text-purple-200">
-            {label}
-          </div>
-          {explanationContent.resume && <p>{explanationContent.resume}</p>}
-          {sources.length > 0 && (
-            <div className="space-y-3 border-t border-gray-100 pt-2 dark:border-gray-700">
-              <div className="font-semibold text-gray-900 dark:text-gray-100">
-                Lecture par émagramme
-              </div>
-              {sources.map((source) => {
-                const observations = explanationContent.par_source[source] ?? [];
-                return (
-                  <div
-                    key={source}
-                    className="rounded-md border border-gray-100 bg-gray-50 p-2 dark:border-gray-700 dark:bg-gray-800/60"
-                  >
-                    <div className="mb-1 flex items-center justify-between gap-2">
-                      <div className="font-semibold text-gray-900 dark:text-gray-100">
-                        {getSourceLabel(source)}
-                      </div>
-                      {screenshotSources.includes(source) && (
-                        <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-medium text-purple-700 dark:bg-purple-900/40 dark:text-purple-200">
-                          image capturée
-                        </span>
-                      )}
-                    </div>
-                    <p className="mb-2 text-[11px] text-gray-600 dark:text-gray-300">
-                      {SOURCE_READING_HINTS[source] ??
-                        "Lis cette image en comparant d'abord température, point de rosée, plafond et vent avec l'altitude."}
-                    </p>
-                    <div className="space-y-1.5">
-                      {CURVE_READING_GUIDE.map((item) => (
-                        <div key={item.label}>
-                          <span className="font-medium text-gray-800 dark:text-gray-100">
-                            {item.label}
-                          </span>{' '}
-                          <span className="text-gray-500 dark:text-gray-400">
-                            Repère : {item.recognize} Sens : {item.meaning}
-                          </span>
-                        </div>
-                      ))}
-                    </div>
-                    {observations.length > 0 && (
-                      <div className="mt-2 border-t border-gray-200 pt-2 dark:border-gray-700">
-                        <div className="mb-1 font-medium text-gray-800 dark:text-gray-100">
-                          Ce que l’IA observe sur cette image
-                        </div>
-                        <ul className="space-y-1 pl-4">
-                          {observations.map((observation) => (
-                            <li key={observation} className="list-disc">
-                              {observation}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {explanationContent.indices.length > 0 && (
-            <div className="border-t border-gray-100 pt-2 dark:border-gray-700">
-              <div className="mb-1 font-semibold text-gray-900 dark:text-gray-100">
-                Indices globaux
-              </div>
-              <ul className="space-y-1 pl-4">
-                {explanationContent.indices.map((indice) => (
-                  <li key={indice} className="list-disc">
-                    {indice}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          <div className="border-t border-gray-100 pt-2 text-[11px] text-gray-500 dark:border-gray-700 dark:text-gray-400">
-            {emagram.llm_model ? `Modèle : ${emagram.llm_model}` : 'Analyse IA'}
-            {emagram.sources_agreement
-              ? ` • Consensus : ${emagram.sources_agreement}`
-              : ''}
-          </div>
-        </div>
-      </Tooltip>
-    </TooltipTrigger>
+      <Popover
+        className="z-50 max-h-[80vh] w-[calc(100vw-2rem)] max-w-2xl overflow-y-auto rounded-lg border border-purple-200 bg-white p-3 text-xs text-gray-700 shadow-xl dark:border-purple-700 dark:bg-gray-900 dark:text-gray-200"
+        offset={8}
+      >
+        <Dialog aria-label={label} className="outline-none">
+          {content}
+        </Dialog>
+      </Popover>
+    </DialogTrigger>
   );
 }

--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -70,12 +70,12 @@ const mockEmagramData = {
       ],
       par_source: {
         'meteo-parapente': [
-          "Courbe observee: temperature bien décroissante sous 2500 m | Comment la reconnaitre: courbe principale inclinée sans cassure nette | Interpretation: couche convective profonde | Consequence parapente: créneau favorable après 11h.",
-          "Courbe observee: point de rosée éloigné de la température | Comment la reconnaitre: grand espace entre les deux courbes | Interpretation: air assez sec | Consequence parapente: plafond correct mais nuages peu nombreux.",
+          'Courbe observee: temperature bien décroissante sous 2500 m | Comment la reconnaitre: courbe principale inclinée sans cassure nette | Interpretation: couche convective profonde | Consequence parapente: créneau favorable après 11h.',
+          'Courbe observee: point de rosée éloigné de la température | Comment la reconnaitre: grand espace entre les deux courbes | Interpretation: air assez sec | Consequence parapente: plafond correct mais nuages peu nombreux.',
         ],
         meteociel: [
-          "Courbe observee: inversion faible vers 2600 m | Comment la reconnaitre: la température devient presque verticale | Interpretation: frein en haut de convection | Consequence parapente: plafond exploitable mais transitions au-dessus plus limitées.",
-          "Courbe observee: vent en altitude modéré | Comment la reconnaitre: barbules plus longues au-dessus de 2000 m | Interpretation: dérive en hausse | Consequence parapente: surveiller le retour au terrain.",
+          'Courbe observee: inversion faible vers 2600 m | Comment la reconnaitre: la température devient presque verticale | Interpretation: frein en haut de convection | Consequence parapente: plafond exploitable mais transitions au-dessus plus limitées.',
+          'Courbe observee: vent en altitude modéré | Comment la reconnaitre: barbules plus longues au-dessus de 2000 m | Interpretation: dérive en hausse | Consequence parapente: surveiller le retour au terrain.',
         ],
       },
     },
@@ -150,8 +150,13 @@ export const Default = meta.story({
 Default.test('displays emagram score and metrics', async ({ canvas }) => {
   await canvas.findByText(/75/);
   await expect(canvas.getByText(/Arguel/)).toBeInTheDocument();
+  const explanationButton = canvas.getByLabelText(/Comment l'IA a analysé/);
+  await expect(explanationButton).toBeInTheDocument();
+
+  await userEvent.click(explanationButton);
+
   await expect(
-    canvas.getByLabelText(/Comment l'IA a analysé/)
+    await within(document.body).findByText(/Lecture par émagramme/)
   ).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
- Replace the emagram help tooltip with a tap-friendly popover so the explanation opens on mobile.
- Add a unit test and update the story interaction check for the explanation panel.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend --runInBand`