### PR TITLE
fix(backend): bound terrain wait during video resume

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -6578,6 +6578,8 @@ async def _regenerate_emagram_screenshot(
 
     day_index = (emagram.forecast_date - datetime.utcnow().date()).days
     hour = emagram.forecast_hour
+    if day_index < 0:
+        return None
 
     if source == "meteo-parapente":
         screenshot_result = await screenshot_meteo_parapente(
@@ -6610,17 +6612,26 @@ async def _regenerate_emagram_screenshot(
     image_path = screenshot_result.get("image_path")
     if not image_path:
         return None
+    regenerated_path = Path(image_path)
+    if not regenerated_path.exists():
+        logger.warning(
+            "Regenerated emagram screenshot missing on disk (analysis=%s, source=%s, path=%s)",
+            emagram.id,
+            source,
+            image_path,
+        )
+        return None
 
     try:
         screenshot_paths = json.loads(emagram.screenshot_paths or "{}")
     except json.JSONDecodeError:
         screenshot_paths = {}
-    screenshot_paths[source] = image_path
+    screenshot_paths[source] = str(regenerated_path)
     emagram.screenshot_paths = json.dumps(screenshot_paths, ensure_ascii=False)
     db.commit()
     db.refresh(emagram)
 
-    return Path(image_path)
+    return regenerated_path
 
 
 # ============================================================================

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -175,6 +175,86 @@ class TestEmagramEndpoints:
         assert regenerated_file.exists()
         assert not missing_file.exists()
 
+    def test_get_emagram_screenshot_does_not_store_missing_regenerated_file(
+        self, client, db_session, tmp_path
+    ):
+        """Regeneration results must point to an existing file before DB update."""
+        missing_file = tmp_path / "missing.png"
+        regenerated_file = tmp_path / "not-written.png"
+        original_paths = json.dumps({"meteo-parapente": str(missing_file)})
+        analysis = EmagramAnalysis(
+            id="screenshot-missing-regenerated",
+            station_code="site-arguel",
+            station_name="Arguel",
+            station_latitude=47.2,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=datetime.utcnow().date(),
+            forecast_hour=12,
+            distance_km=0.0,
+            data_source="multi-source-vision",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="completed",
+            screenshot_paths=original_paths,
+        )
+        db_session.add(analysis)
+        db_session.commit()
+
+        async def _regenerate(*args, **kwargs):
+            return {
+                "success": True,
+                "source": "meteo-parapente",
+                "image_path": str(regenerated_file),
+            }
+
+        with patch("scrapers.emagram_screenshots.screenshot_meteo_parapente", new=_regenerate):
+            response = client.get(
+                "/api/emagram/screenshot/screenshot-missing-regenerated/meteo-parapente"
+            )
+
+        assert response.status_code == 404
+        refreshed = db_session.get(EmagramAnalysis, "screenshot-missing-regenerated")
+        assert refreshed is not None
+        assert refreshed.screenshot_paths == original_paths
+
+    def test_get_emagram_screenshot_does_not_regenerate_past_forecast(
+        self, client, db_session, tmp_path
+    ):
+        """Past forecasts should not trigger invalid screenshot regeneration calls."""
+        missing_file = tmp_path / "missing.png"
+        analysis = EmagramAnalysis(
+            id="screenshot-past-forecast",
+            station_code="site-arguel",
+            station_name="Arguel",
+            station_latitude=47.2,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=(datetime.utcnow() - timedelta(days=1)).date(),
+            forecast_hour=12,
+            distance_km=0.0,
+            data_source="multi-source-vision",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            analysis_status="completed",
+            screenshot_paths=json.dumps({"meteo-parapente": str(missing_file)}),
+        )
+        db_session.add(analysis)
+        db_session.commit()
+
+        regenerate = AsyncMock()
+        with patch("scrapers.emagram_screenshots.screenshot_meteo_parapente", regenerate):
+            response = client.get(
+                "/api/emagram/screenshot/screenshot-past-forecast/meteo-parapente"
+            )
+
+        assert response.status_code == 404
+        regenerate.assert_not_called()
+
     def test_get_latest_with_site_id_not_found(self, client, db_session):
         """Get latest emagram with non-existent site_id returns 404"""
         response = client.get("/api/emagram/latest?site_id=nonexistent")

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -1,5 +1,6 @@
 """Unit tests for video export helpers."""
 
+import asyncio
 import os
 import time
 from datetime import datetime
@@ -220,6 +221,16 @@ class _FakeTerrainPage:
         return False
 
 
+class _HangingTerrainPage:
+    def __init__(self):
+        self.evaluate_calls = 0
+
+    async def evaluate(self, _script: str) -> bool:
+        self.evaluate_calls += 1
+        await asyncio.sleep(60)
+        return True
+
+
 @pytest.mark.asyncio
 async def test_wait_for_export_frame_terrain_waits_until_tiles_loaded():
     page = _FakeTerrainPage([False, False, True])
@@ -242,6 +253,21 @@ async def test_wait_for_export_frame_terrain_returns_false_after_timeout():
         page,
         timeout_seconds=0,
         poll_seconds=0,
+    )
+
+    assert tiles_loaded is False
+    assert page.evaluate_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_export_frame_terrain_returns_false_when_evaluate_hangs():
+    page = _HangingTerrainPage()
+
+    tiles_loaded = await video_export_manual._wait_for_export_frame_terrain(
+        page,
+        timeout_seconds=1,
+        poll_seconds=0,
+        evaluate_timeout_seconds=0.01,
     )
 
     assert tiles_loaded is False

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -75,6 +75,7 @@ _FFMPEG_STALL_TIMEOUT_SECONDS = 10 * 60
 _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS = 30
 _EXPORT_FRAME_TERRAIN_TIMEOUT_SECONDS = 10.0
 _EXPORT_FRAME_TERRAIN_POLL_SECONDS = 0.1
+_EXPORT_FRAME_TERRAIN_EVALUATE_TIMEOUT_SECONDS = 2.0
 
 _EXPORT_VIEWER_STATE_SCRIPT = """
     () => {
@@ -935,30 +936,44 @@ async def _wait_for_export_frame_terrain(
     page: Any,
     timeout_seconds: float = _EXPORT_FRAME_TERRAIN_TIMEOUT_SECONDS,
     poll_seconds: float = _EXPORT_FRAME_TERRAIN_POLL_SECONDS,
+    evaluate_timeout_seconds: float = _EXPORT_FRAME_TERRAIN_EVALUATE_TIMEOUT_SECONDS,
 ) -> bool:
     deadline = time.monotonic() + timeout_seconds
 
     while True:
-        tiles_loaded = await page.evaluate("""
-            () => {
-                const viewer = window._cesiumViewer;
-                const scene = viewer?.scene;
-                const globe = scene?.globe;
+        remaining_seconds = deadline - time.monotonic()
+        evaluate_timeout = evaluate_timeout_seconds
+        if timeout_seconds <= 0:
+            evaluate_timeout = min(evaluate_timeout, 0.1)
+        else:
+            evaluate_timeout = min(evaluate_timeout, max(remaining_seconds, 0.001))
 
-                if (!viewer || !scene || !globe) {
-                    return false;
-                }
+        try:
+            tiles_loaded = await asyncio.wait_for(
+                page.evaluate("""
+                    () => {
+                        const viewer = window._cesiumViewer;
+                        const scene = viewer?.scene;
+                        const globe = scene?.globe;
 
-                try {
-                    scene.requestRender?.();
-                    viewer.render?.();
-                } catch {
-                    return false;
-                }
+                        if (!viewer || !scene || !globe) {
+                            return false;
+                        }
 
-                return Boolean(globe.tilesLoaded);
-            }
-        """)
+                        try {
+                            scene.requestRender?.();
+                            viewer.render?.();
+                        } catch {
+                            return false;
+                        }
+
+                        return Boolean(globe.tilesLoaded);
+                    }
+                """),
+                timeout=evaluate_timeout,
+            )
+        except TimeoutError:
+            return False
 
         if tiles_loaded:
             return True


### PR DESCRIPTION
## Summary
- Bound Cesium terrain readiness checks so video resume cannot hang indefinitely on `Waiting for terrain`.
- Guard emagram screenshot regeneration against stale forecast dates and missing regenerated files.
- Add backend regression coverage for hanging terrain checks and emagram regeneration edge cases.

## Validation
- `../../.venv/bin/pytest tests/unit/test_video_export_manual.py tests/test_emagram_endpoints.py -q --tb=short --no-header`
- `../../.venv/bin/ruff check routes.py video_export_manual.py tests/unit/test_video_export_manual.py tests/test_emagram_endpoints.py`
- `../../.venv/bin/black --check routes.py video_export_manual.py tests/unit/test_video_export_manual.py tests/test_emagram_endpoints.py`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- CodeRabbit CLI: 0 findings after fixes

## Notes
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` was attempted but did not complete within 20 minutes while running existing scraper tests; targeted backend tests for the changed behavior pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced screenshot generation reliability through improved validation and offset handling.
  * Added timeout protection for video exports to prevent indefinite blocking during terrain evaluation.

* **Tests**
  * Added test coverage for screenshot regeneration and video export edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->