### PR TITLE
fix(backend): expose emagram provider failures

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5985,6 +5985,46 @@ async def test_weather_source(
 _pending_emagram_analyses: set[str] = set()
 
 
+def _redact_emagram_failure_text(value: Any) -> str:
+    text = str(value)
+    for secret in [
+        config.GROQ_API_KEY,
+        config.OPENROUTER_API_KEY,
+        config.GOOGLE_API_KEY,
+        config.GITHUB_MODELS_API_KEY,
+        config.HUGGINGFACE_API_KEY,
+        config.CUSTOM_OPENAI_API_KEY,
+    ]:
+        if secret and len(secret) >= 6:
+            text = text.replace(secret, "[redacted]")
+    if len(text) > 1000:
+        return f"{text[:1000]}..."
+    return text
+
+
+def _emagram_generation_failure_detail(result: dict[str, Any]) -> dict[str, Any]:
+    error = _redact_emagram_failure_text(result.get("error", "Unknown error"))
+    details = result.get("details")
+    cause = None
+    provider_errors = []
+    if isinstance(details, dict):
+        if details.get("error"):
+            cause = _redact_emagram_failure_text(details["error"])
+        if isinstance(details.get("provider_errors"), list):
+            provider_errors = [
+                _redact_emagram_failure_text(provider_error)
+                for provider_error in details["provider_errors"]
+            ]
+
+    return {
+        "message": f"Failed to generate emagram: {error}",
+        "error": error,
+        "cause": cause,
+        "provider_errors": provider_errors,
+        "analysis_id": result.get("analysis_id"),
+    }
+
+
 def _auto_emagram_analysis(
     site_id: str, day_index: int = 0, hour: int | None = None, locale: str | None = None
 ):
@@ -6611,7 +6651,7 @@ async def trigger_emagram_analysis(
         if not result.get("success"):
             raise HTTPException(
                 status_code=500,
-                detail=f"Failed to generate emagram: {result.get('error', 'Unknown error')}",
+                detail=_emagram_generation_failure_detail(result),
             )
 
         # Fetch the saved analysis from database

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -672,6 +672,52 @@ class TestEmagramEndpoints:
         )
         assert response.status_code == 400
 
+    def test_analyze_failure_includes_provider_errors(self, client, db_session):
+        """Trigger analysis failure returns provider diagnostics."""
+        site = Site(
+            id="site-llm-failure",
+            code="LLMFAIL",
+            name="LLM Failure Site",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+        db_session.commit()
+
+        with patch(
+            "emagram_multi_source.generate_multi_source_emagram_for_spot",
+            new=AsyncMock(
+                return_value={
+                    "success": False,
+                    "error": "LLM analysis failed",
+                    "analysis_id": "failed-analysis-id",
+                    "details": {
+                        "error": "All configured LLM providers failed",
+                        "provider_errors": [
+                            "groq: quota exhausted",
+                            "google: rejected key test_google_key",
+                        ],
+                    },
+                }
+            ),
+        ):
+            response = client.post(
+                "/api/emagram/analyze",
+                json={"site_id": site.id, "force_refresh": True},
+            )
+
+        assert response.status_code == 500
+        detail = response.json()["detail"]
+        assert detail["message"] == "Failed to generate emagram: LLM analysis failed"
+        assert detail["error"] == "LLM analysis failed"
+        assert detail["cause"] == "All configured LLM providers failed"
+        assert detail["analysis_id"] == "failed-analysis-id"
+        assert detail["provider_errors"] == [
+            "groq: quota exhausted",
+            "google: rejected key [redacted]",
+        ]
+
     def test_list_analyses_empty(self, client):
         """List analyses when DB is empty"""
         response = client.get("/api/emagram/history?user_lat=47.0&user_lon=6.0")


### PR DESCRIPTION
## Summary
- Return structured emagram analysis failure details from `/api/emagram/analyze`
- Include provider diagnostics and redact configured API keys from error text
- Add a regression test for provider error propagation

## Validation
- `../../.venv/bin/pytest tests/test_emagram_endpoints.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (timed out in scrapers after backend tests had already passed)
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for emagram analysis with structured, detailed error messages
  * Added automatic redaction of sensitive data from error responses to improve security
  * Consolidated multi-source generation failures into standardized error format

* **Tests**
  * Added test coverage for emagram analysis error handling with provider diagnostics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->