### PR TITLE
fix(frontend): remove weather hero card

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -20,7 +20,6 @@ import { useAppSettingsStore } from '../stores/appSettingsStore';
 import { useIsMobile } from '../hooks/useIsMobile';
 import WeatherEmptyState from '../components/weather/WeatherEmptyState';
 import WeatherLiveWindPanel from '../components/weather/WeatherLiveWindPanel';
-import WeatherPageHero from '../components/weather/WeatherPageHero';
 import WeatherSearchResultPanel from '../components/weather/WeatherSearchResultPanel';
 import WeatherSelectionPanel, {
   type WeatherSelectionTab,
@@ -397,13 +396,6 @@ export default function WeatherPage() {
       </aside>
 
       <div className="min-w-0 space-y-4">
-        <WeatherPageHero
-          activeWeatherName={activeWeatherName}
-          selectedDayLabel={selectedDayLabel}
-          sourceLabel={sourceLabel}
-          isSearchMode={Boolean(selectedSearchTarget)}
-        />
-
         {!selectedSearchTarget && !selectedSiteId && <WeatherEmptyState />}
 
         {selectedSearchTarget && (


### PR DESCRIPTION
## Summary
- Remove the desktop weather hero card from the weather page.
- Keep the mobile hero layout unchanged.

## Validation
- NX affected lint: pass
- NX affected build: pass
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the desktop weather page layout by removing a header component. The weather content now displays directly without an intermediate header section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->