### PR TITLE
fix: validate emagram thermal strength against hourly weather

### DIFF
--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -46,6 +46,97 @@ PROVIDER_ENV_VARS = {
 _LLM_QUOTA_COOLDOWNS: dict[str, float] = {}
 
 
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed == parsed else None
+
+
+def _select_forecast_hour(
+    consensus_hours: list[dict[str, Any]], target_hour: int | None
+) -> dict[str, Any] | None:
+    if not consensus_hours:
+        return None
+    if target_hour is None:
+        return consensus_hours[0]
+
+    exact = next((hour for hour in consensus_hours if hour.get("hour") == target_hour), None)
+    if exact is not None:
+        return exact
+
+    return min(
+        consensus_hours,
+        key=lambda hour: abs(int(hour.get("hour") or 0) - target_hour),
+    )
+
+
+def validate_ai_thermal_consistency(
+    analysis_result: dict[str, Any],
+    weather_forecast: dict[str, Any] | None,
+    forecast_hour: int | None,
+) -> dict[str, Any]:
+    """Cross-check LLM thermal strength against numeric hourly instability data."""
+    force_ms = _to_float(analysis_result.get("force_thermique_ms"))
+    if force_ms is None:
+        return {
+            "status": "low_confidence",
+            "message": "Force thermique IA absente ou illisible.",
+            "metrics": {"force_thermique_ms": None},
+        }
+
+    selected_hour = _select_forecast_hour(
+        list(weather_forecast.get("consensus", [])) if weather_forecast else [], forecast_hour
+    )
+    if selected_hour is None:
+        return {
+            "status": "not_checked",
+            "message": "Meteo horaire indisponible pour recouper la force thermique IA.",
+            "metrics": {"force_thermique_ms": force_ms},
+        }
+
+    cape = _to_float(selected_hour.get("cape"))
+    lifted_index = _to_float(selected_hour.get("lifted_index"))
+    hour = selected_hour.get("hour")
+    metrics = {
+        "forecast_hour": hour,
+        "requested_hour": forecast_hour,
+        "force_thermique_ms": force_ms,
+        "cape_jkg": cape,
+        "lifted_index": lifted_index,
+    }
+
+    stable_or_unknown_li = lifted_index is None or lifted_index > -3
+    if force_ms >= 3.0 and cape is not None and cape < 200 and stable_or_unknown_li:
+        return {
+            "status": "contradicted",
+            "message": (
+                "Thermiques forts annonces par l'IA, mais CAPE horaire tres faible "
+                "et Lifted Index non instable. A verifier sur l'image source."
+            ),
+            "metrics": metrics,
+        }
+
+    if force_ms >= 3.0 and cape is None and lifted_index is None:
+        return {
+            "status": "low_confidence",
+            "message": (
+                "Thermiques forts annonces par l'IA sans CAPE ni Lifted Index horaire "
+                "pour confirmation."
+            ),
+            "metrics": metrics,
+        }
+
+    return {
+        "status": "plausible",
+        "message": "Force thermique IA coherente avec les donnees horaires disponibles.",
+        "metrics": metrics,
+    }
+
+
 def _configured_llm_providers(locale: str | None = None) -> list[dict[str, Any]]:
     analysis_locale = normalize_analysis_locale(locale)
 
@@ -338,6 +429,8 @@ def _normalize_llm_analysis(
         "success": True,
         "plafond_thermique_m": raw_analysis.get("plafond_thermique_m"),
         "force_thermique_ms": raw_analysis.get("force_thermique_ms"),
+        "force_thermique_confiance": raw_analysis.get("force_thermique_confiance"),
+        "force_thermique_indices": raw_analysis.get("force_thermique_indices", []),
         "heures_volables": raw_analysis.get("heures_volables"),
         "score_volabilite": raw_analysis.get("score_volabilite"),
         "conseils_vol": raw_analysis.get("conseils_vol"),
@@ -532,6 +625,33 @@ async def generate_multi_source_emagram_for_spot(
         logger.info(
             f"🤖 LLM analysis successful ({analyzer_used}): Score {analysis_result.get('score_volabilite')}/100"
         )
+
+        try:
+            from weather_pipeline import get_normalized_forecast
+
+            weather_forecast = await get_normalized_forecast(
+                lat=site.latitude,
+                lon=site.longitude,
+                day_index=day_index,
+                db=db,
+            )
+        except Exception as forecast_error:
+            logger.warning(
+                "Could not cross-check emagram thermal strength against hourly weather: %s",
+                forecast_error,
+            )
+            weather_forecast = None
+
+        thermal_validation = validate_ai_thermal_consistency(
+            analysis_result, weather_forecast, hour
+        )
+        analysis_result["thermal_validation"] = thermal_validation
+        if thermal_validation["status"] == "contradicted":
+            alerts = analysis_result.get("alertes_securite")
+            if not isinstance(alerts, list):
+                alerts = []
+            alerts.append(thermal_validation["message"])
+            analysis_result["alertes_securite"] = alerts
 
         # Step 5: Save to database
         emagram_analysis = save_emagram_analysis(

--- a/apps/backend/llm/emagram_prompt.py
+++ b/apps/backend/llm/emagram_prompt.py
@@ -44,6 +44,8 @@ Reponds UNIQUEMENT avec ce JSON valide, sans markdown:
 {{
   "plafond_thermique_m": <altitude plafond en metres>,
   "force_thermique_ms": <force thermiques en m/s>,
+  "force_thermique_confiance": "high|medium|low",
+  "force_thermique_indices": ["<indice visible utilise pour estimer la force>"],
   "heures_volables": "<ex: 12h-18h>",
   "score_volabilite": <0-100>,
   "conseils_vol": "<conseils courts MAX 50 mots>",
@@ -102,6 +104,12 @@ Reponds UNIQUEMENT avec ce JSON valide, sans markdown:
     }}
   }}
 }}
