### PR TITLE
fix(backend): persist failed emagram analyses

### DIFF
--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -7,7 +7,7 @@ import asyncio
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from datetime import time as dt_time
 from typing import Any
 
@@ -235,6 +235,10 @@ async def generate_multi_source_emagram_for_spot(
         }
     """
 
+    site: Site | None = None
+    forecast_date = None
+    screenshot_result: dict[str, Any] = {"screenshots": []}
+
     try:
         # Step 1: Get site from database
         site = db.query(Site).filter(Site.id == site_id).first()
@@ -293,22 +297,44 @@ async def generate_multi_source_emagram_for_spot(
 
         if not screenshot_result.get("success"):
             logger.error(f"Screenshot fetch failed: {screenshot_result.get('error')}")
-            return {
+            failure_result = {
                 "success": False,
                 "error": "Failed to fetch emagram screenshots",
                 "details": screenshot_result,
             }
+            failed_analysis = _record_failed_analysis(
+                db,
+                site,
+                screenshot_result,
+                failure_result,
+                forecast_date=forecast_date,
+                forecast_hour=hour,
+            )
+            if failed_analysis:
+                failure_result["analysis_id"] = failed_analysis.id
+            return failure_result
 
         screenshots = screenshot_result.get("screenshots", [])
         successful_screenshots = [s for s in screenshots if s.get("success")]
 
         if not successful_screenshots:
             logger.error("No screenshots were successful")
-            return {
+            failure_result = {
                 "success": False,
                 "error": "All screenshot sources failed",
                 "screenshots": screenshots,
             }
+            failed_analysis = _record_failed_analysis(
+                db,
+                site,
+                screenshot_result,
+                failure_result,
+                forecast_date=forecast_date,
+                forecast_hour=hour,
+            )
+            if failed_analysis:
+                failure_result["analysis_id"] = failed_analysis.id
+            return failure_result
 
         logger.info(f"📸 {len(successful_screenshots)}/3 screenshots successful")
 
@@ -352,9 +378,59 @@ async def generate_multi_source_emagram_for_spot(
 
         return emagram_analysis_to_dict(emagram_analysis, db=db)
 
+    except QuotaExhaustedError as e:
+        logger.error(f"LLM quota exhausted during emagram generation: {e}", exc_info=True)
+        failure_result = {"success": False, "error": f"LLM quota exhausted: {e}"}
+        if site is not None:
+            failed_analysis = _record_failed_analysis(
+                db,
+                site,
+                screenshot_result,
+                failure_result,
+                forecast_date=forecast_date,
+                forecast_hour=hour,
+            )
+            if failed_analysis:
+                failure_result["analysis_id"] = failed_analysis.id
+        return failure_result
     except Exception as e:
         logger.error(f"Error in multi-source emagram generation: {e}", exc_info=True)
-        return {"success": False, "error": f"Unexpected error: {str(e)}"}
+        failure_result = {"success": False, "error": f"Unexpected error: {str(e)}"}
+        if site is not None:
+            failed_analysis = _record_failed_analysis(
+                db,
+                site,
+                screenshot_result,
+                failure_result,
+                forecast_date=forecast_date,
+                forecast_hour=hour,
+            )
+            if failed_analysis:
+                failure_result["analysis_id"] = failed_analysis.id
+        return failure_result
+
+
+def _record_failed_analysis(
+    db: Session,
+    site: Site,
+    screenshot_result: dict[str, Any],
+    analysis_result: dict[str, Any],
+    forecast_date: date | None = None,
+    forecast_hour: int | None = None,
+) -> EmagramAnalysis | None:
+    try:
+        return save_failed_analysis(
+            db,
+            site,
+            screenshot_result,
+            analysis_result,
+            forecast_date=forecast_date,
+            forecast_hour=forecast_hour,
+        )
+    except Exception as save_error:
+        db.rollback()
+        logger.error("Failed to persist failed emagram analysis: %s", save_error, exc_info=True)
+        return None
 
 
 def save_emagram_analysis(
@@ -453,7 +529,7 @@ def save_failed_analysis(
     analysis_result: dict[str, Any],
     forecast_date=None,
     forecast_hour: int | None = None,
-):
+) -> EmagramAnalysis:
     """
     Save failed analysis attempt for debugging
     """
@@ -489,8 +565,10 @@ def save_failed_analysis(
 
     db.add(emagram)
     db.commit()
+    db.refresh(emagram)
 
     logger.warning("⚠️ Saved failed analysis attempt to database")
+    return emagram
 
 
 def parse_time_string(time_str: str | None) -> dt_time | None:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5934,7 +5934,7 @@ def _auto_emagram_analysis(
     _pending_emagram_analyses.add(key)
     try:
         with get_db_context() as db:
-            asyncio.run(
+            result = asyncio.run(
                 generate_multi_source_emagram_for_spot(
                     site_id=site_id,
                     db=db,
@@ -5943,6 +5943,14 @@ def _auto_emagram_analysis(
                     locale=locale,
                 )
             )
+            if not result.get("success"):
+                logger.warning(
+                    "Auto emagram analysis ended in failure for %s day_index=%s hour=%s: %s",
+                    site_id,
+                    day_index,
+                    hour,
+                    result.get("error", "unknown error"),
+                )
     except Exception as e:
         logger.error(
             f"Auto emagram analysis failed for {site_id} day_index={day_index} hour={hour}: {e}"

--- a/apps/backend/tests/unit/test_emagram_generation_failures.py
+++ b/apps/backend/tests/unit/test_emagram_generation_failures.py
@@ -1,0 +1,108 @@
+from typing import Any
+
+import pytest
+
+import emagram_multi_source as emagram
+from llm.exceptions import QuotaExhaustedError
+from models import EmagramAnalysis, Site
+
+
+def _site(site_id: str = "site-emagram-failure") -> Site:
+    return Site(
+        id=site_id,
+        code="EGF",
+        name="Emagram Failure Site",
+        latitude=47.0,
+        longitude=6.0,
+        elevation_m=500,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generation_persists_failed_analysis_when_screenshots_fail(
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site = _site()
+    db_session.add(site)
+    db_session.commit()
+
+    async def fail_screenshots(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": False,
+            "error": "all sources timed out",
+            "screenshots": [
+                {
+                    "source": "meteo-parapente",
+                    "success": False,
+                    "error": "timeout",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(emagram, "fetch_all_emagram_screenshots", fail_screenshots)
+
+    result = await emagram.generate_multi_source_emagram_for_spot(
+        site_id=site.id,
+        db=db_session,
+        day_index=0,
+        hour=14,
+    )
+
+    assert result["success"] is False
+    assert result["analysis_id"]
+
+    analysis = db_session.get(EmagramAnalysis, result["analysis_id"])
+    assert analysis is not None
+    assert analysis.analysis_status == "failed"
+    assert analysis.forecast_hour == 14
+    assert analysis.error_message == "Failed to fetch emagram screenshots"
+    assert "meteo-parapente" in (analysis.sources_errors or "")
+
+
+@pytest.mark.asyncio
+async def test_generation_persists_failed_analysis_when_llm_quota_is_exhausted(
+    client,
+    db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    site = _site("site-emagram-quota")
+    db_session.add(site)
+    db_session.commit()
+
+    async def successful_screenshots(**_kwargs: Any) -> dict[str, Any]:
+        return {
+            "success": True,
+            "screenshots": [
+                {
+                    "source": "meteociel",
+                    "success": True,
+                    "image_path": "/tmp/emagram.png",
+                    "external_url": "https://example.test/emagram",
+                }
+            ],
+            "sources_successful": 1,
+        }
+
+    def quota_exhausted(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise QuotaExhaustedError("provider quota")
+
+    monkeypatch.setattr(emagram, "fetch_all_emagram_screenshots", successful_screenshots)
+    monkeypatch.setattr(emagram, "_analyze_emagram_with_fallbacks", quota_exhausted)
+
+    result = await emagram.generate_multi_source_emagram_for_spot(
+        site_id=site.id,
+        db=db_session,
+        day_index=0,
+        hour=12,
+    )
+
+    assert result["success"] is False
+    assert result["analysis_id"]
+
+    response = client.get(f"/api/emagram/latest?site_id={site.id}&hour=12")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == result["analysis_id"]
+    assert data["analysis_status"] == "failed"
+    assert data["error_message"] == "LLM quota exhausted: provider quota"


### PR DESCRIPTION
## Summary
- Persist failed emagram attempts for screenshot, quota, and unexpected-error paths so the UI can leave the loading state.
- Log failed auto-analysis attempts and expose the persisted failure through the existing emagram endpoints.
- Add backend coverage for failed persistence and hour/latest visibility.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/test_emagram_endpoints.py tests/unit/test_emagram_generation_failures.py -q --tb=short --no-header --no-cov`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- CodeRabbit review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced error handling for emagram generation failures, including screenshot fetch and AI processing errors
  * Failed analyses are now recorded in the system with detailed error information for tracking and troubleshooting
  * Improved failure logging and error responses when generation encounters issues

* **Tests**
  * Added test coverage for failure persistence scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->