### PR TITLE
feat(emagram): add annotated vision lightbox

### DIFF
--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 import config
 from emagram_freshness import get_emagram_cutoff_utc, get_emagram_next_update_utc
 from llm.exceptions import QuotaExhaustedError
+from llm.emagram_prompt import normalize_analysis_locale
 from llm.gemini_analyzer import analyze_emagram_with_gemini
 from llm.groq_analyzer import analyze_emagram_with_groq
 from llm.openrouter_analyzer import analyze_emagram_with_openrouter
@@ -35,7 +36,8 @@ PROVIDER_ENV_VARS = {
 }
 
 
-def _configured_llm_providers() -> list[dict[str, Any]]:
+def _configured_llm_providers(locale: str | None = None) -> list[dict[str, Any]]:
+    analysis_locale = normalize_analysis_locale(locale)
     providers = {
         "groq": {
             "key": config.GROQ_API_KEY,
@@ -49,6 +51,7 @@ def _configured_llm_providers() -> list[dict[str, Any]]:
                 spot_name=site.name,
                 coordinates=(site.latitude, site.longitude),
                 model_name=config.GROQ_MODEL,
+                locale=analysis_locale,
             ),
         },
         "openrouter": {
@@ -63,6 +66,7 @@ def _configured_llm_providers() -> list[dict[str, Any]]:
                 spot_name=site.name,
                 coordinates=(site.latitude, site.longitude),
                 model_name=config.OPENROUTER_MODEL,
+                locale=analysis_locale,
             ),
         },
         "google": {
@@ -79,6 +83,7 @@ def _configured_llm_providers() -> list[dict[str, Any]]:
                 api_key=config.GOOGLE_API_KEY,
                 model_name=config.GEMINI_MODEL,
                 max_retries=3,
+                locale=analysis_locale,
             ),
         },
     }
@@ -107,12 +112,12 @@ def _configured_llm_providers() -> list[dict[str, Any]]:
 
 
 def _analyze_emagram_with_fallbacks(
-    screenshots: list[dict[str, str]], site: Site
+    screenshots: list[dict[str, str]], site: Site, locale: str | None = None
 ) -> dict[str, Any]:
     analysis_errors = []
     quota_errors = 0
     providers_tried = 0
-    configured_providers = _configured_llm_providers()
+    configured_providers = _configured_llm_providers(locale)
 
     if not configured_providers:
         env_vars = ", ".join(PROVIDER_ENV_VARS.values())
