### PR TITLE
docs(workflow): run coderabbit after implementation

### DIFF
--- a/.agents/skills/coderabbit-cli/SKILL.md
+++ b/.agents/skills/coderabbit-cli/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: coderabbit-cli
-description: Runs CodeRabbit CLI reviews and turns findings into an interactive correction workflow. Use when a shipping, commit, push, or review workflow needs CodeRabbit checks, when preparing a commit or push with `cr review`, or when the user mentions CodeRabbit CLI, CodeRabbit review, `cr review`, or skipping CodeRabbit review.
+description: Runs CodeRabbit CLI reviews and turns findings into an interactive correction workflow. Use at the end of an implementation, before shipping readiness, when a review workflow needs CodeRabbit checks, or when the user mentions CodeRabbit CLI, CodeRabbit review, `cr review`, or skipping CodeRabbit review.
 ---
 
 # CodeRabbit CLI
 
 ## Quick Start
 
-Use this skill before committing or pushing when a workflow requires CodeRabbit review.
+Use this skill at the end of an implementation, after code changes and relevant validation, before considering the work ready to ship.
+
+Do not trigger this skill as a push-time step. A push should only happen after the implementation review state is already known.
 
 Skip the review only when the user explicitly asks with phrases like:
 
@@ -76,13 +78,15 @@ What would you like to do?
 
 11. Do not commit while unresolved CodeRabbit findings remain.
 
-## Shipping Integration
+## Implementation Integration
 
-Shipping, commit, or push workflows should run this skill before committing or pushing unless the user explicitly asks to skip CodeRabbit review.
+Implementation workflows should run this skill once the code changes are complete and relevant validation has run, unless the user explicitly asks to skip CodeRabbit review.
 
 Recognize skip phrases such as `skip coderabbit`, `skip cr review`, `sans review coderabbit`, and `no coderabbit`.
 
-If CodeRabbit returns findings, pause the shipping flow. Present each finding one by one and ask whether to correct it, ignore it, or follow custom instructions. Resume commit only once all findings are fixed, explicitly ignored, or accepted by the user.
+If CodeRabbit returns findings, pause the implementation handoff. Present each finding one by one and ask whether to correct it, ignore it, or follow custom instructions. Consider the implementation complete only once all findings are fixed, explicitly ignored, or accepted by the user.
+
+Shipping workflows may check whether CodeRabbit was already run for the completed implementation, but they must not treat CodeRabbit as part of the push step.
 
 ## Reporting Rules
 

--- a/.agents/skills/dashboard-parapente-workflow/SKILL.md
+++ b/.agents/skills/dashboard-parapente-workflow/SKILL.md
@@ -77,6 +77,8 @@ Use `gh` for all GitHub interactions: issues, PRs, checks, releases, comments, A
 
 Before creating or updating a PR, check branch status, review commits and diff against the base branch, run impacted checks, and fix failures.
 
+Run the `coderabbit-cli` skill at the end of implementation, after relevant validation and before marking the work ready to ship, unless the user explicitly skips it. Do not defer CodeRabbit to the push step.
+
 For CodeRabbit comments, delegate discovery and triage to a subagent. It should inspect only relevant PR conversations through `gh` and return requested changes, affected files/lines, priority, and conversations to reply to or close. When fixed, reply to each resolved conversation and close it.
 
 ## Git

--- a/.opencode/commands/ship.md
+++ b/.opencode/commands/ship.md
@@ -15,7 +15,7 @@ Follow the dashboard-parapente workflow and these guardrails:
 - Run impacted validation before committing. Prefer targeted Nx checks; for PR validation prefer `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e` when appropriate.
 - For frontend changes, run `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend`, `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5`, and `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`.
 - For backend changes, run `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend` and `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5`.
-- Run the `coderabbit-cli` skill before committing or pushing, unless the user explicitly asks to skip CodeRabbit review.
+- Do not run CodeRabbit as a push-time step. CodeRabbit belongs at the end of implementation, after relevant validation and before the work is considered ready to ship. If that review has not been done and was not explicitly skipped, report it as missing instead of attaching it to the push.
 - Create a Conventional Commit that reflects the actual diff.
 - Push the branch, using upstream setup only when needed.
 - Open a PR with `gh pr create` after fetching the remote and ensuring the branch is not stale against `origin/main`.


### PR DESCRIPTION
## Summary
- Move CodeRabbit CLI guidance to the end of implementation, after relevant validation.
- Clarify that shipping must not treat CodeRabbit as a push-time step.
- Update the ship command to report a missing implementation review instead of attaching it to push.

## Validation
- `cr review`
- `git diff --check`
- pre-commit hook via `git commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance documentation to clarify when code review verification steps occur within the development process, their integration points, and their distinction from deployment-time procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->