### PR TITLE
fix(frontend): open SpotAiR on site coordinates

### DIFF
--- a/apps/frontend/src/components/weather/WeatherLiveWindPanel.test.tsx
+++ b/apps/frontend/src/components/weather/WeatherLiveWindPanel.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import WeatherLiveWindPanel, { getSpotairUrl } from './WeatherLiveWindPanel';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'weather.liveWindTitle': 'Vent en direct',
+        'weather.liveWindExternalInfo': 'Consulter les balises sur SpotAiR',
+        'weather.liveWindOpenSpotair': 'Ouvrir SpotAiR',
+      };
+
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+describe('WeatherLiveWindPanel', () => {
+  it('opens SpotAiR on the selected site coordinates', () => {
+    render(<WeatherLiveWindPanel latitude={47.238} longitude={6.024} />);
+
+    expect(
+      screen.getByRole('link', { name: 'Ouvrir SpotAiR' })
+    ).toHaveAttribute(
+      'href',
+      'https://www.spotair.mobi/?lat=47.238&lng=6.024&zoom=10'
+    );
+  });
+
+  it('falls back to SpotAiR home without coordinates', () => {
+    expect(getSpotairUrl()).toBe('https://www.spotair.mobi/');
+  });
+});

--- a/apps/frontend/src/components/weather/WeatherLiveWindPanel.tsx
+++ b/apps/frontend/src/components/weather/WeatherLiveWindPanel.tsx
@@ -1,8 +1,36 @@
 import { useTranslation } from 'react-i18next';
 import { weatherCardClassName } from './weatherUi';
 
-export default function WeatherLiveWindPanel() {
+type WeatherLiveWindPanelProps = {
+  latitude?: number;
+  longitude?: number;
+};
+
+export const getSpotairUrl = (latitude?: number, longitude?: number) => {
+  if (
+    typeof latitude !== 'number' ||
+    typeof longitude !== 'number' ||
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude)
+  ) {
+    return 'https://www.spotair.mobi/';
+  }
+
+  const params = new URLSearchParams({
+    lat: String(latitude),
+    lng: String(longitude),
+    zoom: '10',
+  });
+
+  return `https://www.spotair.mobi/?${params.toString()}`;
+};
+
+export default function WeatherLiveWindPanel({
+  latitude,
+  longitude,
+}: WeatherLiveWindPanelProps) {
   const { t } = useTranslation();
+  const spotairUrl = getSpotairUrl(latitude, longitude);
 
   return (
     <section
@@ -18,7 +46,7 @@ export default function WeatherLiveWindPanel() {
           </p>
         </div>
         <a
-          href="https://www.spotair.mobi/"
+          href={spotairUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex cursor-pointer items-center justify-center rounded-xl bg-slate-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:bg-cyan-500 dark:text-slate-950 dark:hover:bg-cyan-400"

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -420,7 +420,10 @@ export default function WeatherPage() {
 
   const mobileLiveWindPanel =
     !selectedSearchTarget && selectedSiteId ? (
-      <WeatherLiveWindPanel />
+      <WeatherLiveWindPanel
+        latitude={selectedSite?.latitude}
+        longitude={selectedSite?.longitude}
+      />
     ) : undefined;
 
   const mobileLandingPanel =
@@ -530,7 +533,12 @@ export default function WeatherPage() {
           />
         )}
 
-        {!selectedSearchTarget && selectedSiteId && <WeatherLiveWindPanel />}
+        {!selectedSearchTarget && selectedSiteId && (
+          <WeatherLiveWindPanel
+            latitude={selectedSite?.latitude}
+            longitude={selectedSite?.longitude}
+          />
+        )}
 
         {/* Landing Sites Weather */}
         {!selectedSearchTarget && selectedSiteId && (


### PR DESCRIPTION
## Summary
- Open SpotAiR from the weather page using the selected site coordinates.
- Pass latitude/longitude from the selected site to the live wind panel on desktop and mobile.
- Add a focused test for the generated SpotAiR URL.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- WeatherLiveWindPanel.test.tsx
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- CodeRabbit CLI: no findings