### PR TITLE
feat(weather): add backend-owned flight decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,74 @@ _Avoid_: Takeoff when writing user-facing French
 A **Site** where pilots can land.
 _Avoid_: Landing when writing user-facing French
 
+**Decision de Vol**:
+An aid for deciding whether a pilot should consider flying from a **Site** on a given day and, when relevant, during a specific time window. A **Decision de Vol** is a cautious pre-flight recommendation, not a recorded flight, a hard go/no-go order, or a safety guarantee.
+_Avoid_: Vol, flight record, safety certification, go/no-go order
+
+**Vol Tranquille**:
+A flight objective that favors calm, manageable conditions over strong thermal performance. For the current pilot usage, weak thermals are neutral or positive, while strong thermals and instability require caution.
+_Avoid_: Performance flight, thermal optimization
+
+**Objectif de Vol**:
+The pilot's current intention for evaluating a **Decision de Vol**, such as seeking a **Vol Tranquille** or accepting more thermal activity. The **Objectif de Vol** changes how conditions are interpreted without changing the underlying weather data.
+_Avoid_: Pilot profile, fixed skill level
+
+**Score Objectif**:
+A numeric score for a **Decision de Vol** that reflects the selected **Objectif de Vol**. It complements the general weather score and should not be treated as the same thing as the Para-Index.
+_Avoid_: Para-Index, generic weather score
+
+**Vol de Progression**:
+A flight objective between **Vol Tranquille** and thermal-focused flying. It accepts moderate thermal activity as useful learning conditions while still treating strong thermals and instability cautiously.
+_Avoid_: Performance flight, distance flight
+
+**Vol Thermique**:
+A flight objective that actively values exploitable thermal activity while still treating excessive instability and thunderstorm risk as safety concerns.
+_Avoid_: Vol tranquille, distance flight
+
+**Creneau de Vol**:
+A time window during a day when the conditions for a **Site** are considered usable enough to be highlighted to the pilot. A **Creneau de Vol** is qualified as Favorable, Vigilance, Limite, or Deconseille, with a numeric score used as supporting comparison rather than the main language.
+_Avoid_: Full-day verdict, generic forecast period, score-only ranking
+
+**Moment le Moins Defavorable**:
+The least bad time window on a day where no **Creneau de Vol** is Favorable or Vigilance. It may be shown for situational awareness, but it must not be presented as a recommended time to fly.
+_Avoid_: Best creneau, recommended creneau
+
+**Risque Bloquant**:
+A weather factor severe enough to prevent a **Creneau de Vol** from being presented as Favorable, regardless of its numeric score. Blocking risks take precedence over score, thermal quality, and source confidence.
+_Avoid_: Minor warning, score modifier
+
+**Risque de Vigilance**:
+A weather factor that should be shown to the pilot but does not by itself prevent a **Creneau de Vol** from being usable. Weak wind, low confidence, and non-extreme thermal concerns are vigilance risks unless they cross a blocking threshold.
+_Avoid_: Risque bloquant, cosmetic warning
+
+**Confiance Meteo**:
+The degree to which the available forecasts are complete, fresh, and coherent enough to support a **Decision de Vol**. **Confiance Meteo** can confirm or degrade a recommendation, but it must never improve a risky creneau.
+_Avoid_: Safety guarantee, source count only
+
+**Contexte Meteo**:
+Weather information shown for a **Ville** or another location that is not enough to produce a complete **Decision de Vol**. A **Contexte Meteo** can explain general conditions and guide the pilot toward nearby **Sites**.
+_Avoid_: Decision de Vol, site recommendation
+
+**Site Selectionne**:
+The **Site** currently being evaluated by the pilot on the weather page. The primary **Decision de Vol** is always about the Site Selectionne, even when other sites are shown as alternatives.
+_Avoid_: Best site, nearby city, arbitrary coordinates
+
+**Site Alternatif**:
+A different **Site** shown because its forecast may be more favorable than the **Site Selectionne** for a given day or time window. A **Site Alternatif** is secondary guidance, not the primary subject of the weather page.
+_Avoid_: Site selectionne, automatic destination
+
+**Securite Atterrissage**:
+An assessment of whether an **Atterrissage** appears acceptable for landing during a day or time window. **Securite Atterrissage** complements a **Decision de Vol** but does not replace the decollage-based decision.
+_Avoid_: Decision de Vol, takeoff decision
+
+**Atterrissage Associe**:
+An **Atterrissage** linked to a **Decollage** as a plausible landing option for a flight from that decollage. Atterrissages associes influence the **Decision de Vol** only through their **Securite Atterrissage**.
+_Avoid_: Any nearby landing, selected decollage
+
+**Compatibilite Vent-Decollage**:
+The relationship between the forecast wind direction and the orientation of a **Decollage**. It is described with pilot-facing wind language such as Face, Travers acceptable, Travers fort, or Cul, then translated into the recommendation level used by the **Decision de Vol**.
+_Avoid_: Wind score only, generic wind direction
+
 ## Example Dialogue
 
 Dev: When a pilot searches for Annecy, should Annecy be added as a site?
@@ -81,3 +149,91 @@ Domain expert: No. Show one line and identify it as both.
 Dev: After selecting a search result, should the result list disappear?
 
 Domain expert: No. Keep the list visible and highlight the selected site so the pilot can change their choice.
+
+Dev: Does a weather-based go/no-go assessment create a flight in the history?
+
+Domain expert: No. It is only a decision aid before flying from a site during a day or time window.
+
+Dev: Should the app tell the pilot to go flying?
+
+Domain expert: No. It should give a cautious recommendation and explain the risks, but the pilot remains responsible for the final decision.
+
+Dev: Should weak thermals make a creneau worse?
+
+Domain expert: No. The current goal is a vol tranquille, so weak thermals are acceptable and can even be positive; strong thermals or instability are the concerns.
+
+Dev: Is vol tranquille the only possible objective?
+
+Domain expert: No. The pilot may choose a different objectif de vol from the weather page as confidence and desired thermal activity change.
+
+Dev: Which objectifs de vol should be available first?
+
+Domain expert: Start with vol tranquille, vol de progression, and vol thermique. Do not add distance flight yet because it requires additional criteria beyond the initial decision model.
+
+Dev: What should the objective-aware decision score be called?
+
+Domain expert: Use score objectif, because it is explicitly tied to the selected objectif de vol and is distinct from the general Para-Index.
+
+Dev: Should the weather page lead with a full-day verdict or the best usable time window?
+
+Domain expert: Lead with the best creneau de vol when one exists, while still showing the overall recommendation and risks.
+
+Dev: Should pilots read the score or the condition level first?
+
+Domain expert: They should read the condition level first, then use the score to compare similar creneaux or sites.
+
+Dev: If the whole day is poor, should the least bad hour be called the best creneau?
+
+Domain expert: No. Say that there is no recommended creneau, then optionally show the moment le moins defavorable for awareness.
+
+Dev: Can a high score hide a clearly dangerous weather factor?
+
+Domain expert: No. A risque bloquant must dominate the decision before score, thermal quality, or forecast confidence.
+
+Dev: Which risks block a favorable creneau in the first weather decision model?
+
+Domain expert: Significant rain, excessive average wind, excessive gusts, and tailwind at the decollage are blocking risks. Weak wind, low confidence, and non-extreme thermal concerns are vigilance risks unless later thresholds make them blocking.
+
+Dev: Can strong forecast confidence make a risky creneau favorable?
+
+Domain expert: No. Confiance meteo can only support or degrade the recommendation; it cannot cancel a weather risk.
+
+Dev: Is the weather page primarily a best-site finder?
+
+Domain expert: No. It primarily evaluates the site selectionne, then may show a site alternatif when another site appears clearly better.
+
+Dev: Can a city search produce a complete decision de vol?
+
+Domain expert: No. A ville can provide weather context and help discover nearby sites, but a complete decision de vol requires a site because decollage orientation and atterrissages matter.
+
+Dev: What should the page show for a ville?
+
+Domain expert: Show a contexte meteo and nearby sites, not a complete decision de vol.
+
+Dev: Can an atterrissage alone answer whether the pilot should take off?
+
+Domain expert: No. An atterrissage can have a securite atterrissage assessment, but a complete decision de vol needs a decollage or a site that is both decollage and atterrissage.
+
+Dev: Should a good decollage remain favorable if every associated atterrissage is poor?
+
+Domain expert: No. If all known atterrissages associes are poor, the decision de vol should be degraded. If no atterrissage associe is known, show that landing was not evaluated as a vigilance rather than treating it as proven unsafe.
+
+Dev: Should wind alignment be shown only as a numeric angle?
+
+Domain expert: No. Show the pilot-facing relationship first, such as Face, Travers acceptable, Travers fort, or Cul, then use the angle and score as supporting detail.
+
+Dev: What default angle ranges should describe wind alignment at a decollage?
+
+Domain expert: Treat 0-30 degrees as Face, 31-60 degrees as Travers acceptable, 61-100 degrees as Travers fort, and 101-180 degrees as Cul. These defaults may later be adapted per site.
+
+Dev: How should a decollage with several orientations be evaluated?
+
+Domain expert: Compare the wind with each known orientation, keep the best compatible orientation for the decision de vol, and show the retained orientation in the detail. If no orientation is known, show that orientation was not evaluated as a vigilance rather than blocking the decision.
+
+Dev: Should the decision de vol define separate wind, gust, rain, and instability thresholds?
+
+Domain expert: No. It should reuse the existing configurable weather thresholds as the source of truth, and only introduce new thresholds for concepts not already covered, such as wind-orientation angles, forecast confidence, and landing safety rules.
+
+Dev: Should the weather decision model distinguish between several pilot profiles?
+
+Domain expert: Not initially. The app is currently used by one pilot, so the existing configurable thresholds are enough; pilot profiles may be introduced later if the app becomes multi-user.

--- a/apps/backend/app_settings.py
+++ b/apps/backend/app_settings.py
@@ -52,6 +52,7 @@ DEFAULTS: dict[str, str] = {
     "ui_reason_gust_high_min": "45",
     "ui_reason_cloud_very_cloudy_min": "80",
     "ui_reason_wind_moderate_min": "25",
+    "default_flight_objective": "tranquille",
 }
 
 # Keys that must never be exposed via the public settings API

--- a/apps/backend/flight_decision.py
+++ b/apps/backend/flight_decision.py
@@ -494,15 +494,20 @@ def _thermal(hour: dict[str, Any], objective: FlightObjective) -> dict[str, Any]
 def _hour_confidence(hour: dict[str, Any]) -> dict[str, Any]:
     source_count = int(hour.get("num_sources") or len(hour.get("sources") or {}) or 0)
     score = min(100, max(20, source_count * 20)) if source_count else 20
-    return {"level": _confidence_level(score), "score": score}
+    return {"level": _confidence_level(score), "score": score, "source_count": source_count}
 
 
 def _build_confidence(
     weather_payload: dict[str, Any], hourly: list[dict[str, Any]]
 ) -> dict[str, Any]:
