### PR TITLE
docs(agents): add coderabbit cli skill

### DIFF
--- a/.agents/skills/coderabbit-cli/SKILL.md
+++ b/.agents/skills/coderabbit-cli/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: coderabbit-cli
+description: Runs CodeRabbit CLI reviews and turns findings into an interactive correction workflow. Use when a shipping, commit, or review workflow needs CodeRabbit checks, when preparing a commit with `cr review`, or when the user mentions CodeRabbit CLI, CodeRabbit review, `cr review`, or skipping CodeRabbit review.
+---
+
+# CodeRabbit CLI
+
+## Quick Start
+
+Use this skill before committing when a workflow requires CodeRabbit review.
+
+Skip the review only when the user explicitly asks with phrases like:
+
+- `skip coderabbit`
+- `skip cr review`
+- `sans review coderabbit`
+- `no coderabbit`
+
+## Workflow
+
+1. Check whether CodeRabbit CLI is installed:
+
+```sh
+command -v cr
+```
+
+2. If `cr` is missing, install it:
+
+```sh
+curl -fsSL https://cli.coderabbit.ai/install.sh | sh
+```
+
+3. Run the review:
+
+```sh
+cr review
+```
+
+4. If the command reports that authentication is required, start the login flow:
+
+```sh
+cr login
+```
+
+Then run `cr review` again.
+
+5. Parse CodeRabbit output into individual findings.
+
+For each finding, report:
+
+- severity if available;
+- file and line if available;
+- CodeRabbit message;
+- suggested fix if available.
+
+6. Ask the user what to do for each finding:
+
+```md
+Finding 1: [severity] `path/to/file.ts:42`
+CodeRabbit: ...
+Suggested fix: ...
+
+What would you like to do?
+1. Fix
+2. Ignore
+3. Provide instructions
+```
+
+7. Apply only corrections explicitly approved by the user.
+
+8. If the user gives custom instructions, follow them for that finding only unless they say otherwise.
+
+9. Continue until every finding is fixed, ignored, or explicitly accepted.
+
+10. Re-run relevant checks after making corrections.
+
+11. Do not commit while unresolved CodeRabbit findings remain.
+
+## Shipping Integration
+
+Shipping or commit workflows should run this skill before committing unless the user explicitly asks to skip CodeRabbit review.
+
+Recognize skip phrases such as `skip coderabbit`, `skip cr review`, `sans review coderabbit`, and `no coderabbit`.
+
+If CodeRabbit returns findings, pause the shipping flow. Present each finding one by one and ask whether to correct it, ignore it, or follow custom instructions. Resume commit only once all findings are fixed, explicitly ignored, or accepted by the user.
+
+## Reporting Rules
+
+Do not collapse all findings into a single summary.
+
+Present findings one by one.
+
+Keep each finding actionable and wait for the user's decision before modifying code for that finding.
+
+If CodeRabbit reports no findings, state that the CodeRabbit review passed.


### PR DESCRIPTION
## Summary
- Add a CodeRabbit CLI skill for pre-commit review workflows.
- Document installation, authentication, review execution, skip phrases, and point-by-point finding handling.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e --files=.agents/skills/coderabbit-cli/SKILL.md` (no tasks)
- `/home/capic/.local/bin/coderabbit review --agent --type uncommitted` (0 findings)

## Notes
- The broader default affected command touched unrelated app projects and failed on existing environment/test setup (`backend:test` missing pytest). The targeted affected run for this `.agents` skill change reported no tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CodeRabbit CLI skill documentation including quick start guide, instructions for running reviews and authentication, interactive finding presentation and correction workflow, and integration rules for pre-commit validation and shipping pause when findings exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->