### PR TITLE
fix media state sync between video and overlay

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -275,19 +275,28 @@ def _flight_gopro_camera_file_exists(db: Session, flight: Flight) -> bool:
     return camera_path.exists()
 
 
-def _flight_gopro_overlay_file_path(db: Session, flight: Flight) -> str | None:
+_GOPRO_OVERLAY_IN_PROGRESS_STATUSES = {"queued", "preparing", "running"}
+
+
+def _flight_gopro_overlay_file_path(
+    db: Session, flight: Flight, job: dict[str, Any] | None = None
+) -> str | None:
     stored_path = _resolve_flight_file_path(flight.gopro_overlay_file_path)
     if stored_path and stored_path.exists():
         return str(stored_path)
+
+    if job:
+        job_output_path = _resolve_flight_file_path(job.get("output_path"))
+        if job_output_path and job_output_path.exists():
+            return str(job_output_path)
 
     output_path = _flight_gopro_overlay_path(db, flight, suppress_config_error=True)
     return str(output_path) if output_path else None
 
 
-def _flight_gopro_overlay_status(flight: Flight) -> str | None:
+def _flight_gopro_overlay_status(flight: Flight, job: dict[str, Any] | None = None) -> str | None:
     if not flight.gopro_overlay_job_id:
         return flight.gopro_overlay_status
-    job = get_gopro_overlay_job(flight.gopro_overlay_job_id)
     return str(job["status"]) if job else flight.gopro_overlay_status
 
 
@@ -310,15 +319,31 @@ def _flight_video_export_progress(flight: Flight) -> int | None:
     return _job_progress(_resolve_export_status(flight.video_export_job_id))
 
 
-def _flight_gopro_overlay_progress(flight: Flight) -> int | None:
-    if not flight.gopro_overlay_job_id or flight.gopro_overlay_status not in {"queued", "running"}:
+def _flight_gopro_overlay_progress(flight: Flight, job: dict[str, Any] | None = None) -> int | None:
+    status = _flight_gopro_overlay_status(flight, job)
+    if not flight.gopro_overlay_job_id or status not in _GOPRO_OVERLAY_IN_PROGRESS_STATUSES:
         return None
-    return _job_progress(get_gopro_overlay_job(flight.gopro_overlay_job_id))
+    if job is None:
+        job = get_gopro_overlay_job(flight.gopro_overlay_job_id)
+    return _job_progress(job)
 
 
 def _flight_gopro_overlay_file_exists(db: Session, flight: Flight) -> bool:
     overlay_path = _flight_gopro_overlay_file_path(db, flight)
     return bool(overlay_path)
+
+
+def _flight_gopro_overlay_state(db: Session, flight: Flight) -> dict[str, Any]:
+    job = (
+        get_gopro_overlay_job(flight.gopro_overlay_job_id) if flight.gopro_overlay_job_id else None
+    )
+    overlay_path = _flight_gopro_overlay_file_path(db, flight, job)
+    return {
+        "status": _flight_gopro_overlay_status(flight, job),
+        "progress": _flight_gopro_overlay_progress(flight, job),
+        "file_path": overlay_path,
+        "file_exists": bool(overlay_path),
+    }
 
 
 def _mark_flight_gopro_overlay_job(db: Session, flight: Flight, job: dict[str, Any]) -> None:
@@ -3120,7 +3145,7 @@ def get_flights(
     # Convert to dict (user_id removed - not needed for single-user app)
     flights_data = []
     for flight in flights:
-        gopro_overlay_file_path = _flight_gopro_overlay_file_path(db, flight)
+        gopro_overlay = _flight_gopro_overlay_state(db, flight)
         flight_dict = {
             "id": flight.id,
             "strava_id": flight.strava_id,
@@ -3145,10 +3170,10 @@ def get_flights(
             "video_file_exists": _flight_video_file_exists(flight),
             "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
             "gopro_overlay_job_id": flight.gopro_overlay_job_id,
-            "gopro_overlay_status": _flight_gopro_overlay_status(flight),
-            "gopro_overlay_progress": _flight_gopro_overlay_progress(flight),
-            "gopro_overlay_file_path": gopro_overlay_file_path,
-            "gopro_overlay_file_exists": bool(gopro_overlay_file_path),
+            "gopro_overlay_status": gopro_overlay["status"],
+            "gopro_overlay_progress": gopro_overlay["progress"],
+            "gopro_overlay_file_path": gopro_overlay["file_path"],
+            "gopro_overlay_file_exists": gopro_overlay["file_exists"],
             "external_url": flight.external_url,
             "created_at": flight.created_at.isoformat() if flight.created_at else None,
             "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
@@ -3315,7 +3340,7 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
                 "Failed to persist calculated max speed for flight %s: %s", flight_id, exc
             )
 
-    gopro_overlay_file_path = _flight_gopro_overlay_file_path(db, flight)
+    gopro_overlay = _flight_gopro_overlay_state(db, flight)
 
     # Build response with flight data
     flight_dict = {
@@ -3344,10 +3369,10 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
         "video_file_exists": _flight_video_file_exists(flight),
         "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
         "gopro_overlay_job_id": flight.gopro_overlay_job_id,
-        "gopro_overlay_status": _flight_gopro_overlay_status(flight),
-        "gopro_overlay_progress": _flight_gopro_overlay_progress(flight),
-        "gopro_overlay_file_path": gopro_overlay_file_path,
-        "gopro_overlay_file_exists": bool(gopro_overlay_file_path),
+        "gopro_overlay_status": gopro_overlay["status"],
+        "gopro_overlay_progress": gopro_overlay["progress"],
+        "gopro_overlay_file_path": gopro_overlay["file_path"],
+        "gopro_overlay_file_exists": gopro_overlay["file_exists"],
         "created_at": flight.created_at.isoformat() if flight.created_at else None,
         "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
     }

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -116,6 +116,36 @@ class TestFlightsListEndpoint:
         assert returned["video_export_progress"] == 42
         assert returned["gopro_overlay_progress"] == 55
 
+    def test_get_flights_includes_preparing_gopro_overlay_progress(
+        self, client, db_session, arguel_site
+    ):
+        """GET /flights treats preparing GoPro overlay jobs as active."""
+        flight = Flight(
+            id="flight-overlay-preparing",
+            name="Flight overlay preparing",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            gopro_overlay_job_id="job-overlay-preparing",
+            gopro_overlay_status="queued",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with patch(
+            "routes.get_gopro_overlay_job",
+            return_value={"status": "preparing", "progress": 12.4},
+        ):
+            response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = next(
+            flight
+            for flight in response.json()["flights"]
+            if flight["id"] == "flight-overlay-preparing"
+        )
+        assert returned["gopro_overlay_status"] == "preparing"
+        assert returned["gopro_overlay_progress"] == 12
+
     def test_get_flights_includes_available_gopro_overlay_path(
         self, client, db_session, monkeypatch, tmp_path
     ):
@@ -173,6 +203,39 @@ class TestFlightsListEndpoint:
         assert returned["gopro_overlay_job_id"] == "job-overlay"
         assert returned["gopro_overlay_status"] == "completed"
         assert returned["gopro_overlay_file_path"] == str(overlay_path)
+        assert returned["gopro_overlay_file_exists"] is True
+
+    def test_get_flights_uses_completed_gopro_overlay_job_output_path(
+        self, client, db_session, arguel_site, tmp_path
+    ):
+        """GET /flights exposes an existing completed job output as downloadable."""
+        output_path = tmp_path / "job-final.mp4"
+        output_path.write_bytes(b"overlay")
+        flight = Flight(
+            id="flight-with-job-overlay",
+            name="Flight with job overlay",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            gopro_overlay_job_id="job-overlay-output",
+            gopro_overlay_status="running",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with patch(
+            "routes.get_gopro_overlay_job",
+            return_value={"status": "completed", "output_path": str(output_path)},
+        ):
+            response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = next(
+            flight
+            for flight in response.json()["flights"]
+            if flight["id"] == "flight-with-job-overlay"
+        )
+        assert returned["gopro_overlay_status"] == "completed"
+        assert returned["gopro_overlay_file_path"] == str(output_path)
         assert returned["gopro_overlay_file_exists"] is True
 
     def test_download_flight_video(self, client, db_session, tmp_path):

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -21,6 +21,11 @@ import {
 } from '../../../hooks/gopro/useGoproOverlay';
 import { useToast } from '../../../hooks/useToast';
 import { api, getApiErrorMessage } from '../../../lib/api';
+import {
+  hasFlightGoproOverlay,
+  hasFlightVideo,
+  isGoproOverlayInProgress,
+} from '../../../lib/flightMediaState';
 import type { Flight, FlightFormData, Site } from '../../../types';
 import { FlightEditForm } from '../edit/FlightEditForm';
 import { formatMediaProgressLabel } from '../table/mediaProgress';
@@ -76,13 +81,9 @@ export function FlightDetails({
     useState<DownloadableFlightMedia | null>(null);
 
   const hasGpx = Boolean(flight.gpx_file_path);
-  const hasVideo = Boolean(
-    flight.video_file_path && flight.video_file_exists === true
-  );
+  const hasVideo = hasFlightVideo(flight);
   const hasGoproCameraVideo = flight.gopro_camera_file_exists === true;
-  const hasPersistedGoproOverlay = Boolean(
-    flight.gopro_overlay_file_path && flight.gopro_overlay_file_exists !== false
-  );
+  const hasPersistedGoproOverlay = hasFlightGoproOverlay(flight);
   const effectiveGoproOverlayJobId =
     goproOverlayJobId ?? flight.gopro_overlay_job_id ?? null;
   const { job: streamedGoproOverlayJob } = useGoproOverlayJobStream(
@@ -92,8 +93,7 @@ export function FlightDetails({
   const goproOverlayJob = streamedGoproOverlayJob ?? createGoproOverlayJob.data;
   const goproOverlayStatus =
     goproOverlayJob?.status ?? flight.gopro_overlay_status ?? null;
-  const isGoproOverlayRunning =
-    goproOverlayStatus === 'queued' || goproOverlayStatus === 'running';
+  const isGoproOverlayRunning = isGoproOverlayInProgress(goproOverlayStatus);
   const isVideoExportRunning = Boolean(
     flight.video_export_status &&
     VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -20,6 +20,11 @@ import {
   formatDistanceKm,
   useAppSettingsStore,
 } from '../../../stores/appSettingsStore';
+import {
+  hasFlightGoproOverlay,
+  hasFlightVideo,
+  isGoproOverlayInProgress,
+} from '../../../lib/flightMediaState';
 
 export interface DownloadingMedia {
   flightId: string;
@@ -74,11 +79,11 @@ export function Flight({
   const units = useAppSettingsStore((state) => state.settings.units);
   const isHighlighted = isActive || isSelected;
   const hasGpx = Boolean(flight.gpx_file_path);
-  const hasVideo = Boolean(flight.video_file_path);
-  const hasPersistedGoproOverlay = Boolean(flight.gopro_overlay_file_path);
-  const isGoproOverlayRunning =
-    flight.gopro_overlay_status === 'queued' ||
-    flight.gopro_overlay_status === 'running';
+  const hasVideo = hasFlightVideo(flight);
+  const hasPersistedGoproOverlay = hasFlightGoproOverlay(flight);
+  const isGoproOverlayRunning = isGoproOverlayInProgress(
+    flight.gopro_overlay_status
+  );
   const isGoproOverlayFailed = flight.gopro_overlay_status === 'failed';
   const canDownloadGoproOverlay =
     hasPersistedGoproOverlay && !isGoproOverlayRunning && !isGoproOverlayFailed;

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -206,4 +206,17 @@ describe('FlightVideoExportControls', () => {
       screen.getByRole('button', { name: /Generate video/u })
     ).toBeEnabled();
   });
+
+  it('does not trust a video path without confirmed file existence', () => {
+    mockFlight.video_export_status = 'completed';
+    mockFlight.video_export_job_id = 'job-video';
+    mockFlight.video_file_path = '/exports/unknown.mp4';
+    mockFlight.video_file_exists = undefined;
+
+    render(<FlightVideoExportControls flight={mockFlight} compact />);
+
+    expect(
+      screen.getByRole('button', { name: /Generate video/u })
+    ).toBeEnabled();
+  });
 });

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
@@ -21,6 +21,7 @@ import { useVideoExportStatus } from '../../../hooks/flights/useVideoExportStatu
 import { useFlight } from '../../../hooks/flights/useFlight';
 import { useToast } from '../../../hooks/useToast';
 import { api } from '../../../lib/api';
+import { hasFlightVideo } from '../../../lib/flightMediaState';
 
 type VideoExportMode = 'manual_fast' | 'manual';
 
@@ -118,9 +119,7 @@ export function FlightVideoExportControls({
     null
   );
   const isExportActive = hasActiveVideoExport(flight);
-  const hasGeneratedVideo = Boolean(
-    flight.video_file_path && flight.video_file_exists !== false
-  );
+  const hasGeneratedVideo = hasFlightVideo(flight);
   const shouldReadExportStatus = Boolean(
     flight.video_export_job_id &&
     (isExportActive ||

--- a/apps/frontend/src/hooks/flights/useFlight.ts
+++ b/apps/frontend/src/hooks/flights/useFlight.ts
@@ -5,12 +5,10 @@ import {
   type Flight,
   VIDEO_EXPORT_IN_PROGRESS_STATUSES,
 } from '@dashboard-parapente/shared-types';
+import { isGoproOverlayInProgress } from '../../lib/flightMediaState';
 
 const isExportInProgress = (status?: string | null) =>
   status ? VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(status) : false;
-
-const isOverlayInProgress = (status?: string | null) =>
-  status === 'queued' || status === 'running';
 
 type ExportViewerAccess = {
   exportJobId?: string | null;
@@ -48,7 +46,7 @@ export const useFlight = (
     refetchInterval: (query) => {
       const data = query.state.data as Flight | undefined;
       return isExportInProgress(data?.video_export_status) ||
-        isOverlayInProgress(data?.gopro_overlay_status)
+        isGoproOverlayInProgress(data?.gopro_overlay_status)
         ? 10000
         : false;
     },

--- a/apps/frontend/src/hooks/flights/useFlights.ts
+++ b/apps/frontend/src/hooks/flights/useFlights.ts
@@ -24,13 +24,13 @@ import {
 } from '@dashboard-parapente/shared-types';
 import { isHTTPError } from 'ky';
 import { getStaleTime } from '../../lib/cacheConfig';
+import { isGoproOverlayInProgress } from '../../lib/flightMediaState';
 
 const isMediaExportInProgress = (flight: Flight) =>
   Boolean(
     (flight.video_export_status &&
       VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(flight.video_export_status)) ||
-    flight.gopro_overlay_status === 'queued' ||
-    flight.gopro_overlay_status === 'running'
+    isGoproOverlayInProgress(flight.gopro_overlay_status)
   );
 
 export const flightsQueryOptions = (filters: FlightFilters = {}) => {

--- a/apps/frontend/src/lib/flightMediaState.test.ts
+++ b/apps/frontend/src/lib/flightMediaState.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Flight } from '../types';
+import {
+  hasFlightGoproOverlay,
+  hasFlightVideo,
+  isGoproOverlayInProgress,
+} from './flightMediaState';
+
+const flight = (overrides: Partial<Flight>): Flight =>
+  ({
+    id: 'flight-1',
+    flight_date: '2026-03-15',
+    ...overrides,
+  }) as Flight;
+
+describe('flight media state', () => {
+  it('requires confirmed file existence for downloadable media', () => {
+    expect(
+      hasFlightVideo(
+        flight({
+          video_file_path: '/exports/video.mp4',
+          video_file_exists: true,
+        })
+      )
+    ).toBe(true);
+    expect(
+      hasFlightVideo(
+        flight({
+          video_file_path: '/exports/video.mp4',
+          video_file_exists: false,
+        })
+      )
+    ).toBe(false);
+    expect(
+      hasFlightGoproOverlay(
+        flight({
+          gopro_overlay_file_path: '/exports/final.mp4',
+          gopro_overlay_file_exists: true,
+        })
+      )
+    ).toBe(true);
+    expect(
+      hasFlightGoproOverlay(
+        flight({
+          gopro_overlay_file_path: '/exports/final.mp4',
+          gopro_overlay_file_exists: undefined,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('treats preparing overlay jobs as in progress', () => {
+    expect(isGoproOverlayInProgress('queued')).toBe(true);
+    expect(isGoproOverlayInProgress('preparing')).toBe(true);
+    expect(isGoproOverlayInProgress('running')).toBe(true);
+    expect(isGoproOverlayInProgress('completed')).toBe(false);
+  });
+});

--- a/apps/frontend/src/lib/flightMediaState.ts
+++ b/apps/frontend/src/lib/flightMediaState.ts
@@ -1,0 +1,21 @@
+import type { Flight } from '../types';
+
+export const GOPRO_OVERLAY_IN_PROGRESS_STATUSES = new Set([
+  'queued',
+  'preparing',
+  'running',
+]);
+
+export function hasFlightVideo(flight: Flight): boolean {
+  return Boolean(flight.video_file_path && flight.video_file_exists === true);
+}
+
+export function hasFlightGoproOverlay(flight: Flight): boolean {
+  return Boolean(
+    flight.gopro_overlay_file_path && flight.gopro_overlay_file_exists === true
+  );
+}
+
+export function isGoproOverlayInProgress(status?: string | null): boolean {
+  return Boolean(status && GOPRO_OVERLAY_IN_PROGRESS_STATUSES.has(status));
+}


### PR DESCRIPTION
## Summary
- Consolidate flight media state so video and GoPro overlay badges/actions use consistent existence and progress rules.
- Treat overlay jobs in `preparing` as active and resolve downloadable overlay paths from the job output when available.
- Add backend and frontend tests covering the synchronized media states.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- flightMediaState.test.ts FlightDetails.test.tsx FlightVideoExportControls.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/api/test_routes_flights.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend`

## Notes
- `nx affected -t test backend --parallel=5` was attempted but timed out because it also executed `frontend` and `design-system` test targets; the direct backend target passed.