-    source_count = int(
-        weather_payload.get("total_sources")
-        or max((h["confidence"]["score"] // 20 for h in hourly), default=0)
+    total_sources = weather_payload.get("total_sources")
+    source_count = (
+        int(total_sources)
+        if total_sources is not None
+        else max(
+            (h["confidence"]["source_count"] for h in hourly),
+            default=0,
+        )
     )
     score = min(100, max(10, source_count * 20)) if source_count else 10
     diagnostics: list[dict[str, Any]] = []
@@ -634,7 +639,12 @@ def _build_windows(hours: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def _window_from_hours(hours: list[dict[str, Any]]) -> dict[str, Any]:
     min_level = min(hours, key=lambda h: _LEVEL_RANK[h["level"]])["level"]
     min_score = min(int(h["score_objectif"]) for h in hours)
-    main_risks = list(dict.fromkeys(risk["code"] for h in hours for risk in h["risks"]))
+    ordered_risks = sorted(
+        (risk for h in hours for risk in h["risks"]),
+        key=lambda risk: _severity_rank(risk["severity"]),
+        reverse=True,
+    )
+    main_risks = list(dict.fromkeys(risk["code"] for risk in ordered_risks))
     start_hour = min(h["hour"] for h in hours)
     end_hour = max(h["hour"] for h in hours)
     return {

--- a/apps/backend/flight_decision.py
+++ b/apps/backend/flight_decision.py
@@ -1,0 +1,720 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from zoneinfo import ZoneInfo
+
+from para_index import calculate_hourly_para_index, get_para_index_thresholds
+
+DecisionLevel = Literal["favorable", "vigilance", "limite", "deconseille", "unavailable"]
+RiskSeverity = Literal["info", "vigilance", "limiting", "blocking"]
+FlightObjective = Literal["tranquille", "progression", "thermique"]
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+EXPECTED_SOURCE_COUNT = 5
+
+_LEVEL_RANK: dict[DecisionLevel, int] = {
+    "unavailable": -1,
+    "deconseille": 0,
+    "limite": 1,
+    "vigilance": 2,
+    "favorable": 3,
+}
+
+_CARDINAL_TO_DEGREES = {
+    "N": 0,
+    "NNE": 22.5,
+    "NE": 45,
+    "ENE": 67.5,
+    "E": 90,
+    "ESE": 112.5,
+    "SE": 135,
+    "SSE": 157.5,
+    "S": 180,
+    "SSW": 202.5,
+    "SW": 225,
+    "WSW": 247.5,
+    "W": 270,
+    "WNW": 292.5,
+    "NW": 315,
+    "NNW": 337.5,
+}
+
+
+def normalize_objective(value: str | None) -> FlightObjective:
+    return value if value in {"tranquille", "progression", "thermique"} else "tranquille"
+
+
+def build_flight_decision(
+    *,
+    site: Any,
+    weather_payload: dict[str, Any],
+    objective: FlightObjective,
+    landing_associations: list[Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    thresholds = get_para_index_thresholds()
+    current_time = now.astimezone(PARIS_TZ) if now else datetime.now(PARIS_TZ)
+    day_index = int(weather_payload.get("day_index") or 0)
+    consensus = list(weather_payload.get("consensus") or [])
+    flyable_hours = _filter_daylight_hours(
+        consensus,
+        weather_payload.get("sunrise"),
+        weather_payload.get("sunset"),
+    )
+
+    if not flyable_hours:
+        risks = [
+            _diagnostic(
+                "weather_unavailable",
+                "blocking",
+                "flightDecision.risk.weatherUnavailable",
+            )
+        ]
+        return _empty_response(
+            site=site,
+            objective=objective,
+            day_index=day_index,
+            cached_at=weather_payload.get("cached_at"),
+            risks=risks,
+        )
+
+    hourly = [
+        _build_hour_decision(
+            hour=hour,
+            site_orientation=getattr(site, "orientation", None),
+            objective=objective,
+            thresholds=thresholds,
+            day_index=day_index,
+            current_time=current_time,
+        )
+        for hour in flyable_hours
+    ]
+    global_risks = _global_risks(hourly)
+    confidence = _build_confidence(weather_payload, hourly)
+    landing_safety = _build_landing_safety(landing_associations or [])
+    global_risks.extend(landing_safety.get("decision_risks", []))
+
+    if confidence["level"] in {"low", "very_low"}:
+        global_risks.append(
+            _diagnostic(
+                "forecast_confidence_low",
+                "vigilance",
+                "flightDecision.confidence.lowDiagnostic",
+                {"confidence": confidence["score"]},
+            )
+        )
+
+    best_window = _select_best_window(hourly)
+    least_unfavorable = None if best_window else _select_least_unfavorable_window(hourly)
+    summary_level: DecisionLevel = "unavailable"
+    summary_score = 0
+    main_risk_code = global_risks[0]["code"] if global_risks else None
+
+    if best_window:
+        summary_level = best_window["level"]
+        summary_score = best_window["score_objectif"]
+        main_risk_code = (
+            best_window["main_risk_codes"][0] if best_window["main_risk_codes"] else main_risk_code
+        )
+    elif least_unfavorable:
+        summary_level = least_unfavorable["level"]
+        summary_score = least_unfavorable["score_objectif"]
+        main_risk_code = (
+            least_unfavorable["main_risk_codes"][0]
+            if least_unfavorable["main_risk_codes"]
+            else main_risk_code
+        )
+
+    return {
+        "site": {
+            "id": getattr(site, "id", ""),
+            "name": getattr(site, "name", ""),
+            "usage_type": getattr(site, "usage_type", None),
+            "orientation": getattr(site, "orientation", None),
+        },
+        "objective": objective,
+        "timezone": "Europe/Paris",
+        "day_index": day_index,
+        "summary": {
+            "level": summary_level,
+            "translation_key": _level_key(summary_level),
+            "score_objectif": summary_score,
+            "title_key": f"flightDecision.summary.{summary_level}.title",
+            "message_key": f"flightDecision.summary.{summary_level}.message",
+            "message_params": _summary_params(best_window, least_unfavorable, main_risk_code),
+            "main_risk_code": main_risk_code,
+            "has_recommended_window": best_window is not None,
+        },
+        "best_window": best_window,
+        "least_unfavorable_window": least_unfavorable,
+        "hourly": hourly,
+        "risks": global_risks,
+        "confidence": confidence,
+        "landing_safety": {
+            key: value for key, value in landing_safety.items() if key != "decision_risks"
+        },
+        "live_wind": {
+            "status": "not_evaluated",
+            "influences_confidence": False,
+            "stations": [],
+            "diagnostics": [],
+        },
+        "alternatives": [],
+        "cached_at": weather_payload.get("cached_at"),
+    }
+
+
+def _empty_response(
+    *,
+    site: Any,
+    objective: FlightObjective,
+    day_index: int,
+    cached_at: str | None,
+    risks: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "site": {
+            "id": getattr(site, "id", ""),
+            "name": getattr(site, "name", ""),
+            "usage_type": getattr(site, "usage_type", None),
+            "orientation": getattr(site, "orientation", None),
+        },
+        "objective": objective,
+        "timezone": "Europe/Paris",
+        "day_index": day_index,
+        "summary": {
+            "level": "unavailable",
+            "translation_key": _level_key("unavailable"),
+            "score_objectif": 0,
+            "title_key": "flightDecision.summary.unavailable.title",
+            "message_key": "flightDecision.summary.unavailable.message",
+            "message_params": {},
+            "main_risk_code": risks[0]["code"] if risks else None,
+            "has_recommended_window": False,
+        },
+        "best_window": None,
+        "least_unfavorable_window": None,
+        "hourly": [],
+        "risks": risks,
+        "confidence": {
+            "level": "very_low",
+            "score": 0,
+            "translation_key": "flightDecision.confidence.veryLow",
+            "source_count": 0,
+            "expected_source_count": EXPECTED_SOURCE_COUNT,
+            "freshness": {"cached_at": cached_at, "age_minutes": None, "status": "unknown"},
+            "diagnostics": risks,
+        },
+        "landing_safety": {
+            "status": "unavailable",
+            "level": "unavailable",
+            "translation_key": "flightDecision.landingSafety.unavailable",
+            "summary_key": "flightDecision.landingSafety.unavailableSummary",
+            "summary_params": {},
+            "landings": [],
+        },
+        "live_wind": {
+            "status": "not_evaluated",
+            "influences_confidence": False,
+            "stations": [],
+            "diagnostics": [],
+        },
+        "alternatives": [],
+        "cached_at": cached_at,
+    }
+
+
+def _filter_daylight_hours(
+    consensus: list[dict[str, Any]], sunrise: str | None, sunset: str | None
+) -> list[dict[str, Any]]:
+    if not sunrise or not sunset:
+        return consensus
+    try:
+        sunrise_hour = int(sunrise.split(":", maxsplit=1)[0])
+        sunset_hour = int(sunset.split(":", maxsplit=1)[0])
+    except (ValueError, IndexError):
+        return consensus
+    return [h for h in consensus if sunrise_hour <= int(h.get("hour", 0)) <= sunset_hour]
+
+
+def _build_hour_decision(
+    *,
+    hour: dict[str, Any],
+    site_orientation: str | None,
+    objective: FlightObjective,
+    thresholds: dict[str, float],
+    day_index: int,
+    current_time: datetime,
+) -> dict[str, Any]:
+    hour_num = int(hour.get("hour") or 0)
+    para_index = int(hour.get("para_index") or calculate_hourly_para_index(hour, thresholds))
+    score = _score_for_objective(para_index, hour, objective)
+    risks = _hour_risks(hour, thresholds)
+    wind_decollage = _wind_decollage(hour.get("wind_direction"), site_orientation)
+    if wind_decollage["severity"] != "info":
+        risks.append(
+            _diagnostic(
+                f"wind_decollage_{wind_decollage['status']}",
+                wind_decollage["severity"],
+                wind_decollage["translation_key"],
+                {
+                    "angle_deviation_deg": wind_decollage.get("angle_deviation_deg"),
+                    "selected_orientation": wind_decollage.get("selected_orientation"),
+                },
+            )
+        )
+
+    level = _resolve_level(score, risks, thresholds)
+    thermal = _thermal(hour, objective)
+
+    return {
+        "hour": hour_num,
+        "is_past": day_index == 0 and hour_num < current_time.hour,
+        "level": level,
+        "translation_key": _level_key(level),
+        "score_objectif": score,
+        "para_index": para_index,
+        "risks": risks,
+        "wind": {
+            "speed_kmh": hour.get("wind_speed"),
+            "gust_kmh": hour.get("wind_gust"),
+            "direction_deg": hour.get("wind_direction"),
+            "direction_label": _direction_label(hour.get("wind_direction")),
+        },
+        "wind_decollage": wind_decollage,
+        "thermal": thermal,
+        "confidence": _hour_confidence(hour),
+    }
+
+
+def _score_for_objective(para_index: int, hour: dict[str, Any], objective: FlightObjective) -> int:
+    strength = str(hour.get("thermal_strength") or "faible").lower()
+    thunderstorm = _thunderstorm_risk(hour.get("cape"), hour.get("lifted_index"))
+    adjustment = 0
+    if objective == "tranquille":
+        adjustment = 5 if strength == "faible" else -5 if strength == "modere" else -15
+    elif objective == "progression":
+        adjustment = 0 if strength == "faible" else 7 if strength == "modere" else -5
+    elif objective == "thermique":
+        adjustment = -8 if strength == "faible" else 8 if strength == "modere" else 10
+    if thunderstorm in {"modere", "eleve"}:
+        adjustment = min(adjustment, 0)
+    return max(0, min(100, round(para_index + adjustment)))
+
+
+def _hour_risks(hour: dict[str, Any], thresholds: dict[str, float]) -> list[dict[str, Any]]:
+    risks: list[dict[str, Any]] = []
+    wind = hour.get("wind_speed")
+    gust = hour.get("wind_gust")
+    precipitation = hour.get("precipitation") or 0
+    thunderstorm = _thunderstorm_risk(hour.get("cape"), hour.get("lifted_index"))
+
+    if wind is None:
+        risks.append(_diagnostic("wind_missing", "limiting", "flightDecision.risk.windMissing"))
+    elif wind > thresholds["para_wind_high_max"]:
+        risks.append(
+            _diagnostic(
+                "wind_too_strong",
+                "blocking",
+                "flightDecision.risk.windTooStrong",
+                {"wind_kmh": round(wind, 1), "threshold_kmh": thresholds["para_wind_high_max"]},
+            )
+        )
+    elif wind < thresholds["para_wind_low_max"]:
+        risks.append(
+            _diagnostic(
+                "wind_too_weak",
+                "limiting",
+                "flightDecision.risk.windTooWeak",
+                {"wind_kmh": round(wind, 1), "threshold_kmh": thresholds["para_wind_low_max"]},
+            )
+        )
+    elif wind < thresholds["para_wind_weak_max"]:
+        risks.append(
+            _diagnostic(
+                "wind_weak",
+                "vigilance",
+                "flightDecision.risk.windWeak",
+                {"wind_kmh": round(wind, 1), "threshold_kmh": thresholds["para_wind_weak_max"]},
+            )
+        )
+
+    if gust is not None and gust >= thresholds["para_gust_high_max"]:
+        risks.append(
+            _diagnostic(
+                "gust_high",
+                "blocking",
+                "flightDecision.risk.gustHigh",
+                {"gust_kmh": round(gust, 1), "threshold_kmh": thresholds["para_gust_high_max"]},
+            )
+        )
+
+    if precipitation > thresholds["para_slot_precipitation_max"]:
+        risks.append(
+            _diagnostic(
+                "rain_significant",
+                "blocking",
+                "flightDecision.risk.rainSignificant",
+                {
+                    "precipitation_mm": round(precipitation, 1),
+                    "threshold_mm": thresholds["para_slot_precipitation_max"],
+                },
+            )
+        )
+
+    if thunderstorm == "faible":
+        risks.append(
+            _diagnostic("thunderstorm_low", "vigilance", "flightDecision.risk.thunderstormLow")
+        )
+    elif thunderstorm == "modere":
+        risks.append(
+            _diagnostic(
+                "thunderstorm_moderate", "limiting", "flightDecision.risk.thunderstormModerate"
+            )
+        )
+    elif thunderstorm == "eleve":
+        risks.append(
+            _diagnostic("thunderstorm_high", "blocking", "flightDecision.risk.thunderstormHigh")
+        )
+
+    return risks
+
+
+def _resolve_level(
+    score: int, risks: list[dict[str, Any]], thresholds: dict[str, float]
+) -> DecisionLevel:
+    if score >= thresholds["para_verdict_good_min"]:
+        level: DecisionLevel = "favorable"
+    elif score >= thresholds["para_verdict_medium_min"]:
+        level = "vigilance"
+    elif score >= thresholds["para_verdict_limit_min"]:
+        level = "limite"
+    else:
+        level = "deconseille"
+
+    severities = {risk["severity"] for risk in risks}
+    if "blocking" in severities:
+        return "limite" if score >= thresholds["para_verdict_limit_min"] else "deconseille"
+    if "limiting" in severities and level == "favorable":
+        return "vigilance"
+    if "vigilance" in severities and level == "favorable":
+        return "vigilance"
+    return level
+
+
+def _wind_decollage(direction_deg: float | None, orientation: str | None) -> dict[str, Any]:
+    if direction_deg is None:
+        return {
+            "status": "not_evaluated",
+            "translation_key": "flightDecision.windDecollage.not_evaluated",
+            "angle_deviation_deg": None,
+            "selected_orientation": None,
+            "severity": "vigilance",
+        }
+
+    orientations = _parse_orientations(orientation)
+    if not orientations:
+        return {
+            "status": "orientation_unknown",
+            "translation_key": "flightDecision.windDecollage.orientation_unknown",
+            "angle_deviation_deg": None,
+            "selected_orientation": None,
+            "severity": "vigilance",
+        }
+
+    selected, deviation = min(
+        ((label, _angle_delta(direction_deg, degrees)) for label, degrees in orientations),
+        key=lambda item: item[1],
+    )
+    if deviation <= 30:
+        status, severity = "face", "info"
+    elif deviation <= 60:
+        status, severity = "travers_acceptable", "vigilance"
+    elif deviation <= 100:
+        status, severity = "travers_fort", "limiting"
+    else:
+        status, severity = "cul", "blocking"
+
+    return {
+        "status": status,
+        "translation_key": f"flightDecision.windDecollage.{status}",
+        "angle_deviation_deg": round(deviation),
+        "selected_orientation": selected,
+        "severity": severity,
+    }
+
+
+def _parse_orientations(value: str | None) -> list[tuple[str, float]]:
+    if not value:
+        return []
+    normalized = value.upper().replace("/", ",").replace(";", ",").replace(" ", ",")
+    labels = [part.strip() for part in normalized.split(",") if part.strip()]
+    return [
+        (label, _CARDINAL_TO_DEGREES[label]) for label in labels if label in _CARDINAL_TO_DEGREES
+    ]
+
+
+def _angle_delta(a: float, b: float) -> float:
+    return abs((a - b + 180) % 360 - 180)
+
+
+def _direction_label(degrees: float | None) -> str | None:
+    if degrees is None:
+        return None
+    labels = ["N", "NE", "E", "SE", "S", "SO", "O", "NO"]
+    return labels[round((degrees % 360) / 45) % 8]
+
+
+def _thermal(hour: dict[str, Any], objective: FlightObjective) -> dict[str, Any]:
+    strength = str(hour.get("thermal_strength") or "faible").lower()
+    if objective == "tranquille":
+        effect = (
+            "positive"
+            if strength == "faible"
+            else "vigilance" if strength == "modere" else "limiting"
+        )
+    elif objective == "progression":
+        effect = (
+            "neutral"
+            if strength == "faible"
+            else "positive" if strength == "modere" else "vigilance"
+        )
+    else:
+        effect = "limiting" if strength == "faible" else "positive"
+    return {
+        "strength": strength,
+        "cape": hour.get("cape"),
+        "lifted_index": hour.get("lifted_index"),
+        "objective_effect": effect,
+        "translation_key": f"flightDecision.thermal.{objective}.{effect}",
+    }
+
+
+def _hour_confidence(hour: dict[str, Any]) -> dict[str, Any]:
+    source_count = int(hour.get("num_sources") or len(hour.get("sources") or {}) or 0)
+    score = min(100, max(20, source_count * 20)) if source_count else 20
+    return {"level": _confidence_level(score), "score": score}
+
+
+def _build_confidence(
+    weather_payload: dict[str, Any], hourly: list[dict[str, Any]]
+) -> dict[str, Any]:
+    source_count = int(
+        weather_payload.get("total_sources")
+        or max((h["confidence"]["score"] // 20 for h in hourly), default=0)
+    )
+    score = min(100, max(10, source_count * 20)) if source_count else 10
+    diagnostics: list[dict[str, Any]] = []
+    if source_count <= 1:
+        diagnostics.append(
+            _diagnostic(
+                "single_forecast_source",
+                "vigilance",
+                "flightDecision.confidence.singleForecastSource",
+                {"source_count": source_count},
+            )
+        )
+        score = min(score, 45)
+    cached_at = weather_payload.get("cached_at")
+    freshness = {"cached_at": cached_at, "age_minutes": None, "status": "unknown"}
+    return {
+        "level": _confidence_level(score),
+        "score": score,
+        "translation_key": f"flightDecision.confidence.{_confidence_level(score)}",
+        "source_count": source_count,
+        "expected_source_count": EXPECTED_SOURCE_COUNT,
+        "freshness": freshness,
+        "diagnostics": diagnostics,
+    }
+
+
+def _confidence_level(score: int) -> str:
+    if score >= 80:
+        return "high"
+    if score >= 55:
+        return "medium"
+    if score >= 30:
+        return "low"
+    return "very_low"
+
+
+def _build_landing_safety(associations: list[Any]) -> dict[str, Any]:
+    if not associations:
+        risk = _diagnostic(
+            "landing_not_configured",
+            "vigilance",
+            "flightDecision.landingSafety.notConfiguredDiagnostic",
+        )
+        return {
+            "status": "not_configured",
+            "level": "vigilance",
+            "translation_key": "flightDecision.landingSafety.notConfigured",
+            "summary_key": "flightDecision.landingSafety.notConfiguredSummary",
+            "summary_params": {},
+            "landings": [],
+            "decision_risks": [risk],
+        }
+
+    landings = []
+    for assoc in associations:
+        landing = getattr(assoc, "landing_site", None)
+        landings.append(
+            {
+                "site_id": getattr(landing, "id", getattr(assoc, "landing_site_id", "")),
+                "name": getattr(landing, "name", getattr(assoc, "landing_site_id", "")),
+                "distance_km": getattr(assoc, "distance_km", None),
+                "is_primary": bool(getattr(assoc, "is_primary", False)),
+                "level": "unavailable",
+                "score_objectif": None,
+                "risks": [
+                    _diagnostic(
+                        "landing_weather_not_evaluated",
+                        "vigilance",
+                        "flightDecision.landingSafety.weatherNotEvaluated",
+                    )
+                ],
+            }
+        )
+
+    risk = _diagnostic(
+        "landing_weather_not_evaluated",
+        "vigilance",
+        "flightDecision.landingSafety.weatherNotEvaluated",
+    )
+    return {
+        "status": "unavailable",
+        "level": "vigilance",
+        "translation_key": "flightDecision.landingSafety.unavailable",
+        "summary_key": "flightDecision.landingSafety.unavailableSummary",
+        "summary_params": {"total_count": len(landings)},
+        "landings": landings,
+        "decision_risks": [risk],
+    }
+
+
+def _select_best_window(hourly: list[dict[str, Any]]) -> dict[str, Any] | None:
+    windows = _build_windows(
+        [h for h in hourly if not h["is_past"] and h["level"] in {"favorable", "vigilance"}]
+    )
+    if not windows:
+        return None
+    return max(
+        windows,
+        key=lambda window: (
+            _LEVEL_RANK[window["level"]],
+            window["score_objectif"],
+            len(window["hours"]),
+            -window["start_hour"],
+        ),
+    )
+
+
+def _select_least_unfavorable_window(hourly: list[dict[str, Any]]) -> dict[str, Any] | None:
+    candidates = [h for h in hourly if not h["is_past"] and h["level"] != "unavailable"]
+    if not candidates:
+        return None
+    best_hour = max(candidates, key=lambda h: (_LEVEL_RANK[h["level"]], h["score_objectif"]))
+    return _window_from_hours([best_hour])
+
+
+def _build_windows(hours: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not hours:
+        return []
+    sorted_hours = sorted(hours, key=lambda h: h["hour"])
+    groups: list[list[dict[str, Any]]] = [[sorted_hours[0]]]
+    for hour in sorted_hours[1:]:
+        if hour["hour"] == groups[-1][-1]["hour"] + 1:
+            groups[-1].append(hour)
+        else:
+            groups.append([hour])
+    return [_window_from_hours(group) for group in groups]
+
+
+def _window_from_hours(hours: list[dict[str, Any]]) -> dict[str, Any]:
+    min_level = min(hours, key=lambda h: _LEVEL_RANK[h["level"]])["level"]
+    min_score = min(int(h["score_objectif"]) for h in hours)
+    main_risks = list(dict.fromkeys(risk["code"] for h in hours for risk in h["risks"]))
+    start_hour = min(h["hour"] for h in hours)
+    end_hour = max(h["hour"] for h in hours)
+    return {
+        "start_hour": start_hour,
+        "end_hour": end_hour,
+        "level": min_level,
+        "translation_key": _level_key(min_level),
+        "score_objectif": min_score,
+        "min_score_objectif": min_score,
+        "hours": [h["hour"] for h in hours],
+        "main_risk_codes": main_risks,
+        "summary_key": f"flightDecision.window.{min_level}",
+        "summary_params": {"start_hour": start_hour, "end_hour": end_hour, "score": min_score},
+    }
+
+
+def _global_risks(hourly: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_code: dict[str, dict[str, Any]] = {}
+    for hour in hourly:
+        for risk in hour["risks"]:
+            current = by_code.get(risk["code"])
+            if current is None or _severity_rank(risk["severity"]) > _severity_rank(
+                current["severity"]
+            ):
+                by_code[risk["code"]] = risk
+    return sorted(by_code.values(), key=lambda risk: _severity_rank(risk["severity"]), reverse=True)
+
+
+def _severity_rank(severity: str) -> int:
+    return {"info": 0, "vigilance": 1, "limiting": 2, "blocking": 3}.get(severity, 0)
+
+
+def _summary_params(
+    best_window: dict[str, Any] | None,
+    least_unfavorable: dict[str, Any] | None,
+    main_risk_code: str | None,
+) -> dict[str, Any]:
+    window = best_window or least_unfavorable
+    if not window:
+        return {"main_reason": main_risk_code}
+    return {
+        "main_reason": main_risk_code,
+        "start_hour": window["start_hour"],
+        "end_hour": window["end_hour"],
+    }
+
+
+def _diagnostic(
+    code: str,
+    severity: RiskSeverity,
+    translation_key: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "severity": severity,
+        "translation_key": translation_key,
+        "params": params or {},
+    }
+
+
+def _level_key(level: DecisionLevel) -> str:
+    return f"flightDecision.level.{level}"
+
+
+def _thunderstorm_risk(cape: float | None, lifted_index: float | None) -> str:
+    if cape is None and lifted_index is None:
+        return "nul"
+    if cape is None:
+        if lifted_index is not None and lifted_index <= -7:
+            return "eleve"
+        if lifted_index is not None and lifted_index <= -5:
+            return "modere"
+        if lifted_index is not None and lifted_index <= -3:
+            return "faible"
+        return "nul"
+    if cape >= 2500 or (cape >= 1500 and lifted_index is not None and lifted_index <= -4):
+        return "eleve"
+    if cape >= 1500 or (cape >= 800 and lifted_index is not None and lifted_index <= -2):
+        return "modere"
+    if cape >= 300 or (lifted_index is not None and lifted_index <= -3):
+        return "faible"
+    return "nul"

--- a/apps/backend/flight_decision.py
+++ b/apps/backend/flight_decision.py
@@ -248,7 +248,12 @@ def _build_hour_decision(
     current_time: datetime,
 ) -> dict[str, Any]:
     hour_num = int(hour.get("hour") or 0)
-    para_index = int(hour.get("para_index") or calculate_hourly_para_index(hour, thresholds))
+    raw_para_index = hour.get("para_index")
+    para_index = int(
+        raw_para_index
+        if raw_para_index is not None
+        else calculate_hourly_para_index(hour, thresholds)
+    )
     score = _score_for_objective(para_index, hour, objective)
     risks = _hour_risks(hour, thresholds)
     wind_decollage = _wind_decollage(hour.get("wind_direction"), site_orientation)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -39,6 +39,7 @@ from auth import (
 from database import get_db
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_backfill import calculate_and_persist_missing_max_speed
+from flight_decision import build_flight_decision, normalize_objective
 from flight_storage import flight_sequence_number
 from flight_storage import write_flight_text_file
 from gopro_overlay_export import cancel_gopro_overlay_job
@@ -84,6 +85,7 @@ from schemas import (
     LocationSearchResponse,
     NearbyFlightOptionsResponse,
 )
+from schemas import FlightDecisionResponse
 from schemas import Site as SiteSchema
 from schemas import (
     SiteCreate,
@@ -1672,6 +1674,11 @@ async def get_landing_associations_weather(
     associations = (
         db.query(SiteLandingAssociation)
         .filter(SiteLandingAssociation.takeoff_site_id == site_id)
+        .order_by(
+            SiteLandingAssociation.is_primary.desc(),
+            SiteLandingAssociation.distance_km.asc(),
+            SiteLandingAssociation.id.asc(),
+        )
         .limit(10)
         .all()
     )
@@ -2910,6 +2917,58 @@ async def get_site_live_wind(site_id: str, db: Session = Depends(get_db)):
     }
     await set_cached(cache_key, result, cache_ttl)
     return result
+
+
+@public_router.get("/flight-decision/{site_id}", response_model=FlightDecisionResponse)
+async def get_flight_decision(
+    site_id: str,
+    day_index: int = Query(default=0, ge=0, le=6),
+    objective: str | None = Query(default=None),
+    db: Session = Depends(get_db),
+) -> FlightDecisionResponse:
+    """Get the backend-owned flight decision for a selected site."""
+    from app_settings import get_setting
+
+    site = db.query(Site).filter(Site.id == site_id).first()
+    if not site:
+        raise HTTPException(status_code=404, detail="Site not found")
+    if site.latitude is None or site.longitude is None:
+        raise HTTPException(status_code=400, detail="Site has no coordinates")
+
+    selected_objective = normalize_objective(
+        objective or get_setting("default_flight_objective", db=db, default="tranquille")
+    )
+    day_result = await get_normalized_forecast(
+        site.latitude,
+        site.longitude,
+        day_index,
+        site_name=site.name,
+        elevation_m=site.elevation_m,
+        db=db,
+    )
+    if not day_result.get("success"):
+        raise HTTPException(
+            status_code=502,
+            detail=day_result.get("error", f"No forecast data available for {site.name}"),
+        )
+
+    associations = (
+        db.query(SiteLandingAssociation)
+        .filter(SiteLandingAssociation.takeoff_site_id == site_id)
+        .limit(10)
+        .all()
+    )
+    return build_flight_decision(
+        site=site,
+        weather_payload={
+            **day_result,
+            "site_id": site.id,
+            "site_name": site.name,
+            "day_index": day_index,
+        },
+        objective=selected_objective,
+        landing_associations=associations,
+    )
 
 
 @public_router.get("/weather/{spot_id}/summary")
@@ -7082,6 +7141,9 @@ def update_app_settings(
         "ui_reason_cloud_very_cloudy_min": (0, 100),
         "ui_reason_wind_moderate_min": (0, 150),
     }
+    enum_keys: dict[str, set[str]] = {
+        "default_flight_objective": {"tranquille", "progression", "thermique"},
+    }
     validated_updates: dict[str, str] = {}
 
     for key, value in settings.items():
@@ -7123,6 +7185,13 @@ def update_app_settings(
                     detail=f"{key} must be between {min_value:g} and {max_value:g}",
                 )
             normalized_value = f"{parsed_value:g}"
+        elif key in enum_keys:
+            if normalized_value not in enum_keys[key]:
+                allowed_values = ", ".join(sorted(enum_keys[key]))
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{key} must be one of: {allowed_values}",
+                )
         validated_updates[key] = normalized_value
 
     effective_settings = {**DEFAULTS, **get_all_settings(db), **validated_updates}

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -2936,7 +2936,9 @@ async def get_flight_decision(
         raise HTTPException(status_code=400, detail="Site has no coordinates")
 
     selected_objective = normalize_objective(
-        objective or get_setting("default_flight_objective", db=db, default="tranquille")
+        objective
+        if objective in {"tranquille", "progression", "thermique"}
+        else get_setting("default_flight_objective", db=db, default="tranquille")
     )
     day_result = await get_normalized_forecast(
         site.latitude,
@@ -2955,6 +2957,11 @@ async def get_flight_decision(
     associations = (
         db.query(SiteLandingAssociation)
         .filter(SiteLandingAssociation.takeoff_site_id == site_id)
+        .order_by(
+            SiteLandingAssociation.is_primary.desc(),
+            SiteLandingAssociation.distance_km.asc(),
+            SiteLandingAssociation.id.asc(),
+        )
         .limit(10)
         .all()
     )

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -522,6 +522,7 @@ class FlightDecisionThermal(BaseModel):
 class FlightDecisionHourConfidence(BaseModel):
     level: str
     score: int
+    source_count: int
 
 
 class FlightDecisionHour(BaseModel):

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -453,6 +453,150 @@ class NearbyFlightOptionsResponse(BaseModel):
     landings: list[ParaglidingSpotSearchResult]
 
 
+FlightDecisionLevel = Literal["favorable", "vigilance", "limite", "deconseille", "unavailable"]
+FlightDecisionRiskSeverity = Literal["info", "vigilance", "limiting", "blocking"]
+FlightDecisionObjective = Literal["tranquille", "progression", "thermique"]
+
+
+class FlightDecisionDiagnostic(BaseModel):
+    code: str
+    severity: FlightDecisionRiskSeverity
+    translation_key: str
+    params: dict[str, Any] = {}
+
+
+class FlightDecisionSite(BaseModel):
+    id: str
+    name: str
+    usage_type: str | None = None
+    orientation: str | None = None
+
+
+class FlightDecisionSummary(BaseModel):
+    level: FlightDecisionLevel
+    translation_key: str
+    score_objectif: int
+    title_key: str
+    message_key: str
+    message_params: dict[str, Any]
+    main_risk_code: str | None = None
+    has_recommended_window: bool
+
+
+class FlightDecisionWindow(BaseModel):
+    start_hour: int
+    end_hour: int
+    level: FlightDecisionLevel
+    translation_key: str
+    score_objectif: int
+    min_score_objectif: int
+    hours: list[int]
+    main_risk_codes: list[str]
+    summary_key: str
+    summary_params: dict[str, Any]
+
+
+class FlightDecisionWind(BaseModel):
+    speed_kmh: float | None = None
+    gust_kmh: float | None = None
+    direction_deg: float | None = None
+    direction_label: str | None = None
+
+
+class FlightDecisionWindDecollage(BaseModel):
+    status: str
+    translation_key: str
+    angle_deviation_deg: int | None = None
+    selected_orientation: str | None = None
+    severity: FlightDecisionRiskSeverity
+
+
+class FlightDecisionThermal(BaseModel):
+    strength: str
+    cape: float | None = None
+    lifted_index: float | None = None
+    objective_effect: str
+    translation_key: str
+
+
+class FlightDecisionHourConfidence(BaseModel):
+    level: str
+    score: int
+
+
+class FlightDecisionHour(BaseModel):
+    hour: int
+    is_past: bool
+    level: FlightDecisionLevel
+    translation_key: str
+    score_objectif: int
+    para_index: int
+    risks: list[FlightDecisionDiagnostic]
+    wind: FlightDecisionWind
+    wind_decollage: FlightDecisionWindDecollage
+    thermal: FlightDecisionThermal
+    confidence: FlightDecisionHourConfidence
+
+
+class FlightDecisionFreshness(BaseModel):
+    cached_at: str | None = None
+    age_minutes: int | None = None
+    status: str
+
+
+class FlightDecisionConfidence(BaseModel):
+    level: str
+    score: int
+    translation_key: str
+    source_count: int
+    expected_source_count: int
+    freshness: FlightDecisionFreshness
+    diagnostics: list[FlightDecisionDiagnostic]
+
+
+class FlightDecisionLanding(BaseModel):
+    site_id: str
+    name: str
+    distance_km: float | None = None
+    is_primary: bool
+    level: FlightDecisionLevel
+    score_objectif: int | None = None
+    risks: list[FlightDecisionDiagnostic]
+
+
+class FlightDecisionLandingSafety(BaseModel):
+    status: Literal["evaluated", "not_configured", "unavailable"]
+    level: FlightDecisionLevel
+    translation_key: str
+    summary_key: str
+    summary_params: dict[str, Any]
+    landings: list[FlightDecisionLanding]
+
+
+class FlightDecisionLiveWind(BaseModel):
+    status: Literal["not_evaluated", "unavailable", "evaluated", "stale"]
+    influences_confidence: bool
+    stations: list[dict[str, Any]]
+    diagnostics: list[FlightDecisionDiagnostic]
+
+
+class FlightDecisionResponse(BaseModel):
+    site: FlightDecisionSite
+    objective: FlightDecisionObjective
+    timezone: str
+    day_index: int
+    summary: FlightDecisionSummary
+    best_window: FlightDecisionWindow | None = None
+    least_unfavorable_window: FlightDecisionWindow | None = None
+    hourly: list[FlightDecisionHour]
+    risks: list[FlightDecisionDiagnostic]
+    confidence: FlightDecisionConfidence
+    landing_safety: FlightDecisionLandingSafety
+    live_wind: FlightDecisionLiveWind
+    alternatives: list[dict[str, Any]]
+    cached_at: str | None = None
+
+
 class SyncSpotsResponse(BaseModel):
     """Response for sync operation"""
 

--- a/apps/backend/tests/api/test_routes_flight_decision.py
+++ b/apps/backend/tests/api/test_routes_flight_decision.py
@@ -1,3 +1,6 @@
+import app_settings
+from models import AppSetting
+
 API_PREFIX = "/api"
 
 
@@ -63,6 +66,10 @@ class TestFlightDecisionEndpoint:
     ):
         import routes
 
+        app_settings.invalidate_cache()
+        db_session.add(AppSetting(key="default_flight_objective", value="thermique"))
+        db_session.commit()
+
         async def fake_forecast(*args, **kwargs):
             return _forecast_payload()
 
@@ -71,4 +78,5 @@ class TestFlightDecisionEndpoint:
         response = client.get(f"{API_PREFIX}/flight-decision/site-arguel?objective=distance")
 
         assert response.status_code == 200
-        assert response.json()["objective"] == "tranquille"
+        assert response.json()["objective"] == "thermique"
+        app_settings.invalidate_cache()

--- a/apps/backend/tests/api/test_routes_flight_decision.py
+++ b/apps/backend/tests/api/test_routes_flight_decision.py
@@ -1,0 +1,74 @@
+API_PREFIX = "/api"
+
+
+def _forecast_payload():
+    return {
+        "success": True,
+        "sunrise": "08:00",
+        "sunset": "18:00",
+        "cached_at": "2026-05-30T10:00:00Z",
+        "total_sources": 4,
+        "consensus": [
+            {
+                "hour": 12,
+                "num_sources": 4,
+                "temperature": 20,
+                "wind_speed": 12,
+                "wind_gust": 16,
+                "wind_direction": 225,
+                "precipitation": 0,
+                "cloud_cover": 30,
+                "cape": 100,
+                "lifted_index": 0,
+                "thermal_strength": "faible",
+            }
+        ],
+    }
+
+
+class TestFlightDecisionEndpoint:
+    def test_invalid_site_returns_404(self, client, db_session):
+        response = client.get(f"{API_PREFIX}/flight-decision/missing-site")
+
+        assert response.status_code == 404
+
+    def test_returns_decision_contract(self, client, db_session, arguel_site, monkeypatch):
+        import routes
+
+        async def fake_forecast(*args, **kwargs):
+            return _forecast_payload()
+
+        monkeypatch.setattr(routes, "get_normalized_forecast", fake_forecast)
+
+        response = client.get(
+            f"{API_PREFIX}/flight-decision/site-arguel?day_index=1&objective=progression"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["site"]["id"] == "site-arguel"
+        assert data["objective"] == "progression"
+        assert data["timezone"] == "Europe/Paris"
+        assert data["summary"]["level"] in {"favorable", "vigilance"}
+        assert data["summary"]["translation_key"].startswith("flightDecision.level.")
+        assert data["best_window"] is not None
+        assert data["hourly"][0]["score_objectif"] >= 0
+        assert data["hourly"][0]["wind_decollage"]["status"] == "face"
+        assert data["confidence"]["translation_key"].startswith("flightDecision.confidence.")
+        assert data["live_wind"]["status"] == "not_evaluated"
+        assert data["alternatives"] == []
+
+    def test_invalid_objective_falls_back_to_default(
+        self, client, db_session, arguel_site, monkeypatch
+    ):
+        import routes
+
+        async def fake_forecast(*args, **kwargs):
+            return _forecast_payload()
+
+        monkeypatch.setattr(routes, "get_normalized_forecast", fake_forecast)
+
+        response = client.get(f"{API_PREFIX}/flight-decision/site-arguel?objective=distance")
+
+        assert response.status_code == 200
+        assert response.json()["objective"] == "tranquille"

--- a/apps/backend/tests/api/test_routes_settings.py
+++ b/apps/backend/tests/api/test_routes_settings.py
@@ -25,6 +25,7 @@ class TestGetSettings:
         data = response.json()
         assert "video_export_dir" not in data
         assert "video_temp_images_dir" not in data
+        assert data["default_flight_objective"] == "tranquille"
 
     def test_get_settings_returns_all(self, client, db_session):
         """Returns all settings as key-value pairs."""
@@ -175,6 +176,39 @@ class TestUpdateSettings:
         )
         assert radius_row is not None and radius_row.value == "12"
         assert ttl_row is not None and ttl_row.value == "420"
+
+    def test_update_default_flight_objective(self, client, db_session):
+        """Updates the default flight objective when the value is known."""
+        response = client.put(
+            f"{API_PREFIX}/settings",
+            json={"default_flight_objective": "thermique"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["updated"]["default_flight_objective"] == "thermique"
+
+        row = (
+            db_session.query(AppSetting)
+            .filter(AppSetting.key == "default_flight_objective")
+            .first()
+        )
+        assert row is not None and row.value == "thermique"
+
+    def test_rejects_invalid_default_flight_objective(self, client, db_session):
+        """Rejects unknown flight objectives without persisting them."""
+        response = client.put(
+            f"{API_PREFIX}/settings",
+            json={"default_flight_objective": "distance"},
+        )
+        assert response.status_code == 400
+        assert "default_flight_objective must be one of" in response.json()["detail"]
+
+        row = (
+            db_session.query(AppSetting)
+            .filter(AppSetting.key == "default_flight_objective")
+            .first()
+        )
+        assert row is None
 
     def test_rejects_retired_video_storage_settings(self, client, db_session):
         """Video storage folders are managed by Docker volume mapping only."""

--- a/apps/backend/tests/unit/test_flight_decision.py
+++ b/apps/backend/tests/unit/test_flight_decision.py
@@ -14,17 +14,19 @@ def _site(orientation: str | None = "SW"):
     )
 
 
-def _payload(consensus: list[dict], total_sources: int = 4):
-    return {
+def _payload(consensus: list[dict], total_sources: int | None = 4):
+    payload = {
         "site_id": "site-arguel",
         "site_name": "Arguel",
         "day_index": 1,
         "sunrise": "08:00",
         "sunset": "18:00",
         "consensus": consensus,
-        "total_sources": total_sources,
         "cached_at": "2026-05-30T10:00:00Z",
     }
+    if total_sources is not None:
+        payload["total_sources"] = total_sources
+    return payload
 
 
 def _hour(hour: int, **overrides):
@@ -70,6 +72,32 @@ def test_blocking_gust_prevents_recommended_window():
     assert result["best_window"] is None
     assert result["least_unfavorable_window"]["level"] == "limite"
     assert any(risk["code"] == "gust_high" for risk in result["hourly"][0]["risks"])
+
+
+def test_summary_uses_highest_severity_window_risk_first():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([_hour(11, wind_speed=2, wind_gust=38)]),
+        objective="progression",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["best_window"] is None
+    assert result["least_unfavorable_window"]["main_risk_codes"][0] == "gust_high"
+    assert result["summary"]["main_risk_code"] == "gust_high"
+
+
+def test_confidence_keeps_zero_source_hours_when_total_sources_missing():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([_hour(11, num_sources=0)], total_sources=None),
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["hourly"][0]["confidence"]["source_count"] == 0
+    assert result["confidence"]["source_count"] == 0
+    assert result["confidence"]["score"] == 10
 
 
 def test_tailwind_is_blocking_for_decollage_orientation():

--- a/apps/backend/tests/unit/test_flight_decision.py
+++ b/apps/backend/tests/unit/test_flight_decision.py
@@ -1,0 +1,117 @@
+from datetime import datetime
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+from flight_decision import build_flight_decision
+
+
+def _site(orientation: str | None = "SW"):
+    return SimpleNamespace(
+        id="site-arguel",
+        name="Arguel",
+        usage_type="takeoff",
+        orientation=orientation,
+    )
+
+
+def _payload(consensus: list[dict], total_sources: int = 4):
+    return {
+        "site_id": "site-arguel",
+        "site_name": "Arguel",
+        "day_index": 1,
+        "sunrise": "08:00",
+        "sunset": "18:00",
+        "consensus": consensus,
+        "total_sources": total_sources,
+        "cached_at": "2026-05-30T10:00:00Z",
+    }
+
+
+def _hour(hour: int, **overrides):
+    data = {
+        "hour": hour,
+        "num_sources": 4,
+        "temperature": 18,
+        "wind_speed": 12,
+        "wind_gust": 16,
+        "wind_direction": 225,
+        "precipitation": 0,
+        "cloud_cover": 30,
+        "cape": 100,
+        "lifted_index": 0,
+        "thermal_strength": "faible",
+    }
+    data.update(overrides)
+    return data
+
+
+def test_builds_favorable_window_for_quiet_objective():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([_hour(11), _hour(12)]),
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["summary"]["level"] == "favorable"
+    assert result["best_window"]["start_hour"] == 11
+    assert result["best_window"]["end_hour"] == 12
+    assert result["best_window"]["score_objectif"] >= result["hourly"][0]["para_index"]
+
+
+def test_blocking_gust_prevents_recommended_window():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([_hour(11, wind_gust=38)]),
+        objective="progression",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["best_window"] is None
+    assert result["least_unfavorable_window"]["level"] == "limite"
+    assert any(risk["code"] == "gust_high" for risk in result["hourly"][0]["risks"])
+
+
+def test_tailwind_is_blocking_for_decollage_orientation():
+    result = build_flight_decision(
+        site=_site("SW"),
+        weather_payload=_payload([_hour(11, wind_direction=45)]),
+        objective="progression",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["hourly"][0]["wind_decollage"]["status"] == "cul"
+    assert result["hourly"][0]["level"] == "limite"
+    assert result["best_window"] is None
+
+
+def test_objective_changes_thermal_score_without_changing_para_index():
+    payload = _payload([_hour(11, thermal_strength="fort", cape=700, lifted_index=-1)])
+    quiet = build_flight_decision(
+        site=_site(),
+        weather_payload=payload,
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+    thermal = build_flight_decision(
+        site=_site(),
+        weather_payload=payload,
+        objective="thermique",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert quiet["hourly"][0]["para_index"] == thermal["hourly"][0]["para_index"]
+    assert quiet["hourly"][0]["score_objectif"] < thermal["hourly"][0]["score_objectif"]
+
+
+def test_unavailable_when_no_hourly_weather():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([]),
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["summary"]["level"] == "unavailable"
+    assert result["hourly"] == []
+    assert result["risks"][0]["translation_key"] == "flightDecision.risk.weatherUnavailable"

--- a/apps/backend/tests/unit/test_flight_decision.py
+++ b/apps/backend/tests/unit/test_flight_decision.py
@@ -132,6 +132,17 @@ def test_objective_changes_thermal_score_without_changing_para_index():
     assert quiet["hourly"][0]["score_objectif"] < thermal["hourly"][0]["score_objectif"]
 
 
+def test_preserves_explicit_zero_para_index():
+    result = build_flight_decision(
+        site=_site(),
+        weather_payload=_payload([_hour(11, para_index=0)]),
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 9, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["hourly"][0]["para_index"] == 0
+
+
 def test_unavailable_when_no_hourly_weather():
     result = build_flight_decision(
         site=_site(),

--- a/apps/frontend/src/components/weather/FlightDecisionCockpit.tsx
+++ b/apps/frontend/src/components/weather/FlightDecisionCockpit.tsx
@@ -1,0 +1,225 @@
+import { useTranslation } from 'react-i18next';
+import {
+  AlertTriangle,
+  Clock,
+  Compass,
+  ShieldCheck,
+  Target,
+} from 'lucide-react';
+import type {
+  FlightDecisionResponse,
+  FlightObjective,
+} from '@dashboard-parapente/shared-types';
+import { Button } from '@dashboard-parapente/design-system';
+import {
+  FLIGHT_OBJECTIVES,
+  DEFAULT_FLIGHT_OBJECTIVE,
+} from '../../hooks/weather/useFlightDecision';
+import {
+  getVerdictVisual,
+  weatherCardClassName,
+  weatherSectionTitleClassName,
+} from './weatherUi';
+
+type FlightDecisionCockpitProps = {
+  decision?: FlightDecisionResponse;
+  objective: FlightObjective;
+  isLoading?: boolean;
+  isError?: boolean;
+  isCityContext?: boolean;
+  onObjectiveChange: (objective: FlightObjective) => void;
+};
+
+const levelToVerdict = (level: string) => {
+  if (level === 'favorable') return 'bon';
+  if (level === 'vigilance') return 'moyen';
+  if (level === 'limite') return 'limite';
+  return 'mauvais';
+};
+
+const formatHourWindow = (start: number, end: number) =>
+  start === end ? `${start}h` : `${start}h-${end}h`;
+
+export default function FlightDecisionCockpit({
+  decision,
+  objective,
+  isLoading = false,
+  isError = false,
+  isCityContext = false,
+  onObjectiveChange,
+}: FlightDecisionCockpitProps) {
+  const { t } = useTranslation();
+  const activeObjective = objective ?? DEFAULT_FLIGHT_OBJECTIVE;
+  const translate = (key: string, params?: Record<string, unknown>) =>
+    String(t(key, params));
+
+  if (isCityContext) {
+    return (
+      <section className={`${weatherCardClassName} p-4 sm:p-5`}>
+        <p className={weatherSectionTitleClassName}>
+          {t('flightDecision.context.title')}
+        </p>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          {t('flightDecision.context.description')}
+        </p>
+      </section>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <section
+        className={`${weatherCardClassName} p-4 sm:p-5`}
+        aria-live="polite"
+      >
+        <p className={weatherSectionTitleClassName}>
+          {t('flightDecision.title')}
+        </p>
+        <div className="mt-4 rounded-2xl bg-slate-100 p-4 text-sm font-semibold text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+          {t('common.loading')}
+        </div>
+      </section>
+    );
+  }
+
+  if (isError || !decision) {
+    return (
+      <section className={`${weatherCardClassName} p-4 sm:p-5`} role="alert">
+        <p className={weatherSectionTitleClassName}>
+          {t('flightDecision.title')}
+        </p>
+        <div className="mt-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm font-semibold text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+          {t('flightDecision.loadError')}
+        </div>
+      </section>
+    );
+  }
+
+  const visual = getVerdictVisual(levelToVerdict(decision.summary.level));
+  const VerdictIcon = visual.Icon;
+  const window = decision.best_window ?? decision.least_unfavorable_window;
+  const topRisks = decision.risks.slice(0, 3);
+
+  return (
+    <section className={`${weatherCardClassName} overflow-hidden`}>
+      <div className="border-l-4 border-l-sky-600 p-4 sm:p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className={weatherSectionTitleClassName}>
+              {t('flightDecision.title')}
+            </p>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span
+                className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-black ${visual.badgeClassName}`}
+              >
+                <VerdictIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {t(decision.summary.translation_key)}
+              </span>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-bold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                {t('flightDecision.objective.active', {
+                  objective: t(
+                    `flightDecision.objective.${decision.objective}`
+                  ),
+                })}
+              </span>
+            </div>
+            <h2 className="mt-3 text-2xl font-black tracking-tight text-slate-950 dark:text-white">
+              {t(decision.summary.title_key)}
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {translate(
+                decision.summary.message_key,
+                decision.summary.message_params
+              )}
+            </p>
+          </div>
+
+          <div className="rounded-3xl bg-gradient-to-br from-sky-600 to-cyan-600 p-4 text-white shadow-lg shadow-sky-900/20 lg:min-w-44">
+            <span className="text-xs font-bold uppercase tracking-[0.18em] text-sky-100">
+              {t('flightDecision.scoreObjectif')}
+            </span>
+            <strong className="mt-1 block text-5xl font-black leading-none">
+              {decision.summary.score_objectif}
+            </strong>
+            <span className="text-sm font-bold text-sky-100">/100</span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          {FLIGHT_OBJECTIVES.map((nextObjective) => (
+            <Button
+              key={nextObjective}
+              type="button"
+              onClick={() => onObjectiveChange(nextObjective)}
+              className={`cursor-pointer rounded-full border px-3 py-1.5 text-xs font-black transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
+                activeObjective === nextObjective
+                  ? 'border-sky-600 bg-sky-600 text-white'
+                  : 'border-slate-200 bg-white text-slate-700 hover:border-sky-400 hover:bg-sky-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-sky-950/30'
+              }`}
+            >
+              <Target className="mr-1 inline h-3.5 w-3.5" aria-hidden="true" />
+              {t(`flightDecision.objective.${nextObjective}`)}
+            </Button>
+          ))}
+        </div>
+
+        <div className="mt-5 grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900/60">
+            <span className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <Clock className="h-4 w-4 text-sky-500" aria-hidden="true" />
+              {decision.best_window
+                ? t('flightDecision.bestWindow')
+                : t('flightDecision.leastUnfavorable')}
+            </span>
+            <strong className="mt-1 block text-lg font-black text-slate-950 dark:text-white">
+              {window
+                ? formatHourWindow(window.start_hour, window.end_hour)
+                : t('flightDecision.noWindow')}
+            </strong>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900/60">
+            <span className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <ShieldCheck
+                className="h-4 w-4 text-emerald-500"
+                aria-hidden="true"
+              />
+              {t('flightDecision.confidence.title')}
+            </span>
+            <strong className="mt-1 block text-lg font-black text-slate-950 dark:text-white">
+              {t(decision.confidence.translation_key)} ·{' '}
+              {decision.confidence.score}/100
+            </strong>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900/60">
+            <span className="inline-flex items-center gap-1.5 text-xs font-bold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <Compass className="h-4 w-4 text-violet-500" aria-hidden="true" />
+              {t('flightDecision.landing.title')}
+            </span>
+            <strong className="mt-1 block text-lg font-black text-slate-950 dark:text-white">
+              {t(decision.landing_safety.translation_key)}
+            </strong>
+          </div>
+        </div>
+
+        {topRisks.length > 0 && (
+          <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/60 dark:bg-amber-950/25">
+            <div className="inline-flex items-center gap-1.5 text-xs font-black uppercase tracking-wide text-amber-700 dark:text-amber-300">
+              <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+              {t('flightDecision.mainRisks')}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {topRisks.map((risk) => (
+                <span
+                  key={risk.code}
+                  className="rounded-full bg-white px-3 py-1 text-xs font-bold text-amber-800 shadow-sm dark:bg-slate-950/60 dark:text-amber-200"
+                >
+                  {translate(risk.translation_key, risk.params)}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/frontend/src/hooks/settings/useAppSettings.ts
+++ b/apps/frontend/src/hooks/settings/useAppSettings.ts
@@ -33,6 +33,7 @@ export interface AppSettings {
   ui_reason_gust_high_min: string;
   ui_reason_cloud_very_cloudy_min: string;
   ui_reason_wind_moderate_min: string;
+  default_flight_objective: string;
 }
 
 export function useAppSettings() {
@@ -53,6 +54,7 @@ export function useUpdateAppSettings() {
       void queryClient.invalidateQueries({ queryKey: ['app-settings'] });
       void queryClient.invalidateQueries({ queryKey: ['weather'] });
       void queryClient.invalidateQueries({ queryKey: ['bestSpot'] });
+      void queryClient.invalidateQueries({ queryKey: ['flight-decision'] });
       void queryClient.invalidateQueries({ queryKey: ['live-wind'] });
       void queryClient.invalidateQueries({ queryKey: ['landings-weather'] });
     },

--- a/apps/frontend/src/hooks/weather/useFlightDecision.ts
+++ b/apps/frontend/src/hooks/weather/useFlightDecision.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  FlightDecisionResponseSchema,
+  type FlightDecisionResponse,
+  type FlightObjective,
+} from '@dashboard-parapente/shared-types';
+import { api } from '../../lib/api';
+import { getStaleTime } from '../../lib/cacheConfig';
+
+export const FLIGHT_OBJECTIVES: FlightObjective[] = [
+  'tranquille',
+  'progression',
+  'thermique',
+];
+
+export const DEFAULT_FLIGHT_OBJECTIVE: FlightObjective = 'tranquille';
+
+export const parseFlightObjective = (
+  value: unknown
+): FlightObjective | undefined =>
+  typeof value === 'string' &&
+  FLIGHT_OBJECTIVES.includes(value as FlightObjective)
+    ? (value as FlightObjective)
+    : undefined;
+
+export const useFlightDecision = (
+  siteId: string | undefined,
+  dayIndex: number,
+  objective: FlightObjective
+) =>
+  useQuery<FlightDecisionResponse>({
+    queryKey: ['flight-decision', siteId, dayIndex, objective],
+    queryFn: async () => {
+      if (!siteId) throw new Error('Site ID is required');
+      const data = await api
+        .get(`flight-decision/${siteId}`, {
+          searchParams: {
+            day_index: String(dayIndex),
+            objective,
+          },
+        })
+        .json();
+      return FlightDecisionResponseSchema.parse(data);
+    },
+    staleTime: getStaleTime(1000 * 60 * 10),
+    enabled: Boolean(siteId),
+  });

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -315,6 +315,113 @@
       "noPrecipitation": "No precipitation"
     }
   },
+  "flightDecision": {
+    "title": "Flight decision",
+    "loadError": "Unable to calculate the flight decision.",
+    "scoreObjectif": "Objective score",
+    "bestWindow": "Best window",
+    "leastUnfavorable": "Least unfavorable moment",
+    "noWindow": "No window",
+    "mainRisks": "Watch points",
+    "level": {
+      "favorable": "Favorable",
+      "vigilance": "Caution",
+      "limite": "Limit",
+      "deconseille": "Discouraged",
+      "unavailable": "Unavailable"
+    },
+    "summary": {
+      "favorable": {
+        "title": "Favorable window identified",
+        "message": "A usable window stands out for the selected objective. Still check risks and local conditions before deciding."
+      },
+      "vigilance": {
+        "title": "Flight possible with caution",
+        "message": "A window exists, but {{main_reason}} needs attention between {{start_hour}}h and {{end_hour}}h."
+      },
+      "limite": {
+        "title": "No clearly recommended window",
+        "message": "Conditions remain limited. The least unfavorable moment is around {{start_hour}}h-{{end_hour}}h, mainly because of {{main_reason}}."
+      },
+      "deconseille": {
+        "title": "Flight discouraged",
+        "message": "Available risks do not allow a recommended flight window today."
+      },
+      "unavailable": {
+        "title": "Decision unavailable",
+        "message": "Available data is not sufficient to produce a reliable flight decision."
+      }
+    },
+    "objective": {
+      "active": "Objective: {{objective}}",
+      "tranquille": "Calm",
+      "progression": "Progression",
+      "thermique": "Thermal"
+    },
+    "context": {
+      "title": "Weather context",
+      "description": "A city or ad hoc search gives weather context. Select a takeoff to get a complete flight decision with orientation and landings."
+    },
+    "confidence": {
+      "title": "Confidence",
+      "high": "High",
+      "medium": "Medium",
+      "low": "Low",
+      "very_low": "Very low",
+      "singleForecastSource": "Only one forecast source available",
+      "lowDiagnostic": "Low forecast confidence"
+    },
+    "landing": { "title": "Landings" },
+    "landingSafety": {
+      "notConfigured": "Not evaluated",
+      "unavailable": "Unavailable",
+      "evaluated": "Evaluated",
+      "notConfiguredDiagnostic": "Landing not configured",
+      "weatherNotEvaluated": "Landing weather not evaluated"
+    },
+    "risk": {
+      "weatherUnavailable": "Weather unavailable",
+      "windMissing": "Missing wind",
+      "windTooStrong": "Wind too strong",
+      "windTooWeak": "Wind too weak",
+      "windWeak": "Weak wind",
+      "gustHigh": "Strong gusts",
+      "rainSignificant": "Significant rain",
+      "thunderstormLow": "Low thunderstorm risk",
+      "thunderstormModerate": "Moderate thunderstorm risk",
+      "thunderstormHigh": "High thunderstorm risk"
+    },
+    "windDecollage": {
+      "face": "Headwind",
+      "travers_acceptable": "Acceptable crosswind",
+      "travers_fort": "Strong crosswind",
+      "cul": "Tailwind",
+      "orientation_unknown": "Unknown orientation",
+      "not_evaluated": "Orientation not evaluated"
+    },
+    "thermal": {
+      "tranquille": {
+        "positive": "Calm thermals",
+        "vigilance": "Moderate thermals",
+        "limiting": "Strong thermals"
+      },
+      "progression": {
+        "neutral": "Weak thermals",
+        "positive": "Useful thermals",
+        "vigilance": "Strong thermals"
+      },
+      "thermique": {
+        "limiting": "Weak thermals",
+        "positive": "Usable thermals"
+      }
+    },
+    "window": {
+      "favorable": "Favorable window",
+      "vigilance": "Caution window",
+      "limite": "Limited moment",
+      "deconseille": "Discouraged moment"
+    }
+  },
   "filters": {
     "title": "Filters",
     "reset": "Reset",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -315,6 +315,113 @@
       "noPrecipitation": "Pas de précipitations"
     }
   },
+  "flightDecision": {
+    "title": "Décision de vol",
+    "loadError": "Impossible de calculer la décision de vol.",
+    "scoreObjectif": "Score objectif",
+    "bestWindow": "Meilleur créneau",
+    "leastUnfavorable": "Moment le moins défavorable",
+    "noWindow": "Aucun créneau",
+    "mainRisks": "Points de vigilance",
+    "level": {
+      "favorable": "Favorable",
+      "vigilance": "Vigilance",
+      "limite": "Limite",
+      "deconseille": "Déconseillé",
+      "unavailable": "Indisponible"
+    },
+    "summary": {
+      "favorable": {
+        "title": "Créneau favorable identifié",
+        "message": "Un créneau exploitable ressort pour l'objectif choisi. Vérifiez quand même les risques et le terrain avant de décider."
+      },
+      "vigilance": {
+        "title": "Vol possible avec vigilance",
+        "message": "Un créneau existe, mais {{main_reason}} demande une attention particulière entre {{start_hour}}h et {{end_hour}}h."
+      },
+      "limite": {
+        "title": "Aucun créneau conseillé net",
+        "message": "Les conditions restent limites. Le moment le moins défavorable est autour de {{start_hour}}h-{{end_hour}}h, principalement à cause de {{main_reason}}."
+      },
+      "deconseille": {
+        "title": "Vol déconseillé",
+        "message": "Les risques disponibles ne permettent pas de proposer un créneau conseillé aujourd'hui."
+      },
+      "unavailable": {
+        "title": "Décision indisponible",
+        "message": "Les données disponibles ne suffisent pas à produire une décision de vol fiable."
+      }
+    },
+    "objective": {
+      "active": "Objectif : {{objective}}",
+      "tranquille": "Tranquille",
+      "progression": "Progression",
+      "thermique": "Thermique"
+    },
+    "context": {
+      "title": "Contexte météo",
+      "description": "Une ville ou une recherche ponctuelle donne un contexte météo. Sélectionnez un décollage pour obtenir une décision de vol complète avec orientation et atterrissages."
+    },
+    "confidence": {
+      "title": "Confiance",
+      "high": "Élevée",
+      "medium": "Moyenne",
+      "low": "Faible",
+      "very_low": "Très faible",
+      "singleForecastSource": "Une seule source météo disponible",
+      "lowDiagnostic": "Confiance météo faible"
+    },
+    "landing": { "title": "Atterrissages" },
+    "landingSafety": {
+      "notConfigured": "Non évalués",
+      "unavailable": "Non disponibles",
+      "evaluated": "Évalués",
+      "notConfiguredDiagnostic": "Atterrissage non configuré",
+      "weatherNotEvaluated": "Météo atterrissage non évaluée"
+    },
+    "risk": {
+      "weatherUnavailable": "Météo indisponible",
+      "windMissing": "Vent manquant",
+      "windTooStrong": "Vent trop fort",
+      "windTooWeak": "Vent trop faible",
+      "windWeak": "Vent faible",
+      "gustHigh": "Rafales fortes",
+      "rainSignificant": "Pluie significative",
+      "thunderstormLow": "Risque orage faible",
+      "thunderstormModerate": "Risque orage modéré",
+      "thunderstormHigh": "Risque orage élevé"
+    },
+    "windDecollage": {
+      "face": "Vent de face",
+      "travers_acceptable": "Travers acceptable",
+      "travers_fort": "Travers fort",
+      "cul": "Vent arrière",
+      "orientation_unknown": "Orientation inconnue",
+      "not_evaluated": "Orientation non évaluée"
+    },
+    "thermal": {
+      "tranquille": {
+        "positive": "Thermiques calmes",
+        "vigilance": "Thermiques modérés",
+        "limiting": "Thermiques forts"
+      },
+      "progression": {
+        "neutral": "Thermiques faibles",
+        "positive": "Thermiques utiles",
+        "vigilance": "Thermiques forts"
+      },
+      "thermique": {
+        "limiting": "Thermiques faibles",
+        "positive": "Thermiques exploitables"
+      }
+    },
+    "window": {
+      "favorable": "Créneau favorable",
+      "vigilance": "Créneau avec vigilance",
+      "limite": "Moment limite",
+      "deconseille": "Moment déconseillé"
+    }
+  },
   "filters": {
     "title": "Filtres",
     "reset": "Réinitialiser",

--- a/apps/frontend/src/pages/WeatherPage.mobile.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile.tsx
@@ -12,6 +12,7 @@ type WeatherPageMobileProps = {
   isSearchMode: boolean;
   isAuthenticated: boolean;
   selectionPanel: ReactNode;
+  decisionPanel?: ReactNode;
   searchResultPanel?: ReactNode;
   emptyPanel?: ReactNode;
   currentConditions?: ReactNode;
@@ -67,6 +68,7 @@ export default function WeatherPageMobileLayout({
   isSearchMode,
   isAuthenticated,
   selectionPanel,
+  decisionPanel,
   searchResultPanel,
   emptyPanel,
   currentConditions,
@@ -97,6 +99,7 @@ export default function WeatherPageMobileLayout({
       />
 
       {emptyPanel}
+      {decisionPanel}
       {currentConditions}
       {searchResultPanel}
       <ExpandableSection

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -406,16 +406,17 @@ export default function WeatherPage() {
       />
     ) : undefined;
 
-  const mobileDecisionPanel = (
-    <FlightDecisionCockpit
-      decision={flightDecision.data}
-      objective={selectedObjective}
-      isLoading={flightDecision.isLoading}
-      isError={flightDecision.isError}
-      isCityContext={Boolean(selectedSearchTarget)}
-      onObjectiveChange={handleObjectiveChange}
-    />
-  );
+  const mobileDecisionPanel =
+    selectedSearchTarget || selectedSiteId ? (
+      <FlightDecisionCockpit
+        decision={flightDecision.data}
+        objective={selectedObjective}
+        isLoading={flightDecision.isLoading}
+        isError={flightDecision.isError}
+        isCityContext={Boolean(selectedSearchTarget)}
+        onObjectiveChange={handleObjectiveChange}
+      />
+    ) : undefined;
 
   const mobileLiveWindPanel =
     !selectedSearchTarget && selectedSiteId ? (

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -24,6 +24,14 @@ import WeatherSearchResultPanel from '../components/weather/WeatherSearchResultP
 import WeatherSelectionPanel, {
   type WeatherSelectionTab,
 } from '../components/weather/WeatherSelectionPanel';
+import FlightDecisionCockpit from '../components/weather/FlightDecisionCockpit';
+import {
+  DEFAULT_FLIGHT_OBJECTIVE,
+  parseFlightObjective,
+  useFlightDecision,
+} from '../hooks/weather/useFlightDecision';
+import type { FlightObjective } from '@dashboard-parapente/shared-types';
+import { useAppSettings } from '../hooks/settings/useAppSettings';
 import WeatherPageMobileLayout from './WeatherPage.mobile';
 import { getSiteDisplayName } from '../lib/siteDisplay';
 
@@ -49,7 +57,7 @@ const getSearchDayLabel = (day: number, t: (key: string) => string) => {
   return `J+${day}`;
 };
 
-const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const formatLocalDate = (date: Date) => {
@@ -101,6 +109,7 @@ type WeatherSearchParams = {
   orientation?: string;
   country?: string;
   source?: string;
+  objective?: FlightObjective;
 };
 
 const hasCoordinates = (
@@ -152,10 +161,14 @@ const getTargetFromSearch = (
   return null;
 };
 
-const getSearchForTarget = (target: CityWeatherTarget | null, day: number) => {
+const getSearchForTarget = (
+  target: CityWeatherTarget | null,
+  day: number,
+  objective: FlightObjective
+) => {
   const daySearch = getForecastDaySearch(day);
 
-  if (!target) return { day: daySearch };
+  if (!target) return { day: daySearch, objective };
 
   if (target.type === 'city') {
     return {
@@ -166,6 +179,7 @@ const getSearchForTarget = (target: CityWeatherTarget | null, day: number) => {
       lon: target.location.longitude,
       country: target.location.country,
       day: daySearch,
+      objective,
     };
   }
 
@@ -181,6 +195,7 @@ const getSearchForTarget = (target: CityWeatherTarget | null, day: number) => {
     country: target.spot.country,
     source: target.spot.source,
     day: daySearch,
+    objective,
   };
 };
 
@@ -191,10 +206,15 @@ export default function WeatherPage() {
   const favoriteSiteIds = useAppSettingsStore(
     (state) => state.settings.favoriteSites
   );
+  const { data: appSettings } = useAppSettings();
   const isMobile = useIsMobile();
   const search = useSearch({ from: '/weather' });
   const routeSiteId = search ? search.siteId : '';
   const selectedDayIndex = getDayIndexFromSearch(search.day);
+  const selectedObjective =
+    parseFlightObjective(search.objective) ??
+    parseFlightObjective(appSettings?.default_flight_objective) ??
+    DEFAULT_FLIGHT_OBJECTIVE;
   const selectedSearchTarget = getTargetFromSearch(search);
   const { data: bestSpot } = useBestSpotAPI(selectedDayIndex);
   const { data: hourlyBestSpots } = useHourlyBestSpotsAPI(selectedDayIndex);
@@ -220,6 +240,11 @@ export default function WeatherPage() {
     sites[0]?.id ??
     '';
   const selectedSite = sites.find((site) => site.id === selectedSiteId);
+  const flightDecision = useFlightDecision(
+    !selectedSearchTarget && selectedSiteId ? selectedSiteId : undefined,
+    selectedDayIndex,
+    selectedObjective
+  );
   const selectedSearchTitle = getSearchTargetName(selectedSearchTarget);
   const selectedSearchLocation = getSearchTargetLocation(selectedSearchTarget);
   const coordinateWeather = useCoordinateWeather(
@@ -250,6 +275,7 @@ export default function WeatherPage() {
   const weatherSearch = {
     siteId: selectedSiteId,
     day: getForecastDaySearch(selectedDayIndex),
+    objective: selectedObjective,
   };
   const selectedDayLabel = getSearchDayLabel(selectedDayIndex, t);
   const selectedSiteDisplayName = selectedSite
@@ -269,6 +295,7 @@ export default function WeatherPage() {
       search: {
         siteId: selectedSiteId || undefined,
         day: getForecastDaySearch(selectedDayIndex),
+        objective: selectedObjective,
       },
     });
   };
@@ -287,6 +314,7 @@ export default function WeatherPage() {
       search: {
         siteId,
         day: getForecastDaySearch(selectedDayIndex),
+        objective: selectedObjective,
       },
     });
   };
@@ -295,14 +323,14 @@ export default function WeatherPage() {
     setSelectionTab('search');
     void navigate({
       to: '/weather',
-      search: getSearchForTarget(target, selectedDayIndex),
+      search: getSearchForTarget(target, selectedDayIndex, selectedObjective),
     });
   };
 
   const handleSelectSearchDay = (day: number) => {
     void navigate({
       to: '/weather',
-      search: getSearchForTarget(selectedSearchTarget, day),
+      search: getSearchForTarget(selectedSearchTarget, day, selectedObjective),
     });
   };
 
@@ -313,6 +341,19 @@ export default function WeatherPage() {
         ...weatherSearch,
         day: getForecastDaySearch(day),
       },
+    });
+  };
+
+  const handleObjectiveChange = (objective: FlightObjective) => {
+    void navigate({
+      to: '/weather',
+      search: selectedSearchTarget
+        ? getSearchForTarget(selectedSearchTarget, selectedDayIndex, objective)
+        : {
+            siteId: selectedSiteId || undefined,
+            day: getForecastDaySearch(selectedDayIndex),
+            objective,
+          },
     });
   };
 
@@ -364,6 +405,17 @@ export default function WeatherPage() {
         }
       />
     ) : undefined;
+
+  const mobileDecisionPanel = (
+    <FlightDecisionCockpit
+      decision={flightDecision.data}
+      objective={selectedObjective}
+      isLoading={flightDecision.isLoading}
+      isError={flightDecision.isError}
+      isCityContext={Boolean(selectedSearchTarget)}
+      onObjectiveChange={handleObjectiveChange}
+    />
+  );
 
   const mobileLiveWindPanel =
     !selectedSearchTarget && selectedSiteId ? (
@@ -418,6 +470,7 @@ export default function WeatherPage() {
         isSearchMode={Boolean(selectedSearchTarget)}
         isAuthenticated={isAuthenticated}
         selectionPanel={selectionPanel}
+        decisionPanel={mobileDecisionPanel}
         searchResultPanel={mobileSearchResultPanel}
         emptyPanel={mobileEmptyPanel}
         currentConditions={mobileCurrentConditions}
@@ -445,6 +498,17 @@ export default function WeatherPage() {
             selectedDayIndex={selectedDayIndex}
             getDayLabel={(day) => getSearchDayLabel(day, t)}
             onSelectDay={handleSelectSearchDay}
+          />
+        )}
+
+        {(selectedSearchTarget || selectedSiteId) && (
+          <FlightDecisionCockpit
+            decision={flightDecision.data}
+            objective={selectedObjective}
+            isLoading={flightDecision.isLoading}
+            isError={flightDecision.isError}
+            isCityContext={Boolean(selectedSearchTarget)}
+            onObjectiveChange={handleObjectiveChange}
           />
         )}
 

--- a/apps/frontend/src/routes/weather.tsx
+++ b/apps/frontend/src/routes/weather.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { queryClient } from '../lib/queryClient';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
+import { parseFlightObjective } from '../hooks/weather/useFlightDecision';
 
 type WeatherSearch = {
   variant?: 'A' | 'B' | 'C';
@@ -18,6 +19,7 @@ type WeatherSearch = {
   orientation?: string;
   country?: string;
   source?: string;
+  objective?: 'tranquille' | 'progression' | 'thermique';
 };
 
 const parseOptionalNumber = (value: unknown) => {
@@ -31,7 +33,7 @@ const parseOptionalNumber = (value: unknown) => {
 const parseString = (value: unknown) =>
   typeof value === 'string' && value.length > 0 ? value : undefined;
 
-const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const parseLocalDate = (value: string) => {
@@ -94,6 +96,7 @@ export const Route = createFileRoute('/weather')({
       orientation: parseString(search.orientation),
       country: parseString(search.country),
       source: parseString(search.source),
+      objective: parseFlightObjective(search.objective),
     };
   },
   loader: () => {

--- a/docs/adr/0001-backend-decision-de-vol.md
+++ b/docs/adr/0001-backend-decision-de-vol.md
@@ -1,0 +1,63 @@
+# Backend as Source of Truth for Decision de Vol
+
+The **Decision de Vol** is calculated by the backend and exposed through a dedicated `flight-decision` API rather than being assembled inside frontend components or folded into the generic weather endpoint. This keeps weather decision rules, risk precedence, configurable thresholds, and future tests in one place, while the frontend remains primarily responsible for presenting the structured recommendation returned by the API.
+
+The API returns both a decision summary and an analyzed hourly breakdown. The frontend should receive ready-to-display levels, scores, risks, confidence, wind-orientation analysis, landing safety, and optional alternative sites instead of recalculating those concepts from raw weather data.
+
+Decision levels are returned as stable French domain API codes without accents (`favorable`, `vigilance`, `limite`, `deconseille`, `unavailable`) with translation keys, not translated labels. The backend remains the source of truth for the chosen level, while the frontend is responsible only for localization. `unavailable` means the backend cannot produce a reliable decision from the available data; it is not the same as a discouraged flight window.
+
+Risks and reasons are returned as structured diagnostics with stable codes, severities, translation keys, parameters, and optional affected periods. The backend identifies the risk and its severity; the frontend translates and presents it without reinterpreting the weather data.
+
+Decision levels and risk severities are separate concepts. Decision levels use `favorable`, `vigilance`, `limite`, `deconseille`, and `unavailable`; risk severities use `info`, `vigilance`, `limiting`, and `blocking`.
+
+The final level for a time window is resolved with a hybrid rule: blocking risks prevent `favorable` and `vigilance`, limiting risks prevent `favorable`, vigilance risks require visible caution, and the numeric score is used only after those risk constraints are applied.
+
+Recommended flight windows group consecutive hourly decisions whose level is `favorable` or `vigilance`. A single acceptable hour is enough to form a recommended window. The displayed level for the grouped window is the most cautious level inside the group, and the displayed score is the minimum hourly score in that group.
+
+When several recommended windows exist, the primary window is selected by best decision level first, then highest minimum score, then longest duration. For the current day, past windows are ignored; ties prefer the nearest upcoming window.
+
+For the current day, the hourly analysis may include past hours marked as past, but the summary must not recommend a past window. If all good windows are already past, the summary should say that no recommended window remains and may show the best past window for awareness.
+
+Decision times are expressed in the current canonical app timezone, `Europe/Paris`, and the API should make that timezone explicit in its response.
+
+Live SpotAiR wind is initially treated as a confidence modifier and discrepancy alert, not as a direct blocking source for the Decision de Vol. If nearby live readings strongly contradict the forecast, the backend should expose that discrepancy so the frontend can warn the pilot and lower confidence.
+
+SpotAiR influence on confidence is weighted by station distance: readings within 5 km have strong influence, readings from 5 to 10 km have moderate influence, and farther readings are informational only unless the configured live-wind search radius is lower.
+
+Alternative sites are returned only when they are clearly better than the selected site: either a better decision level or the same level with a minimum window score at least 15 points higher. At most three alternatives are shown, and they remain secondary to the selected site's decision.
+
+Missing data degrades the decision according to its criticality. Missing hourly weather makes the decision unavailable or discouraged; missing decollage orientation or associated landing data creates vigilance and lowers confidence; missing SpotAiR or thermal details is informational unless other risks are present; relying on a single forecast source lowers confidence.
+
+Thunderstorm and convective risk is part of the backend decision model when CAPE and Lifted Index are available. A low risk is treated as vigilance, moderate risk as limiting, and high risk as blocking.
+
+The decision model accepts an Objectif de Vol selected from the weather page. The objective changes how thermal activity and related risks are interpreted without moving decision logic into the frontend.
+
+The initial supported objectives are `tranquille`, `progression`, and `thermique`. Distance flying is intentionally excluded from the first model because it requires additional criteria such as ceiling, wind aloft, route drift, and airspace constraints.
+
+The selected objective changes thermal interpretation: `tranquille` treats weak thermals as neutral or positive and strong thermals as limiting; `progression` values moderate thermals while treating strong thermals cautiously; `thermique` values exploitable thermal activity but still treats moderate or high thunderstorm risk as limiting or blocking.
+
+The active objective is carried by the weather page URL when explicitly selected, while a settings value provides the default objective. The URL value wins for the current page so decisions are shareable and navigation remains predictable.
+
+The existing Para-Index remains a general weather score. The Decision de Vol exposes a separate objective-aware Score Objectif so changing the Objectif de Vol does not mutate the meaning of Para-Index elsewhere in the application.
+
+The decision cockpit should lead with Score Objectif, while existing detailed weather views can continue to show Para-Index. Both scores may coexist, but each must be shown in its own context to avoid implying they are interchangeable.
+
+The weather page presents the Decision de Vol as a synthetic cockpit first, followed by detailed panels for windows, risks, wind-decollage compatibility, landing safety, confidence, and alternatives. Mobile presentation prioritizes the summary and uses collapsible detail sections.
+
+The Objectif de Vol selector is shown inside or immediately below the Decision de Vol cockpit, not hidden in settings. Changing it updates the weather page URL and triggers a backend recalculation for the active decision.
+
+Changing the active Objectif de Vol does not automatically change the persisted default objective. Persisting a new default remains an explicit user action so temporary comparisons do not silently alter future weather decisions.
+
+City searches show weather context rather than a complete Decision de Vol. A complete decision requires a Site with decollage context because wind orientation and landing safety are part of the decision model.
+
+The complete decision API is reserved for Sites, while free coordinates and city searches use a separate weather-context API. This keeps the boundary clear between complete flight decisions and general weather context.
+
+The first implementation focuses on `flight-decision` for Sites. City search continues to use the existing weather display and should clearly tell the pilot to select a Decollage for a complete Decision de Vol.
+
+Landing safety influences the V1 decision when associated landings and their weather are available. When landing data cannot be evaluated, the API returns a vigilance diagnostic that landing safety was not evaluated instead of fabricating a result.
+
+V1 prepares the response shape for live-wind confidence diagnostics, but SpotAiR integration is not required for the first complete Decision de Vol implementation. The initial decision can be computed from forecasts, site orientation, available landing safety, risk precedence, and source confidence.
+
+V1 also prepares an `alternatives` field but does not need to calculate alternative sites. The first implementation should make the selected site's Decision de Vol reliable before expanding into multi-site recommendation.
+
+V1 requires both unit tests for the backend decision engine and endpoint tests for the public API contract. Tests must cover the decision levels, blocking risks, objective-specific thermal interpretation, unavailable data, and presence of stable codes plus translation keys.

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -234,6 +234,143 @@ export const BackendWeatherResponseSchema = z.object({
   cached_at: z.string().nullish(),
 });
 
+export const FlightDecisionLevelSchema = z.enum([
+  'favorable',
+  'vigilance',
+  'limite',
+  'deconseille',
+  'unavailable',
+]);
+
+export const FlightObjectiveSchema = z.enum([
+  'tranquille',
+  'progression',
+  'thermique',
+]);
+
+export const FlightDecisionRiskSeveritySchema = z.enum([
+  'info',
+  'vigilance',
+  'limiting',
+  'blocking',
+]);
+
+export const FlightDecisionDiagnosticSchema = z.object({
+  code: z.string(),
+  severity: FlightDecisionRiskSeveritySchema,
+  translation_key: z.string(),
+  params: z.record(z.string(), z.any()).default({}),
+});
+
+export const FlightDecisionWindowSchema = z.object({
+  start_hour: z.number(),
+  end_hour: z.number(),
+  level: FlightDecisionLevelSchema,
+  translation_key: z.string(),
+  score_objectif: z.number(),
+  min_score_objectif: z.number(),
+  hours: z.array(z.number()),
+  main_risk_codes: z.array(z.string()),
+  summary_key: z.string(),
+  summary_params: z.record(z.string(), z.any()),
+});
+
+export const FlightDecisionResponseSchema = z.object({
+  site: z.object({
+    id: z.string(),
+    name: z.string(),
+    usage_type: z.string().nullish(),
+    orientation: z.string().nullish(),
+  }),
+  objective: FlightObjectiveSchema,
+  timezone: z.string(),
+  day_index: z.number(),
+  summary: z.object({
+    level: FlightDecisionLevelSchema,
+    translation_key: z.string(),
+    score_objectif: z.number(),
+    title_key: z.string(),
+    message_key: z.string(),
+    message_params: z.record(z.string(), z.any()),
+    main_risk_code: z.string().nullish(),
+    has_recommended_window: z.boolean(),
+  }),
+  best_window: FlightDecisionWindowSchema.nullish(),
+  least_unfavorable_window: FlightDecisionWindowSchema.nullish(),
+  hourly: z.array(
+    z.object({
+      hour: z.number(),
+      is_past: z.boolean(),
+      level: FlightDecisionLevelSchema,
+      translation_key: z.string(),
+      score_objectif: z.number(),
+      para_index: z.number(),
+      risks: z.array(FlightDecisionDiagnosticSchema),
+      wind: z.object({
+        speed_kmh: z.number().nullish(),
+        gust_kmh: z.number().nullish(),
+        direction_deg: z.number().nullish(),
+        direction_label: z.string().nullish(),
+      }),
+      wind_decollage: z.object({
+        status: z.string(),
+        translation_key: z.string(),
+        angle_deviation_deg: z.number().nullish(),
+        selected_orientation: z.string().nullish(),
+        severity: FlightDecisionRiskSeveritySchema,
+      }),
+      thermal: z.object({
+        strength: z.string(),
+        cape: z.number().nullish(),
+        lifted_index: z.number().nullish(),
+        objective_effect: z.string(),
+        translation_key: z.string(),
+      }),
+      confidence: z.object({ level: z.string(), score: z.number() }),
+    })
+  ),
+  risks: z.array(FlightDecisionDiagnosticSchema),
+  confidence: z.object({
+    level: z.string(),
+    score: z.number(),
+    translation_key: z.string(),
+    source_count: z.number(),
+    expected_source_count: z.number(),
+    freshness: z.object({
+      cached_at: z.string().nullish(),
+      age_minutes: z.number().nullish(),
+      status: z.string(),
+    }),
+    diagnostics: z.array(FlightDecisionDiagnosticSchema),
+  }),
+  landing_safety: z.object({
+    status: z.enum(['evaluated', 'not_configured', 'unavailable']),
+    level: FlightDecisionLevelSchema,
+    translation_key: z.string(),
+    summary_key: z.string(),
+    summary_params: z.record(z.string(), z.any()),
+    landings: z.array(
+      z.object({
+        site_id: z.string(),
+        name: z.string(),
+        distance_km: z.number().nullish(),
+        is_primary: z.boolean(),
+        level: FlightDecisionLevelSchema,
+        score_objectif: z.number().nullish(),
+        risks: z.array(FlightDecisionDiagnosticSchema),
+      })
+    ),
+  }),
+  live_wind: z.object({
+    status: z.enum(['not_evaluated', 'unavailable', 'evaluated', 'stale']),
+    influences_confidence: z.boolean(),
+    stations: z.array(z.record(z.string(), z.any())),
+    diagnostics: z.array(FlightDecisionDiagnosticSchema),
+  }),
+  alternatives: z.array(z.record(z.string(), z.any())),
+  cached_at: z.string().nullish(),
+});
+
 // ============================================================================
 // API WRAPPER SCHEMA
 // ============================================================================
@@ -496,6 +633,10 @@ export type Alert = z.infer<typeof AlertSchema>;
 export type ConsensusHour = z.infer<typeof ConsensusHourSchema>;
 export type BackendWeatherResponse = z.infer<
   typeof BackendWeatherResponseSchema
+>;
+export type FlightObjective = z.infer<typeof FlightObjectiveSchema>;
+export type FlightDecisionResponse = z.infer<
+  typeof FlightDecisionResponseSchema
 >;
 export type Slot = z.infer<typeof SlotSchema>;
 export type Metrics = z.infer<typeof MetricsSchema>;

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -326,7 +326,11 @@ export const FlightDecisionResponseSchema = z.object({
         objective_effect: z.string(),
         translation_key: z.string(),
       }),
-      confidence: z.object({ level: z.string(), score: z.number() }),
+      confidence: z.object({
+        level: z.string(),
+        score: z.number(),
+        source_count: z.number(),
+      }),
     })
   ),
   risks: z.array(FlightDecisionDiagnosticSchema),


### PR DESCRIPTION
## Summary
- Add a backend-owned flight decision endpoint and decision engine.
- Wire the weather cockpit to the new decision data, objectives, translations, and shared types.
- Add backend/API tests and an ADR for the decision model.

## Validation
- `pytest apps/backend/tests/unit/test_flight_decision.py apps/backend/tests/api/test_routes_flight_decision.py apps/backend/tests/api/test_routes_settings.py -q --tb=short` -> 30 passed
- `ruff check ...` -> passed
- `black --check ...` -> passed
- `oxlint` on touched frontend files -> 0 warnings, 0 errors
- `nx type-check frontend` -> passed
- `nx build frontend` -> passed
- CodeRabbit review -> no findings

## Notes
- `nx test frontend` hangs in this environment; direct Vitest also timed out without test output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added flight decision assessment system to help pilots evaluate flying conditions with customizable flight objectives
  * Flight decision scoring includes hourly diagnostics, risk assessment, and landing safety evaluation
  * Integrated best-window recommendations and objective selection in weather view
  * Added default flight objective configuration
  * Full English and French localization support

* **Documentation**
  * Expanded domain terminology guide with flight decision model specifications
  * Added architectural decision record documenting flight decision API design and implementation scope

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->