### PR TITLE
fix backend emagram screenshot 404s

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -6541,7 +6541,14 @@ async def get_emagram_screenshot(analysis_id: str, source: str, db: Session = De
     # Check if file exists
     image_file = Path(image_path)
     if not image_file.exists():
-        raise HTTPException(status_code=404, detail=f"Screenshot file not found: {image_path}")
+        regenerated_path = await _regenerate_emagram_screenshot(
+            db=db,
+            emagram=emagram,
+            source=source,
+        )
+        if regenerated_path is None or not regenerated_path.exists():
+            raise HTTPException(status_code=404, detail=f"Screenshot file not found: {image_path}")
+        image_file = regenerated_path
 
     # Serve the image
     return FileResponse(
@@ -6549,6 +6556,71 @@ async def get_emagram_screenshot(analysis_id: str, source: str, db: Session = De
         media_type="image/png",
         filename=f"emagram_{source}_{analysis_id[:8]}.png",
     )
+
+
+async def _regenerate_emagram_screenshot(
+    db: Session,
+    emagram: EmagramAnalysis,
+    source: str,
+) -> Path | None:
+    """Regenerate a missing emagram screenshot on demand."""
+
+    if emagram.station_latitude is None or emagram.station_longitude is None:
+        return None
+    if emagram.forecast_date is None:
+        return None
+
+    from scrapers.emagram_screenshots import (
+        screenshot_meteo_parapente,
+        screenshot_meteociel_emagram,
+        screenshot_topmeteo,
+    )
+
+    day_index = (emagram.forecast_date - datetime.utcnow().date()).days
+    hour = emagram.forecast_hour
+
+    if source == "meteo-parapente":
+        screenshot_result = await screenshot_meteo_parapente(
+            emagram.station_latitude,
+            emagram.station_longitude,
+            emagram.station_name,
+            day_index=day_index,
+            hour=hour,
+        )
+    elif source == "meteociel":
+        screenshot_result = await screenshot_meteociel_emagram(
+            emagram.station_latitude,
+            emagram.station_longitude,
+            emagram.station_name,
+            day_index=day_index,
+            hour=hour,
+        )
+    elif source == "topmeteo":
+        screenshot_result = await screenshot_topmeteo(
+            emagram.station_latitude,
+            emagram.station_longitude,
+            emagram.station_name,
+        )
+    else:
+        return None
+
+    if not screenshot_result.get("success"):
+        return None
+
+    image_path = screenshot_result.get("image_path")
+    if not image_path:
+        return None
+
+    try:
+        screenshot_paths = json.loads(emagram.screenshot_paths or "{}")
+    except json.JSONDecodeError:
+        screenshot_paths = {}
+    screenshot_paths[source] = image_path
+    emagram.screenshot_paths = json.dumps(screenshot_paths, ensure_ascii=False)
+    db.commit()
+    db.refresh(emagram)
+
+    return Path(image_path)
 
 
 # ============================================================================

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -114,6 +114,67 @@ class TestEmagramEndpoints:
         assert data["station_code"] == "site-arguel"
         assert data["score_volabilite"] == 72
 
+    def test_get_emagram_screenshot_regenerates_missing_file(self, client, db_session, tmp_path):
+        """Missing screenshot files are regenerated instead of returning 404"""
+        from models import EmagramAnalysis
+
+        missing_file = tmp_path / "missing.png"
+        regenerated_file = tmp_path / "regenerated.png"
+
+        site = Site(
+            id="site-arguel",
+            code="ARG",
+            name="Arguel",
+            latitude=47.2,
+            longitude=6.0,
+            elevation_m=427,
+        )
+        db_session.add(site)
+
+        analysis = EmagramAnalysis(
+            id="screenshot-analysis",
+            station_code="site-arguel",
+            station_name="Arguel",
+            station_latitude=47.2,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=12,
+            distance_km=0.0,
+            data_source="multi-source-vision",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="completed",
+            screenshot_paths=json.dumps({"meteo-parapente": str(missing_file)}),
+        )
+        db_session.add(analysis)
+        db_session.commit()
+
+        async def _regenerate(*args, **kwargs):
+            regenerated_file.write_bytes(b"png")
+            return {
+                "success": True,
+                "source": "meteo-parapente",
+                "image_path": str(regenerated_file),
+                "external_url": "https://example.test",
+                "timestamp": datetime.now().isoformat(),
+            }
+
+        with patch("scrapers.emagram_screenshots.screenshot_meteo_parapente", new=_regenerate):
+            response = client.get("/api/emagram/screenshot/screenshot-analysis/meteo-parapente")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "image/png"
+        assert response.content == b"png"
+
+        refreshed = db_session.get(EmagramAnalysis, "screenshot-analysis")
+        assert refreshed is not None
+        assert json.loads(refreshed.screenshot_paths)["meteo-parapente"] == str(regenerated_file)
+        assert regenerated_file.exists()
+        assert not missing_file.exists()
+
     def test_get_latest_with_site_id_not_found(self, client, db_session):
         """Get latest emagram with non-existent site_id returns 404"""
         response = client.get("/api/emagram/latest?site_id=nonexistent")


### PR DESCRIPTION
## Summary
- Regenerate a missing emagram screenshot on demand instead of returning 404.
- Persist the regenerated path back into the emagram analysis record.
- Cover the missing-file path with a backend endpoint test.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key .venv/bin/pytest apps/backend/tests/test_emagram_endpoints.py -q --tb=short --no-header`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Emagram screenshot endpoint now automatically regenerates missing image files on demand. When a screenshot is requested but missing, the system regenerates it from source data and serves it immediately, providing reliable access to all emagram images.

* **Tests**
  * Added comprehensive test coverage for the emagram screenshot regeneration functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->