### PR TITLE
fix(frontend): remove redundant weather selection badge

### DIFF
--- a/apps/frontend/src/components/weather/WeatherSelectionPanel.tsx
+++ b/apps/frontend/src/components/weather/WeatherSelectionPanel.tsx
@@ -23,7 +23,6 @@ import {
 export type WeatherSelectionTab = 'favorites' | 'search';
 
 type WeatherSelectionPanelProps = {
-  activeWeatherName?: string;
   selectionTab: WeatherSelectionTab;
   sites: Site[];
   selectedSearchTarget: CityWeatherTarget | null;
@@ -41,7 +40,6 @@ type WeatherSelectionPanelProps = {
 };
 
 export default function WeatherSelectionPanel({
-  activeWeatherName,
   selectionTab,
   sites,
   selectedSearchTarget,
@@ -75,16 +73,6 @@ export default function WeatherSelectionPanel({
                 {t('weather.selection.description')}
               </p>
             </div>
-            {activeWeatherName && (
-              <div className="min-w-0 rounded-2xl border border-sky-100 bg-white/80 px-3 py-2 text-sm shadow-sm dark:border-sky-900/60 dark:bg-slate-950/50">
-                <span className="block text-xs font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
-                  {t('weather.selection.current')}
-                </span>
-                <span className="block truncate font-bold text-sky-800 dark:text-sky-200">
-                  {activeWeatherName}
-                </span>
-              </div>
-            )}
           </div>
         </div>
         <div className="p-3 sm:p-4">

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -278,7 +278,6 @@ export default function WeatherPage() {
 
   const selectionPanel = (
     <WeatherSelectionPanel
-      activeWeatherName={activeWeatherName}
       selectionTab={selectionTab}
       sites={sites}
       selectedSearchTarget={selectedSearchTarget}


### PR DESCRIPTION
## Summary
- Remove the duplicate "Actuel" badge from the weather site selection panel.
- Keep the active weather name where it is still used elsewhere in the page.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:test:unit` ✅
- `nx test frontend` hit a pre-existing hang/timeout in the broader vitest target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the active weather name indicator from the weather selection panel interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->