### PR TITLE
fix(frontend): use date query params for weather days

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -631,6 +631,33 @@ const defaultHandlersWithoutSpotsAndDetails = defaultHandlers.filter(
   (handler) => handler !== spotsHandler && handler !== spotDetailsHandler
 );
 
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const parseLocalDate = (value: string) => {
+  if (!DAY_SEARCH_DATE_RE.test(value)) return null;
+  const [year = '', month = '', day = ''] = value.split('-');
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  return date.getFullYear() === Number(year) &&
+    date.getMonth() === Number(month) - 1 &&
+    date.getDate() === Number(day)
+    ? date
+    : null;
+};
+
+const getLocalDayStart = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const parseForecastDaySearch = (value: unknown) => {
+  if (typeof value !== 'string') return undefined;
+  const date = parseLocalDate(value);
+  if (!date) return undefined;
+
+  const today = getLocalDayStart(new Date());
+  const dayIndex = Math.round((date.getTime() - today.getTime()) / DAY_MS);
+  return dayIndex >= 0 && dayIndex <= 6 ? value : undefined;
+};
+
 const weatherRouteConfig = {
   initialPath: '/weather',
   routes: [
@@ -638,11 +665,6 @@ const weatherRouteConfig = {
       path: '/weather',
       element: 'story' as const,
       validateSearch: (search: Record<string, unknown>) => {
-        const rawDay = search.day;
-        const parsedDay =
-          typeof rawDay === 'string' || typeof rawDay === 'number'
-            ? Number(rawDay)
-            : Number.NaN;
         const parseNumber = (value: unknown) => {
           const parsed =
             typeof value === 'string' || typeof value === 'number'
@@ -667,10 +689,7 @@ const weatherRouteConfig = {
 
         return {
           siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
-          day:
-            Number.isInteger(parsedDay) && parsedDay >= 0 && parsedDay <= 6
-              ? parsedDay
-              : undefined,
+          day: parseForecastDaySearch(search.day),
           target,
           city: parseString(search.city),
           displayName: parseString(search.displayName),

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -49,9 +49,46 @@ const getSearchDayLabel = (day: number, t: (key: string) => string) => {
   return `J+${day}`;
 };
 
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const formatLocalDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getLocalDayStart = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const getForecastDaySearch = (dayIndex: number) => {
+  if (dayIndex <= 0) return undefined;
+  const date = getLocalDayStart(new Date());
+  date.setDate(date.getDate() + dayIndex);
+  return formatLocalDate(date);
+};
+
+const getDayIndexFromSearch = (value: string | undefined) => {
+  if (!value || !DAY_SEARCH_DATE_RE.test(value)) return 0;
+  const [year = '', month = '', day = ''] = value.split('-');
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  if (
+    date.getFullYear() !== Number(year) ||
+    date.getMonth() !== Number(month) - 1 ||
+    date.getDate() !== Number(day)
+  ) {
+    return 0;
+  }
+
+  const today = getLocalDayStart(new Date());
+  const dayIndex = Math.round((date.getTime() - today.getTime()) / DAY_MS);
+  return dayIndex >= 0 && dayIndex <= 6 ? dayIndex : 0;
+};
+
 type WeatherSearchParams = {
   siteId?: string;
-  day?: number;
+  day?: string;
   target?: 'city' | 'takeoff' | 'landing';
   city?: string;
   displayName?: string;
@@ -116,7 +153,7 @@ const getTargetFromSearch = (
 };
 
 const getSearchForTarget = (target: CityWeatherTarget | null, day: number) => {
-  const daySearch = day > 0 ? day : undefined;
+  const daySearch = getForecastDaySearch(day);
 
   if (!target) return { day: daySearch };
 
@@ -157,7 +194,7 @@ export default function WeatherPage() {
   const isMobile = useIsMobile();
   const search = useSearch({ from: '/weather' });
   const routeSiteId = search ? search.siteId : '';
-  const selectedDayIndex = search.day ?? 0;
+  const selectedDayIndex = getDayIndexFromSearch(search.day);
   const selectedSearchTarget = getTargetFromSearch(search);
   const { data: bestSpot } = useBestSpotAPI(selectedDayIndex);
   const { data: hourlyBestSpots } = useHourlyBestSpotsAPI(selectedDayIndex);
@@ -212,7 +249,7 @@ export default function WeatherPage() {
   );
   const weatherSearch = {
     siteId: selectedSiteId,
-    day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+    day: getForecastDaySearch(selectedDayIndex),
   };
   const selectedDayLabel = getSearchDayLabel(selectedDayIndex, t);
   const selectedSiteDisplayName = selectedSite
@@ -231,7 +268,7 @@ export default function WeatherPage() {
       to: '/weather',
       search: {
         siteId: selectedSiteId || undefined,
-        day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+        day: getForecastDaySearch(selectedDayIndex),
       },
     });
   };
@@ -249,7 +286,7 @@ export default function WeatherPage() {
       to: '/weather',
       search: {
         siteId,
-        day: selectedDayIndex > 0 ? selectedDayIndex : undefined,
+        day: getForecastDaySearch(selectedDayIndex),
       },
     });
   };
@@ -274,7 +311,7 @@ export default function WeatherPage() {
       to: '/weather',
       search: {
         ...weatherSearch,
-        day: day > 0 ? day : undefined,
+        day: getForecastDaySearch(day),
       },
     });
   };

--- a/apps/frontend/src/routes/weather.tsx
+++ b/apps/frontend/src/routes/weather.tsx
@@ -5,7 +5,7 @@ import { sitesQueryOptions } from '../hooks/sites/useSites';
 type WeatherSearch = {
   variant?: 'A' | 'B' | 'C';
   siteId?: string;
-  day?: number;
+  day?: string;
   target?: 'city' | 'takeoff' | 'landing';
   city?: string;
   displayName?: string;
@@ -31,13 +31,35 @@ const parseOptionalNumber = (value: unknown) => {
 const parseString = (value: unknown) =>
   typeof value === 'string' && value.length > 0 ? value : undefined;
 
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const parseLocalDate = (value: string) => {
+  if (!DAY_SEARCH_DATE_RE.test(value)) return null;
+  const [year = '', month = '', day = ''] = value.split('-');
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+  return date.getFullYear() === Number(year) &&
+    date.getMonth() === Number(month) - 1 &&
+    date.getDate() === Number(day)
+    ? date
+    : null;
+};
+
+const getLocalDayStart = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+const parseForecastDaySearch = (value: unknown) => {
+  if (typeof value !== 'string') return undefined;
+  const date = parseLocalDate(value);
+  if (!date) return undefined;
+
+  const today = getLocalDayStart(new Date());
+  const dayIndex = Math.round((date.getTime() - today.getTime()) / DAY_MS);
+  return dayIndex >= 0 && dayIndex <= 6 ? value : undefined;
+};
+
 export const Route = createFileRoute('/weather')({
   validateSearch: (search: Record<string, unknown>): WeatherSearch => {
-    const rawDay = search.day;
-    const parsedDay =
-      typeof rawDay === 'string' || typeof rawDay === 'number'
-        ? Number(rawDay)
-        : Number.NaN;
     const target =
       search.target === 'city' ||
       search.target === 'takeoff' ||
@@ -59,10 +81,7 @@ export const Route = createFileRoute('/weather')({
           ? search.variant
           : undefined,
       siteId: typeof search.siteId === 'string' ? search.siteId : undefined,
-      day:
-        Number.isInteger(parsedDay) && parsedDay >= 0 && parsedDay <= 6
-          ? parsedDay
-          : undefined,
+      day: parseForecastDaySearch(search.day),
       target,
       city: parseString(search.city),
       displayName: parseString(search.displayName),


### PR DESCRIPTION
## Summary
- Keep `day` as the weather query param, but store it as a local `YYYY-MM-DD` date instead of an index.
- Convert between URL dates and internal day indexes in the weather page while preserving existing weather queries.
- Align the weather Storybook router validation with the new date-based search param.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend`
- CodeRabbit CLI: no findings

## Notes
- Full affected test run was blocked by `backend:test` because `pytest` is not available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Weather forecast day selection now uses human-readable calendar dates (YYYY-MM-DD format) in URLs instead of numeric indices, improving clarity and shareability of weather forecast links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->