### PR TITLE
fix(frontend): restore weather toggle visual state

### DIFF
--- a/apps/frontend/src/components/settings/WeatherSourceCard.tsx
+++ b/apps/frontend/src/components/settings/WeatherSourceCard.tsx
@@ -302,8 +302,8 @@ export const WeatherSourceCard: React.FC<WeatherSourceCardProps> = ({
           }
         >
           <div className="relative inline-flex items-center cursor-pointer">
-            <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
-              <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+            <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-data-[selected]:bg-sky-600 transition-colors">
+              <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-data-[selected]:translate-x-full"></div>
             </div>
           </div>
         </Switch>

--- a/apps/frontend/src/pages/Settings.tsx
+++ b/apps/frontend/src/pages/Settings.tsx
@@ -1436,8 +1436,8 @@ export default function Settings() {
                     className="group"
                   >
                     <div className="relative inline-flex items-center cursor-pointer">
-                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
-                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-data-[selected]:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-data-[selected]:translate-x-full"></div>
                       </div>
                     </div>
                   </Switch>
@@ -1466,8 +1466,8 @@ export default function Settings() {
                     className="group"
                   >
                     <div className="relative inline-flex items-center cursor-pointer">
-                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
-                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-data-[selected]:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-data-[selected]:translate-x-full"></div>
                       </div>
                     </div>
                   </Switch>
@@ -1496,8 +1496,8 @@ export default function Settings() {
                     className="group"
                   >
                     <div className="relative inline-flex items-center cursor-pointer">
-                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-selected:bg-sky-600 transition-colors">
-                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-selected:translate-x-full"></div>
+                      <div className="w-11 h-6 bg-gray-300 group-focus-visible:outline-none group-focus-visible:ring-2 group-focus-visible:ring-sky-300 rounded-full group-data-[selected]:bg-sky-600 transition-colors">
+                        <div className="absolute top-[2px] left-[2px] bg-white border-gray-300 border rounded-full h-5 w-5 transition-transform group-data-[selected]:translate-x-full"></div>
                       </div>
                     </div>
                   </Switch>


### PR DESCRIPTION
## Summary
- Fix React Aria switch styling so weather source toggles reflect the selected state visually.
- Apply the same data-selected-based styling to the notification toggles in Settings for consistency.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test,build --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected toggle switch display styling for weather source settings. Switches now properly show the enabled/disabled state with correct visual indicators.
  * Corrected toggle switch display styling for notification settings including weather alerts, new flights, and custom alerts. These switches now properly display selection states and visual feedback when toggled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->