### PR TITLE
fix(backend): prevent emagram source timeouts

### DIFF
--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -4,12 +4,17 @@ Captures emagram images from Meteo-Parapente, TopMeteo, and Windy
 """
 
 import asyncio
+import base64
 import logging
+from contextlib import suppress
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin
 
+import httpx
+from bs4 import BeautifulSoup
 from playwright.async_api import async_playwright
 
 logger = logging.getLogger(__name__)
@@ -17,6 +22,8 @@ logger = logging.getLogger(__name__)
 # Cache directory for temporary screenshots
 EMAGRAM_CACHE_DIR = Path("/tmp/emagram_cache")
 EMAGRAM_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS = 35
+METEOCIEL_SCREENSHOT_TIMEOUT_SECONDS = 30
 
 
 def _meteo_parapente_day_labels(day_index: int) -> list[str]:
@@ -41,6 +48,35 @@ async def _click_first_available(page: Any, selectors: list[str], timeout: int) 
         except Exception:
             continue
     return None
+
+
+async def _capture_page_png(
+    page: Any, image_path: Path, clip: dict[str, float] | None = None
+) -> None:
+    params: dict[str, Any] = {"format": "png", "captureBeyondViewport": False}
+    if clip:
+        params["clip"] = {
+            "x": clip["x"],
+            "y": clip["y"],
+            "width": clip["width"],
+            "height": clip["height"],
+            "scale": 1,
+        }
+
+    try:
+        cdp = await page.context.new_cdp_session(page)
+        result = await cdp.send("Page.captureScreenshot", params)
+        image_path.write_bytes(base64.b64decode(result["data"]))
+        return
+    except Exception as cdp_error:
+        logger.warning("CDP screenshot failed, using Playwright screenshot: %s", cdp_error)
+
+    screenshot_kwargs: dict[str, Any] = {"path": str(image_path), "timeout": 8000}
+    if clip:
+        screenshot_kwargs["clip"] = clip
+    else:
+        screenshot_kwargs["full_page"] = False
+    await page.screenshot(**screenshot_kwargs)
 
 
 async def screenshot_meteo_parapente(
@@ -84,7 +120,11 @@ async def screenshot_meteo_parapente(
             page = await browser.new_page(viewport={"width": 1920, "height": 1080})
 
             logger.info(f"📸 Meteo-Parapente: Loading {url}")
-            await page.goto(url, wait_until="networkidle", timeout=timeout)
+            await page.goto(url, wait_until="domcontentloaded", timeout=timeout)
+            try:
+                await page.wait_for_load_state("networkidle", timeout=8000)
+            except Exception as e:
+                logger.warning("Meteo-Parapente network did not become idle, continuing: %s", e)
 
             # Wait for page to load
             await page.wait_for_timeout(3000)
@@ -228,8 +268,9 @@ async def screenshot_meteo_parapente(
 
             # Take screenshot of LEFT PANEL ONLY (clip to left side of screen)
             # Assume left panel is roughly 50% of screen width
-            await page.screenshot(
-                path=str(image_path),
+            await _capture_page_png(
+                page,
+                image_path,
                 clip={"x": 0, "y": 0, "width": 960, "height": 1080},  # Left half
             )
 
@@ -327,57 +368,29 @@ async def screenshot_meteociel_emagram(
     image_path = EMAGRAM_CACHE_DIR / filename
 
     try:
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=True)
-            page = await browser.new_page(viewport={"width": 1600, "height": 1200})
+        logger.info(f"Meteociel emagram: Loading {url}")
+        async with httpx.AsyncClient(follow_redirects=True, timeout=timeout / 1000) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            image_src = None
+            for img in soup.find_all("img"):
+                src = str(img.get("src") or "")
+                if "sondage" in src or "emagram" in src:
+                    image_src = urljoin(str(response.url), src)
+                    break
 
-            try:
-                logger.info(f"Meteociel emagram: Loading {url}")
-                await page.goto(url, wait_until="domcontentloaded", timeout=timeout)
+            if not image_src:
+                raise RuntimeError("Meteociel emagram image not found in page")
 
-                image_selector = "img[src*='sondagegfs'], img[src*='sondage'], img[src*='emagram']"
-                await page.wait_for_selector(image_selector, state="visible", timeout=timeout)
-                try:
-                    await page.wait_for_function(
-                        """
-                        selector => {
-                            const img = document.querySelector(selector);
-                            return img instanceof HTMLImageElement
-                                && img.complete
-                                && img.naturalWidth > 0
-                                && img.naturalHeight > 0;
-                        }
-                        """,
-                        arg=image_selector,
-                        timeout=min(timeout, 8000),
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Meteociel image load check timed out, trying visible image capture: %s",
-                        e,
-                    )
+            image_response = await client.get(image_src)
+            image_response.raise_for_status()
+            image_path.write_bytes(image_response.content)
 
-                # Meteociel shows emagram as an image; fail instead of storing a blank fallback.
-                emagram_img = page.locator(image_selector).first
-                parent = emagram_img.locator("xpath=ancestor::td").first
-                if await parent.count() > 0:
-                    await parent.screenshot(path=str(image_path))
-                    logger.info("Captured emagram with parent container (includes date)")
-                else:
-                    parent_table = emagram_img.locator("xpath=ancestor::table").first
-                    if await parent_table.count() > 0:
-                        await parent_table.screenshot(path=str(image_path))
-                        logger.info("Captured emagram with table container (includes date)")
-                    else:
-                        await emagram_img.screenshot(path=str(image_path))
-                        logger.info("Captured emagram image directly (no parent found)")
+        if not image_path.exists() or image_path.stat().st_size == 0:
+            raise RuntimeError("Meteociel emagram image was not written")
 
-                if not image_path.exists() or image_path.stat().st_size == 0:
-                    raise RuntimeError("Meteociel emagram screenshot was not written")
-
-                logger.info(f"Meteociel emagram screenshot saved: {image_path}")
-            finally:
-                await browser.close()
+        logger.info(f"Meteociel emagram image saved: {image_path}")
 
         return {
             "success": True,
@@ -394,6 +407,33 @@ async def screenshot_meteociel_emagram(
             "source": "meteociel",
             "error": str(e),
             "external_url": url,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+async def _run_screenshot_with_timeout(
+    source: str, screenshot_coro: Any, timeout_seconds: float, external_url: str
+) -> dict[str, Any]:
+    task = asyncio.create_task(screenshot_coro)
+    try:
+        return await asyncio.wait_for(task, timeout=timeout_seconds)
+    except TimeoutError:
+        task.cancel()
+        with suppress(BaseException):
+            await task
+        return {
+            "success": False,
+            "source": source,
+            "error": f"{source} screenshot timed out after {timeout_seconds}s",
+            "external_url": external_url,
+            "timestamp": datetime.now().isoformat(),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "source": source,
+            "error": str(e),
+            "external_url": external_url,
             "timestamp": datetime.now().isoformat(),
         }
 
@@ -433,12 +473,33 @@ async def fetch_all_emagram_screenshots(
 
     logger.info(f"🎬 Starting screenshot fetch for {spot_name} ({spot_id})")
     logger.info(f"   Coordinates: {latitude}, {longitude}")
+    meteo_parapente_url = f"https://meteo-parapente.com/#/sounding/{latitude}/{longitude}"
+    if hour is not None:
+        meteociel_ech = hour + (day_index * 24)
+    else:
+        meteociel_ech = 3 + (day_index * 24)
+    meteociel_url = (
+        "https://www.meteociel.fr/modeles/sondage2.php"
+        f"?mode=0&lon={longitude}&lat={latitude}&ech={meteociel_ech}&map=0"
+    )
 
     # Fetch sources in parallel
     tasks = [
-        screenshot_meteo_parapente(latitude, longitude, spot_name, day_index=day_index, hour=hour),
-        screenshot_meteociel_emagram(
-            latitude, longitude, spot_name, day_index=day_index, hour=hour
+        _run_screenshot_with_timeout(
+            "meteo-parapente",
+            screenshot_meteo_parapente(
+                latitude, longitude, spot_name, day_index=day_index, hour=hour
+            ),
+            timeout_seconds=METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS,
+            external_url=meteo_parapente_url,
+        ),
+        _run_screenshot_with_timeout(
+            "meteociel",
+            screenshot_meteociel_emagram(
+                latitude, longitude, spot_name, day_index=day_index, hour=hour
+            ),
+            timeout_seconds=METEOCIEL_SCREENSHOT_TIMEOUT_SECONDS,
+            external_url=meteociel_url,
         ),
     ]
 

--- a/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
+++ b/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -21,7 +22,7 @@ class _FakeLocator:
     async def count(self) -> int:
         return self._count
 
-    async def screenshot(self, path: str) -> None:
+    async def screenshot(self, path: str, *args, **kwargs) -> None:
         Path(path).write_bytes(b"png")
 
     async def click(self, *args, **kwargs) -> None:
@@ -31,6 +32,7 @@ class _FakeLocator:
 class _FakePage:
     def __init__(self, *, image_loaded: bool) -> None:
         self.image_loaded = image_loaded
+        self.context = _FakeContext()
         self.full_page_screenshot_called = False
 
     async def goto(self, *args, **kwargs) -> None:
@@ -46,9 +48,22 @@ class _FakePage:
     def locator(self, selector: str):
         return _FakeLocator()
 
+    async def evaluate(self, *args, **kwargs) -> dict[str, int]:
+        return {"x": 10, "y": 20, "width": 300, "height": 400}
+
     async def screenshot(self, *args, **kwargs) -> None:
         self.full_page_screenshot_called = True
         raise AssertionError("Meteociel should not fall back to a full-page screenshot")
+
+
+class _FakeCdpSession:
+    async def send(self, *args, **kwargs) -> dict[str, str]:
+        return {"data": "cG5n"}
+
+
+class _FakeContext:
+    async def new_cdp_session(self, *args, **kwargs) -> _FakeCdpSession:
+        return _FakeCdpSession()
 
 
 class _FakeKeyboard:
@@ -68,6 +83,9 @@ class _FakeMeteoParapentePage:
         return None
 
     async def wait_for_timeout(self, *args, **kwargs) -> None:
+        return None
+
+    async def wait_for_load_state(self, *args, **kwargs) -> None:
         return None
 
     def locator(self, selector: str):
@@ -107,16 +125,41 @@ class _FakePlaywright:
         return None
 
 
+class _FakeHttpResponse:
+    def __init__(self, *, text: str = "", content: bytes = b"", url: str = "https://example.test"):
+        self.text = text
+        self.content = content
+        self.url = url
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeAsyncClient:
+    def __init__(self, *, page_html: str) -> None:
+        self.page_html = page_html
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str) -> _FakeHttpResponse:
+        if url.endswith(".png"):
+            return _FakeHttpResponse(content=b"png", url=url)
+        return _FakeHttpResponse(text=self.page_html, url=url)
+
+
 @pytest.mark.asyncio
-async def test_meteociel_screenshot_captures_visible_image_after_load_timeout(
-    monkeypatch, tmp_path
-) -> None:
-    page = _FakePage(image_loaded=False)
+async def test_meteociel_screenshot_downloads_emagram_image(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
     monkeypatch.setattr(
-        emagram_screenshots,
-        "async_playwright",
-        lambda: _FakePlaywright(page),
+        emagram_screenshots.httpx,
+        "AsyncClient",
+        lambda **kwargs: _FakeAsyncClient(
+            page_html='<html><img src="/modeles/sondagegfs/sondagegfs_6_47.2_27_0.png"></html>'
+        ),
     )
 
     result = await emagram_screenshots.screenshot_meteociel_emagram(
@@ -129,17 +172,15 @@ async def test_meteociel_screenshot_captures_visible_image_after_load_timeout(
     assert result["success"] is True
     assert result["source"] == "meteociel"
     assert Path(result["image_path"]).read_bytes() == b"png"
-    assert not page.full_page_screenshot_called
 
 
 @pytest.mark.asyncio
-async def test_meteociel_screenshot_captures_loaded_image(monkeypatch, tmp_path) -> None:
-    page = _FakePage(image_loaded=True)
+async def test_meteociel_screenshot_fails_without_image(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(emagram_screenshots, "EMAGRAM_CACHE_DIR", tmp_path)
     monkeypatch.setattr(
-        emagram_screenshots,
-        "async_playwright",
-        lambda: _FakePlaywright(page),
+        emagram_screenshots.httpx,
+        "AsyncClient",
+        lambda **kwargs: _FakeAsyncClient(page_html="<html></html>"),
     )
 
     result = await emagram_screenshots.screenshot_meteociel_emagram(
@@ -149,10 +190,10 @@ async def test_meteociel_screenshot_captures_loaded_image(monkeypatch, tmp_path)
         hour=12,
     )
 
-    assert result["success"] is True
+    assert result["success"] is False
     assert result["source"] == "meteociel"
-    assert Path(result["image_path"]).read_bytes() == b"png"
-    assert not page.full_page_screenshot_called
+    assert "image not found" in result["error"]
+    assert list(tmp_path.glob("*.png")) == []
 
 
 @pytest.mark.asyncio
@@ -176,3 +217,37 @@ async def test_meteo_parapente_uses_keyboard_day_fallback(monkeypatch, tmp_path)
     assert result["source"] == "meteo-parapente"
     assert page.keyboard.pressed == ["ArrowRight"]
     assert Path(result["image_path"]).read_bytes() == b"png"
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_returns_success_when_one_source_times_out(monkeypatch) -> None:
+    async def slow_meteo_parapente(*args, **kwargs) -> None:
+        await emagram_screenshots.asyncio.sleep(10)
+
+    async def successful_meteociel(*args, **kwargs) -> dict[str, str | bool]:
+        return {
+            "success": True,
+            "source": "meteociel",
+            "image_path": "/tmp/meteociel.png",
+            "external_url": "https://example.test",
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    monkeypatch.setattr(emagram_screenshots, "screenshot_meteo_parapente", slow_meteo_parapente)
+    monkeypatch.setattr(emagram_screenshots, "screenshot_meteociel_emagram", successful_meteociel)
+    monkeypatch.setattr(emagram_screenshots, "METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS", 0.01)
+
+    result = await emagram_screenshots.fetch_all_emagram_screenshots(
+        spot_id="site-arguel",
+        latitude=47.2,
+        longitude=6.0,
+        spot_name="Arguel",
+        day_index=1,
+    )
+
+    assert result["success"] is True
+    assert result["sources_successful"] == 1
+    assert result["screenshots"][0]["source"] == "meteo-parapente"
+    assert "timed out" in result["screenshots"][0]["error"]
+    assert result["screenshots"][0]["external_url"].startswith("https://meteo-parapente.com")
+    assert result["screenshots"][1]["source"] == "meteociel"


### PR DESCRIPTION
## Summary
- Fetch Meteociel emagram images directly over HTTP instead of relying on Playwright for this static source.
- Add per-source screenshot timeouts so a stuck Meteo-Parapente browser session does not block successful sources.
- Cover HTTP Meteociel extraction and partial-source timeout success with unit tests.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key BACKEND_LOG_FILE=/tmp/dashboard-parapente-test.log ../../.venv/bin/pytest tests/unit/test_meteociel_emagram_screenshot.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- Live local check: `fetch_all_emagram_screenshots(..., day_index=1)` returns `success: true` with Meteociel successful while Meteo-Parapente times out.

## Review
- CodeRabbit passed with no findings on the same diff before this clean follow-up branch was created.
- Re-running CodeRabbit on this branch is blocked by organization usage credits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load handling for weather data retrieval with graceful error handling.
  * Enhanced emagram screenshot capture with more reliable image fetching.

* **New Features**
  * Added timeout protection for screenshot operations with structured error reporting.

* **Tests**
  * Added test coverage for missing images and timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->