### PR TITLE
fix(frontend): attach auth token to emagram screenshots

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -17,7 +17,8 @@ import {
 } from '../../types/emagram';
 import { useState, useMemo, useEffect } from 'react';
 import { parseApiUtcDate } from '../../lib/date';
-import { getApiUrl } from '../../lib/api';
+import { getApiUrlWithSearchParams } from '../../lib/api';
+import { useAuthStore } from '../../stores/authStore';
 import { Lightbox } from '@dashboard-parapente/design-system';
 import { EmagramExplanationTooltip } from './EmagramExplanationTooltip';
 import {
@@ -200,6 +201,7 @@ export default function EmagramWidget({
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [selectedHour, setSelectedHour] = useState<number | null>(null);
+  const authToken = useAuthStore((s) => s.token);
 
   useEffect(() => {
     setSelectedHour(null);
@@ -649,7 +651,10 @@ export default function EmagramWidget({
                   })
                 : '';
               const lightboxImages = sourceKeys.map((source) => ({
-                src: getApiUrl(`/emagram/screenshot/${emagram.id}/${source}`),
+                src: getApiUrlWithSearchParams(
+                  `/emagram/screenshot/${emagram.id}/${source}`,
+                  { access_token: authToken }
+                ),
                 alt: [
                   source
                     .replace('-', ' ')

--- a/apps/frontend/src/lib/api.test.ts
+++ b/apps/frontend/src/lib/api.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getApiUrlWithSearchParams } from './api';
+
+describe('getApiUrlWithSearchParams', () => {
+  it('appends non-empty search params to api urls', () => {
+    const url = getApiUrlWithSearchParams('/emagram/screenshot/abc/source', {
+      access_token: 'token-123',
+    });
+
+    expect(url).toContain(
+      '/api/emagram/screenshot/abc/source?access_token=token-123'
+    );
+  });
+
+  it('ignores empty search params', () => {
+    const url = getApiUrlWithSearchParams('/emagram/screenshot/abc/source', {
+      access_token: null,
+      unused: undefined,
+    });
+
+    expect(url).toContain('/api/emagram/screenshot/abc/source');
+    expect(url).not.toContain('access_token=');
+  });
+});

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -16,6 +16,26 @@ export function getApiUrl(path: string) {
   return `${apiPrefix}${normalizedPath}`;
 }
 
+export function getApiUrlWithSearchParams(
+  path: string,
+  searchParams: Record<string, string | null | undefined>
+) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+
+  const queryString = params.toString();
+  if (!queryString) {
+    return getApiUrl(path);
+  }
+
+  const url = getApiUrl(path);
+  return `${url}${url.includes('?') ? '&' : '?'}${queryString}`;
+}
+
 // Instance Ky configurée pour l'API backend
 // eslint-disable-next-line import/no-mutable-exports
 export let api = ky.create({

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -25,7 +25,8 @@ import {
   Lightbox,
 } from '@dashboard-parapente/design-system';
 import { parseApiUtcDate } from '../lib/date';
-import { getApiUrl } from '../lib/api';
+import { getApiUrlWithSearchParams } from '../lib/api';
+import { useAuthStore } from '../stores/authStore';
 import { EmagramExplanationTooltip } from '../components/dashboard/EmagramExplanationTooltip';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
@@ -145,6 +146,7 @@ export default function ThermalAnalysis() {
   const triggerMutation = useTriggerEmagram();
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+  const authToken = useAuthStore((s) => s.token);
 
   const screenshotImages = useMemo(() => {
     if (!latest?.screenshot_paths) return [];
@@ -160,13 +162,16 @@ export default function ThermalAnalysis() {
       }
 
       return Object.keys(screenshots).map((source) => ({
-        src: getApiUrl(`/emagram/screenshot/${latest.id}/${source}`),
+        src: getApiUrlWithSearchParams(
+          `/emagram/screenshot/${latest.id}/${source}`,
+          { access_token: authToken }
+        ),
         alt: formatSourceName(source),
       }));
     } catch {
       return [];
     }
-  }, [latest?.id, latest?.screenshot_paths]);
+  }, [authToken, latest?.id, latest?.screenshot_paths]);
 
   const handleRefresh = async () => {
     if (!selectedSiteId) return;


### PR DESCRIPTION
## Summary
- Send the authenticated access token with direct emagram screenshot URLs so the lightbox image request no longer hits 401.
- Reuse the same auth-aware URL helper in the thermal analysis page.
- Add a small unit test for the API URL helper.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend` (backend lint failed in environment: missing `ruff`)
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5` (backend test failed in environment: missing `pytest`, frontend suite did not complete within shell timeout)
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `/home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts src/lib/api.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication for thermal analysis screenshots, ensuring proper credential handling when loading images.

* **Tests**
  * Added test coverage for URL generation with query parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->