@@ -156,6 +161,10 @@ def _analyze_emagram_with_fallbacks(
 def _normalize_llm_analysis(
     raw_analysis: dict[str, Any], provider: dict[str, Any]
 ) -> dict[str, Any]:
+    explication_analyse = raw_analysis.get("explication_analyse")
+    if isinstance(explication_analyse, dict):
+        explication_analyse.setdefault("locale", normalize_analysis_locale(None))
+
     return {
         "success": True,
         "plafond_thermique_m": raw_analysis.get("plafond_thermique_m"),
@@ -165,7 +174,7 @@ def _normalize_llm_analysis(
         "conseils_vol": raw_analysis.get("conseils_vol"),
         "alertes_securite": raw_analysis.get("alertes_securite", []),
         "details_analyse": raw_analysis.get("details_analyse"),
-        "explication_analyse": raw_analysis.get("explication_analyse"),
+        "explication_analyse": explication_analyse,
         "llm_provider": provider["provider"],
         "llm_model": raw_analysis.get("llm_model", provider["model"]),
         "llm_tokens_used": raw_analysis.get("llm_tokens_used"),
@@ -199,6 +208,7 @@ async def generate_multi_source_emagram_for_spot(
     force_refresh: bool = False,
     day_index: int = 0,
     hour: int | None = None,
+    locale: str | None = None,
 ) -> dict[str, Any]:
     """
     Complete workflow to generate multi-source emagram analysis for a spot
@@ -306,7 +316,9 @@ async def generate_multi_source_emagram_for_spot(
         image_sources = [
             {"source": s["source"], "path": s["image_path"]} for s in successful_screenshots
         ]
-        analysis_result = _analyze_emagram_with_fallbacks(image_sources, site)
+        analysis_result = _analyze_emagram_with_fallbacks(
+            image_sources, site, locale=normalize_analysis_locale(locale)
+        )
 
         if not analysis_result.get("success"):
             logger.error(f"LLM analysis failed: {analysis_result.get('error')}")

--- a/apps/backend/llm/emagram_prompt.py
+++ b/apps/backend/llm/emagram_prompt.py
@@ -1,0 +1,120 @@
+"""Shared prompt contract for vision-based emagram analysis."""
+
+from __future__ import annotations
+
+SUPPORTED_LOCALES = {"fr", "en"}
+
+
+def normalize_analysis_locale(locale: str | None) -> str:
+    """Return a supported analysis locale, defaulting to French."""
+    if not locale:
+        return "fr"
+    normalized = locale.lower().split("-", maxsplit=1)[0]
+    return normalized if normalized in SUPPORTED_LOCALES else "fr"
+
+
+def language_instruction(locale: str | None) -> str:
+    """Return the natural-language instruction for generated explanations."""
+    normalized = normalize_analysis_locale(locale)
+    if normalized == "en":
+        return "Write every user-facing explanation in simple English."
+    return "Rédige toutes les explications visibles par l'utilisateur en français simple."
+
+
+def build_emagram_analysis_prompt(
+    *,
+    spot_name: str,
+    lat: float,
+    lon: float,
+    source_lines: str,
+    image_count: int,
+    locale: str | None,
+) -> str:
+    """Build the shared JSON contract used by all vision providers."""
+    normalized_locale = normalize_analysis_locale(locale)
+    return f"""Tu es un expert meteorologue specialise en parapente. Analyse ces {image_count} emagrammes pour {spot_name} ({lat:.4f}, {lon:.4f}).
+
+Correspondance des images:
+{source_lines}
+
+{language_instruction(normalized_locale)}
+
+Reponds UNIQUEMENT avec ce JSON valide, sans markdown:
+
+{{
+  "plafond_thermique_m": <altitude plafond en metres>,
+  "force_thermique_ms": <force thermiques en m/s>,
+  "heures_volables": "<ex: 12h-18h>",
+  "score_volabilite": <0-100>,
+  "conseils_vol": "<conseils courts MAX 50 mots>",
+  "alertes_securite": ["<alerte courte>"],
+  "details_analyse": "<analyse courte MAX 100 mots>",
+  "explication_analyse": {{
+    "locale": "{normalized_locale}",
+    "resume": "<pourquoi ce score en 1 phrase>",
+    "indices": [
+      "<indice global observe -> consequence parapente simple>"
+    ],
+    "par_source": {{
+      "<source exacte ci-dessus>": [
+        "<observation utile mais non localisee ou complementaire>"
+      ]
+    }},
+    "annotations_image": {{
+      "<source exacte ci-dessus>": [
+        {{
+          "id": "<identifiant-court-stable>",
+          "type": "point",
+          "label": "<titre court>",
+          "priority": "important",
+          "category": "thermal",
+          "display_order": 1,
+          "confidence": 0.84,
+          "x": 42,
+          "y": 58,
+          "visual_cue": "<repere visuel simple, incluant pourquoi ce point est place ici>",
+          "weather_reading": "<lecture meteo simple>",
+          "flight_impact": "<impact concret pour voler>",
+          "term": "<mot meteo utile optionnel>",
+          "term_definition": "<definition courte optionnelle>",
+          "uncertainty_note": "<raison simple si lecture moins certaine, sinon null>"
+        }},
+        {{
+          "id": "<identifiant-zone>",
+          "type": "zone",
+          "label": "<titre court>",
+          "priority": "watch",
+          "category": "stability",
+          "display_order": 2,
+          "confidence": 0.78,
+          "x": 35,
+          "y": 30,
+          "width": 12,
+          "height": 10,
+          "visual_cue": "<repere visuel simple de la zone>",
+          "weather_reading": "<lecture meteo simple>",
+          "flight_impact": "<impact concret pour voler>",
+          "term": null,
+          "term_definition": null,
+          "uncertainty_note": null
+        }}
+      ]
+    }}
+  }}
+}}
+
+Contraintes obligatoires pour annotations_image:
+- Produis au maximum 6 annotations par source, uniquement sur les points importants pour comprendre les conditions de vol et apprendre a lire l'emagramme.
+- Chaque source doit etre independante. Ne copie jamais une annotation d'une source vers une autre.
+- Coordonnees x, y, width, height en pourcentage de l'image originale, origine en haut a gauche, valeurs entre 0 et 100.
+- Pour type "point", x et y sont obligatoires. Pour type "zone", x, y, width et height sont obligatoires.
+- confidence est obligatoire entre 0 et 1. N'invente pas de coordonnees si la courbe n'est pas lisible.
+- priority doit etre exactement: "important", "watch" ou "educational".
+- category doit etre exactement: "thermal", "ceiling", "stability", "humidity", "wind" ou "risk".
+- visual_cue, weather_reading et flight_impact doivent etre courts, clairs, avec des mots simples.
+- Utilise term et term_definition seulement si un mot meteo utile merite d'etre appris.
+- Si une lecture est incertaine mais utile, garde confidence adaptee et explique pourquoi dans uncertainty_note.
+
+Explique les courbes visibles: temperature, point de rosee, ecart temperature/point de rosee, parcelle/thermique si visible, plafond/base nuageuse, inversions/couches stables et vent altitude si visible.
+IMPORTANT: Reponds UNIQUEMENT le JSON complet, rien d'autre.
+"""

--- a/apps/backend/llm/gemini_analyzer.py
+++ b/apps/backend/llm/gemini_analyzer.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from llm.emagram_prompt import build_emagram_analysis_prompt, normalize_analysis_locale
 from llm.screenshot_inputs import ScreenshotInput, normalize_screenshot_inputs
 
 try:
@@ -34,6 +35,7 @@ def analyze_emagram_with_gemini(
     model_name: str = "gemini-2.5-flash",
     max_retries: int = 3,
     retry_delay: float = 2.0,
+    locale: str | None = None,
 ) -> dict:
     """
     Analyze emagram screenshots using Google Gemini Vision API.
@@ -70,7 +72,7 @@ def analyze_emagram_with_gemini(
     genai.configure(api_key=api_key)
 
     # Build prompt with images
-    prompt_parts = _build_analysis_prompt(screenshot_paths, spot_name, coordinates)
+    prompt_parts = _build_analysis_prompt(screenshot_paths, spot_name, coordinates, locale)
 
     # Retry loop
     last_error = None
@@ -115,6 +117,10 @@ def analyze_emagram_with_gemini(
 
             # Parse response
             analysis = _parse_gemini_response(response_text)
+            if isinstance(analysis.get("explication_analyse"), dict):
+                analysis["explication_analyse"].setdefault(
+                    "locale", normalize_analysis_locale(locale)
+                )
 
             usage = getattr(response, "usage_metadata", None)
             prompt_tokens = getattr(usage, "prompt_token_count", 0) or 0
@@ -156,7 +162,10 @@ def analyze_emagram_with_gemini(
 
 
 def _build_analysis_prompt(
-    screenshot_paths: list[ScreenshotInput], spot_name: str, coordinates: tuple
+    screenshot_paths: list[ScreenshotInput],
+    spot_name: str,
+    coordinates: tuple,
+    locale: str | None = None,
 ) -> list[Any]:
     """
     Build the analysis prompt with embedded images.
@@ -172,42 +181,14 @@ def _build_analysis_prompt(
         for index, screenshot in enumerate(screenshots, start=1)
     )
 
-    # Text prompt - CONCIS pour économiser les tokens
-    text_prompt = f"""Analyse ces {len(screenshots)} emagrammes pour {spot_name} ({lat:.4f}, {lon:.4f}).
-
-Correspondance des images:
-{source_lines}
-
-Réponds UNIQUEMENT avec ce JSON (sans markdown):
-
-{{
-  "plafond_thermique_m": <altitude plafond en mètres>,
-  "force_thermique_ms": <force thermiques en m/s>,
-  "heures_volables": "<ex: 12h-18h>",
-  "score_volabilite": <0-100>,
-  "conseils_vol": "<conseils courts MAX 50 mots>",
-  "alertes_securite": [<liste ou []>],
-  "details_analyse": "<analyse courte MAX 100 mots>",
-  "explication_analyse": {{
-    "resume": "<pourquoi ce score en 1 phrase>",
-    "indices": [
-      "<indice global observe -> interpretation parapente>",
-      "<indice global observe -> interpretation parapente>"
-    ],
-    "par_source": {{
-      "<source exacte ci-dessus>": [
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>",
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>"
-      ]
-    }}
-  }}
-}}
-
-Pour chaque image/source, remplis obligatoirement explication_analyse.par_source avec la cle source exacte indiquee plus haut.
-Explique les courbes visibles: temperature, point de rosee, ecart temperature/point de rosee, parcelle/thermique si visible, base nuageuse/LCL, inversions/couches stables et vent altitude si visible.
-
-IMPORTANT: Réponds UNIQUEMENT le JSON complet, rien d'autre.
-"""
+    text_prompt = build_emagram_analysis_prompt(
+        spot_name=spot_name,
+        lat=lat,
+        lon=lon,
+        source_lines=source_lines,
+        image_count=len(screenshots),
+        locale=locale,
+    )
 
     # Build parts list: [text, image1, image2, ...]
     parts = [text_prompt]

--- a/apps/backend/llm/groq_analyzer.py
+++ b/apps/backend/llm/groq_analyzer.py
@@ -16,41 +16,10 @@ except ImportError:
     GROQ_AVAILABLE = False
 
 import config
+from llm.emagram_prompt import build_emagram_analysis_prompt, normalize_analysis_locale
 from llm.screenshot_inputs import ScreenshotInput, normalize_screenshot_inputs
 
 logger = logging.getLogger(__name__)
-
-ANALYSIS_PROMPT = """Tu es un expert météorologue spécialisé en parapente. Analyse ces emagrammes pour le spot "{spot_name}" ({lat}, {lon}).
-
-Correspondance des images:
-{source_lines}
-
-Réponds UNIQUEMENT en JSON valide avec cette structure exacte :
-{{
-  "plafond_thermique_m": <altitude en metres du sommet des thermiques>,
-  "force_thermique_ms": <vitesse ascendante moyenne en m/s>,
-  "heures_volables": "<heure debut>-<heure fin>",
-  "score_volabilite": <score 0-100>,
-  "conseils_vol": "<conseils pratiques pour le pilote>",
-  "alertes_securite": ["<alerte 1>", "<alerte 2>"],
-  "details_analyse": "<resume technique de l'analyse>",
-  "explication_analyse": {{
-    "resume": "<pourquoi ce score en 1 phrase>",
-    "indices": [
-      "<indice global observe -> interpretation parapente>",
-      "<indice global observe -> interpretation parapente>"
-    ],
-    "par_source": {{
-      "<source exacte ci-dessus>": [
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>",
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>"
-      ]
-    }}
-  }}
-}}
-
-Pour chaque image/source, remplis obligatoirement explication_analyse.par_source avec la cle source exacte indiquee plus haut.
-Explique les courbes visibles: temperature, point de rosee, ecart temperature/point de rosee, parcelle/thermique si visible, base nuageuse/LCL, inversions/couches stables et vent altitude si visible."""
 
 
 def analyze_emagram_with_groq(
@@ -59,6 +28,7 @@ def analyze_emagram_with_groq(
     coordinates: tuple,
     model_name: str = "meta-llama/llama-4-scout-17b-16e-instruct",
     max_retries: int = 2,
+    locale: str | None = None,
 ) -> dict:
     """
     Analyze emagram screenshots using Groq API (Llama Vision).
@@ -87,8 +57,13 @@ def analyze_emagram_with_groq(
     content.append(
         {
             "type": "text",
-            "text": ANALYSIS_PROMPT.format(
-                spot_name=spot_name, lat=lat, lon=lon, source_lines=source_lines
+            "text": build_emagram_analysis_prompt(
+                spot_name=spot_name,
+                lat=lat,
+                lon=lon,
+                source_lines=source_lines,
+                image_count=len(screenshots),
+                locale=locale,
             ),
         }
     )
@@ -148,6 +123,10 @@ def analyze_emagram_with_groq(
             result.setdefault("alertes_securite", [])
             result.setdefault("details_analyse", "Analyse par Groq Llama Vision")
             result.setdefault("explication_analyse", None)
+            if isinstance(result["explication_analyse"], dict):
+                result["explication_analyse"].setdefault(
+                    "locale", normalize_analysis_locale(locale)
+                )
             usage = getattr(response, "usage", None)
             prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
             completion_tokens = getattr(usage, "completion_tokens", 0) or 0

--- a/apps/backend/llm/openrouter_analyzer.py
+++ b/apps/backend/llm/openrouter_analyzer.py
@@ -15,44 +15,13 @@ from typing import Any
 import httpx
 
 import config
+from llm.emagram_prompt import build_emagram_analysis_prompt, normalize_analysis_locale
 from llm.exceptions import QuotaExhaustedError
 from llm.screenshot_inputs import ScreenshotInput, normalize_screenshot_inputs
 
 logger = logging.getLogger(__name__)
 
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
-
-ANALYSIS_PROMPT = """Tu es un expert météorologue spécialisé en parapente. Analyse ces emagrammes pour le spot "{spot_name}" ({lat}, {lon}).
-
-Correspondance des images:
-{source_lines}
-
-Réponds UNIQUEMENT en JSON valide avec cette structure exacte :
-{{
-  "plafond_thermique_m": <altitude en metres du sommet des thermiques>,
-  "force_thermique_ms": <vitesse ascendante moyenne en m/s>,
-  "heures_volables": "<heure debut>-<heure fin>",
-  "score_volabilite": <score 0-100>,
-  "conseils_vol": "<conseils pratiques pour le pilote>",
-  "alertes_securite": ["<alerte 1>", "<alerte 2>"],
-  "details_analyse": "<resume technique de l'analyse>",
-  "explication_analyse": {{
-    "resume": "<pourquoi ce score en 1 phrase>",
-    "indices": [
-      "<indice global observe -> interpretation parapente>",
-      "<indice global observe -> interpretation parapente>"
-    ],
-    "par_source": {{
-      "<source exacte ci-dessus>": [
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>",
-        "Courbe observee: <nom/couleur/position> | Comment la reconnaitre: <repere visuel> | Interpretation: <sens meteo> | Consequence parapente: <impact concret>"
-      ]
-    }}
-  }}
-}}
-
-Pour chaque image/source, remplis obligatoirement explication_analyse.par_source avec la cle source exacte indiquee plus haut.
-Explique les courbes visibles: temperature, point de rosee, ecart temperature/point de rosee, parcelle/thermique si visible, base nuageuse/LCL, inversions/couches stables et vent altitude si visible."""
 
 
 def analyze_emagram_with_openrouter(
@@ -61,6 +30,7 @@ def analyze_emagram_with_openrouter(
     coordinates: tuple[float, float],
     model_name: str = "qwen/qwen2.5-vl-72b-instruct:free",
     max_retries: int = 2,
+    locale: str | None = None,
 ) -> dict[str, Any]:
     """Analyze emagram screenshots using OpenRouter vision models."""
     api_key = config.OPENROUTER_API_KEY
@@ -69,7 +39,7 @@ def analyze_emagram_with_openrouter(
 
     logger.info(f"Analyzing emagram for {spot_name} using OpenRouter {model_name}")
 
-    content = _build_message_content(screenshot_paths, spot_name, coordinates)
+    content = _build_message_content(screenshot_paths, spot_name, coordinates, locale)
     last_error = None
 
     headers = {
@@ -102,6 +72,10 @@ def analyze_emagram_with_openrouter(
             data = response.json()
             raw_text = data["choices"][0]["message"].get("content") or ""
             result = _parse_openrouter_response(raw_text)
+            if isinstance(result.get("explication_analyse"), dict):
+                result["explication_analyse"].setdefault(
+                    "locale", normalize_analysis_locale(locale)
+                )
 
             usage = data.get("usage") or {}
             prompt_tokens = usage.get("prompt_tokens") or 0
@@ -129,7 +103,10 @@ def analyze_emagram_with_openrouter(
 
 
 def _build_message_content(
-    screenshot_paths: list[ScreenshotInput], spot_name: str, coordinates: tuple[float, float]
+    screenshot_paths: list[ScreenshotInput],
+    spot_name: str,
+    coordinates: tuple[float, float],
+    locale: str | None = None,
 ) -> list[dict[str, Any]]:
     content: list[dict[str, Any]] = []
     screenshots = normalize_screenshot_inputs(screenshot_paths)
@@ -141,8 +118,13 @@ def _build_message_content(
     content.append(
         {
             "type": "text",
-            "text": ANALYSIS_PROMPT.format(
-                spot_name=spot_name, lat=lat, lon=lon, source_lines=source_lines
+            "text": build_emagram_analysis_prompt(
+                spot_name=spot_name,
+                lat=lat,
+                lon=lon,
+                source_lines=source_lines,
+                image_count=len(screenshots),
+                locale=locale,
             ),
         }
     )

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3253,7 +3253,7 @@ def get_flight_stats(db: Session = Depends(get_db)):
 
 
 @router.get("/flights/records", response_model=FlightRecordsResponse)
-def get_flight_records(db: Session = Depends(get_db)):
+def get_flight_records(db: Session = Depends(get_db)) -> FlightRecordsResponse:
     """
     Get personal flight records (longest duration, highest altitude, longest distance, max speed)
 
@@ -3280,7 +3280,7 @@ def get_flight_records(db: Session = Depends(get_db)):
     }
 
     if not flights:
-        return empty_records
+        return FlightRecordsResponse(**empty_records)
 
     # Filter out None values and find records
     flights_with_duration = [f for f in flights if f.duration_minutes is not None]
@@ -3420,12 +3420,12 @@ def get_flight_records(db: Session = Depends(get_db)):
         max(month_records, key=lambda item: (item[1], item[0])) if month_records else None
     )
 
-    return {
-        "longest_duration": format_record(longest, "duration_minutes", flights_with_duration),
-        "highest_altitude": format_record(highest, "max_altitude_m", flights_with_altitude),
-        "longest_distance": format_record(farthest, "distance_km", flights_with_distance),
-        "max_speed": format_record(fastest, "max_speed_kmh", flights_with_speed),
-        "takeoff_elevation_gain": format_computed_flight_record(
+    return FlightRecordsResponse(
+        longest_duration=format_record(longest, "duration_minutes", flights_with_duration),
+        highest_altitude=format_record(highest, "max_altitude_m", flights_with_altitude),
+        longest_distance=format_record(farthest, "distance_km", flights_with_distance),
+        max_speed=format_record(fastest, "max_speed_kmh", flights_with_speed),
+        takeoff_elevation_gain=format_computed_flight_record(
             greatest_takeoff_gain,
             (
                 greatest_takeoff_gain.max_altitude_m - greatest_takeoff_gain.site.elevation_m
@@ -3434,9 +3434,9 @@ def get_flight_records(db: Session = Depends(get_db)):
             ),
             flights_with_takeoff_elevation_gain,
         ),
-        "earliest_takeoff": format_time_record(earliest_takeoff, flights_with_departure_time),
-        "latest_takeoff": format_time_record(latest_takeoff, flights_with_departure_time),
-        "most_used_takeoff": (
+        earliest_takeoff=format_time_record(earliest_takeoff, flights_with_departure_time),
+        latest_takeoff=format_time_record(latest_takeoff, flights_with_departure_time),
+        most_used_takeoff=(
             {
                 "value": most_used_takeoff[1],
                 "site_id": most_used_takeoff[0].id,
@@ -3446,7 +3446,7 @@ def get_flight_records(db: Session = Depends(get_db)):
             if most_used_takeoff
             else None
         ),
-        "most_active_month": (
+        most_active_month=(
             {
                 "value": most_active_month[1],
                 "month": most_active_month[0],
@@ -3455,7 +3455,7 @@ def get_flight_records(db: Session = Depends(get_db)):
             if most_active_month
             else None
         ),
-    }
+    )
 
 
 @router.get("/flights/{flight_id}")
@@ -5833,7 +5833,9 @@ async def test_weather_source(
 _pending_emagram_analyses: set[str] = set()
 
 
-def _auto_emagram_analysis(site_id: str, day_index: int = 0, hour: int | None = None):
+def _auto_emagram_analysis(
+    site_id: str, day_index: int = 0, hour: int | None = None, locale: str | None = None
+):
     """Background task: auto-trigger emagram analysis for a site."""
     import asyncio
 
@@ -5852,6 +5854,7 @@ def _auto_emagram_analysis(site_id: str, day_index: int = 0, hour: int | None = 
                     db=db,
                     day_index=day_index,
                     hour=hour,
+                    locale=locale,
                 )
             )
     except Exception as e:
@@ -5869,6 +5872,7 @@ async def get_latest_emagram(
     user_lon: float | None = Query(None, description="User longitude"),
     day_index: int = Query(0, description="Day index (0=today, 1=tomorrow, ...)"),
     hour: int | None = Query(None, description="Specific hour (0-23) for hourly analysis"),
+    locale: str | None = Query(None, description="Analysis language: fr or en"),
     max_distance_km: float = Query(200, description="Maximum station distance in km"),
     auto_analyze: bool = Query(False, description="Auto-trigger analysis if none found"),
     background_tasks: BackgroundTasks = BackgroundTasks(),
@@ -5992,7 +5996,7 @@ async def get_latest_emagram(
 
         # Auto-trigger analysis in background if no data found
         if result is None and auto_analyze and site_id:
-            background_tasks.add_task(_auto_emagram_analysis, site_id, day_index, hour)
+            background_tasks.add_task(_auto_emagram_analysis, site_id, day_index, hour, locale)
 
         return result
 
@@ -6441,6 +6445,7 @@ async def trigger_emagram_analysis(
             force_refresh=request.force_refresh,
             day_index=request.day_index,
             hour=request.hour,
+            locale=request.locale,
         )
 
         if not result.get("success"):

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -659,6 +659,7 @@ class EmagramTriggerRequest(BaseModel):
     force_refresh: bool = False
     day_index: int = 0
     hour: int | None = None
+    locale: str | None = None
 
     @validator("user_latitude")
     def validate_latitude(cls, v):
@@ -671,6 +672,15 @@ class EmagramTriggerRequest(BaseModel):
         if v is not None and not -180 <= v <= 180:
             raise ValueError("Longitude must be between -180 and 180")
         return v
+
+    @validator("locale")
+    def validate_locale(cls, v):
+        if v is None:
+            return v
+        normalized = v.lower().split("-", maxsplit=1)[0]
+        if normalized not in {"fr", "en"}:
+            raise ValueError("Locale must be 'fr' or 'en'")
+        return normalized
 
 
 class VideoExportTempCleanupError(BaseModel):

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -95,7 +95,7 @@
     },
     "build-storybook": {
       "executor": "nx:run-commands",
-      "outputs": ["dist/storybook/frontend"],
+      "outputs": ["{workspaceRoot}/dist/storybook/frontend"],
       "options": {
         "command": "pnpm exec storybook build",
         "cwd": "apps/frontend"

--- a/apps/frontend/src/components/dashboard/AnnotatedEmagramLightbox.stories.tsx
+++ b/apps/frontend/src/components/dashboard/AnnotatedEmagramLightbox.stories.tsx
@@ -1,0 +1,361 @@
+import preview from '../../../.storybook/preview';
+import { expect } from 'storybook/test';
+import { AnnotatedEmagramLightbox } from './AnnotatedEmagramLightbox';
+
+const emagramSvg = encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="620" viewBox="0 0 900 620">
+  <rect width="900" height="620" fill="#f8fafc"/>
+  <g stroke="#cbd5e1" stroke-width="1">
+    ${Array.from({ length: 12 }, (_, i) => `<line x1="${80 + i * 65}" y1="40" x2="${80 + i * 65}" y2="560"/>`).join('')}
+    ${Array.from({ length: 9 }, (_, i) => `<line x1="70" y1="${70 + i * 55}" x2="820" y2="${70 + i * 55}"/>`).join('')}
+  </g>
+  <polyline points="250,540 300,470 335,390 355,315 350,250 390,190 410,115" fill="none" stroke="#dc2626" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="190,545 230,480 260,420 280,350 315,290 330,230 345,165" fill="none" stroke="#16a34a" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="310,540 350,470 385,390 405,330 430,265 455,205 485,145" fill="none" stroke="#7c3aed" stroke-width="4" stroke-dasharray="12 10" stroke-linecap="round"/>
+  <g fill="#334155" font-family="Arial" font-size="18">
+    <text x="80" y="35">Emagramme test</text>
+    <text x="835" y="570">Vent</text>
+  </g>
+  <g stroke="#0284c7" stroke-width="3">
+    <line x1="805" y1="150" x2="850" y2="130"/><line x1="805" y1="250" x2="850" y2="245"/><line x1="805" y1="360" x2="850" y2="380"/>
+  </g>
+</svg>`);
+
+const image = {
+  src: `data:image/svg+xml,${emagramSvg}`,
+  alt: 'Meteociel',
+  source: 'meteociel',
+};
+
+const secondImage = {
+  ...image,
+  alt: 'Météo-Parapente',
+  source: 'meteo-parapente',
+};
+
+const annotatedResponse = JSON.stringify({
+  explication_analyse: {
+    locale: 'fr',
+    resume:
+      'La masse d air est exploitable, mais le plafond et le vent demandent de la vigilance.',
+    indices: [
+      'Thermiques utilisables en milieu de jour.',
+      'Vent plus sensible au-dessus du plafond.',
+    ],
+    par_source: {
+      meteociel: ['La courbe rouge reste assez inclinée en basses couches.'],
+    },
+    annotations_image: {
+      meteociel: [
+        {
+          id: 'thermals',
+          type: 'point',
+          label: 'Thermiques',
+          priority: 'important',
+          category: 'thermal',
+          display_order: 1,
+          confidence: 0.86,
+          x: 38,
+          y: 58,
+          visual_cue:
+            'Le point est placé sur la pente régulière de la courbe rouge.',
+          weather_reading: 'L air se refroidit assez vite avec l altitude.',
+          flight_impact:
+            'Les ascendances devraient être présentes et lisibles.',
+          term: 'Gradient thermique',
+          term_definition:
+            'Vitesse à laquelle l air se refroidit quand on monte.',
+          uncertainty_note: null,
+        },
+        {
+          id: 'inversion',
+          type: 'zone',
+          label: 'Couche stable',
+          priority: 'watch',
+          category: 'stability',
+          display_order: 2,
+          confidence: 0.78,
+          x: 39,
+          y: 34,
+          width: 12,
+          height: 12,
+          visual_cue:
+            'La zone couvre la partie où la courbe rouge se redresse.',
+          weather_reading: 'Cette forme indique une couche plus stable.',
+          flight_impact: 'Les thermiques peuvent ralentir sous cette couche.',
+          term: 'Inversion',
+          term_definition: 'Couche qui freine ou bloque les ascendances.',
+          uncertainty_note: 'Lecture assez fiable, mais la courbe est serrée.',
+        },
+        {
+          id: 'wind',
+          type: 'point',
+          label: 'Vent altitude',
+          priority: 'important',
+          category: 'wind',
+          display_order: 3,
+          confidence: 0.81,
+          x: 91,
+          y: 40,
+          visual_cue: 'Le point vise les barbules de vent sur la droite.',
+          weather_reading: 'Le vent semble plus marqué avec l altitude.',
+          flight_impact: 'Prévoir de la dérive et une rentrée moins directe.',
+          term: null,
+          term_definition: null,
+          uncertainty_note: null,
+        },
+      ],
+      'meteo-parapente': [
+        {
+          id: 'ceiling',
+          type: 'point',
+          label: 'Plafond',
+          priority: 'important',
+          category: 'ceiling',
+          display_order: 1,
+          confidence: 0.83,
+          x: 48,
+          y: 32,
+          visual_cue:
+            'Le point est placé près du niveau où les courbes se rapprochent.',
+          weather_reading: 'L humidité peut limiter la hauteur exploitable.',
+          flight_impact: 'Le plafond pourrait rester sous cette zone.',
+        },
+      ],
+    },
+  },
+});
+
+const fallbackResponse = JSON.stringify({
+  explication_analyse: {
+    locale: 'fr',
+    resume: 'Analyse utile mais sans point assez fiable sur l image.',
+    indices: ['Le plafond semble limité.', 'Le vent doit être surveillé.'],
+    par_source: {
+      meteociel: ['Observation globale sans coordonnées précises.'],
+    },
+    annotations_image: {
+      meteociel: [
+        {
+          id: 'low-confidence',
+          type: 'point',
+          label: 'Humidité',
+          priority: 'watch',
+          category: 'humidity',
+          display_order: 1,
+          confidence: 0.52,
+          x: 34,
+          y: 45,
+          visual_cue:
+            'Les courbes semblent proches, mais la lecture est peu sûre.',
+          weather_reading: 'L air pourrait être humide.',
+          flight_impact: 'La base nuageuse peut être plus basse.',
+        },
+      ],
+    },
+  },
+});
+
+const meta = preview.meta({
+  title: 'Components/Complex/AnnotatedEmagramLightbox',
+  component: AnnotatedEmagramLightbox,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+});
+
+export const Default = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image],
+    aiRawResponse: annotatedResponse,
+  },
+});
+
+Default.test(
+  'opens marker details and toggles annotations',
+  async ({ canvas, userEvent }) => {
+    await expect(
+      await canvas.findByRole('button', { name: 'Thermiques' })
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Thermiques' })
+    );
+    await expect(await canvas.findByText('Repère visuel')).toBeInTheDocument();
+    await expect(await canvas.findByText('Lecture météo')).toBeInTheDocument();
+    await expect(await canvas.findByText('Impact vol')).toBeInTheDocument();
+    await expect(
+      await canvas.findByText('Confiance : 86 %')
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Masquer les explications' })
+    );
+    await expect(
+      canvas.queryByRole('button', { name: 'Thermiques' })
+    ).toBeNull();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Afficher les explications' })
+    );
+    await expect(
+      await canvas.findByRole('button', { name: 'Thermiques' })
+    ).toBeInTheDocument();
+  }
+);
+
+export const Fallback = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image],
+    aiRawResponse: fallbackResponse,
+  },
+});
+
+Fallback.test(
+  'opens the fallback panel when no precise marker exists',
+  async ({ canvas }) => {
+    await expect(
+      await canvas.findByText('Résumé et autres explications')
+    ).toBeInTheDocument();
+    await expect(
+      await canvas.findByText(
+        'Analyse utile mais sans point assez fiable sur l image.'
+      )
+    ).toBeInTheDocument();
+  }
+);
+
+export const MultipleSources = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image, secondImage],
+    aiRawResponse: annotatedResponse,
+  },
+});
+
+MultipleSources.test(
+  'resets active annotation and zoom when changing source',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Thermiques' })
+    );
+    await expect(
+      await canvas.findByText('Gradient thermique')
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Zoom +' })
+    );
+    await expect(
+      await canvas.findByRole('button', { name: /Réinitialiser \(1.5x\)/u })
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Suivant' })
+    );
+    await expect(canvas.queryByText('Gradient thermique')).toBeNull();
+    await expect(
+      await canvas.findByRole('button', { name: /Réinitialiser \(1x\)/u })
+    ).toBeInTheDocument();
+  }
+);
+
+export const GroupedMarkers = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image],
+    aiRawResponse: JSON.stringify({
+      explication_analyse: {
+        annotations_image: {
+          meteociel: [
+            {
+              ...JSON.parse(annotatedResponse).explication_analyse
+                .annotations_image.meteociel[0],
+              x: 42,
+              y: 44,
+            },
+            {
+              ...JSON.parse(annotatedResponse).explication_analyse
+                .annotations_image.meteociel[1],
+              x: 42.5,
+              y: 44.2,
+            },
+          ],
+        },
+      },
+    }),
+  },
+});
+
+GroupedMarkers.test(
+  'opens grouped marker explanations',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      await canvas.findByRole('button', { name: '2 explications' })
+    );
+    await expect(await canvas.findByText('Thermiques')).toBeInTheDocument();
+    await expect(await canvas.findByText('Couche stable')).toBeInTheDocument();
+  }
+);
+
+export const MobileDense = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image],
+    aiRawResponse: JSON.stringify({
+      explication_analyse: {
+        annotations_image: {
+          meteociel: [
+            {
+              ...JSON.parse(annotatedResponse).explication_analyse
+                .annotations_image.meteociel[0],
+              x: 42,
+              y: 44,
+            },
+            {
+              ...JSON.parse(annotatedResponse).explication_analyse
+                .annotations_image.meteociel[1],
+              x: 42.5,
+              y: 44.2,
+            },
+          ],
+        },
+      },
+    }),
+  },
+  parameters: { layout: 'fullscreen' },
+});
+
+export const Zoom = meta.story({
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    images: [image],
+    aiRawResponse: annotatedResponse,
+  },
+});
+
+Zoom.test(
+  'keeps annotations interactive after zoom',
+  async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Zoom +' })
+    );
+    await expect(
+      await canvas.findByRole('button', { name: /Réinitialiser \(1.5x\)/u })
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: 'Thermiques' })
+    );
+    await expect(
+      await canvas.findByText('Confiance : 86 %')
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await canvas.findByRole('button', { name: /Réinitialiser \(1.5x\)/u })
+    );
+    await expect(
+      await canvas.findByRole('button', { name: /Réinitialiser \(1x\)/u })
+    ).toBeInTheDocument();
+  }
+);

--- a/apps/frontend/src/components/dashboard/AnnotatedEmagramLightbox.tsx
+++ b/apps/frontend/src/components/dashboard/AnnotatedEmagramLightbox.tsx
@@ -1,0 +1,526 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  formatConfidence,
+  groupEmagramAnnotations,
+  parseEmagramAnnotationModel,
+  type EmagramAnnotationGroup,
+  type EmagramImageAnnotation,
+  type EmagramPanelExplanation,
+} from '../../lib/emagramAnnotations';
+
+export interface AnnotatedEmagramImage {
+  src: string;
+  alt: string;
+  source: string;
+}
+
+interface AnnotatedEmagramLightboxProps {
+  isOpen: boolean;
+  onClose: () => void;
+  images: AnnotatedEmagramImage[];
+  aiRawResponse: string | null | undefined;
+  initialIndex?: number;
+}
+
+const ZOOM_LEVELS = [1, 1.5, 2] as const;
+
+const priorityClass: Record<EmagramImageAnnotation['priority'], string> = {
+  important: 'border-orange-500 bg-orange-500 text-white ring-orange-200',
+  watch: 'border-amber-500 bg-amber-400 text-gray-950 ring-amber-200',
+  educational: 'border-sky-500 bg-sky-500 text-white ring-sky-200',
+};
+
+const zoneClass: Record<EmagramImageAnnotation['priority'], string> = {
+  important: 'border-orange-500 bg-orange-400/15',
+  watch: 'border-amber-500 bg-amber-300/15',
+  educational: 'border-sky-500 bg-sky-400/15',
+};
+
+function useCurrentIndex(
+  isOpen: boolean,
+  initialIndex: number,
+  length: number
+) {
+  const [index, setIndex] = useState(initialIndex);
+  useEffect(() => {
+    if (isOpen)
+      setIndex(Math.min(Math.max(initialIndex, 0), Math.max(length - 1, 0)));
+  }, [initialIndex, isOpen, length]);
+  return [index, setIndex] as const;
+}
+
+function AnnotationText({
+  annotation,
+}: {
+  annotation: EmagramImageAnnotation | EmagramPanelExplanation;
+}) {
+  const { t } = useTranslation();
+  const confidence = formatConfidence(annotation.confidence);
+  return (
+    <div className="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="font-semibold text-gray-950 dark:text-gray-50">
+          {annotation.label}
+        </div>
+        {confidence && (
+          <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+            {t('thermal.annotations.confidence', { value: confidence })}
+          </span>
+        )}
+      </div>
+      {'priority' in annotation && 'category' in annotation && (
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          {t(`thermal.annotations.priority.${annotation.priority}`)} ·{' '}
+          {t(`thermal.annotations.category.${annotation.category}`)}
+        </div>
+      )}
+      {'reason' in annotation && annotation.reason && (
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          {t(`thermal.annotations.reason.${annotation.reason}`)}
+        </div>
+      )}
+      {annotation.term && annotation.termDefinition && (
+        <div className="rounded-md bg-purple-50 p-2 text-xs text-purple-900 dark:bg-purple-900/30 dark:text-purple-100">
+          <span className="font-semibold">
+            {t('thermal.annotations.termToRemember')}: {annotation.term}
+          </span>{' '}
+          {annotation.termDefinition}
+        </div>
+      )}
+      {annotation.visualCue && (
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('thermal.annotations.visualCue')}
+          </div>
+          <div>{annotation.visualCue}</div>
+        </div>
+      )}
+      {annotation.weatherReading && (
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('thermal.annotations.weatherReading')}
+          </div>
+          <div>{annotation.weatherReading}</div>
+        </div>
+      )}
+      {annotation.flightImpact && (
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('thermal.annotations.flightImpact')}
+          </div>
+          <div>{annotation.flightImpact}</div>
+        </div>
+      )}
+      {'text' in annotation && annotation.text && <div>{annotation.text}</div>}
+      {'uncertaintyNote' in annotation && annotation.uncertaintyNote && (
+        <div className="rounded-md bg-amber-50 p-2 text-xs text-amber-900 dark:bg-amber-900/30 dark:text-amber-100">
+          {annotation.uncertaintyNote}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExplanationPanel({
+  title,
+  model,
+}: {
+  title: string;
+  model: ReturnType<typeof parseEmagramAnnotationModel>;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="max-h-[45vh] overflow-y-auto rounded-xl border border-gray-200 bg-white p-4 shadow-xl dark:border-gray-700 dark:bg-gray-900">
+      <div className="mb-3 font-semibold text-gray-950 dark:text-gray-50">
+        {title}
+      </div>
+      <div className="space-y-4">
+        {model.resume && (
+          <section>
+            <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('thermal.annotations.globalSummary')}
+            </h3>
+            <p className="text-sm text-gray-700 dark:text-gray-200">
+              {model.resume}
+            </p>
+          </section>
+        )}
+        {model.indices.length > 0 && (
+          <section>
+            <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('thermal.annotations.flightTakeaways')}
+            </h3>
+            <ul className="space-y-1 pl-4 text-sm text-gray-700 dark:text-gray-200">
+              {model.indices.map((indice) => (
+                <li key={indice} className="list-disc">
+                  {indice}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {model.panelExplanations.length > 0 && (
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {t('thermal.annotations.otherExplanations')}
+            </h3>
+            <div className="space-y-3">
+              {model.panelExplanations.map((explanation) => (
+                <div
+                  key={explanation.id}
+                  className="rounded-lg border border-gray-100 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/70"
+                >
+                  <AnnotationText annotation={explanation} />
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+        {!model.resume &&
+          model.indices.length === 0 &&
+          model.panelExplanations.length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t('thermal.annotations.noExplanation')}
+            </p>
+          )}
+      </div>
+    </div>
+  );
+}
+
+function GroupPopover({ group }: { group: EmagramAnnotationGroup }) {
+  return (
+    <div className="w-80 max-w-[calc(100vw-2rem)] rounded-xl border border-gray-200 bg-white p-3 shadow-2xl dark:border-gray-700 dark:bg-gray-900">
+      <div className="space-y-3">
+        {group.annotations.map((annotation) => (
+          <AnnotationText key={annotation.id} annotation={annotation} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AnnotatedEmagramLightbox({
+  isOpen,
+  onClose,
+  images,
+  aiRawResponse,
+  initialIndex = 0,
+}: AnnotatedEmagramLightboxProps) {
+  const { t } = useTranslation();
+  const [index, setIndex] = useCurrentIndex(
+    isOpen,
+    initialIndex,
+    images.length
+  );
+  const [annotationsVisible, setAnnotationsVisible] = useState(true);
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+  const [hoverGroupId, setHoverGroupId] = useState<string | null>(null);
+  const [zoomIndex, setZoomIndex] = useState(0);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [imageSize, setImageSize] = useState({ width: 1000, height: 700 });
+  const current = images[index];
+  const zoom = ZOOM_LEVELS[zoomIndex];
+
+  const model = useMemo(
+    () => parseEmagramAnnotationModel(aiRawResponse, current?.source ?? ''),
+    [aiRawResponse, current?.source]
+  );
+  const groups = useMemo(
+    () =>
+      annotationsVisible
+        ? groupEmagramAnnotations(model.preciseAnnotations, {
+            imageWidth: imageSize.width,
+            imageHeight: imageSize.height,
+            zoom,
+            thresholdPx: 40,
+          })
+        : [],
+    [
+      annotationsVisible,
+      imageSize.height,
+      imageSize.width,
+      model.preciseAnnotations,
+      zoom,
+    ]
+  );
+  const selectedGroup = groups.find(
+    (group) => group.id === (activeGroupId ?? hoverGroupId)
+  );
+  const hasPanelContent = Boolean(
+    model.resume ||
+    model.indices.length > 0 ||
+    model.panelExplanations.length > 0
+  );
+  const shouldShowAutoPanel =
+    annotationsVisible && groups.length === 0 && hasPanelContent;
+
+  useEffect(() => {
+    setActiveGroupId(null);
+    setHoverGroupId(null);
+    setZoomIndex(0);
+    setPanelOpen(false);
+  }, [index, isOpen]);
+
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image) return;
+
+    const updateImageSize = () => {
+      if (image.clientWidth > 0 && image.clientHeight > 0) {
+        setImageSize({ width: image.clientWidth, height: image.clientHeight });
+      }
+    };
+
+    updateImageSize();
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const resizeObserver = new ResizeObserver(updateImageSize);
+    resizeObserver.observe(image);
+    return () => resizeObserver.disconnect();
+  }, [current?.src]);
+
+  if (!isOpen || !current) return null;
+
+  const hasPrev = index > 0;
+  const hasNext = index < images.length - 1;
+  const showPanel = shouldShowAutoPanel || panelOpen;
+  const activateAnnotation = (annotationId: string) => {
+    const group = groups.find((item) =>
+      item.annotations.some((annotation) => annotation.id === annotationId)
+    );
+    setActiveGroupId(group?.id ?? annotationId);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/75 p-2 backdrop-blur-sm sm:p-4">
+      <dialog
+        open
+        aria-modal="true"
+        aria-label={current.alt}
+        className="relative flex max-h-[96vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-gray-950 text-white shadow-2xl"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-white/10 p-3">
+          <div>
+            <div className="font-semibold">{current.alt}</div>
+            <div className="text-xs text-gray-300">
+              {t('thermal.annotations.source')}: {current.source}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              onClick={() => {
+                setAnnotationsVisible((visible) => !visible);
+                setActiveGroupId(null);
+                setPanelOpen(false);
+              }}
+            >
+              {annotationsVisible
+                ? t('thermal.annotations.hideAnnotations')
+                : t('thermal.annotations.showAnnotations')}
+            </button>
+            {hasPanelContent && annotationsVisible && !shouldShowAutoPanel && (
+              <button
+                type="button"
+                className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400"
+                onClick={() => setPanelOpen((open) => !open)}
+              >
+                {t('thermal.annotations.summaryAndMore')}
+              </button>
+            )}
+            <button
+              type="button"
+              className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              onClick={() =>
+                setZoomIndex((value) =>
+                  Math.min(value + 1, ZOOM_LEVELS.length - 1)
+                )
+              }
+            >
+              {t('thermal.annotations.zoomIn')}
+            </button>
+            <button
+              type="button"
+              className="rounded-full bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              onClick={() => {
+                setZoomIndex(0);
+                setActiveGroupId(null);
+              }}
+            >
+              {t('thermal.annotations.reset')} ({zoom}x)
+            </button>
+            <button
+              type="button"
+              aria-label={t('common.close')}
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-white text-gray-900 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              onClick={onClose}
+            >
+              <span aria-hidden="true">x</span>
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-gray-900 p-3">
+          <div className="relative mx-auto w-max max-w-none">
+            <div
+              className="relative origin-top-left"
+              style={{
+                transform: `scale(${zoom})`,
+                transformOrigin: 'top left',
+              }}
+            >
+              <img
+                ref={imageRef}
+                src={current.src}
+                alt={current.alt}
+                className="max-h-[70vh] max-w-[92vw] rounded-xl object-contain shadow-2xl"
+                onLoad={() => {
+                  const image = imageRef.current;
+                  if (image?.clientWidth && image.clientHeight) {
+                    setImageSize({
+                      width: image.clientWidth,
+                      height: image.clientHeight,
+                    });
+                  }
+                }}
+              />
+              {annotationsVisible &&
+                model.preciseAnnotations
+                  .filter((annotation) => annotation.type === 'zone')
+                  .map((annotation) => (
+                    <button
+                      key={annotation.id}
+                      type="button"
+                      className={`absolute rounded-md border-2 transition focus:outline-none focus:ring-2 ${zoneClass[annotation.priority]}`}
+                      style={{
+                        left: `${annotation.x}%`,
+                        top: `${annotation.y}%`,
+                        width: `${annotation.width}%`,
+                        height: `${annotation.height}%`,
+                      }}
+                      aria-label={annotation.label}
+                      onClick={() => activateAnnotation(annotation.id)}
+                    />
+                  ))}
+              {annotationsVisible &&
+                groups.map((group) => (
+                  <div
+                    key={group.id}
+                    className="absolute"
+                    style={{
+                      left: `${group.annotations[0].x}%`,
+                      top: `${group.annotations[0].y}%`,
+                      transform: `translate(-50%, -50%) scale(${1 / zoom})`,
+                    }}
+                    onMouseEnter={() => setHoverGroupId(group.id)}
+                    onMouseLeave={() => setHoverGroupId(null)}
+                  >
+                    <button
+                      type="button"
+                      aria-label={
+                        group.annotations.length > 1
+                          ? t('thermal.annotations.groupLabel', {
+                              count: group.annotations.length,
+                            })
+                          : group.annotations[0].label
+                      }
+                      className={`flex h-9 min-w-9 items-center justify-center rounded-full border-2 px-2 text-sm font-bold shadow-lg ring-4 transition hover:scale-105 focus:outline-none focus:ring-4 ${priorityClass[group.annotations[0].priority]}`}
+                      onClick={() =>
+                        setActiveGroupId((active) =>
+                          active === group.id ? null : group.id
+                        )
+                      }
+                    >
+                      {group.annotations.length > 1
+                        ? group.annotations.length
+                        : 'i'}
+                    </button>
+                    {selectedGroup?.id === group.id && (
+                      <div className="absolute left-1/2 top-11 hidden -translate-x-1/2 text-gray-900 sm:block dark:text-gray-100">
+                        <GroupPopover group={group} />
+                      </div>
+                    )}
+                  </div>
+                ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-white/10 p-3 text-xs text-gray-300">
+          {annotationsVisible && groups.length > 0 && !selectedGroup && (
+            <span>{t('thermal.annotations.help')}</span>
+          )}
+          {!annotationsVisible && (
+            <span>{t('thermal.annotations.hidden')}</span>
+          )}
+        </div>
+
+        <div className="flex items-center justify-center gap-3 border-t border-white/10 p-3">
+          {images.length > 1 && (
+            <button
+              type="button"
+              disabled={!hasPrev}
+              className="rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 disabled:cursor-default disabled:opacity-40"
+              onClick={() => setIndex(index - 1)}
+            >
+              {t('thermal.annotations.previous')}
+            </button>
+          )}
+          <span className="rounded-full bg-black/40 px-3 py-1 text-sm text-white">
+            {current.alt}{' '}
+            {images.length > 1 && `(${index + 1}/${images.length})`}
+          </span>
+          {images.length > 1 && (
+            <button
+              type="button"
+              disabled={!hasNext}
+              className="rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-white/20 disabled:cursor-default disabled:opacity-40"
+              onClick={() => setIndex(index + 1)}
+            >
+              {t('thermal.annotations.next')}
+            </button>
+          )}
+        </div>
+
+        {selectedGroup && (
+          <div className="fixed inset-x-0 bottom-0 z-[110] rounded-t-2xl bg-white p-4 text-gray-900 shadow-2xl sm:hidden dark:bg-gray-900 dark:text-gray-100">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="font-semibold">
+                {selectedGroup.annotations.length > 1
+                  ? t('thermal.annotations.groupLabel', {
+                      count: selectedGroup.annotations.length,
+                    })
+                  : selectedGroup.annotations[0].label}
+              </div>
+              <button
+                type="button"
+                className="rounded-full bg-gray-100 px-3 py-1 text-sm dark:bg-gray-800"
+                onClick={() => setActiveGroupId(null)}
+              >
+                {t('common.close')}
+              </button>
+            </div>
+            <div className="max-h-[50vh] space-y-4 overflow-y-auto">
+              {selectedGroup.annotations.map((annotation) => (
+                <AnnotationText key={annotation.id} annotation={annotation} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {showPanel && annotationsVisible && (
+          <div className="absolute inset-x-3 bottom-20 z-[105] text-gray-900 sm:bottom-24 sm:left-auto sm:right-4 sm:w-[28rem] dark:text-gray-100">
+            <ExplanationPanel
+              title={t('thermal.annotations.summaryAndMore')}
+              model={model}
+            />
+          </div>
+        )}
+      </dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
+++ b/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
@@ -3,6 +3,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import { getStaleTime, getWeatherRefetchInterval } from '../../lib/cacheConfig';
 import type { EmagramAnalysis, EmagramListItem } from '../../types/emagram';
 import { api } from '../../lib/api';
@@ -26,6 +27,7 @@ export function useLatestEmagram(
   hour?: number | null,
   options?: { enabled?: boolean }
 ) {
+  const { i18n } = useTranslation();
   return useQuery({
     queryKey: emagramKeys.latest(siteId, dayIndex, hour),
     queryFn: async (): Promise<EmagramAnalysis | null> => {
@@ -35,6 +37,7 @@ export function useLatestEmagram(
         site_id: siteId,
         day_index: dayIndex.toString(),
         auto_analyze: 'true',
+        locale: i18n.language,
       });
       if (hour != null) {
         params.set('hour', hour.toString());
@@ -126,6 +129,7 @@ export function useEmagramHistory(
  */
 export function useTriggerEmagram() {
   const queryClient = useQueryClient();
+  const { i18n } = useTranslation();
 
   return useMutation({
     mutationFn: async (request: {
@@ -135,9 +139,12 @@ export function useTriggerEmagram() {
       force_refresh?: boolean;
       day_index?: number;
       hour?: number | null;
+      locale?: string;
     }): Promise<EmagramAnalysis> => {
       return api
-        .post('emagram/analyze', { json: request })
+        .post('emagram/analyze', {
+          json: { locale: i18n.language, ...request },
+        })
         .json<EmagramAnalysis>();
     },
     onSuccess: () => {

--- a/apps/frontend/src/lib/emagramAnnotations.test.ts
+++ b/apps/frontend/src/lib/emagramAnnotations.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatConfidence,
+  groupEmagramAnnotations,
+  parseEmagramAnnotationModel,
+  type EmagramImageAnnotation,
+} from './emagramAnnotations';
+
+const validAnnotation = {
+  id: 'thermal-profile',
+  type: 'point',
+  label: 'Thermiques',
+  priority: 'important',
+  category: 'thermal',
+  display_order: 1,
+  confidence: 0.84,
+  x: 42,
+  y: 58,
+  visual_cue: 'Le point est sur la courbe qui monte regulierement.',
+  weather_reading: 'La masse d air permet des ascendances.',
+  flight_impact: 'Les thermiques devraient etre exploitables.',
+};
+
+function rawResponse(annotations: unknown[]) {
+  return JSON.stringify({
+    explication_analyse: {
+      locale: 'fr',
+      resume: 'Conditions correctes.',
+      indices: ['Plafond utile.'],
+      par_source: {
+        meteociel: ['Observation ancienne utile.'],
+      },
+      annotations_image: {
+        meteociel: annotations,
+      },
+    },
+  });
+}
+
+describe('parseEmagramAnnotationModel', () => {
+  it('keeps valid high-confidence annotations as precise markers', () => {
+    const model = parseEmagramAnnotationModel(
+      rawResponse([validAnnotation]),
+      'meteociel'
+    );
+
+    expect(model.preciseAnnotations).toHaveLength(1);
+    expect(model.preciseAnnotations[0]).toMatchObject({
+      id: 'thermal-profile',
+      confidence: 0.84,
+      priority: 'important',
+    });
+    expect(model.panelExplanations).toHaveLength(1);
+  });
+
+  it('moves low-confidence annotations to the panel', () => {
+    const model = parseEmagramAnnotationModel(
+      rawResponse([{ ...validAnnotation, confidence: 0.54 }]),
+      'meteociel'
+    );
+
+    expect(model.preciseAnnotations).toHaveLength(0);
+    expect(model.panelExplanations[0]).toMatchObject({
+      reason: 'low_confidence',
+      confidence: 0.54,
+    });
+  });
+
+  it('rejects large zones as non-localized explanations', () => {
+    const model = parseEmagramAnnotationModel(
+      rawResponse([
+        {
+          ...validAnnotation,
+          id: 'large-zone',
+          type: 'zone',
+          width: 60,
+          height: 20,
+        },
+      ]),
+      'meteociel'
+    );
+
+    expect(model.preciseAnnotations).toHaveLength(0);
+    expect(model.panelExplanations[0]?.reason).toBe('invalid_zone');
+  });
+
+  it('limits precise markers to the six most important annotations', () => {
+    const annotations = Array.from({ length: 8 }, (_, index) => ({
+      ...validAnnotation,
+      id: `annotation-${index}`,
+      display_order: index,
+      x: 10 + index,
+    }));
+
+    const model = parseEmagramAnnotationModel(
+      rawResponse(annotations),
+      'meteociel'
+    );
+
+    expect(model.preciseAnnotations).toHaveLength(6);
+    expect(
+      model.panelExplanations.some((item) => item.reason === 'overflow')
+    ).toBe(true);
+  });
+});
+
+describe('groupEmagramAnnotations', () => {
+  const base: EmagramImageAnnotation = {
+    id: 'a',
+    source: 'meteociel',
+    type: 'point',
+    label: 'A',
+    priority: 'important',
+    category: 'thermal',
+    displayOrder: 1,
+    confidence: 0.8,
+    x: 10,
+    y: 10,
+    visualCue: 'cue',
+    weatherReading: 'reading',
+    flightImpact: 'impact',
+  };
+
+  it('groups nearby annotations using screen distance', () => {
+    const groups = groupEmagramAnnotations(
+      [base, { ...base, id: 'b', x: 12, y: 10 }],
+      { imageWidth: 1000, imageHeight: 500, zoom: 1, thresholdPx: 44 }
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].annotations).toHaveLength(2);
+  });
+
+  it('can separate annotations after zoom changes displayed distance', () => {
+    const groups = groupEmagramAnnotations(
+      [base, { ...base, id: 'b', x: 12, y: 10 }],
+      { imageWidth: 1000, imageHeight: 500, zoom: 2, thresholdPx: 32 }
+    );
+
+    expect(groups).toHaveLength(2);
+  });
+});
+
+describe('formatConfidence', () => {
+  it('rounds confidence to an integer percentage', () => {
+    expect(formatConfidence(0.734)).toBe('73 %');
+  });
+});

--- a/apps/frontend/src/lib/emagramAnnotations.ts
+++ b/apps/frontend/src/lib/emagramAnnotations.ts
@@ -1,0 +1,421 @@
+export type EmagramAnnotationType = 'point' | 'zone';
+export type EmagramAnnotationPriority = 'important' | 'watch' | 'educational';
+export type EmagramAnnotationCategory =
+  | 'thermal'
+  | 'ceiling'
+  | 'stability'
+  | 'humidity'
+  | 'wind'
+  | 'risk';
+
+export interface EmagramImageAnnotation {
+  id: string;
+  source: string;
+  type: EmagramAnnotationType;
+  label: string;
+  priority: EmagramAnnotationPriority;
+  category: EmagramAnnotationCategory;
+  displayOrder: number;
+  confidence: number;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  visualCue: string;
+  weatherReading: string;
+  flightImpact: string;
+  term?: string;
+  termDefinition?: string;
+  uncertaintyNote?: string;
+}
+
+export interface EmagramPanelExplanation {
+  id: string;
+  source: string;
+  label: string;
+  confidence?: number;
+  reason?: string;
+  visualCue?: string;
+  weatherReading?: string;
+  flightImpact?: string;
+  term?: string;
+  termDefinition?: string;
+  text?: string;
+}
+
+export interface EmagramAnnotationModel {
+  locale: string | null;
+  resume: string | null;
+  indices: string[];
+  preciseAnnotations: EmagramImageAnnotation[];
+  panelExplanations: EmagramPanelExplanation[];
+}
+
+export interface EmagramAnnotationGroup {
+  id: string;
+  x: number;
+  y: number;
+  annotations: EmagramImageAnnotation[];
+}
+
+const VALID_PRIORITIES = ['important', 'watch', 'educational'] as const;
+const VALID_CATEGORIES = [
+  'thermal',
+  'ceiling',
+  'stability',
+  'humidity',
+  'wind',
+  'risk',
+] as const;
+const VALID_TYPES = ['point', 'zone'] as const;
+const MIN_CONFIDENCE = 0.7;
+const MAX_VISIBLE_ANNOTATIONS = 6;
+const MAX_ZONE_SIZE = 40;
+const MAX_ZONE_AREA = 900;
+
+const PRIORITY_ORDER: Record<EmagramAnnotationPriority, number> = {
+  important: 0,
+  watch: 1,
+  educational: 2,
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value !== 'number' || Number.isNaN(value)) return null;
+  return value;
+}
+
+function inPercentRange(value: unknown): value is number {
+  const numberValue = asNumber(value);
+  return numberValue !== null && numberValue >= 0 && numberValue <= 100;
+}
+
+function isValidPriority(value: unknown): value is EmagramAnnotationPriority {
+  return VALID_PRIORITIES.includes(value as EmagramAnnotationPriority);
+}
+
+function isValidCategory(value: unknown): value is EmagramAnnotationCategory {
+  return VALID_CATEGORIES.includes(value as EmagramAnnotationCategory);
+}
+
+function isValidType(value: unknown): value is EmagramAnnotationType {
+  return VALID_TYPES.includes(value as EmagramAnnotationType);
+}
+
+function panelTextKey(explanation: EmagramPanelExplanation): string {
+  return [
+    explanation.visualCue,
+    explanation.weatherReading,
+    explanation.flightImpact,
+    explanation.text,
+  ]
+    .filter(Boolean)
+    .join('|')
+    .trim();
+}
+
+function hasUsefulExplanation(annotation: EmagramPanelExplanation): boolean {
+  return Boolean(panelTextKey(annotation));
+}
+
+function sortAnnotations<
+  T extends {
+    priority?: EmagramAnnotationPriority;
+    displayOrder?: number;
+    confidence?: number;
+  },
+>(annotations: T[]): T[] {
+  return [...annotations].sort((a, b) => {
+    const priorityA = a.priority ? PRIORITY_ORDER[a.priority] : 99;
+    const priorityB = b.priority ? PRIORITY_ORDER[b.priority] : 99;
+    if (priorityA !== priorityB) return priorityA - priorityB;
+    const orderA = a.displayOrder ?? Number.MAX_SAFE_INTEGER;
+    const orderB = b.displayOrder ?? Number.MAX_SAFE_INTEGER;
+    if (orderA !== orderB) return orderA - orderB;
+    return (b.confidence ?? 0) - (a.confidence ?? 0);
+  });
+}
+
+function toPanelExplanation(
+  source: string,
+  raw: Record<string, unknown>,
+  reason: string
+): EmagramPanelExplanation | null {
+  const explanation: EmagramPanelExplanation = {
+    id: isString(raw.id) ? raw.id : `${source}-panel-${reason}`,
+    source,
+    label: isString(raw.label) ? raw.label : source,
+    confidence: asNumber(raw.confidence) ?? undefined,
+    reason,
+    visualCue: isString(raw.visual_cue) ? raw.visual_cue : undefined,
+    weatherReading: isString(raw.weather_reading)
+      ? raw.weather_reading
+      : undefined,
+    flightImpact: isString(raw.flight_impact) ? raw.flight_impact : undefined,
+    term: isString(raw.term) ? raw.term : undefined,
+    termDefinition: isString(raw.term_definition)
+      ? raw.term_definition
+      : undefined,
+  };
+  return hasUsefulExplanation(explanation) ? explanation : null;
+}
+
+function parseSingleAnnotation(
+  source: string,
+  raw: unknown
+): {
+  precise?: EmagramImageAnnotation;
+  panel?: EmagramPanelExplanation;
+} | null {
+  if (!isObject(raw)) return null;
+  const type = raw.type;
+  const priority = raw.priority;
+  const category = raw.category;
+  const confidence = asNumber(raw.confidence);
+
+  if (
+    !isValidType(type) ||
+    !isValidPriority(priority) ||
+    !isValidCategory(category)
+  ) {
+    const panel = toPanelExplanation(source, raw, 'invalid_metadata');
+    return panel ? { panel } : null;
+  }
+
+  if (confidence === null) {
+    const panel = toPanelExplanation(source, raw, 'missing_confidence');
+    return panel ? { panel } : null;
+  }
+
+  if (!inPercentRange(raw.x) || !inPercentRange(raw.y)) {
+    const panel = toPanelExplanation(source, raw, 'invalid_coordinates');
+    return panel ? { panel } : null;
+  }
+
+  const width = asNumber(raw.width);
+  const height = asNumber(raw.height);
+  if (type === 'zone') {
+    const hasInvalidZone =
+      width === null ||
+      height === null ||
+      width < 0 ||
+      width > 100 ||
+      height < 0 ||
+      height > 100 ||
+      width > MAX_ZONE_SIZE ||
+      height > MAX_ZONE_SIZE ||
+      width * height > MAX_ZONE_AREA;
+    if (hasInvalidZone) {
+      const panel = toPanelExplanation(source, raw, 'invalid_zone');
+      return panel ? { panel } : null;
+    }
+  }
+
+  if (confidence < MIN_CONFIDENCE) {
+    const panel = toPanelExplanation(source, raw, 'low_confidence');
+    return panel ? { panel } : null;
+  }
+
+  if (!isString(raw.label) || !isString(raw.visual_cue)) {
+    const panel = toPanelExplanation(source, raw, 'missing_text');
+    return panel ? { panel } : null;
+  }
+
+  if (!isString(raw.weather_reading) || !isString(raw.flight_impact)) {
+    const panel = toPanelExplanation(source, raw, 'missing_text');
+    return panel ? { panel } : null;
+  }
+
+  const precise: EmagramImageAnnotation = {
+    id: isString(raw.id) ? raw.id : `${source}-${raw.label}`,
+    source,
+    type,
+    label: raw.label,
+    priority,
+    category,
+    displayOrder: asNumber(raw.display_order) ?? Number.MAX_SAFE_INTEGER,
+    confidence,
+    x: raw.x,
+    y: raw.y,
+    width: type === 'zone' ? (width ?? undefined) : undefined,
+    height: type === 'zone' ? (height ?? undefined) : undefined,
+    visualCue: raw.visual_cue,
+    weatherReading: raw.weather_reading,
+    flightImpact: raw.flight_impact,
+    term: isString(raw.term) ? raw.term : undefined,
+    termDefinition: isString(raw.term_definition)
+      ? raw.term_definition
+      : undefined,
+    uncertaintyNote: isString(raw.uncertainty_note)
+      ? raw.uncertainty_note
+      : undefined,
+  };
+
+  return { precise };
+}
+
+function parseLegacyObservations(
+  source: string,
+  rawExplanation: Record<string, unknown>
+): EmagramPanelExplanation[] {
+  const parSource = rawExplanation.par_source;
+  if (!isObject(parSource)) return [];
+  const observations = parSource[source];
+  const values = Array.isArray(observations)
+    ? observations
+    : isString(observations)
+      ? [observations]
+      : [];
+  return values.filter(isString).map((text, index) => ({
+    id: `${source}-legacy-${index}`,
+    source,
+    label: source,
+    text,
+  }));
+}
+
+function dedupePanelExplanations(
+  explanations: EmagramPanelExplanation[]
+): EmagramPanelExplanation[] {
+  const seen = new Set<string>();
+  return explanations.filter((explanation) => {
+    const key = panelTextKey(explanation);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function parseEmagramAnnotationModel(
+  aiRawResponse: string | null | undefined,
+  source: string
+): EmagramAnnotationModel {
+  if (!aiRawResponse) {
+    return {
+      locale: null,
+      resume: null,
+      indices: [],
+      preciseAnnotations: [],
+      panelExplanations: [],
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(aiRawResponse);
+    const rawExplanation =
+      parsed?.explication_analyse ?? parsed?.details_analyse;
+    if (!isObject(rawExplanation)) {
+      return {
+        locale: null,
+        resume: isString(rawExplanation) ? rawExplanation : null,
+        indices: [],
+        preciseAnnotations: [],
+        panelExplanations: [],
+      };
+    }
+
+    const annotationsBySource = rawExplanation.annotations_image;
+    const rawSourceAnnotations = isObject(annotationsBySource)
+      ? annotationsBySource[source]
+      : [];
+    const rawAnnotations = Array.isArray(rawSourceAnnotations)
+      ? rawSourceAnnotations
+      : [];
+
+    const preciseAnnotations: EmagramImageAnnotation[] = [];
+    const panelExplanations: EmagramPanelExplanation[] = [];
+
+    for (const raw of rawAnnotations) {
+      const parsedAnnotation = parseSingleAnnotation(source, raw);
+      if (parsedAnnotation?.precise)
+        preciseAnnotations.push(parsedAnnotation.precise);
+      if (parsedAnnotation?.panel)
+        panelExplanations.push(parsedAnnotation.panel);
+    }
+
+    const sortedPrecise = sortAnnotations(preciseAnnotations);
+    const visiblePrecise = sortedPrecise.slice(0, MAX_VISIBLE_ANNOTATIONS);
+    const overflowPanel = sortedPrecise
+      .slice(MAX_VISIBLE_ANNOTATIONS)
+      .map((annotation) => ({
+        id: `${annotation.id}-overflow`,
+        source,
+        label: annotation.label,
+        confidence: annotation.confidence,
+        reason: 'overflow',
+        visualCue: annotation.visualCue,
+        weatherReading: annotation.weatherReading,
+        flightImpact: annotation.flightImpact,
+        term: annotation.term,
+        termDefinition: annotation.termDefinition,
+      }));
+
+    const indices = Array.isArray(rawExplanation.indices)
+      ? rawExplanation.indices.filter(isString)
+      : [];
+
+    return {
+      locale: isString(rawExplanation.locale) ? rawExplanation.locale : null,
+      resume: isString(rawExplanation.resume) ? rawExplanation.resume : null,
+      indices,
+      preciseAnnotations: visiblePrecise,
+      panelExplanations: dedupePanelExplanations([
+        ...panelExplanations,
+        ...overflowPanel,
+        ...parseLegacyObservations(source, rawExplanation),
+      ]),
+    };
+  } catch {
+    return {
+      locale: null,
+      resume: null,
+      indices: [],
+      preciseAnnotations: [],
+      panelExplanations: [],
+    };
+  }
+}
+
+export function formatConfidence(
+  confidence: number | undefined
+): string | null {
+  if (confidence === undefined || Number.isNaN(confidence)) return null;
+  return `${Math.round(confidence * 100)} %`;
+}
+
+export function groupEmagramAnnotations(
+  annotations: EmagramImageAnnotation[],
+  options: {
+    imageWidth: number;
+    imageHeight: number;
+    zoom: number;
+    thresholdPx: number;
+  }
+): EmagramAnnotationGroup[] {
+  const groups: EmagramAnnotationGroup[] = [];
+  for (const annotation of sortAnnotations(annotations)) {
+    const x = (annotation.x / 100) * options.imageWidth * options.zoom;
+    const y = (annotation.y / 100) * options.imageHeight * options.zoom;
+    const existing = groups.find((group) => {
+      const dx = group.x - x;
+      const dy = group.y - y;
+      return Math.sqrt(dx * dx + dy * dy) <= options.thresholdPx;
+    });
+    if (existing) {
+      existing.annotations = sortAnnotations([
+        ...existing.annotations,
+        annotation,
+      ]);
+    } else {
+      groups.push({ id: annotation.id, x, y, annotations: [annotation] });
+    }
+  }
+  return groups;
+}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1021,7 +1021,51 @@
     "openImage": "Open",
     "summaryTitle": "📊 Conditions Summary",
     "tipsTitle": "💡 Flight Tips",
-    "safetyAlertsTitle": "⚠️ Safety Alerts"
+    "safetyAlertsTitle": "⚠️ Safety Alerts",
+    "annotations": {
+      "source": "Source",
+      "hideAnnotations": "Hide explanations",
+      "showAnnotations": "Show explanations",
+      "summaryAndMore": "Summary and other explanations",
+      "zoomIn": "Zoom +",
+      "reset": "Reset",
+      "previous": "Previous",
+      "next": "Next",
+      "help": "Click an info point to understand this part of the emagram.",
+      "hidden": "Explanations hidden.",
+      "groupLabel": "{{count}} explanations",
+      "confidence": "Confidence: {{value}}",
+      "termToRemember": "Word to remember",
+      "visualCue": "Visual cue",
+      "weatherReading": "Weather reading",
+      "flightImpact": "Flight impact",
+      "globalSummary": "Summary",
+      "flightTakeaways": "Flight takeaways",
+      "otherExplanations": "Other explanations",
+      "noExplanation": "No explanation available for this image.",
+      "priority": {
+        "important": "Important",
+        "watch": "Watch",
+        "educational": "Educational"
+      },
+      "category": {
+        "thermal": "Thermals",
+        "ceiling": "Ceiling",
+        "stability": "Stability",
+        "humidity": "Humidity",
+        "wind": "Wind",
+        "risk": "Risk"
+      },
+      "reason": {
+        "invalid_metadata": "Not placed precisely: incomplete metadata.",
+        "missing_confidence": "Not placed precisely: confidence was not provided.",
+        "invalid_coordinates": "Not placed precisely: invalid coordinates.",
+        "invalid_zone": "Not placed precisely: zone is too large or invalid.",
+        "low_confidence": "Not placed precisely: confidence is too low.",
+        "missing_text": "Not placed precisely: text is incomplete.",
+        "overflow": "Useful explanation, not shown on the image to keep it readable."
+      }
+    }
   },
   "landings": {
     "loading": "Loading landings...",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1025,7 +1025,51 @@
     "openImage": "Ouvrir",
     "summaryTitle": "📊 Résumé des Conditions",
     "tipsTitle": "💡 Conseils de Vol",
-    "safetyAlertsTitle": "⚠️ Alertes de Sécurité"
+    "safetyAlertsTitle": "⚠️ Alertes de Sécurité",
+    "annotations": {
+      "source": "Source",
+      "hideAnnotations": "Masquer les explications",
+      "showAnnotations": "Afficher les explications",
+      "summaryAndMore": "Résumé et autres explications",
+      "zoomIn": "Zoom +",
+      "reset": "Réinitialiser",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "help": "Clique sur un point d'info pour comprendre cette partie de l'émagramme.",
+      "hidden": "Explications masquées.",
+      "groupLabel": "{{count}} explications",
+      "confidence": "Confiance : {{value}}",
+      "termToRemember": "Mot à retenir",
+      "visualCue": "Repère visuel",
+      "weatherReading": "Lecture météo",
+      "flightImpact": "Impact vol",
+      "globalSummary": "Résumé",
+      "flightTakeaways": "À retenir pour voler",
+      "otherExplanations": "Autres explications",
+      "noExplanation": "Aucune explication disponible pour cette image.",
+      "priority": {
+        "important": "Important",
+        "watch": "À surveiller",
+        "educational": "Pédagogique"
+      },
+      "category": {
+        "thermal": "Thermiques",
+        "ceiling": "Plafond",
+        "stability": "Stabilité",
+        "humidity": "Humidité",
+        "wind": "Vent",
+        "risk": "Risque"
+      },
+      "reason": {
+        "invalid_metadata": "Explication non placée précisément : métadonnées incomplètes.",
+        "missing_confidence": "Explication non placée précisément : confiance non fournie.",
+        "invalid_coordinates": "Explication non placée précisément : coordonnées invalides.",
+        "invalid_zone": "Explication non placée précisément : zone trop large ou invalide.",
+        "low_confidence": "Explication non placée précisément : confiance insuffisante.",
+        "missing_text": "Explication non placée précisément : texte incomplet.",
+        "overflow": "Explication utile, mais non affichée sur l'image pour garder la lecture simple."
+      }
+    }
   },
   "landings": {
     "loading": "Chargement des atterrissages...",

--- a/apps/frontend/src/pages/ThermalAnalysis.tsx
+++ b/apps/frontend/src/pages/ThermalAnalysis.tsx
@@ -19,21 +19,18 @@ import {
 import { useSite } from '../hooks/sites/useSites';
 import { parseAlerts, getScoreColor } from '../types/emagram';
 import type { EmagramListItem } from '../types/emagram';
-import {
-  DataTable,
-  Button,
-  Lightbox,
-} from '@dashboard-parapente/design-system';
+import { DataTable, Button } from '@dashboard-parapente/design-system';
 import { parseApiUtcDate } from '../lib/date';
 import { getApiUrlWithSearchParams } from '../lib/api';
 import { useAuthStore } from '../stores/authStore';
+import { AnnotatedEmagramLightbox } from '../components/dashboard/AnnotatedEmagramLightbox';
 import { EmagramExplanationTooltip } from '../components/dashboard/EmagramExplanationTooltip';
 
 const historyColumnHelper = createColumnHelper<EmagramListItem>();
 
 function formatSourceName(source: string): string {
   return source
-    .replace(/-/g, ' ')
+    .replace(/-/gu, ' ')
     .split(' ')
     .filter(Boolean)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -167,6 +164,7 @@ export default function ThermalAnalysis() {
           { access_token: authToken }
         ),
         alt: formatSourceName(source),
+        source,
       }));
     } catch {
       return [];
@@ -224,6 +222,75 @@ export default function ThermalAnalysis() {
   const skewtUnavailableSvg = `data:image/svg+xml,${encodeURIComponent(
     `<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400"><rect width="600" height="400" fill="#f3f4f6"/><text x="50%" y="50%" text-anchor="middle" fill="#9ca3af" font-size="16">${t('thermal.imageUnavailable')}</text></svg>`
   )}`;
+  const imageTimestamp = (
+    <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
+      {latest.station_name} • {latest.sounding_time} •{' '}
+      {parseApiUtcDate(latest.analysis_datetime).toLocaleDateString()}
+    </p>
+  );
+
+  let emagramImageContent = (
+    <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-8 text-center text-gray-500 dark:text-gray-400">
+      {t('thermal.skewtUnavailable')}
+    </div>
+  );
+
+  if (screenshotImages.length > 0) {
+    emagramImageContent = (
+      <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {screenshotImages.map((image, idx) => (
+            <button
+              key={image.src}
+              type="button"
+              onClick={() => {
+                setLightboxIndex(idx);
+                setLightboxOpen(true);
+              }}
+              className="group overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-left shadow-sm transition hover:border-purple-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-purple-500"
+            >
+              <img
+                src={image.src}
+                alt={image.alt}
+                className="h-52 w-full object-cover object-top transition group-hover:scale-[1.02]"
+                onError={(e) => {
+                  (e.target as HTMLImageElement).src = skewtUnavailableSvg;
+                }}
+              />
+              <span className="flex items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                <span>{image.alt}</span>
+                <span className="text-purple-600 dark:text-purple-300">
+                  {t('thermal.openImage')}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+        {imageTimestamp}
+        <AnnotatedEmagramLightbox
+          isOpen={lightboxOpen}
+          onClose={() => setLightboxOpen(false)}
+          images={screenshotImages}
+          aiRawResponse={latest.ai_raw_response}
+          initialIndex={lightboxIndex}
+        />
+      </div>
+    );
+  } else if (latest.skewt_image_path) {
+    emagramImageContent = (
+      <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
+        <img
+          src={`/api/files${latest.skewt_image_path}`}
+          alt={t('thermal.skewtAlt')}
+          className="w-full h-auto rounded"
+          onError={(e) => {
+            (e.target as HTMLImageElement).src = skewtUnavailableSvg;
+          }}
+        />
+        {imageTimestamp}
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 max-w-7xl mx-auto">
@@ -341,68 +408,7 @@ export default function ThermalAnalysis() {
               : t('thermal.skewtTitle')}
           </h2>
 
-          {screenshotImages.length > 0 ? (
-            <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                {screenshotImages.map((image, idx) => (
-                  <button
-                    key={image.src}
-                    type="button"
-                    onClick={() => {
-                      setLightboxIndex(idx);
-                      setLightboxOpen(true);
-                    }}
-                    className="group overflow-hidden rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-left shadow-sm transition hover:border-purple-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-purple-500"
-                  >
-                    <img
-                      src={image.src}
-                      alt={image.alt}
-                      className="h-52 w-full object-cover object-top transition group-hover:scale-[1.02]"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).src =
-                          skewtUnavailableSvg;
-                      }}
-                    />
-                    <span className="flex items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200">
-                      <span>{image.alt}</span>
-                      <span className="text-purple-600 dark:text-purple-300">
-                        {t('thermal.openImage')}
-                      </span>
-                    </span>
-                  </button>
-                ))}
-              </div>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
-                {latest.station_name} • {latest.sounding_time} •{' '}
-                {parseApiUtcDate(latest.analysis_datetime).toLocaleDateString()}
-              </p>
-              <Lightbox
-                isOpen={lightboxOpen}
-                onClose={() => setLightboxOpen(false)}
-                images={screenshotImages}
-                initialIndex={lightboxIndex}
-              />
-            </div>
-          ) : latest.skewt_image_path ? (
-            <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-4">
-              <img
-                src={`/api/files${latest.skewt_image_path}`}
-                alt={t('thermal.skewtAlt')}
-                className="w-full h-auto rounded"
-                onError={(e) => {
-                  (e.target as HTMLImageElement).src = skewtUnavailableSvg;
-                }}
-              />
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
-                {latest.station_name} • {latest.sounding_time} •{' '}
-                {parseApiUtcDate(latest.analysis_datetime).toLocaleDateString()}
-              </p>
-            </div>
-          ) : (
-            <div className="bg-gray-100 dark:bg-gray-700 rounded-lg p-8 text-center text-gray-500 dark:text-gray-400">
-              {t('thermal.skewtUnavailable')}
-            </div>
-          )}
+          {emagramImageContent}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add backend locale-aware emagram prompt/analysis propagation and stricter annotation handling.
- Replace the thermal lightbox with an annotated, grouped, zoomable emagram viewer with mobile fallback and stories.
- Update translations and frontend parsing/tests for the new annotation model.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/test_emagram_endpoints.py tests/unit/test_emagram_llm_fallback.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:build-storybook`
- `CodeRabbit review` passed with 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emagram analysis now supports language selection (French and English) for AI-generated weather insights.
  * Interactive annotations overlay emagram images, highlighting thermal features and weather patterns with grouping, zoom, and navigation controls.
  * Enhanced emagram viewer with full-screen dialog, image navigation, and interactive summary panels for detailed weather analysis.
  * Added French and English translations for annotation controls and informational UI elements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->