### PR TITLE
fix video export orphan reconciliation

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -18,7 +18,7 @@ from fastapi import UploadFile
 
 import config
 from database import SessionLocal
-from models import GoproOverlayJob
+from models import Flight, GoproOverlayJob
 from sqlalchemy.exc import OperationalError
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,8 @@ _STATUS_RUNNING = "running"
 _STATUS_COMPLETED = "completed"
 _STATUS_FAILED = "failed"
 _STATUS_CANCELLED = "cancelled"
+_ACTIVE_STATUSES = {_STATUS_QUEUED, _STATUS_PREPARING, _STATUS_RUNNING}
+_INTERRUPTIBLE_STATUSES = {_STATUS_PREPARING, _STATUS_RUNNING}
 _TERMINAL_STATUSES = {_STATUS_COMPLETED, _STATUS_FAILED, _STATUS_CANCELLED}
 
 _VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
@@ -265,6 +267,7 @@ def _touch_db_job(job_id: str, **changes: Any) -> dict[str, Any] | None:
                     job.cancelled_at = _utc_now_dt()
                 if job.status in {_STATUS_COMPLETED, _STATUS_FAILED} and not job.completed_at:
                     job.completed_at = _utc_now_dt()
+            _sync_flights_from_job(db, job)
             db.commit()
             payload = _job_to_payload(job)
             _set_memory_snapshot(payload)
@@ -296,6 +299,50 @@ def _update_job(job_id: str, **changes: Any) -> dict[str, Any]:
         job.update(changes)
         job["updated_at"] = _utc_now()
         return job.copy()
+
+
+def _sync_flights_from_job(db: Any, job: GoproOverlayJob) -> None:
+    flights = db.query(Flight).filter(Flight.gopro_overlay_job_id == job.id).all()
+    for flight in flights:
+        flight.gopro_overlay_status = job.status
+        if job.status == _STATUS_COMPLETED:
+            flight.gopro_overlay_file_path = job.output_path
+
+
+def reconcile_gopro_overlay_flight_refs() -> int:
+    """Clear or sync active flight overlay references that no longer have a live job."""
+    reconciled = 0
+    try:
+        with SessionLocal() as db:
+            flights = (
+                db.query(Flight).filter(Flight.gopro_overlay_status.in_(_ACTIVE_STATUSES)).all()
+            )
+            for flight in flights:
+                if not flight.gopro_overlay_job_id:
+                    flight.gopro_overlay_status = None
+                    reconciled += 1
+                    continue
+
+                job = (
+                    db.query(GoproOverlayJob)
+                    .filter(GoproOverlayJob.id == flight.gopro_overlay_job_id)
+                    .first()
+                )
+                if not job:
+                    flight.gopro_overlay_job_id = None
+                    flight.gopro_overlay_status = None
+                    reconciled += 1
+                    continue
+
+                if job.status != flight.gopro_overlay_status:
+                    _sync_flights_from_job(db, job)
+                    reconciled += 1
+            if reconciled:
+                db.commit()
+    except OperationalError as exc:
+        if "no such table" not in str(exc):
+            raise
+    return reconciled
 
 
 def _progress_from_output_chunk(chunk: str) -> int | None:
@@ -1057,10 +1104,14 @@ def _queued_job_ids() -> list[str]:
             return [job_id for job_id, job in _JOBS.items() if job.get("status") == _STATUS_QUEUED]
 
 
-def _mark_running_jobs_interrupted() -> None:
+def _mark_interrupted_jobs_failed() -> None:
     try:
         with SessionLocal() as db:
-            jobs = db.query(GoproOverlayJob).filter(GoproOverlayJob.status == _STATUS_RUNNING).all()
+            jobs = (
+                db.query(GoproOverlayJob)
+                .filter(GoproOverlayJob.status.in_(_INTERRUPTIBLE_STATUSES))
+                .all()
+            )
             for job in jobs:
                 job.status = _STATUS_FAILED
                 job.progress = 100
