### PR TITLE
fix(frontend): focus safe action in delete dialogs

### DIFF
--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -896,6 +896,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
             </p>
             <div className="flex justify-end gap-3">
               <Button
+                initialFocus
                 variant="secondary"
                 onPress={() => setPendingConfirm(null)}
               >

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -566,6 +566,7 @@ export default function FlightHistory() {
         </p>
         <div className="flex gap-3 justify-end">
           <Button
+            initialFocus
             onClick={() => setFlightToDelete(null)}
             className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
           >
@@ -594,6 +595,7 @@ export default function FlightHistory() {
         </p>
         <div className="flex gap-3 justify-end">
           <Button
+            initialFocus
             onClick={() => setShowMultiDeleteConfirm(false)}
             className="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-all"
           >

--- a/apps/frontend/src/pages/InfrastructurePage.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.tsx
@@ -673,6 +673,7 @@ function CacheSection({
             </p>
             <div className="flex justify-end gap-3">
               <Button
+                initialFocus
                 onPress={() => setPendingConfirm(null)}
                 className="px-4 py-2 rounded-md text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors cursor-pointer"
               >

--- a/apps/frontend/src/pages/Sites.tsx
+++ b/apps/frontend/src/pages/Sites.tsx
@@ -303,6 +303,7 @@ export const Sites: React.FC = () => {
         </p>
         <div className="flex flex-col sm:flex-row gap-3 pt-4">
           <Button
+            initialFocus
             onPress={() => setSiteToDelete(null)}
             isDisabled={deleteSite.isPending}
             className="flex-1 px-4 py-2 bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 rounded hover:bg-gray-300 dark:hover:bg-gray-500 cursor-pointer disabled:opacity-50 transition-colors"

--- a/libs/design-system/src/components/Button/Button.tsx
+++ b/libs/design-system/src/components/Button/Button.tsx
@@ -58,6 +58,7 @@ export interface ButtonProps extends AriaButtonProps {
     | 'outline';
   size?: 'sm' | 'md' | 'lg' | 'icon';
   fullWidth?: boolean;
+  initialFocus?: boolean;
   className?: string;
   isDisabled?: boolean;
   title?: string;
@@ -68,6 +69,7 @@ export function Button({
   variant,
   size,
   fullWidth,
+  initialFocus,
   isDisabled,
   ...props
 }: ButtonProps) {
@@ -76,6 +78,7 @@ export function Button({
   return (
     <AriaButton
       {...props}
+      {...(initialFocus ? { autoFocus: true } : {})}
       type={type}
       isDisabled={isDisabled}
       className={twMerge(


### PR DESCRIPTION
## Summary
- Add a reusable `initialFocus` flag to the shared `Button` component.
- Use it on destructive confirmation dialogs so keyboard users land on the safe action first.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test --parallel=5 --exclude=e2e` (test step timed out in Vitest, lint passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved focus management in confirmation and deletion dialogs. Cancel buttons now automatically receive focus when modals open, enhancing keyboard navigation across flight management, infrastructure, and site settings pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->