### PR TITLE
fix backend Meteociel emagram screenshots

### DIFF
--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -285,39 +285,47 @@ async def screenshot_meteociel_emagram(
             browser = await p.chromium.launch(headless=True)
             page = await browser.new_page(viewport={"width": 1600, "height": 1200})
 
-            logger.info(f"Meteociel emagram: Loading {url}")
-            await page.goto(url, wait_until="domcontentloaded", timeout=timeout)
-
-            # Wait for emagram image to load
-            await page.wait_for_timeout(5000)
-
-            # Meteociel shows emagram as an image - capture with surrounding context (title/date)
             try:
-                emagram_img = page.locator("img[src*='sondage'], img[src*='emagram']").first
-                if await emagram_img.count() > 0:
-                    # Try to capture parent container to include the title with the date
-                    parent = emagram_img.locator("xpath=ancestor::td").first
-                    if await parent.count() > 0:
-                        await parent.screenshot(path=str(image_path))
-                        logger.info("Captured emagram with parent container (includes date)")
-                    else:
-                        # Fallback: try broader container
-                        parent_table = emagram_img.locator("xpath=ancestor::table").first
-                        if await parent_table.count() > 0:
-                            await parent_table.screenshot(path=str(image_path))
-                            logger.info("Captured emagram with table container (includes date)")
-                        else:
-                            await emagram_img.screenshot(path=str(image_path))
-                            logger.info("Captured emagram image directly (no parent found)")
-                else:
-                    await page.screenshot(path=str(image_path), full_page=False)
-                    logger.warning("Emagram image not found, took full screenshot")
-            except Exception as e:
-                logger.warning(f"Could not find emagram element: {e}, taking full screenshot")
-                await page.screenshot(path=str(image_path), full_page=False)
+                logger.info(f"Meteociel emagram: Loading {url}")
+                await page.goto(url, wait_until="domcontentloaded", timeout=timeout)
 
-            logger.info(f"Meteociel emagram screenshot saved: {image_path}")
-            await browser.close()
+                image_selector = "img[src*='sondagegfs'], img[src*='sondage'], img[src*='emagram']"
+                await page.wait_for_selector(image_selector, state="visible", timeout=timeout)
+                await page.wait_for_function(
+                    """
+                    selector => {
+                        const img = document.querySelector(selector);
+                        return img instanceof HTMLImageElement
+                            && img.complete
+                            && img.naturalWidth > 0
+                            && img.naturalHeight > 0;
+                    }
+                    """,
+                    arg=image_selector,
+                    timeout=timeout,
+                )
+
+                # Meteociel shows emagram as an image; fail instead of storing a blank fallback.
+                emagram_img = page.locator(image_selector).first
+                parent = emagram_img.locator("xpath=ancestor::td").first
+                if await parent.count() > 0:
+                    await parent.screenshot(path=str(image_path))
+                    logger.info("Captured emagram with parent container (includes date)")
+                else:
+                    parent_table = emagram_img.locator("xpath=ancestor::table").first
+                    if await parent_table.count() > 0:
+                        await parent_table.screenshot(path=str(image_path))
+                        logger.info("Captured emagram with table container (includes date)")
+                    else:
+                        await emagram_img.screenshot(path=str(image_path))
+                        logger.info("Captured emagram image directly (no parent found)")
+
+                if not image_path.exists() or image_path.stat().st_size == 0:
+                    raise RuntimeError("Meteociel emagram screenshot was not written")
+
+                logger.info(f"Meteociel emagram screenshot saved: {image_path}")
+            finally:
+                await browser.close()
 
         return {
             "success": True,

--- a/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
+++ b/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import pytest
+
+from scrapers import emagram_screenshots
+
+
+class _FakeLocator:
+    def __init__(self, count: int = 1) -> None:
+        self._count = count
+
+    @property
+    def first(self):
+        return self
+
+    def locator(self, selector: str):
+        if selector == "xpath=ancestor::td":
+            return _FakeLocator(count=1)
+        return _FakeLocator(count=0)
+
+    async def count(self) -> int:
+        return self._count
+
+    async def screenshot(self, path: str) -> None:
+        Path(path).write_bytes(b"png")
+
+
+class _FakePage:
+    def __init__(self, *, image_loaded: bool) -> None:
+        self.image_loaded = image_loaded
+        self.full_page_screenshot_called = False
+
+    async def goto(self, *args, **kwargs) -> None:
+        return None
+
+    async def wait_for_selector(self, *args, **kwargs) -> None:
+        return None
+
+    async def wait_for_function(self, *args, **kwargs) -> None:
+        if not self.image_loaded:
+            raise RuntimeError("image not loaded")
+
+    def locator(self, selector: str):
+        return _FakeLocator()
+
+    async def screenshot(self, *args, **kwargs) -> None:
+        self.full_page_screenshot_called = True
+        raise AssertionError("Meteociel should not fall back to a full-page screenshot")
+
+
+class _FakeBrowser:
+    def __init__(self, page: _FakePage) -> None:
+        self.page = page
+
+    async def new_page(self, *args, **kwargs) -> _FakePage:
+        return self.page
+
+    async def close(self) -> None:
+        return None
+
+
+class _FakeChromium:
+    def __init__(self, page: _FakePage) -> None:
+        self.page = page
+
+    async def launch(self, *args, **kwargs) -> _FakeBrowser:
+        return _FakeBrowser(self.page)
+
+
+class _FakePlaywright:
+    def __init__(self, page: _FakePage) -> None:
+        self.chromium = _FakeChromium(page)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_meteociel_screenshot_requires_loaded_image(monkeypatch, tmp_path) -> None:
+    page = _FakePage(image_loaded=False)
+    monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(
+        emagram_screenshots,
+        "async_playwright",
+        lambda: _FakePlaywright(page),
+    )
+
+    result = await emagram_screenshots.screenshot_meteociel_emagram(
+        latitude=47.2,
+        longitude=6.0,
+        spot_name="Arguel",
+        hour=12,
+    )
+
+    assert result["success"] is False
+    assert result["source"] == "meteociel"
+    assert "image not loaded" in result["error"]
+    assert not page.full_page_screenshot_called
+    assert list(tmp_path.glob("*.png")) == []
+
+
+@pytest.mark.asyncio
+async def test_meteociel_screenshot_captures_loaded_image(monkeypatch, tmp_path) -> None:
+    page = _FakePage(image_loaded=True)
+    monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(
+        emagram_screenshots,
+        "async_playwright",
+        lambda: _FakePlaywright(page),
+    )
+
+    result = await emagram_screenshots.screenshot_meteociel_emagram(
+        latitude=47.2,
+        longitude=6.0,
+        spot_name="Arguel",
+        hour=12,
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "meteociel"
+    assert Path(result["image_path"]).read_bytes() == b"png"
+    assert not page.full_page_screenshot_called


### PR DESCRIPTION
## Summary
- Require Meteociel emagram images to be visibly loaded before capturing them.
- Reject blank or missing captures instead of falling back to a full-page screenshot.
- Add targeted unit coverage for loaded and unloaded Meteociel image cases.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --uncommitted --parallel=5`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --uncommitted --parallel=5` (timed out after long progress)
- `.venv/bin/python -m pytest apps/backend/tests/unit/test_meteociel_emagram_screenshot.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend --skip-nx-cache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced emagram screenshot capture with stricter image detection and post-capture validation
  * Improved error handling when image loading fails
  * Removed fallback full-page screenshot behavior for more consistent results

* **Tests**
  * Added unit tests for emagram screenshot functionality to verify image loading and capture behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->