@@ -1068,13 +1119,14 @@ def _mark_running_jobs_interrupted() -> None:
                 job.error = "The backend stopped while the overlay process was running"
                 job.completed_at = _utc_now_dt()
                 job.updated_at = _utc_now_dt()
+                _sync_flights_from_job(db, job)
             db.commit()
     except OperationalError as exc:
         if "no such table: gopro_overlay_jobs" not in str(exc):
             raise
         with _LOCK:
             for job in _JOBS.values():
-                if job.get("status") == _STATUS_RUNNING:
+                if job.get("status") in _INTERRUPTIBLE_STATUSES:
                     job.update(
                         status=_STATUS_FAILED,
                         progress=100,
@@ -1087,7 +1139,7 @@ def _mark_running_jobs_interrupted() -> None:
 
 def _worker_loop() -> None:
     logger.info("GoPro overlay worker started")
-    _mark_running_jobs_interrupted()
+    _mark_interrupted_jobs_failed()
     while not _WORKER_STOP.is_set():
         for job_id in _queued_job_ids():
             with _LOCK:
@@ -1112,6 +1164,7 @@ def start_gopro_overlay_worker() -> None:
     with _WORKER_LOCK:
         if _WORKER_THREAD and _WORKER_THREAD.is_alive() is True:
             return
+        reconcile_gopro_overlay_flight_refs()
         _WORKER_STOP.clear()
         _WORKER_THREAD = threading.Thread(
             target=_worker_loop,
@@ -1175,9 +1228,12 @@ def delete_gopro_overlay_job(job_id: str) -> dict[str, Any] | None:
     try:
         with SessionLocal() as db:
             db_job = db.query(GoproOverlayJob).filter(GoproOverlayJob.id == job_id).first()
+            for flight in db.query(Flight).filter(Flight.gopro_overlay_job_id == job_id).all():
+                flight.gopro_overlay_job_id = None
+                flight.gopro_overlay_status = None
             if db_job:
                 db.delete(db_job)
-                db.commit()
+            db.commit()
     except OperationalError as exc:
         if "no such table: gopro_overlay_jobs" not in str(exc):
             raise

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -312,12 +312,27 @@ def _job_progress(job: dict[str, Any] | None) -> int | None:
 
 
 def _flight_video_export_progress(flight: Flight) -> int | None:
-    if (
-        not flight.video_export_job_id
-        or flight.video_export_status not in _VIDEO_EXPORT_IN_PROGRESS_STATUSES
-    ):
-        return None
-    return _job_progress(_resolve_export_status(flight.video_export_job_id))
+    return _flight_video_export_state(None, flight)["progress"]
+
+
+def _flight_video_export_state(db: Session | None, flight: Flight) -> dict[str, Any]:
+    status = flight.video_export_status
+    if status not in _VIDEO_EXPORT_IN_PROGRESS_STATUSES:
+        return {"status": status, "progress": None}
+
+    if not flight.video_export_job_id:
+        if db is not None:
+            flight.video_export_status = None
+        return {"status": None, "progress": None}
+
+    job = _resolve_export_status(flight.video_export_job_id)
+    if not job:
+        if db is not None:
+            flight.video_export_job_id = None
+            flight.video_export_status = None
+        return {"status": None, "progress": None}
+
+    return {"status": status, "progress": _job_progress(job)}
 
 
 def _flight_gopro_overlay_progress(flight: Flight, job: dict[str, Any] | None = None) -> int | None:
@@ -338,6 +353,18 @@ def _flight_gopro_overlay_state(db: Session, flight: Flight) -> dict[str, Any]:
     job = (
         get_gopro_overlay_job(flight.gopro_overlay_job_id) if flight.gopro_overlay_job_id else None
     )
+    if flight.gopro_overlay_status in _GOPRO_OVERLAY_IN_PROGRESS_STATUSES and (
+        not flight.gopro_overlay_job_id or not job
+    ):
+        flight.gopro_overlay_job_id = None
+        flight.gopro_overlay_status = None
+        return {
+            "status": None,
+            "progress": None,
+            "file_path": _flight_gopro_overlay_file_path(db, flight),
+            "file_exists": _flight_gopro_overlay_file_exists(db, flight),
+        }
+
     overlay_path = _flight_gopro_overlay_file_path(db, flight, job)
     return {
         "status": _flight_gopro_overlay_status(flight, job),
@@ -3145,8 +3172,20 @@ def get_flights(
 
     # Convert to dict (user_id removed - not needed for single-user app)
     flights_data = []
+    export_state_changed = False
     for flight in flights:
+        previous_video_job_id = flight.video_export_job_id
+        previous_video_status = flight.video_export_status
+        previous_overlay_job_id = flight.gopro_overlay_job_id
+        previous_overlay_status = flight.gopro_overlay_status
+        video_export = _flight_video_export_state(db, flight)
         gopro_overlay = _flight_gopro_overlay_state(db, flight)
+        export_state_changed = export_state_changed or (
+            previous_video_job_id != flight.video_export_job_id
+            or previous_video_status != flight.video_export_status
+            or previous_overlay_job_id != flight.gopro_overlay_job_id
+            or previous_overlay_status != flight.gopro_overlay_status
+        )
         flight_dict = {
             "id": flight.id,
             "strava_id": flight.strava_id,
@@ -3165,8 +3204,8 @@ def get_flights(
             "notes": flight.notes,
             "gpx_file_path": flight.gpx_file_path,
             "video_export_job_id": flight.video_export_job_id,
-            "video_export_status": flight.video_export_status,
-            "video_export_progress": _flight_video_export_progress(flight),
+            "video_export_status": video_export["status"],
+            "video_export_progress": video_export["progress"],
             "video_file_path": flight.video_file_path,
             "video_file_exists": _flight_video_file_exists(flight),
             "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
@@ -3180,6 +3219,13 @@ def get_flights(
             "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
         }
         flights_data.append(flight_dict)
+
+    if export_state_changed:
+        try:
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Failed to persist reconciled export state in /flights: %s", exc)
 
     return {"flights": flights_data}
 
@@ -3481,7 +3527,18 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
                 "Failed to persist calculated max speed for flight %s: %s", flight_id, exc
             )
 
+    previous_video_job_id = flight.video_export_job_id
+    previous_video_status = flight.video_export_status
+    previous_overlay_job_id = flight.gopro_overlay_job_id
+    previous_overlay_status = flight.gopro_overlay_status
+    video_export = _flight_video_export_state(db, flight)
     gopro_overlay = _flight_gopro_overlay_state(db, flight)
+    export_state_changed = (
+        previous_video_job_id != flight.video_export_job_id
+        or previous_video_status != flight.video_export_status
+        or previous_overlay_job_id != flight.gopro_overlay_job_id
+        or previous_overlay_status != flight.gopro_overlay_status
+    )
 
     # Build response with flight data
     flight_dict = {
@@ -3504,8 +3561,8 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
         "gpx_elevation_gain_m": flight.gpx_elevation_gain_m,
         "external_url": flight.external_url,
         "video_export_job_id": flight.video_export_job_id,
-        "video_export_status": flight.video_export_status,
-        "video_export_progress": _flight_video_export_progress(flight),
+        "video_export_status": video_export["status"],
+        "video_export_progress": video_export["progress"],
         "video_file_path": flight.video_file_path,
         "video_file_exists": _flight_video_file_exists(flight),
         "gopro_camera_file_exists": _flight_gopro_camera_file_exists(db, flight),
@@ -3537,6 +3594,17 @@ def get_flight(flight_id: str, db: Session = Depends(get_db)):
                 "region": site.region,
                 "country": site.country,
             }
+
+    if export_state_changed:
+        try:
+            db.commit()
+        except Exception as exc:
+            db.rollback()
+            logger.warning(
+                "Failed to persist reconciled export state for flight %s: %s",
+                flight_id,
+                exc,
+            )
 
     return flight_dict
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -332,7 +332,22 @@ def _flight_video_export_state(db: Session | None, flight: Flight) -> dict[str, 
             flight.video_export_status = None
         return {"status": None, "progress": None}
 
-    return {"status": status, "progress": _job_progress(job)}
+    resolved_status = _video_export_public_status(job)
+    if db is not None and resolved_status != flight.video_export_status:
+        flight.video_export_status = resolved_status
+    if db is not None and resolved_status in _VIDEO_EXPORT_TERMINAL_STATUSES:
+        flight.video_export_job_id = None
+        if resolved_status == "completed":
+            video_path = job.get("video_path")
+            if isinstance(video_path, str):
+                flight.video_file_path = video_path
+
+    return {
+        "status": resolved_status,
+        "progress": (
+            _job_progress(job) if resolved_status in _VIDEO_EXPORT_IN_PROGRESS_STATUSES else None
+        ),
+    }
 
 
 def _flight_gopro_overlay_progress(flight: Flight, job: dict[str, Any] | None = None) -> int | None:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -796,6 +796,15 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
                 output_filename="final.mp4",
             )
         )
+        session.add(
+            Flight(
+                id="flight-gopro-delete",
+                name="Flight GoPro delete",
+                flight_date=date(2026, 3, 15),
+                gopro_overlay_job_id=job_id,
+                gopro_overlay_status="failed",
+            )
+        )
         session.commit()
 
         result = delete_gopro_overlay_job(job_id)
@@ -807,38 +816,86 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
     assert result["files_deleted"] == 1
     assert not work_dir.exists()
     assert gopro_overlay_export.get_gopro_overlay_job(job_id) is None
+    session = test_db()
+    try:
+        flight = session.get(Flight, "flight-gopro-delete")
+        assert flight is not None
+        assert flight.gopro_overlay_job_id is None
+        assert flight.gopro_overlay_status is None
+    finally:
+        session.close()
 
 
-def test_mark_running_jobs_interrupted_marks_rows_failed(test_db, monkeypatch):
+def test_reconcile_gopro_overlay_flight_refs_clears_missing_active_job(test_db, monkeypatch):
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    session = test_db()
+    try:
+        session.add(
+            Flight(
+                id="flight-orphan-gopro",
+                name="Flight orphan GoPro",
+                flight_date=date(2026, 3, 15),
+                gopro_overlay_job_id="missing-gopro-job",
+                gopro_overlay_status="queued",
+            )
+        )
+        session.commit()
+
+        assert gopro_overlay_export.reconcile_gopro_overlay_flight_refs() == 1
+
+        session.expire_all()
+        refreshed = session.get(Flight, "flight-orphan-gopro")
+        assert refreshed is not None
+        assert refreshed.gopro_overlay_job_id is None
+        assert refreshed.gopro_overlay_status is None
+    finally:
+        session.close()
+
+
+def test_mark_interrupted_jobs_failed_marks_active_rows_failed(test_db, monkeypatch):
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     session = test_db()
     try:
         from models import GoproOverlayJob
 
-        session.add(
-            GoproOverlayJob(
-                id="job-running",
-                status="running",
-                progress=55,
-                message="Rendering overlay",
-                video_path="video.mp4",
-                gpx_path="track.gpx",
-                layout_id="parapente-1080",
-                layout_label="Parapente 1920x1080",
-                layout_path="layout.xml",
-                output_path="final.mp4",
-                temp_output_path=".final.job-running.part.mp4",
-                output_filename="final.mp4",
+        for job_id, status in (("job-preparing", "preparing"), ("job-running", "running")):
+            session.add(
+                GoproOverlayJob(
+                    id=job_id,
+                    status=status,
+                    progress=55,
+                    message="Rendering overlay",
+                    video_path="video.mp4",
+                    gpx_path="track.gpx",
+                    layout_id="parapente-1080",
+                    layout_label="Parapente 1920x1080",
+                    layout_path="layout.xml",
+                    output_path="final.mp4",
+                    temp_output_path=f".final.{job_id}.part.mp4",
+                    output_filename="final.mp4",
+                )
             )
-        )
+            session.add(
+                Flight(
+                    id=f"flight-{job_id}",
+                    name=f"Flight {job_id}",
+                    flight_date=date(2026, 3, 15),
+                    gopro_overlay_job_id=job_id,
+                    gopro_overlay_status=status,
+                )
+            )
         session.commit()
 
-        gopro_overlay_export._mark_running_jobs_interrupted()
+        gopro_overlay_export._mark_interrupted_jobs_failed()
 
-        refreshed = gopro_overlay_export.get_gopro_overlay_job("job-running")
-        assert refreshed is not None
-        assert refreshed["status"] == "failed"
-        assert refreshed["message"] == "Overlay interrupted by backend restart"
+        for job_id in ("job-preparing", "job-running"):
+            refreshed = gopro_overlay_export.get_gopro_overlay_job(job_id)
+            assert refreshed is not None
+            assert refreshed["status"] == "failed"
+            assert refreshed["message"] == "Overlay interrupted by backend restart"
+            refreshed_flight = session.get(Flight, f"flight-{job_id}")
+            assert refreshed_flight is not None
+            assert refreshed_flight.gopro_overlay_status == "failed"
     finally:
         session.close()
 

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -156,6 +156,49 @@ class TestFlightsListEndpoint:
         assert flight.gopro_overlay_job_id is None
         assert flight.gopro_overlay_status is None
 
+    def test_get_flights_reconciles_active_video_export_from_terminal_job(
+        self, client, db_session, arguel_site
+    ):
+        flight = Flight(
+            id="flight-terminal-export",
+            name="Flight terminal export",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            video_export_job_id="completed-video-job",
+            video_export_status="processing",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with (
+            patch(
+                "routes.get_export_status_manual",
+                return_value={
+                    "job_id": "completed-video-job",
+                    "status": "completed",
+                    "internal_status": "completed",
+                    "progress": 100,
+                    "video_path": "/exports/flight-terminal-export.mp4",
+                },
+            ),
+            patch("routes.get_export_status_stream", return_value=None),
+        ):
+            response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = next(
+            flight
+            for flight in response.json()["flights"]
+            if flight["id"] == "flight-terminal-export"
+        )
+        assert returned["video_export_status"] == "completed"
+        assert returned["video_export_progress"] is None
+        assert returned["video_file_path"] == "/exports/flight-terminal-export.mp4"
+        db_session.refresh(flight)
+        assert flight.video_export_job_id is None
+        assert flight.video_export_status == "completed"
+        assert flight.video_file_path == "/exports/flight-terminal-export.mp4"
+
     def test_get_flights_includes_preparing_gopro_overlay_progress(
         self, client, db_session, arguel_site
     ):

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -116,6 +116,46 @@ class TestFlightsListEndpoint:
         assert returned["video_export_progress"] == 42
         assert returned["gopro_overlay_progress"] == 55
 
+    def test_get_flights_hides_orphan_active_media_export_state(
+        self, client, db_session, arguel_site
+    ):
+        """GET /flights does not report missing active jobs as still in progress."""
+        flight = Flight(
+            id="flight-orphan-export",
+            name="Flight orphan export",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            video_export_job_id="missing-video-job",
+            video_export_status="processing",
+            gopro_overlay_job_id="missing-overlay-job",
+            gopro_overlay_status="queued",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with (
+            patch("routes.get_export_status_manual", return_value=None),
+            patch("routes.get_export_status_stream", return_value=None),
+            patch("routes.get_gopro_overlay_job", return_value=None),
+        ):
+            response = client.get(f"{API_PREFIX}/flights")
+
+        assert response.status_code == 200
+        returned = next(
+            flight
+            for flight in response.json()["flights"]
+            if flight["id"] == "flight-orphan-export"
+        )
+        assert returned["video_export_status"] is None
+        assert returned["video_export_progress"] is None
+        assert returned["gopro_overlay_status"] is None
+        assert returned["gopro_overlay_progress"] is None
+        db_session.refresh(flight)
+        assert flight.video_export_job_id is None
+        assert flight.video_export_status is None
+        assert flight.gopro_overlay_job_id is None
+        assert flight.gopro_overlay_status is None
+
     def test_get_flights_includes_preparing_gopro_overlay_progress(
         self, client, db_session, arguel_site
     ):
@@ -145,6 +185,40 @@ class TestFlightsListEndpoint:
         )
         assert returned["gopro_overlay_status"] == "preparing"
         assert returned["gopro_overlay_progress"] == 12
+
+    def test_get_flight_hides_and_persists_orphan_active_media_export_state(
+        self, client, db_session, arguel_site
+    ):
+        flight = Flight(
+            id="flight-detail-orphan-export",
+            name="Flight detail orphan export",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            video_export_job_id="missing-video-job",
+            video_export_status="processing",
+            gopro_overlay_status="queued",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        with (
+            patch("routes.get_export_status_manual", return_value=None),
+            patch("routes.get_export_status_stream", return_value=None),
+            patch("routes.get_gopro_overlay_job", return_value=None),
+        ):
+            response = client.get(f"{API_PREFIX}/flights/{flight.id}")
+
+        assert response.status_code == 200
+        returned = response.json()
+        assert returned["video_export_status"] is None
+        assert returned["video_export_progress"] is None
+        assert returned["gopro_overlay_status"] is None
+        assert returned["gopro_overlay_progress"] is None
+        db_session.refresh(flight)
+        assert flight.video_export_job_id is None
+        assert flight.video_export_status is None
+        assert flight.gopro_overlay_job_id is None
+        assert flight.gopro_overlay_status is None
 
     def test_get_flights_includes_available_gopro_overlay_path(
         self, client, db_session, monkeypatch, tmp_path

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -9,7 +9,7 @@ from urllib.error import URLError
 import pytest
 
 from auth import create_access_token, create_job_token, decode_job_token
-from models import VideoExportJob
+from models import Flight, VideoExportJob
 
 import video_export
 import video_export_manual
@@ -744,6 +744,84 @@ def test_delete_video_export_job_removes_started_rq_job(test_db, monkeypatch):
         .first()
         is None
     )
+    db_session.close()
+
+
+def test_reconcile_video_export_flight_refs_clears_missing_active_job(test_db, monkeypatch):
+    monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
+    db_session = test_db()
+    db_session.add(
+        Flight(
+            id="flight-orphan-video",
+            flight_date=datetime.utcnow().date(),
+            video_export_job_id="missing-job",
+            video_export_status="processing",
+        )
+    )
+    db_session.commit()
+    db_session.close()
+
+    assert video_export_manual.reconcile_video_export_flight_refs() == 1
+
+    db_session = test_db()
+    flight = db_session.get(Flight, "flight-orphan-video")
+    assert flight is not None
+    assert flight.video_export_job_id is None
+    assert flight.video_export_status is None
+    db_session.close()
+
+
+def test_delete_video_export_job_clears_flight_reference(test_db, monkeypatch):
+    monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
+    monkeypatch.setattr(video_export_manual, "_delete_rq_video_export_job", lambda _job_id: True)
+    monkeypatch.setattr(
+        video_export_manual,
+        "cleanup_video_export_job_temp_files",
+        lambda _job_id: {
+            "files_deleted": 0,
+            "dirs_deleted": 0,
+            "bytes_deleted": 0,
+            "paths_deleted": [],
+            "errors": [],
+        },
+    )
+    db_session = test_db()
+    db_session.add(
+        VideoExportJob(
+            id="job-delete-clears-flight",
+            flight_id="flight-delete-clears-job",
+            status="failed",
+            mode="manual",
+            quality="1080p",
+            fps=15,
+            speed=1,
+            progress=100,
+            message="failed",
+            frontend_url="http://localhost:5173",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+    )
+    db_session.add(
+        Flight(
+            id="flight-delete-clears-job",
+            flight_date=datetime.utcnow().date(),
+            video_export_job_id="job-delete-clears-flight",
+            video_export_status="processing",
+        )
+    )
+    db_session.commit()
+    db_session.close()
+
+    result = video_export_manual.delete_video_export_job("job-delete-clears-flight")
+
+    assert result is not None
+    assert result["deleted"] is True
+    db_session = test_db()
+    flight = db_session.get(Flight, "flight-delete-clears-job")
+    assert flight is not None
+    assert flight.video_export_job_id is None
+    assert flight.video_export_status is None
     db_session.close()
 
 

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -56,6 +56,7 @@ _ACTIVE_STATUSES = {
     _STATUS_ENCODING,
     _STATUS_INITIALIZING,
 }
+_FLIGHT_ACTIVE_STATUSES = {*_ACTIVE_STATUSES, "processing"}
 
 _TERMINAL_STATUSES = {_STATUS_COMPLETED, _STATUS_FAILED, _STATUS_CANCELLED}
 
@@ -532,6 +533,41 @@ def _queued_job_ids() -> list[str]:
     return [str(job_id) for (job_id,) in jobs]
 
 
+def reconcile_video_export_flight_refs() -> int:
+    """Clear active flight video export references that no longer point to a live job."""
+    reconciled = 0
+    with SessionLocal() as db:
+        flights = (
+            db.query(Flight).filter(Flight.video_export_status.in_(_FLIGHT_ACTIVE_STATUSES)).all()
+        )
+        for flight in flights:
+            if not flight.video_export_job_id:
+                flight.video_export_status = None
+                reconciled += 1
+                continue
+
+            job = (
+                db.query(VideoExportJob)
+                .filter(VideoExportJob.id == flight.video_export_job_id)
+                .first()
+            )
+            if not job:
+                flight.video_export_job_id = None
+                flight.video_export_status = None
+                reconciled += 1
+                continue
+
+            expected_status = _to_public_status(job.status)
+            if flight.video_export_status != expected_status:
+                flight.video_export_status = expected_status
+                if job.status == _STATUS_COMPLETED:
+                    flight.video_file_path = job.video_path
+                reconciled += 1
+        if reconciled:
+            db.commit()
+    return reconciled
+
+
 def _rq_job_id(job_id: str) -> str:
     return f"video-export-{job_id}"
 
@@ -582,6 +618,7 @@ def enqueue_pending_video_export_jobs() -> int:
     """Enqueue queued DB jobs into RQ after an API or worker restart."""
     from job_queue import is_rq_enabled
 
+    reconcile_video_export_flight_refs()
     if not is_rq_enabled():
         return 0
 
@@ -852,9 +889,16 @@ def delete_video_export_job(job_id: str) -> dict[str, Any] | None:
     if job:
         with SessionLocal() as db:
             db_job = db.query(VideoExportJob).filter(VideoExportJob.id == job_id).first()
+            for flight in db.query(Flight).filter(Flight.video_export_job_id == job_id).all():
+                flight.video_export_job_id = None
+                if (
+                    flight.video_export_status in _FLIGHT_ACTIVE_STATUSES
+                    or not flight.video_file_path
+                ):
+                    flight.video_export_status = None
             if db_job:
                 db.delete(db_job)
-                db.commit()
+            db.commit()
 
     _set_memory_snapshot(job_id, None)
     _clear_job_runtime(job_id)


### PR DESCRIPTION
## Summary
- Reconcile orphaned video and GoPro export references on flight reads and job deletion.
- Persist cleanup so flights stop reporting phantom active exports after job loss or restart.
- Add tests covering list/detail reconciliation and job deletion cleanup.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/api/test_routes_flights.py tests/api/test_gopro_overlay_endpoints.py tests/unit/test_video_export_manual.py -q --tb=short --no-header`
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Flight records now automatically stay synchronized with export job references.
* Missing or deleted export jobs are properly detected and cleaned up.

**Bug Fixes**
* Fixed orphan export states when jobs disappear unexpectedly.
* Flight references are now properly cleared when export jobs are deleted.
* Improved worker restart behavior for better job status consistency.

**Tests**
* Added test coverage for flight reference reconciliation and orphan state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->