+
+Contraintes obligatoires pour force_thermique_ms:
+- N'invente jamais une vitesse ascendante forte. Une valeur >= 3.0 m/s est autorisee seulement si une indication visible et lisible montre des ascendances fortes, une parcelle nettement plus chaude que l'environnement sur une couche profonde, ou une instabilite franche sans inversion bloquante.
+- Si l'echelle ou les courbes ne permettent pas d'estimer la force, mets force_thermique_ms a 0.0, force_thermique_confiance a "low", et explique l'incertitude dans force_thermique_indices et details_analyse.
+- Une belle hauteur de plafond ne suffit pas a conclure a des thermiques forts. Separe toujours plafond, declenchement, force et risque.
+- Chaque valeur de force_thermique_ms doit etre justifiee par au moins un indice concret dans force_thermique_indices.
 
 Contraintes obligatoires pour annotations_image:
 - Produis au maximum 6 annotations par source, uniquement sur les points importants pour comprendre les conditions de vol et apprendre a lire l'emagramme.

--- a/apps/backend/tests/unit/test_emagram_thermal_validation.py
+++ b/apps/backend/tests/unit/test_emagram_thermal_validation.py
@@ -1,0 +1,38 @@
+from emagram_multi_source import validate_ai_thermal_consistency
+
+
+def test_strong_ai_thermal_is_contradicted_by_low_cape_and_unknown_li():
+    result = validate_ai_thermal_consistency(
+        {"force_thermique_ms": 3.2},
+        {"consensus": [{"hour": 14, "cape": 20, "lifted_index": None}]},
+        14,
+    )
+
+    assert result["status"] == "contradicted"
+    assert result["metrics"]["cape_jkg"] == 20.0
+
+
+def test_strong_ai_thermal_without_instability_indices_is_low_confidence():
+    result = validate_ai_thermal_consistency(
+        {"force_thermique_ms": 3.1},
+        {"consensus": [{"hour": 13, "cape": None, "lifted_index": None}]},
+        13,
+    )
+
+    assert result["status"] == "low_confidence"
+
+
+def test_moderate_ai_thermal_with_cape_is_plausible():
+    result = validate_ai_thermal_consistency(
+        {"force_thermique_ms": 2.0},
+        {"consensus": [{"hour": 13, "cape": 600, "lifted_index": -2}]},
+        13,
+    )
+
+    assert result["status"] == "plausible"
+
+
+def test_missing_hourly_weather_is_not_checked():
+    result = validate_ai_thermal_consistency({"force_thermique_ms": 2.0}, None, 13)
+
+    assert result["status"] == "not_checked"

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -12,6 +12,7 @@ import {
 import {
   parseAlerts,
   parseSourcesErrors,
+  parseThermalValidation,
   getScoreColor,
   getScoreCategory,
 } from '../../types/emagram';
@@ -549,6 +550,11 @@ export default function EmagramWidget({
   const scoreColor = getScoreColor(score);
   const scoreCategory = getScoreCategory(score);
   const alerts = parseAlerts(emagram.alertes_securite);
+  const thermalValidation = parseThermalValidation(emagram.ai_raw_response);
+  const shouldShowThermalValidation =
+    thermalValidation?.status === 'contradicted' ||
+    thermalValidation?.status === 'low_confidence' ||
+    thermalValidation?.status === 'not_checked';
 
   // Format analysis time
   const analysisDate = parseApiUtcDate(emagram.analysis_datetime);
@@ -665,6 +671,26 @@ export default function EmagramWidget({
           />
         )}
       </div>
+
+      {shouldShowThermalValidation && thermalValidation && (
+        <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-100">
+          <div className="flex items-start gap-2">
+            <span className="mt-0.5 flex-shrink-0">⚠️</span>
+            <div className="min-w-0">
+              <div className="font-semibold">Force thermique IA à vérifier</div>
+              <p className="mt-1 text-xs leading-relaxed">
+                {thermalValidation.message}
+              </p>
+              {thermalValidation.metrics?.cape_jkg != null && (
+                <p className="mt-1 text-xs opacity-80">
+                  CAPE horaire: {Math.round(thermalValidation.metrics.cape_jkg)}{' '}
+                  J/kg
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Summary */}
       {emagram.resume_conditions && (

--- a/apps/frontend/src/types/emagram.test.ts
+++ b/apps/frontend/src/types/emagram.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseThermalValidation } from './emagram';
+
+describe('parseThermalValidation', () => {
+  it('parses backend thermal validation from the raw AI response', () => {
+    const validation = parseThermalValidation(
+      JSON.stringify({
+        thermal_validation: {
+          status: 'contradicted',
+          message: 'CAPE tres faible.',
+          metrics: { cape_jkg: 20, force_thermique_ms: 3.2 },
+        },
+      })
+    );
+
+    expect(validation).toMatchObject({
+      status: 'contradicted',
+      message: 'CAPE tres faible.',
+    });
+    expect(validation?.metrics?.cape_jkg).toBe(20);
+  });
+
+  it('ignores unknown validation statuses', () => {
+    const validation = parseThermalValidation(
+      JSON.stringify({ thermal_validation: { status: 'unknown' } })
+    );
+
+    expect(validation).toBeNull();
+  });
+});

--- a/apps/frontend/src/types/emagram.ts
+++ b/apps/frontend/src/types/emagram.ts
@@ -105,6 +105,12 @@ export interface EmagramAnalysisExplanation {
   par_source: Record<string, string[]>;
 }
 
+export interface EmagramThermalValidation {
+  status: 'plausible' | 'contradicted' | 'low_confidence' | 'not_checked';
+  message: string;
+  metrics?: Record<string, number | null | undefined>;
+}
+
 // Parsed alerts (from JSON string)
 type SafetyAlert = string;
 
@@ -188,6 +194,39 @@ export function parseAnalysisExplanation(
   }
 
   return null;
+}
+
+export function parseThermalValidation(
+  ai_raw_response: string | null | undefined
+): EmagramThermalValidation | null {
+  if (!ai_raw_response) return null;
+
+  try {
+    const parsed = JSON.parse(ai_raw_response);
+    const validation = parsed?.thermal_validation;
+    if (!validation || typeof validation !== 'object') return null;
+
+    const status = validation.status;
+    if (
+      status !== 'plausible' &&
+      status !== 'contradicted' &&
+      status !== 'low_confidence' &&
+      status !== 'not_checked'
+    ) {
+      return null;
+    }
+
+    return {
+      status,
+      message: typeof validation.message === 'string' ? validation.message : '',
+      metrics:
+        typeof validation.metrics === 'object' && validation.metrics !== null
+          ? validation.metrics
+          : undefined,
+    };
+  } catch {
+    return null;
+  }
 }
 
 // Score categories


### PR DESCRIPTION
## Summary
- Cross-check AI-emagram thermal strength against hourly CAPE/Lifted Index before trusting strong thermal claims.
- Tighten the vision prompt so thermal strength must be justified by visible evidence.
- Surface a warning in the emagram widget when the AI thermal estimate is contradicted or low confidence.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- /media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-emagram-ai-validation/apps/backend/.venv/bin/pytest tests/unit/test_emagram_thermal_validation.py -q --tb=short
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec vitest run src/types/emagram.test.ts --config vitest.config.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thermal consistency validation that cross-checks AI thermal strength assessments against real weather data.
  * Enhanced AI analysis now provides confidence levels and supporting indices for thermal force estimates.
  * Dashboard widget displays thermal validation warnings when contradictions are detected.

* **Tests**
  * Added comprehensive test coverage for thermal validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/capic2/dashboard-parapente/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->