### PR TITLE
fix(backend): tolerate stale rq job executions

### DIFF
--- a/apps/backend/job_queue.py
+++ b/apps/backend/job_queue.py
@@ -40,6 +40,15 @@ def _job_status_value(job: Job) -> str | None:
     return _status_value(job.get_status(refresh=True))
 
 
+def _delete_stale_job(job: Job) -> None:
+    try:
+        job.delete()
+    except ValueError as error:
+        message = str(error)
+        if "Execution" not in message or "not found in Redis" not in message:
+            raise
+
+
 def delete_job(job_id: str, queue_name: str | None = None) -> bool:
     queue = get_queue(queue_name)
     job = queue.fetch_job(job_id)
@@ -47,7 +56,7 @@ def delete_job(job_id: str, queue_name: str | None = None) -> bool:
         return False
     if _job_status_value(job) == "started":
         send_stop_job_command(queue.connection, job_id)
-    job.delete()
+    _delete_stale_job(job)
     return True
 
 
@@ -64,7 +73,7 @@ def enqueue_once(
     if existing_job is not None:
         if _job_status_value(existing_job) in _PENDING_JOB_STATUSES:
             return existing_job
-        existing_job.delete()
+        _delete_stale_job(existing_job)
 
     return queue.enqueue(
         function_path,

--- a/apps/backend/tests/unit/test_job_queue.py
+++ b/apps/backend/tests/unit/test_job_queue.py
@@ -4,14 +4,17 @@ import job_queue
 
 
 class FakeJob:
-    def __init__(self, status: str):
+    def __init__(self, status: str, delete_error: Exception | None = None):
         self.status = status
+        self.delete_error = delete_error
         self.deleted = False
 
     def get_status(self, refresh: bool = True) -> str:
         return self.status
 
     def delete(self) -> None:
+        if self.delete_error:
+            raise self.delete_error
         self.deleted = True
 
 
@@ -74,3 +77,21 @@ def test_enqueue_once_replaces_terminal_existing_job(monkeypatch):
 
     assert existing_job.deleted is True
     assert len(queue.enqueued) == 1
+
+
+def test_enqueue_once_ignores_stale_rq_execution_metadata(monkeypatch):
+    existing_job = FakeJob(
+        "failed",
+        delete_error=ValueError("Execution stale-execution-id not found in Redis"),
+    )
+    queue = FakeQueue(existing_job)
+    monkeypatch.setattr(job_queue, "get_queue", lambda _name=None: queue)
+
+    result = job_queue.enqueue_once(
+        "video_export_manual.process_video_export_job",
+        "job-recovered",
+        job_id="video-export-job-recovered",
+    )
+
+    assert result == queue.enqueued[0]
+    assert queue.enqueued[0]["kwargs"]["job_id"] == "video-export-job-recovered"


### PR DESCRIPTION
## Summary
- tolerate stale RQ execution metadata when replacing old jobs
- keep backend startup from failing on orphaned Redis job state
- add a regression test for the stale execution case

## Validation
- `pytest tests/unit/test_job_queue.py -q --tb=short --no-header` ✅
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend` ✅
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` ⚠️ timed out after running the suite; the changed unit test path passed and the target was executing successfully when the shell timeout hit