### PR TITLE
Fix emagram screenshot visibility

### DIFF
--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -416,7 +416,7 @@ async def fetch_all_emagram_screenshots(
 def cleanup_old_screenshots(max_age_hours: int = 1, cache_dir: Path | None = None):
     """
     Delete screenshot images that are no longer needed.
-    Protects screenshots referenced by the latest completed analysis per site.
+    Protects screenshots referenced by fresh completed analyses.
     Files younger than max_age_hours are never deleted (race-condition guard).
 
     Args:
@@ -431,39 +431,28 @@ def cleanup_old_screenshots(max_age_hours: int = 1, cache_dir: Path | None = Non
 
     target_dir = cache_dir or EMAGRAM_CACHE_DIR
 
-    # Build set of protected file paths from latest analysis per site
+    # Build set of protected file paths from analyses the UI can still display.
     protected_paths: set[str] = set()
     try:
         with get_db_context() as db:
-            from sqlalchemy import func
+            from emagram_freshness import get_emagram_cutoff_utc
 
-            latest_subq = (
-                db.query(
-                    EmagramAnalysis.station_code,
-                    func.max(EmagramAnalysis.analysis_datetime).label("max_dt"),
-                )
-                .filter(EmagramAnalysis.analysis_status == "completed")
-                .group_by(EmagramAnalysis.station_code)
-                .subquery()
-            )
-
-            latest_analyses = (
+            fresh_analyses = (
                 db.query(EmagramAnalysis)
-                .join(
-                    latest_subq,
-                    (EmagramAnalysis.station_code == latest_subq.c.station_code)
-                    & (EmagramAnalysis.analysis_datetime == latest_subq.c.max_dt),
+                .filter(
+                    EmagramAnalysis.analysis_status == "completed",
+                    EmagramAnalysis.analysis_datetime >= get_emagram_cutoff_utc(db=db),
+                    EmagramAnalysis.screenshot_paths.isnot(None),
                 )
                 .all()
             )
 
-            for analysis in latest_analyses:
-                if analysis.screenshot_paths:
-                    try:
-                        paths = json.loads(analysis.screenshot_paths)
-                        protected_paths.update(paths.values())
-                    except (json.JSONDecodeError, AttributeError):
-                        pass
+            for analysis in fresh_analyses:
+                try:
+                    paths = json.loads(analysis.screenshot_paths)
+                    protected_paths.update(paths.values())
+                except (json.JSONDecodeError, AttributeError, TypeError):
+                    pass
     except Exception as e:
         logger.warning(f"Could not query DB for protected paths, skipping cleanup: {e}")
         return 0

--- a/apps/backend/tests/test_emagram.py
+++ b/apps/backend/tests/test_emagram.py
@@ -319,6 +319,76 @@ class TestCleanupOldScreenshots:
         assert not old_file.exists(), "Old analysis screenshot should be deleted"
         assert new_file.exists(), "Latest analysis screenshot should be preserved"
 
+    def test_cleanup_preserves_fresh_hourly_analysis_screenshots(self, db_session, tmp_path):
+        """Fresh hourly analyses remain viewable even when they are not latest per site"""
+        import json
+        import os
+        from datetime import datetime, timedelta
+        from unittest.mock import patch
+
+        from models import EmagramAnalysis
+
+        morning_file = tmp_path / "Arguel_meteo-parapente_h9.png"
+        morning_file.write_bytes(b"morning")
+        noon_file = tmp_path / "Arguel_meteo-parapente_h12.png"
+        noon_file.write_bytes(b"noon")
+        stale_file = tmp_path / "Arguel_meteo-parapente_stale.png"
+        stale_file.write_bytes(b"stale")
+
+        old_mtime = (datetime.now() - timedelta(hours=2)).timestamp()
+        os.utime(morning_file, (old_mtime, old_mtime))
+        os.utime(noon_file, (old_mtime, old_mtime))
+        os.utime(stale_file, (old_mtime, old_mtime))
+
+        common = {
+            "analysis_date": datetime.now().date(),
+            "analysis_time": datetime.now().time(),
+            "station_code": "site-arguel",
+            "station_name": "Arguel",
+            "station_latitude": 47.2,
+            "station_longitude": 6.0,
+            "distance_km": 0.0,
+            "data_source": "test",
+            "sounding_time": "12Z",
+            "analysis_method": "llm_vision",
+            "analysis_status": "completed",
+        }
+        morning_analysis = EmagramAnalysis(
+            id="fresh-hour-9",
+            analysis_datetime=datetime.utcnow() - timedelta(hours=2),
+            forecast_hour=9,
+            screenshot_paths=json.dumps({"meteo-parapente": str(morning_file)}),
+            **common,
+        )
+        noon_analysis = EmagramAnalysis(
+            id="fresh-hour-12",
+            analysis_datetime=datetime.utcnow() - timedelta(hours=1),
+            forecast_hour=12,
+            screenshot_paths=json.dumps({"meteo-parapente": str(noon_file)}),
+            **common,
+        )
+        stale_analysis = EmagramAnalysis(
+            id="stale-hour-15",
+            analysis_datetime=datetime.utcnow() - timedelta(hours=4),
+            forecast_hour=15,
+            screenshot_paths=json.dumps({"meteo-parapente": str(stale_file)}),
+            **common,
+        )
+        db_session.add_all([morning_analysis, noon_analysis, stale_analysis])
+        db_session.commit()
+
+        from scrapers.emagram_screenshots import cleanup_old_screenshots
+
+        with patch("database.get_db_context") as mock_ctx:
+            mock_ctx.return_value.__enter__ = lambda s: db_session
+            mock_ctx.return_value.__exit__ = lambda s, *a: None
+            deleted = cleanup_old_screenshots(max_age_hours=1, cache_dir=tmp_path)
+
+        assert deleted == 1
+        assert morning_file.exists(), "Fresh non-latest hourly screenshot should be preserved"
+        assert noon_file.exists(), "Latest hourly screenshot should be preserved"
+        assert not stale_file.exists(), "Stale screenshot should be deleted"
+
     def test_cleanup_deletes_orphan_files(self, db_session, tmp_path):
         """PNG files not referenced by any analysis are deleted if old enough"""
         from datetime import datetime, timedelta

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../types/emagram';
 import { useState, useMemo, useEffect } from 'react';
 import { parseApiUtcDate } from '../../lib/date';
+import { getApiUrl } from '../../lib/api';
 import { Lightbox } from '@dashboard-parapente/design-system';
 import { EmagramExplanationTooltip } from './EmagramExplanationTooltip';
 import {
@@ -648,7 +649,7 @@ export default function EmagramWidget({
                   })
                 : '';
               const lightboxImages = sourceKeys.map((source) => ({
-                src: `/api/emagram/screenshot/${emagram.id}/${source}`,
+                src: getApiUrl(`/emagram/screenshot/${emagram.id}/${source}`),
                 alt: [
                   source
                     .replace('-', ' ')

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -9,11 +9,17 @@ type ApiErrorPayload = {
 let _apiLogsEnabled = import.meta.env.DEV;
 
 const apiBaseUrl = import.meta.env.VITE_API_URL?.replace(/\/$/, '');
+const apiPrefix = apiBaseUrl ? `${apiBaseUrl}/api` : '/api';
+
+export function getApiUrl(path: string) {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${apiPrefix}${normalizedPath}`;
+}
 
 // Instance Ky configurée pour l'API backend
 // eslint-disable-next-line import/no-mutable-exports
 export let api = ky.create({
-  prefix: apiBaseUrl ? `${apiBaseUrl}/api` : '/api',
+  prefix: apiPrefix,
   timeout: 30000, // 30 secondes
   retry: {
     limit: 2, // Retry 2 fois en cas d'échec

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -25,6 +25,7 @@ import {
   Lightbox,
 } from '@dashboard-parapente/design-system';
 import { parseApiUtcDate } from '../lib/date';
+import { getApiUrl } from '../lib/api';
 import { EmagramExplanationTooltip } from '../components/dashboard/EmagramExplanationTooltip';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
@@ -159,7 +160,7 @@ export default function ThermalAnalysis() {
       }
 
       return Object.keys(screenshots).map((source) => ({
-        src: `/api/emagram/screenshot/${latest.id}/${source}`,
+        src: getApiUrl(`/emagram/screenshot/${latest.id}/${source}`),
         alt: formatSourceName(source),
       }));
     } catch {


### PR DESCRIPTION
## Summary
- Preserve emagram screenshots for analyses that are still fresh enough to be shown in the UI.
- Build screenshot URLs through the API base helper so `VITE_API_URL` works for image requests too.

## Validation
- `pytest tests/test_emagram.py -q --tb=short --no-header` ✅
- `ruff check scrapers/emagram_screenshots.py tests/test_emagram.py` ✅
- `black --check --diff scrapers/emagram_screenshots.py tests/test_emagram.py` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5` timed out on the long-running suite