### PR TITLE
fix(backend): harden emagram screenshot capture

### DIFF
--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -6,6 +6,7 @@ Captures emagram images from Meteo-Parapente, TopMeteo, and Windy
 import asyncio
 import logging
 from datetime import datetime
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,30 @@ logger = logging.getLogger(__name__)
 # Cache directory for temporary screenshots
 EMAGRAM_CACHE_DIR = Path("/tmp/emagram_cache")
 EMAGRAM_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _meteo_parapente_day_labels(day_index: int) -> list[str]:
+    target_date = datetime.now() + timedelta(days=day_index)
+    day = target_date.day
+    month = target_date.month
+    return [
+        target_date.strftime("%Y-%m-%d"),
+        target_date.strftime("%d/%m"),
+        f"{day}/{month}",
+        f"{day:02d}/{month:02d}",
+    ]
+
+
+async def _click_first_available(page: Any, selectors: list[str], timeout: int) -> str | None:
+    for selector in selectors:
+        try:
+            element = page.locator(selector).first
+            if await element.count() > 0:
+                await element.click(timeout=timeout)
+                return selector
+        except Exception:
+            continue
+    return None
 
 
 async def screenshot_meteo_parapente(
@@ -80,16 +105,10 @@ async def screenshot_meteo_parapente(
                     "a:has-text('Sounding')",
                 ]
 
-                for selector in tab_selectors:
-                    try:
-                        element = page.locator(selector).first
-                        if await element.count() > 0:
-                            await element.click(timeout=3000)
-                            logger.info(f"✅ Clicked sounding tab: {selector}")
-                            emagram_tab_clicked = True
-                            break
-                    except Exception:
-                        continue
+                clicked_selector = await _click_first_available(page, tab_selectors, timeout=3000)
+                if clicked_selector:
+                    logger.info(f"✅ Clicked sounding tab: {clicked_selector}")
+                    emagram_tab_clicked = True
 
             except Exception as e:
                 logger.warning(f"Could not click sounding tab: {e}")
@@ -105,22 +124,53 @@ async def screenshot_meteo_parapente(
                         "button.next-day",
                         "[data-action='next-day']",
                         ".day-nav-next",
+                        "[aria-label*='Next']",
+                        "[aria-label*='next']",
+                        "[aria-label*='suivant']",
+                        "[title*='Next']",
+                        "[title*='Suivant']",
                         "button:has-text('▶')",
                         "button:has-text('›')",
+                        "button:has-text('>')",
+                        "a:has-text('›')",
+                        "a:has-text('>')",
                         ".nav-next",
                     ]
-                    clicked = False
-                    for sel in next_day_selectors:
+                    clicked_selector = await _click_first_available(
+                        page, next_day_selectors, timeout=2000
+                    )
+                    clicked = clicked_selector is not None
+                    if clicked_selector:
+                        await page.wait_for_timeout(1500)
+                        logger.info(f"Clicked next-day button: {clicked_selector}")
+
+                    if not clicked:
+                        day_selectors = []
+                        for label in _meteo_parapente_day_labels(day_index):
+                            day_selectors.extend(
+                                [
+                                    f"button:has-text('{label}')",
+                                    f"a:has-text('{label}')",
+                                    f"[role='button']:has-text('{label}')",
+                                ]
+                            )
+                        clicked_selector = await _click_first_available(
+                            page, day_selectors, timeout=2000
+                        )
+                        clicked = clicked_selector is not None
+                        if clicked_selector:
+                            await page.wait_for_timeout(1500)
+                            logger.info(f"Clicked target-day selector: {clicked_selector}")
+
+                    if not clicked:
                         try:
-                            el = page.locator(sel).first
-                            if await el.count() > 0:
-                                await el.click(timeout=2000)
-                                await page.wait_for_timeout(1500)
-                                clicked = True
-                                logger.info(f"Clicked next-day button: {sel}")
-                                break
-                        except Exception:
-                            continue
+                            await page.keyboard.press("ArrowRight")
+                            await page.wait_for_timeout(1500)
+                            clicked = True
+                            logger.info("Navigated to next day with ArrowRight fallback")
+                        except Exception as e:
+                            logger.warning(f"ArrowRight day navigation fallback failed: {e}")
+
                     if not clicked:
                         raise RuntimeError(
                             f"Could not navigate Meteo-Parapente to day_index={day_index}"
@@ -138,16 +188,12 @@ async def screenshot_meteo_parapente(
                         f"button:has-text('{hour}:00')",
                         f".hour-label:has-text('{hour}')",
                     ]
-                    for sel in hour_selectors:
-                        try:
-                            el = page.locator(sel).first
-                            if await el.count() > 0:
-                                await el.click(timeout=2000)
-                                hour_navigated = True
-                                logger.info(f"Clicked hour selector: {sel}")
-                                break
-                        except Exception:
-                            continue
+                    clicked_selector = await _click_first_available(
+                        page, hour_selectors, timeout=2000
+                    )
+                    if clicked_selector:
+                        hour_navigated = True
+                        logger.info(f"Clicked hour selector: {clicked_selector}")
 
                     # Strategy 2: Try to set a range slider via JS
                     if not hour_navigated:
@@ -291,19 +337,25 @@ async def screenshot_meteociel_emagram(
 
                 image_selector = "img[src*='sondagegfs'], img[src*='sondage'], img[src*='emagram']"
                 await page.wait_for_selector(image_selector, state="visible", timeout=timeout)
-                await page.wait_for_function(
-                    """
-                    selector => {
-                        const img = document.querySelector(selector);
-                        return img instanceof HTMLImageElement
-                            && img.complete
-                            && img.naturalWidth > 0
-                            && img.naturalHeight > 0;
-                    }
-                    """,
-                    arg=image_selector,
-                    timeout=timeout,
-                )
+                try:
+                    await page.wait_for_function(
+                        """
+                        selector => {
+                            const img = document.querySelector(selector);
+                            return img instanceof HTMLImageElement
+                                && img.complete
+                                && img.naturalWidth > 0
+                                && img.naturalHeight > 0;
+                        }
+                        """,
+                        arg=image_selector,
+                        timeout=min(timeout, 8000),
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Meteociel image load check timed out, trying visible image capture: %s",
+                        e,
+                    )
 
                 # Meteociel shows emagram as an image; fail instead of storing a blank fallback.
                 emagram_img = page.locator(image_selector).first

--- a/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
+++ b/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
@@ -24,6 +24,9 @@ class _FakeLocator:
     async def screenshot(self, path: str) -> None:
         Path(path).write_bytes(b"png")
 
+    async def click(self, *args, **kwargs) -> None:
+        return None
+
 
 class _FakePage:
     def __init__(self, *, image_loaded: bool) -> None:
@@ -46,6 +49,32 @@ class _FakePage:
     async def screenshot(self, *args, **kwargs) -> None:
         self.full_page_screenshot_called = True
         raise AssertionError("Meteociel should not fall back to a full-page screenshot")
+
+
+class _FakeKeyboard:
+    def __init__(self) -> None:
+        self.pressed: list[str] = []
+
+    async def press(self, key: str) -> None:
+        self.pressed.append(key)
+
+
+class _FakeMeteoParapentePage:
+    def __init__(self, output_path: Path) -> None:
+        self.keyboard = _FakeKeyboard()
+        self.output_path = output_path
+
+    async def goto(self, *args, **kwargs) -> None:
+        return None
+
+    async def wait_for_timeout(self, *args, **kwargs) -> None:
+        return None
+
+    def locator(self, selector: str):
+        return _FakeLocator(count=0)
+
+    async def screenshot(self, path: str, *args, **kwargs) -> None:
+        Path(path).write_bytes(b"png")
 
 
 class _FakeBrowser:
@@ -79,7 +108,9 @@ class _FakePlaywright:
 
 
 @pytest.mark.asyncio
-async def test_meteociel_screenshot_requires_loaded_image(monkeypatch, tmp_path) -> None:
+async def test_meteociel_screenshot_captures_visible_image_after_load_timeout(
+    monkeypatch, tmp_path
+) -> None:
     page = _FakePage(image_loaded=False)
     monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
     monkeypatch.setattr(
@@ -95,11 +126,10 @@ async def test_meteociel_screenshot_requires_loaded_image(monkeypatch, tmp_path)
         hour=12,
     )
 
-    assert result["success"] is False
+    assert result["success"] is True
     assert result["source"] == "meteociel"
-    assert "image not loaded" in result["error"]
+    assert Path(result["image_path"]).read_bytes() == b"png"
     assert not page.full_page_screenshot_called
-    assert list(tmp_path.glob("*.png")) == []
 
 
 @pytest.mark.asyncio
@@ -123,3 +153,26 @@ async def test_meteociel_screenshot_captures_loaded_image(monkeypatch, tmp_path)
     assert result["source"] == "meteociel"
     assert Path(result["image_path"]).read_bytes() == b"png"
     assert not page.full_page_screenshot_called
+
+
+@pytest.mark.asyncio
+async def test_meteo_parapente_uses_keyboard_day_fallback(monkeypatch, tmp_path) -> None:
+    page = _FakeMeteoParapentePage(tmp_path)
+    monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(
+        emagram_screenshots,
+        "async_playwright",
+        lambda: _FakePlaywright(page),
+    )
+
+    result = await emagram_screenshots.screenshot_meteo_parapente(
+        latitude=47.2,
+        longitude=6.0,
+        spot_name="Arguel",
+        day_index=1,
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "meteo-parapente"
+    assert page.keyboard.pressed == ["ArrowRight"]
+    assert Path(result["image_path"]).read_bytes() == b"png"


### PR DESCRIPTION
## Summary
- Make Meteo-Parapente day navigation more resilient with extra selectors, date matching, and keyboard fallback.
- Treat Meteociel image load timeouts as recoverable when the image is visible and capturable.
- Add targeted unit coverage for both failure modes.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_meteociel_emagram_screenshot.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (completed within Nx, but the shell timeout cut off the run after long-running scraper tests)

## Review
- CodeRabbit review passed with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reliability of weather data screenshot captures with optimized image loading detection and timeout handling.
  * Enhanced navigation and UI element detection across weather platforms.
  * Added fallback mechanisms for more consistent data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->