### PR TITLE
fix(emagram): show annotations in dashboard widget

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -19,7 +19,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { parseApiUtcDate } from '../../lib/date';
 import { getApiUrlWithSearchParams } from '../../lib/api';
 import { useAuthStore } from '../../stores/authStore';
-import { Lightbox } from '@dashboard-parapente/design-system';
+import { AnnotatedEmagramLightbox } from './AnnotatedEmagramLightbox';
 import { EmagramExplanationTooltip } from './EmagramExplanationTooltip';
 import {
   Slider,
@@ -657,7 +657,7 @@ export default function EmagramWidget({
                 ),
                 alt: [
                   source
-                    .replace('-', ' ')
+                    .replace(/-/gu, ' ')
                     .split(' ')
                     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
                     .join(' '),
@@ -665,6 +665,7 @@ export default function EmagramWidget({
                 ]
                   .filter(Boolean)
                   .join(' — '),
+                source,
               }));
               return (
                 <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
@@ -713,7 +714,7 @@ export default function EmagramWidget({
                             <span className="flex-shrink-0">⚠️</span>
                             <span>
                               <span className="font-medium capitalize">
-                                {source.replace('-', ' ')}
+                                {source.replace(/-/gu, ' ')}
                               </span>{' '}
                               — {errMsg}
                             </span>
@@ -722,10 +723,11 @@ export default function EmagramWidget({
                       </div>
                     );
                   })()}
-                  <Lightbox
+                  <AnnotatedEmagramLightbox
                     isOpen={lightboxOpen}
                     onClose={() => setLightboxOpen(false)}
                     images={lightboxImages}
+                    aiRawResponse={emagram.ai_raw_response}
                     initialIndex={lightboxIndex}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- Use the annotated emagram lightbox from the dashboard weather widget.
- Pass image source metadata and AI raw response through so vision annotations can render in widget lightboxes.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `/home/capic/.local/share/pnpm/pnpm --dir apps/frontend exec vitest run --config vitest.config.ts --project unit`

## Notes
- The requested `nx affected -t lint frontend` / `nx affected -t test frontend --parallel=5` form defaulted to local `main` and included backend; backend failed because `ruff`/`pytest` are unavailable in this worktree.
- Full frontend Vitest including the Storybook browser project did not exit before timeout; the unit project completed successfully.
- CodeRabbit was not run as part of this push step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emagram widget now displays enhanced information when viewing screenshot details in the lightbox.

* **Style**
  * Improved formatting of source names and error messages for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->