### PR TITLE
fix(frontend): remove redundant selected flight badge

### DIFF
--- a/apps/frontend/src/components/flights/table/Flight.test.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { expect, test, vi } from 'vitest';
+import type { Flight as FlightRecord } from '../../../types';
+
+vi.mock('@dashboard-parapente/design-system', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  Card: ({
+    children,
+    selected,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & { selected?: boolean }) => (
+    <div data-selected={selected ? 'true' : 'false'} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'fr' },
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../../stores/appSettingsStore', () => ({
+  formatAltitudeMeters: (value: number) => `${value} m`,
+  formatDistanceKm: (value: number) => `${value} km`,
+  useAppSettingsStore: () => ({
+    settings: { units: { altitude: 'metric', distance: 'metric' } },
+  }),
+}));
+
+import { Flight } from './Flight';
+
+const flight = {
+  id: 'flight-1',
+  flight_date: '2024-03-15',
+  title: 'Vol thermique',
+  name: 'Vol thermique',
+  duration_minutes: 90,
+  distance_km: 12.5,
+  max_altitude_m: 1465,
+  site_name: 'Puy de Dôme',
+  site_id: 'site-1',
+} as FlightRecord;
+
+test('does not render the selected flight badge', () => {
+  render(
+    <Flight
+      flight={flight}
+      isActive={true}
+      isSelected={false}
+      selectionMode={false}
+      downloadingMedia={null}
+      onSelectFlight={() => undefined}
+      onDeleteFlight={() => undefined}
+      onDownloadGpx={() => undefined}
+      onDownloadVideo={() => undefined}
+      onDownloadOverlay={() => undefined}
+    />
+  );
+
+  expect(screen.queryByText('flights.activeFlight')).not.toBeInTheDocument();
+  expect(screen.getByTestId('flight-row-flight-1')).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  expect(screen.getByTestId('flight-row-flight-1')).toHaveAttribute(
+    'data-selected',
+    'true'
+  );
+});

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next';
 import { Button, Card } from '@dashboard-parapente/design-system';
 import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
 import {
-  Check,
   Clock3,
   Download,
   FileText,
@@ -162,12 +161,6 @@ export function Flight({
       )}
       <div className="flex justify-between items-start mb-2 gap-2 pl-1.5">
         <div className="min-w-0 flex-1">
-          {isHighlighted && (
-            <span className="mb-1 inline-flex items-center gap-1 rounded-full bg-sky-700 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white dark:bg-sky-300 dark:text-sky-950">
-              <Check className="h-3 w-3" aria-hidden="true" />
-              {t('flights.activeFlight')}
-            </span>
-          )}
           <h3 className={`truncate text-sm font-semibold ${titleColor}`}>
             {flight.title || t('flights.untitledFlight')}
           </h3>


### PR DESCRIPTION
## Summary
- remove the extra "Vol sélectionné" badge from flight cards
- keep the active selection styling already applied to the card
- add a focused unit test covering the badge removal

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec vitest run src/components/flights/table/Flight.test.tsx --config vitest.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant "active flight" badge from flight rows. Active flight state is now indicated through visual styling only.

* **Tests**
  * Added test coverage for the flight table row component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->