### PR TITLE
docs(workflow): run coderabbit before push

### DIFF
--- a/.agents/skills/coderabbit-cli/SKILL.md
+++ b/.agents/skills/coderabbit-cli/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: coderabbit-cli
-description: Runs CodeRabbit CLI reviews and turns findings into an interactive correction workflow. Use when a shipping, commit, or review workflow needs CodeRabbit checks, when preparing a commit with `cr review`, or when the user mentions CodeRabbit CLI, CodeRabbit review, `cr review`, or skipping CodeRabbit review.
+description: Runs CodeRabbit CLI reviews and turns findings into an interactive correction workflow. Use when a shipping, commit, push, or review workflow needs CodeRabbit checks, when preparing a commit or push with `cr review`, or when the user mentions CodeRabbit CLI, CodeRabbit review, `cr review`, or skipping CodeRabbit review.
 ---
 
 # CodeRabbit CLI
 
 ## Quick Start
 
-Use this skill before committing when a workflow requires CodeRabbit review.
+Use this skill before committing or pushing when a workflow requires CodeRabbit review.
 
 Skip the review only when the user explicitly asks with phrases like:
 
@@ -78,7 +78,7 @@ What would you like to do?
 
 ## Shipping Integration
 
-Shipping or commit workflows should run this skill before committing unless the user explicitly asks to skip CodeRabbit review.
+Shipping, commit, or push workflows should run this skill before committing or pushing unless the user explicitly asks to skip CodeRabbit review.
 
 Recognize skip phrases such as `skip coderabbit`, `skip cr review`, `sans review coderabbit`, and `no coderabbit`.
 

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -15,6 +15,7 @@ Follow the dashboard-parapente workflow and these guardrails:
 - Run impacted validation before committing. Prefer targeted Nx checks; for PR validation prefer `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e` when appropriate.
 - For frontend changes, run `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend`, `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5`, and `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`.
 - For backend changes, run `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend` and `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5`.
+- Run the `coderabbit-cli` skill before committing or pushing, unless the user explicitly asks to skip CodeRabbit review.
 - Create a Conventional Commit that reflects the actual diff.
 - Push the branch, using upstream setup only when needed.
 - Open a PR with `gh pr create` after fetching the remote and ensuring the branch is not stale against `origin/main`.


### PR DESCRIPTION
## Summary
- Run the `coderabbit-cli` skill before commit/push in the ship workflow.
- Update the skill wording so push workflows explicitly trigger CodeRabbit.

## Validation
- `git diff --check`
- `coderabbit doctor`