### PR TITLE
feat(weather): expand forecast sources and confidence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,18 @@ _Avoid_: Safety guarantee, source count only
 Weather information shown for a **Ville** or another location that is not enough to produce a complete **Decision de Vol**. A **Contexte Meteo** can explain general conditions and guide the pilot toward nearby **Sites**.
 _Avoid_: Decision de Vol, site recommendation
 
+**Source de Prevision**:
+A weather source that predicts future conditions and can contribute to the forecast consensus used by a **Decision de Vol**.
+_Avoid_: Observation live, source meteo generic
+
+**Source d'Observation**:
+A weather source that reports current or recent real-world conditions and can confirm, contradict, or lower **Confiance Meteo** without replacing the forecast basis of a **Decision de Vol**.
+_Avoid_: Source de prevision, forecast model
+
+**Heure Courante**:
+The current clock hour for which live observations can meaningfully affect a **Decision de Vol**.
+_Avoid_: Whole day, future forecast window
+
 **Site Selectionne**:
 The **Site** currently being evaluated by the pilot on the weather page. The primary **Decision de Vol** is always about the Site Selectionne, even when other sites are shown as alternatives.
 _Avoid_: Best site, nearby city, arbitrary coordinates
@@ -197,6 +209,118 @@ Domain expert: Significant rain, excessive average wind, excessive gusts, and ta
 Dev: Can strong forecast confidence make a risky creneau favorable?
 
 Domain expert: No. Confiance meteo can only support or degrade the recommendation; it cannot cancel a weather risk.
+
+Dev: Does adding more weather sources automatically make a decision more precise?
+
+Domain expert: No. More sources are useful when they improve confiance meteo and the decision de vol, but source count alone is not precision.
+
+Dev: Should every available weather source be required for the weather page to work?
+
+Domain expert: No. The app should support as many activable sources as practical, but each source may fail or be disabled without blocking the main weather context or decision.
+
+Dev: If weather sources strongly disagree on a blocking risk, should the average hide it?
+
+Domain expert: No. A credible source that reports a blocking risk should degrade the decision instead of being diluted by more optimistic sources.
+
+Dev: What makes a weather source credible enough to influence a blocking risk?
+
+Domain expert: A weather source is credible for this purpose when its data is fresh, valid, and not known to be failing repeatedly.
+
+Dev: Should forecasts and live observations influence the decision in the same way?
+
+Domain expert: No. Sources de prevision build the forecast basis, while sources d'observation confirm, contradict, or lower confiance meteo without replacing the forecast.
+
+Dev: Should the expanded weather source work include observations live from the start?
+
+Domain expert: Yes. The app should expand both sources de prevision and sources d'observation, while keeping their roles distinct in the decision.
+
+Dev: Can a source d'observation affect every forecast hour of the day?
+
+Domain expert: No. A source d'observation can affect the decision only for the heure courante, because it reports current or recent conditions rather than the full future day.
+
+Dev: Does heure courante include the next forecast hour?
+
+Domain expert: No. Heure courante means only the current clock hour, not the next hour or a broader preparation window.
+
+Dev: If a live observation contradicts the forecast during the heure courante, should it replace the forecast display?
+
+Domain expert: No. Keep the forecast visible as the forecast basis, show the live observation beside it, and flag the contradiction clearly.
+
+Dev: Can several weather models from the same provider count as separate sources de prevision?
+
+Domain expert: Yes, but only when each model is clearly identified and traceable separately; otherwise source count would overstate confiance meteo.
+
+Dev: How should sources requiring an API key appear before the key is configured?
+
+Domain expert: They should be visible but disabled until their key is configured, so they do not break the main weather experience.
+
+Dev: Can a source de prevision influence the decision if it lacks the necessary flight weather fields?
+
+Domain expert: No. A source de prevision must provide the necessary flight weather fields, including wind, wind direction, gusts, and precipitation, to influence the decision de vol.
+
+Dev: Can a source de prevision contribute when it provides only some necessary fields?
+
+Domain expert: Yes. It may influence only the risks and confidence for the fields it provides, without increasing confidence for missing fields.
+
+Dev: Should many weak weather sources outweigh a fresher, more reliable local source by simple averaging?
+
+Domain expert: No. Consensus should account for source quality such as freshness, reliability, local resolution, and configured priority rather than using source count alone.
+
+Dev: When a reliable local source disagrees with global sources, which one wins?
+
+Domain expert: Blocking risks should follow the most cautious credible signal, while non-blocking displayed values may give more weight to the reliable local source for the fields where it is relevant.
+
+Dev: Should a failed specialized forecast source make the whole decision unavailable?
+
+Domain expert: No. A failed specialized source should be visible and may lower confiance meteo, but it should not by itself make the decision unavailable when enough other credible data remains.
+
+Dev: What is the minimum credible forecast basis for a decision de vol?
+
+Domain expert: A decision de vol should have at least two credible sources for the essential fields such as wind, wind direction, gusts, and precipitation; with fewer, the app should treat the decision as too fragile or low-confidence.
+
+Dev: If only one credible source is available, should the app still show a normal favorable decision?
+
+Domain expert: No. It may still provide a useful decision aid, but the result should be degraded because a single credible source is too fragile for a normal favorable decision.
+
+Dev: What is the best possible decision level when only one credible source supports otherwise good conditions?
+
+Domain expert: Vigilance is the best possible level in that case; favorable requires at least two credible sources for the essential fields.
+
+Dev: Should weather settings show every possible source all the time?
+
+Domain expert: Use a simple view for active sources and an advanced view for all potential configurable sources, so the pilot can enable many sources without making the default settings noisy.
+
+Dev: Can experimental or fragile weather sources be enabled?
+
+Domain expert: Yes, as long as their status is clear and the pilot keeps direct control to enable or disable them easily.
+
+Dev: Can an experimental weather source create a blocking risk by itself?
+
+Domain expert: No. An experimental source may alert and lower confiance meteo, but it should not create a blocking risk on its own until it is considered reliable.
+
+Dev: How does an experimental weather source become reliable?
+
+Domain expert: Reliability should combine observed history such as success rate, freshness, and coherence with other sources with explicit pilot control over the final source status.
+
+Dev: Should the pilot see whether a weather source is experimental, fragile, reliable, or disabled?
+
+Domain expert: Yes. The source status should be visible in settings and weather details so the pilot understands how source quality affects confiance meteo and decision de vol.
+
+Dev: Where should the pilot understand which sources influenced risks and confidence?
+
+Domain expert: Keep quick per-hour source details in the hourly hover, and use a collapsible detail panel to explain how sources affected risks and the decision de vol.
+
+Dev: At what level should detailed source explanations be shown?
+
+Domain expert: Show global source confidence for the day, source impact per creneau de vol, and keep per-hour source values in the hourly hover.
+
+Dev: Should every technically possible fragile web source be integrated automatically?
+
+Domain expert: No. Fragile or unofficial web sources should be evaluated case by case, can be marked experimental, and should not block the decision by themselves.
+
+Dev: Who decides whether a fragile weather source is worth integrating?
+
+Domain expert: A fragile source should meet minimum technical criteria, then the pilot decides whether its weather value justifies the maintenance cost.
 
 Dev: Is the weather page primarily a best-site finder?
 

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -87,6 +87,7 @@ API_DEBUG = os.getenv("BACKEND_API_DEBUG", "false").lower() == "true"
 # ============================================================================
 WEATHERAPI_KEY = os.getenv("BACKEND_WEATHERAPI_KEY")
 METEOBLUE_API_KEY = os.getenv("BACKEND_METEOBLUE_API_KEY")
+OPENWEATHERMAP_API_KEY = os.getenv("BACKEND_OPENWEATHERMAP_API_KEY")
 SPOTAIR_BALISES_API_KEY = os.getenv("BACKEND_SPOTAIR_BALISES_API_KEY")
 
 # ============================================================================

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -274,6 +274,7 @@ def seed_weather_sources():
     import uuid
 
     from models import WeatherSourceConfig
+    from weather_sources import default_weather_source_rows
 
     logger.info("Checking for existing weather sources...")
 
@@ -286,32 +287,21 @@ def seed_weather_sources():
         if source_count > 0:
             logger.info(f"✓ Weather sources already exist ({source_count}) - checking API keys...")
 
-            # Update sources with API keys that may have been added after initial seed
-            weatherapi_key = config.WEATHERAPI_KEY
-            meteoblue_key = config.METEOBLUE_API_KEY
+            for source_data in default_weather_source_rows():
+                source = (
+                    db.query(WeatherSourceConfig)
+                    .filter(WeatherSourceConfig.source_name == source_data["source_name"])
+                    .first()
+                )
+                if source is None:
+                    db.add(WeatherSourceConfig(id=str(uuid.uuid4()), **source_data))
+                    logger.info(f"✓ Added missing weather source: {source_data['display_name']}")
+                    continue
 
-            wa_source = (
-                db.query(WeatherSourceConfig)
-                .filter(WeatherSourceConfig.source_name == "weatherapi")
-                .first()
-            )
-            if (
-                wa_source
-                and weatherapi_key
-                and (wa_source.api_key != weatherapi_key or not wa_source.is_enabled)
-            ):
-                wa_source.api_key = weatherapi_key
-                wa_source.is_enabled = True
-                logger.info("✓ WeatherAPI: updated API key and re-enabled")
-
-            mb_source = (
-                db.query(WeatherSourceConfig)
-                .filter(WeatherSourceConfig.source_name == "meteoblue")
-                .first()
-            )
-            if mb_source and meteoblue_key and mb_source.api_key != meteoblue_key:
-                mb_source.api_key = meteoblue_key
-                logger.info("✓ Meteoblue: updated API key")
+                configured_api_key = source_data.get("api_key")
+                if configured_api_key and source.api_key != configured_api_key:
+                    source.api_key = configured_api_key
+                    logger.info(f"✓ Updated API key for {source.display_name}")
 
             db.commit()
             db.close()
@@ -319,82 +309,9 @@ def seed_weather_sources():
 
         logger.info("No weather sources found - seeding defaults...")
 
-        # Get API keys from config
-        weatherapi_key = config.WEATHERAPI_KEY
-        meteoblue_key = config.METEOBLUE_API_KEY
-
-        # Define default sources (5 sources)
-        default_sources = [
-            {
-                "id": str(uuid.uuid4()),
-                "source_name": "open-meteo",
-                "display_name": "Open-Meteo",
-                "description": "API météo open-source gratuite, aucune clé requise. Données mondiales avec haute précision.",
-                "is_enabled": True,
-                "requires_api_key": False,
-                "api_key": None,
-                "priority": 10,
-                "scraper_type": "api",
-                "base_url": "https://api.open-meteo.com/v1/forecast",
-                "documentation_url": "https://open-meteo.com/en/docs",
-            },
-            {
-                "id": str(uuid.uuid4()),
-                "source_name": "weatherapi",
-                "display_name": "WeatherAPI.com",
-                "description": "API météo mondiale avec données détaillées. Clé API requise (plan gratuit disponible).",
-                "is_enabled": bool(weatherapi_key),  # Enabled only if API key present
-                "requires_api_key": True,
-                "api_key": weatherapi_key,
-                "priority": 9,
-                "scraper_type": "api",
-                "base_url": "https://api.weatherapi.com/v1/forecast.json",
-                "documentation_url": "https://www.weatherapi.com/docs/",
-            },
-            {
-                "id": str(uuid.uuid4()),
-                "source_name": "meteo-parapente",
-                "display_name": "Météo Parapente",
-                "description": "Prévisions spécialisées parapente avec thermiques et conditions de vol.",
-                "is_enabled": True,
-                "requires_api_key": False,
-                "api_key": None,
-                "priority": 8,
-                "scraper_type": "playwright",
-                "base_url": "https://meteo-parapente.com",
-                "documentation_url": None,
-            },
-            {
-                "id": str(uuid.uuid4()),
-                "source_name": "meteociel",
-                "display_name": "Météociel",
-                "description": "Prévisions AROME haute résolution pour la France. Scraping de données HTML.",
-                "is_enabled": True,
-                "requires_api_key": False,
-                "api_key": None,
-                "priority": 7,
-                "scraper_type": "playwright",
-                "base_url": "https://www.meteociel.fr",
-                "documentation_url": None,
-            },
-            {
-                "id": str(uuid.uuid4()),
-                "source_name": "meteoblue",
-                "display_name": "Meteoblue",
-                "description": "Prévisions météo professionnelles avec modèles multiples. API key optionnelle.",
-                "is_enabled": True,
-                "requires_api_key": False,
-                "api_key": meteoblue_key,
-                "priority": 6,
-                "scraper_type": "stealth",
-                "base_url": "https://www.meteoblue.com",
-                "documentation_url": "https://docs.meteoblue.com/",
-            },
-        ]
-
         # Insert sources using ORM
-        for source_data in default_sources:
-            source = WeatherSourceConfig(**source_data)
+        for source_data in default_weather_source_rows():
+            source = WeatherSourceConfig(id=str(uuid.uuid4()), **source_data)
             db.add(source)
             status = "✅" if source.is_enabled else "⚠️  (disabled - no API key)"
             logger.info(f"  {status} Seeded: {source.display_name}")

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5837,8 +5837,9 @@ def delete_weather_source(source_name: str, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail=f"Weather source '{source_name}' not found")
 
     # Protection: Cannot delete system sources
-    SYSTEM_SOURCES = ["open-meteo", "weatherapi", "meteo-parapente", "meteociel", "meteoblue"]
-    if source_name in SYSTEM_SOURCES:
+    from weather_sources import SYSTEM_WEATHER_SOURCE_NAMES
+
+    if source_name in SYSTEM_WEATHER_SOURCE_NAMES:
         raise HTTPException(
             status_code=400,
             detail=f"Cannot delete system weather source '{source_name}'. You can disable it instead.",
@@ -5885,24 +5886,10 @@ async def test_weather_source(
     if not source:
         raise HTTPException(status_code=404, detail=f"Weather source '{source_name}' not found")
 
-    # Import fetch functions
-    from scrapers.meteo_parapente import fetch_meteo_parapente
-    from scrapers.meteoblue import fetch_meteoblue
-    from scrapers.meteociel import fetch_meteociel
-    from scrapers.open_meteo import fetch_open_meteo
-    from scrapers.weatherapi import fetch_weatherapi
+    from weather_sources import get_weather_source_definition
 
-    # Map source_name to fetch function
-    fetch_functions = {
-        "open-meteo": fetch_open_meteo,
-        "weatherapi": fetch_weatherapi,
-        "meteo-parapente": fetch_meteo_parapente,
-        "meteociel": fetch_meteociel,
-        "meteoblue": fetch_meteoblue,
-    }
-
-    fetch_func = fetch_functions.get(source_name)
-    if not fetch_func:
+    source_definition = get_weather_source_definition(source_name)
+    if not source_definition:
         raise HTTPException(
             status_code=400, detail=f"No fetch function available for source '{source_name}'"
         )
@@ -5913,15 +5900,12 @@ async def test_weather_source(
     start_time = time.time()
 
     try:
-        # Call fetch with appropriate parameters per source
-        if source_name == "meteo-parapente":
-            result = await fetch_func(lat, lon, site_name="Test Site", elevation_m=1000)
-        elif source_name == "meteociel":
-            result = await fetch_func(lat, lon, site_name="Test Site")
-        elif source_name == "meteoblue":
-            result = await fetch_func(lat, lon, city_name="Test City")
-        else:
-            result = await fetch_func(lat, lon)
+        result = await source_definition.fetch(
+            lat,
+            lon,
+            site_name="Test Site",
+            elevation_m=1000,
+        )
 
         response_time_ms = int((time.time() - start_time) * 1000)
 

--- a/apps/backend/scrapers/met_no.py
+++ b/apps/backend/scrapers/met_no.py
@@ -1,0 +1,98 @@
+"""MET Norway Locationforecast scraper."""
+
+from datetime import datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+USER_AGENT = "dashboard-parapente/0.2.0 https://github.com/capic2/dashboard-parapente"
+
+
+async def fetch_met_no(lat: float, lon: float, days: int = 7) -> dict[str, Any]:
+    """Fetch weather forecast from MET Norway Locationforecast API."""
+
+    try:
+        params = {"lat": round(lat, 4), "lon": round(lon, 4)}
+        headers = {"User-Agent": USER_AGENT}
+
+        async with httpx.AsyncClient(timeout=10.0, headers=headers) as client:
+            response = await client.get(
+                "https://api.met.no/weatherapi/locationforecast/2.0/complete",
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        return {
+            "success": True,
+            "source": "met-no",
+            "data": data,
+            "timestamp": datetime.now().isoformat(),
+            "forecast_days": days,
+        }
+    except httpx.HTTPStatusError as e:
+        return {
+            "success": False,
+            "source": "met-no",
+            "error": f"HTTP {e.response.status_code}: {str(e)}",
+            "timestamp": datetime.now().isoformat(),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "source": "met-no",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+def extract_hourly_forecast(data: dict[str, Any], day_index: int = 0) -> list[dict[str, Any]]:
+    """Extract hourly forecast values from MET Norway response."""
+
+    raw_data = data.get("data") if isinstance(data, dict) and "data" in data else data
+    if not raw_data:
+        return []
+
+    timeseries = raw_data.get("properties", {}).get("timeseries", [])
+    if not timeseries:
+        return []
+
+    first_time = datetime.fromisoformat(timeseries[0]["time"].replace("Z", "+00:00")).astimezone(
+        PARIS_TZ
+    )
+    target_day = first_time.date() + timedelta(days=day_index)
+    forecasts: list[dict[str, Any]] = []
+
+    for item in timeseries:
+        time_str = item.get("time")
+        if not time_str:
+            continue
+
+        dt = datetime.fromisoformat(time_str.replace("Z", "+00:00")).astimezone(PARIS_TZ)
+        if dt.date() != target_day:
+            continue
+
+        instant = item.get("data", {}).get("instant", {}).get("details", {})
+        next_hour = item.get("data", {}).get("next_1_hours", {}).get("details", {})
+
+        wind_speed_ms = instant.get("wind_speed")
+        gust_ms = instant.get("wind_speed_of_gust")
+
+        forecasts.append(
+            {
+                "time": time_str,
+                "hour": dt.hour,
+                "temperature": instant.get("air_temperature"),
+                "wind_speed": round(wind_speed_ms * 3.6, 1) if wind_speed_ms is not None else None,
+                "wind_gust": round(gust_ms * 3.6, 1) if gust_ms is not None else None,
+                "wind_direction": instant.get("wind_from_direction"),
+                "cloud_cover": instant.get("cloud_area_fraction"),
+                "precipitation": next_hour.get("precipitation_amount"),
+                "cape": None,
+                "lifted_index": None,
+            }
+        )
+
+    return forecasts

--- a/apps/backend/scrapers/open_meteo.py
+++ b/apps/backend/scrapers/open_meteo.py
@@ -78,6 +78,77 @@ async def fetch_open_meteo(lat: float, lon: float, days: int = 2) -> dict[str, A
         }
 
 
+async def fetch_open_meteo_icon(lat: float, lon: float, days: int = 7) -> dict[str, Any]:
+    """Fetch a traceable ICON model forecast from Open-Meteo."""
+
+    return await _fetch_open_meteo_model(
+        lat=lat,
+        lon=lon,
+        days=days,
+        model="icon_seamless",
+        source="open-meteo-icon",
+    )
+
+
+async def fetch_open_meteo_gfs(lat: float, lon: float, days: int = 7) -> dict[str, Any]:
+    """Fetch a traceable GFS model forecast from Open-Meteo."""
+
+    return await _fetch_open_meteo_model(
+        lat=lat,
+        lon=lon,
+        days=days,
+        model="gfs_seamless",
+        source="open-meteo-gfs",
+    )
+
+
+async def _fetch_open_meteo_model(
+    lat: float,
+    lon: float,
+    days: int,
+    model: str,
+    source: str,
+) -> dict[str, Any]:
+    """Fetch a specific Open-Meteo forecast model as its own traceable source."""
+
+    try:
+        params = {
+            "latitude": lat,
+            "longitude": lon,
+            "hourly": "temperature_2m,windspeed_10m,wind_direction_10m,windgusts_10m,precipitation,cloudcover,cape,lifted_index",
+            "timezone": "Europe/Paris",
+            "forecast_days": days,
+            "models": model,
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get("https://api.open-meteo.com/v1/forecast", params=params)
+            response.raise_for_status()
+            data = response.json()
+
+        return {
+            "success": True,
+            "source": source,
+            "model": model,
+            "data": data,
+            "timestamp": datetime.now().isoformat(),
+        }
+    except httpx.HTTPStatusError as e:
+        return {
+            "success": False,
+            "source": source,
+            "error": f"HTTP {e.response.status_code}: {str(e)}",
+            "timestamp": datetime.now().isoformat(),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "source": source,
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
 def extract_hourly_forecast(data: dict[str, Any], day_index: int = 0) -> list[dict[str, Any]]:
     """
     Extract hourly forecast for a specific day

--- a/apps/backend/scrapers/openweathermap.py
+++ b/apps/backend/scrapers/openweathermap.py
@@ -1,0 +1,121 @@
+"""OpenWeatherMap forecast scraper."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from config import OPENWEATHERMAP_API_KEY
+
+PARIS_TZ = ZoneInfo("Europe/Paris")
+
+
+async def fetch_openweathermap(lat: float, lon: float, days: int = 5) -> dict[str, Any]:
+    """Fetch 5-day/3-hour forecast from OpenWeatherMap."""
+
+    if not OPENWEATHERMAP_API_KEY:
+        return {
+            "success": False,
+            "source": "openweathermap",
+            "error": "BACKEND_OPENWEATHERMAP_API_KEY is not configured",
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    try:
+        params = {
+            "lat": lat,
+            "lon": lon,
+            "appid": OPENWEATHERMAP_API_KEY,
+            "units": "metric",
+            "cnt": min(days * 8, 40),
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(
+                "https://api.openweathermap.org/data/2.5/forecast",
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        return {
+            "success": True,
+            "source": "openweathermap",
+            "data": data,
+            "timestamp": datetime.now().isoformat(),
+        }
+    except httpx.HTTPStatusError as e:
+        return {
+            "success": False,
+            "source": "openweathermap",
+            "error": f"HTTP {e.response.status_code}: {str(e)}",
+            "timestamp": datetime.now().isoformat(),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "source": "openweathermap",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+def extract_hourly_forecast(data: dict[str, Any], day_index: int = 0) -> list[dict[str, Any]]:
+    """Extract available 3-hour forecast points from OpenWeatherMap response."""
+
+    raw_data = data.get("data") if isinstance(data, dict) and "data" in data else data
+    if not raw_data:
+        return []
+
+    items = raw_data.get("list", [])
+    if not items:
+        return []
+
+    first_dt_txt = next(
+        (
+            item.get("dt_txt")
+            for item in items
+            if isinstance(item, dict) and isinstance(item.get("dt_txt"), str)
+        ),
+        None,
+    )
+    if not first_dt_txt:
+        return []
+
+    first_time = datetime.fromisoformat(first_dt_txt).replace(tzinfo=UTC).astimezone(PARIS_TZ)
+    target_day = first_time.date() + timedelta(days=day_index)
+    forecasts: list[dict[str, Any]] = []
+
+    for item in items:
+        time_str = item.get("dt_txt", "")
+        if not time_str:
+            continue
+
+        dt = datetime.fromisoformat(time_str).replace(tzinfo=UTC).astimezone(PARIS_TZ)
+        if dt.date() != target_day:
+            continue
+
+        wind = item.get("wind", {})
+        wind_speed_ms = wind.get("speed")
+        gust_ms = wind.get("gust")
+        rain = item.get("rain", {})
+        snow = item.get("snow", {})
+        precipitation_3h = (rain.get("3h") or 0) + (snow.get("3h") or 0)
+
+        forecasts.append(
+            {
+                "time": time_str,
+                "hour": dt.hour,
+                "temperature": item.get("main", {}).get("temp"),
+                "wind_speed": round(wind_speed_ms * 3.6, 1) if wind_speed_ms is not None else None,
+                "wind_gust": round(gust_ms * 3.6, 1) if gust_ms is not None else None,
+                "wind_direction": wind.get("deg"),
+                "cloud_cover": item.get("clouds", {}).get("all"),
+                "precipitation": round(precipitation_3h / 3, 2),
+                "cape": None,
+                "lifted_index": None,
+            }
+        )
+
+    return forecasts

--- a/apps/backend/tests/scrapers/test_met_no.py
+++ b/apps/backend/tests/scrapers/test_met_no.py
@@ -1,0 +1,46 @@
+from scrapers.met_no import extract_hourly_forecast
+
+
+def test_extract_met_no_hourly_forecast_converts_wind_to_kmh():
+    result = extract_hourly_forecast(
+        {
+            "success": True,
+            "data": {
+                "properties": {
+                    "timeseries": [
+                        {
+                            "time": "2026-06-01T12:00:00Z",
+                            "data": {
+                                "instant": {
+                                    "details": {
+                                        "air_temperature": 18.4,
+                                        "wind_speed": 5.0,
+                                        "wind_speed_of_gust": 8.0,
+                                        "wind_from_direction": 245,
+                                        "cloud_area_fraction": 40,
+                                    }
+                                },
+                                "next_1_hours": {"details": {"precipitation_amount": 0.2}},
+                            },
+                        }
+                    ]
+                }
+            },
+        },
+        day_index=0,
+    )
+
+    assert result == [
+        {
+            "time": "2026-06-01T12:00:00Z",
+            "hour": 14,
+            "temperature": 18.4,
+            "wind_speed": 18.0,
+            "wind_gust": 28.8,
+            "wind_direction": 245,
+            "cloud_cover": 40,
+            "precipitation": 0.2,
+            "cape": None,
+            "lifted_index": None,
+        }
+    ]

--- a/apps/backend/tests/scrapers/test_openweathermap.py
+++ b/apps/backend/tests/scrapers/test_openweathermap.py
@@ -1,0 +1,42 @@
+from scrapers.openweathermap import extract_hourly_forecast
+
+
+def test_extract_openweathermap_hourly_forecast_normalizes_utc_and_precipitation():
+    result = extract_hourly_forecast(
+        {
+            "success": True,
+            "data": {
+                "list": [
+                    {
+                        "dt_txt": "2026-06-01 15:00:00",
+                        "main": {"temp": 21.2},
+                        "wind": {"speed": 4.0, "gust": 7.5, "deg": 260},
+                        "clouds": {"all": 35},
+                        "rain": {"3h": 0.4},
+                    }
+                ]
+            },
+        },
+        day_index=0,
+    )
+
+    assert result == [
+        {
+            "time": "2026-06-01 15:00:00",
+            "hour": 17,
+            "temperature": 21.2,
+            "wind_speed": 14.4,
+            "wind_gust": 27.0,
+            "wind_direction": 260,
+            "cloud_cover": 35,
+            "precipitation": 0.13,
+            "cape": None,
+            "lifted_index": None,
+        }
+    ]
+
+
+def test_extract_openweathermap_returns_empty_when_dt_txt_is_missing():
+    result = extract_hourly_forecast({"success": True, "data": {"list": [{"main": {}}]}})
+
+    assert result == []

--- a/apps/backend/tests/unit/test_seed_weather_sources.py
+++ b/apps/backend/tests/unit/test_seed_weather_sources.py
@@ -1,0 +1,46 @@
+import uuid
+
+from models import WeatherSourceConfig
+
+
+def test_seed_weather_sources_adds_missing_sources_and_updates_api_keys(db_session, monkeypatch):
+    import main
+
+    existing_weatherapi = WeatherSourceConfig(
+        id=str(uuid.uuid4()),
+        source_name="weatherapi",
+        display_name="WeatherAPI.com",
+        description="Existing source",
+        is_enabled=False,
+        requires_api_key=True,
+        api_key="old-key",
+        priority=9,
+        scraper_type="api",
+        base_url="https://www.weatherapi.com/",
+        documentation_url="https://www.weatherapi.com/docs/",
+    )
+    db_session.add(existing_weatherapi)
+    db_session.commit()
+
+    class TestSessionLocal:
+        def __call__(self):
+            return db_session
+
+    monkeypatch.setattr(main, "SessionLocal", TestSessionLocal())
+
+    assert main.seed_weather_sources() is True
+
+    weatherapi = (
+        db_session.query(WeatherSourceConfig)
+        .filter(WeatherSourceConfig.source_name == "weatherapi")
+        .one()
+    )
+    met_no = (
+        db_session.query(WeatherSourceConfig)
+        .filter(WeatherSourceConfig.source_name == "met-no")
+        .one()
+    )
+
+    assert weatherapi.api_key == "test_weather_key"
+    assert weatherapi.is_enabled is False
+    assert met_no.is_enabled is True

--- a/apps/backend/tests/unit/test_weather_pipeline_sources.py
+++ b/apps/backend/tests/unit/test_weather_pipeline_sources.py
@@ -1,0 +1,29 @@
+from weather_pipeline import calculate_consensus
+
+
+def test_calculate_consensus_preserves_registered_source_details():
+    result = calculate_consensus(
+        {
+            "success": True,
+            "normalized": [
+                {
+                    "hour": 12,
+                    "sources": ["open-meteo", "met-no"],
+                    "temperature": [18.0, 20.0],
+                    "wind_speed": [12.0, 16.0],
+                    "wind_gust": [20.0, 24.0],
+                    "wind_direction": [250.0, 260.0],
+                    "precipitation": [0.0, 0.2],
+                    "cloud_cover": [30.0, 40.0],
+                    "cape": [None, None],
+                    "lifted_index": [None, None],
+                }
+            ],
+        }
+    )
+
+    assert result["success"] is True
+    assert result["total_sources"] == 2
+    assert result["consensus"][0]["sources"]["met-no"]["wind_speed"] == 16.0
+    assert result["consensus"][0]["sources"]["open-meteo"]["wind_speed"] == 12.0
+    assert result["consensus"][0]["sources"]["open-meteo-icon"]["wind_speed"] is None

--- a/apps/backend/tests/unit/test_weather_sources_registry.py
+++ b/apps/backend/tests/unit/test_weather_sources_registry.py
@@ -1,0 +1,17 @@
+import config
+from weather_sources import SYSTEM_WEATHER_SOURCE_NAMES, WEATHER_SOURCE_REGISTRY
+
+
+def test_registry_contains_new_forecast_sources():
+    assert "open-meteo-icon" in WEATHER_SOURCE_REGISTRY
+    assert "open-meteo-gfs" in WEATHER_SOURCE_REGISTRY
+    assert "met-no" in WEATHER_SOURCE_REGISTRY
+    assert "openweathermap" in WEATHER_SOURCE_REGISTRY
+    assert "met-no" in SYSTEM_WEATHER_SOURCE_NAMES
+
+
+def test_openweathermap_enablement_follows_api_key_configuration():
+    source = WEATHER_SOURCE_REGISTRY["openweathermap"]
+
+    assert source.requires_api_key is True
+    assert source.is_enabled is bool(config.OPENWEATHERMAP_API_KEY)

--- a/apps/backend/weather_pipeline.py
+++ b/apps/backend/weather_pipeline.py
@@ -13,20 +13,10 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from para_index import calculate_para_index
-from scrapers.meteo_parapente import extract_hourly_forecast as extract_mp
-from scrapers.meteo_parapente import fetch_meteo_parapente
-from scrapers.meteoblue import extract_hourly_forecast as extract_mb
-from scrapers.meteoblue import fetch_meteoblue
-from scrapers.meteociel import extract_hourly_forecast as extract_mc
-from scrapers.meteociel import fetch_meteociel
-
-# Import all scrapers
-from scrapers.open_meteo import extract_hourly_forecast as extract_om
-from scrapers.open_meteo import fetch_open_meteo
-from scrapers.weatherapi import extract_hourly_forecast as extract_wa
-from scrapers.weatherapi import fetch_weatherapi
+from weather_sources import WEATHER_SOURCE_REGISTRY
 
 logger = logging.getLogger(__name__)
+FULL_CONFIDENCE_SOURCE_BASELINE = 5
 
 
 # ============================================================================
@@ -151,36 +141,18 @@ async def fetch_from_enabled_sources(
             f"{[s.source_name for s in enabled_sources]}"
         )
 
-        # Map sources to fetch functions
-        fetch_map = {
-            "open-meteo": fetch_open_meteo,
-            "weatherapi": fetch_weatherapi,
-            "meteo-parapente": fetch_meteo_parapente,
-            "meteociel": fetch_meteociel,
-            "meteoblue": fetch_meteoblue,
-        }
-
         # Create instrumented tasks
-        async def instrumented_fetch(src_name, func):
+        async def instrumented_fetch(src_name: str):
             """Wrapper to instrument each fetch call"""
             result = None
             try:
-                # Clean site name for scrapers (remove suffixes like "Test", "Nord", etc. for better matching)
-                clean_site_name = site_name.split()[0] if site_name else site_name
-
-                # Adapt arguments per source
-                if src_name == "open-meteo":
-                    result = await func(lat, lon, days=7)
-                elif src_name == "meteo-parapente":
-                    result = await func(
-                        lat, lon, site_name=site_name, elevation_m=elevation_m, days=1
-                    )
-                elif src_name == "meteociel":
-                    result = await func(lat, lon, site_name=clean_site_name)
-                elif src_name == "meteoblue":
-                    result = await func(lat, lon, city_name=site_name)
-                else:
-                    result = await func(lat, lon)
+                source_definition = WEATHER_SOURCE_REGISTRY[src_name]
+                result = await source_definition.fetch(
+                    lat,
+                    lon,
+                    site_name=site_name,
+                    elevation_m=elevation_m,
+                )
 
                 # Update stats based on result
                 from models import WeatherSourceConfig
@@ -207,17 +179,7 @@ async def fetch_from_enabled_sources(
                 # Scrapers return {'success': True, 'data': {...}}
                 # but normalize_data() expects {'success': True, 'hourly': [...]}
                 if result and result.get("success") and "data" in result:
-                    # Extract hourly data for the requested day
-                    if src_name == "open-meteo":
-                        result["hourly"] = extract_om(result, day_index)
-                    elif src_name == "weatherapi":
-                        result["hourly"] = extract_wa(result, day_index)
-                    elif src_name == "meteo-parapente":
-                        result["hourly"] = extract_mp(result, day_index)
-                    elif src_name == "meteociel":
-                        result["hourly"] = extract_mc(result, day_index)
-                    elif src_name == "meteoblue":
-                        result["hourly"] = extract_mb(result, day_index)
+                    result["hourly"] = source_definition.extract(result, day_index)
 
                 return result
 
@@ -251,12 +213,11 @@ async def fetch_from_enabled_sources(
         source_names = []
 
         for source in enabled_sources:
-            fetch_func = fetch_map.get(source.source_name)
-            if not fetch_func:
+            if source.source_name not in WEATHER_SOURCE_REGISTRY:
                 logger.warning(f"No fetch function for source '{source.source_name}', skipping")
                 continue
 
-            tasks.append(instrumented_fetch(source.source_name, fetch_func))
+            tasks.append(instrumented_fetch(source.source_name))
             source_names.append(source.source_name)
 
         # Execute all fetches in parallel
@@ -425,12 +386,16 @@ def calculate_consensus(normalized: dict[str, Any]) -> dict[str, Any]:
 
             avg = statistics.mean(valid_values)
             # Confidence based on number of sources and variance
+            expected_sources = max(FULL_CONFIDENCE_SOURCE_BASELINE, len(valid_values))
             if len(valid_values) == 1:
                 confidence = 0.5
             else:
                 # Higher confidence with more sources and lower variance
                 variance = statistics.variance(valid_values) if len(valid_values) > 1 else 0
-                confidence = min(1.0, (len(valid_values) / 5) * (1 - min(variance / 100, 0.5)))
+                confidence = min(
+                    1.0,
+                    (len(valid_values) / expected_sources) * (1 - min(variance / 100, 0.5)),
+                )
             return avg, confidence
 
         temp_avg, temp_conf = safe_avg(hour_data["temperature"])
@@ -467,7 +432,8 @@ def calculate_consensus(normalized: dict[str, Any]) -> dict[str, Any]:
 
                 # Calculate confidence based on number of sources and vector magnitude
                 # magnitude close to 1.0 = all sources agree, close to 0 = sources disagree
-                source_factor = len(valid_directions) / 5
+                expected_sources = max(FULL_CONFIDENCE_SOURCE_BASELINE, len(valid_directions))
+                source_factor = len(valid_directions) / expected_sources
                 agreement_factor = magnitude / len(valid_directions)  # Normalize by count
                 dir_conf = min(1.0, source_factor * agreement_factor)
         else:
@@ -485,7 +451,7 @@ def calculate_consensus(normalized: dict[str, Any]) -> dict[str, Any]:
         sources_data = {}
 
         # Build initial per-source structure for all known sources
-        for source in ["open-meteo", "weatherapi", "meteo-parapente", "meteociel", "meteoblue"]:
+        for source in WEATHER_SOURCE_REGISTRY:
             sources_data[source] = {
                 "wind_speed": None,
                 "temperature": None,

--- a/apps/backend/weather_sources.py
+++ b/apps/backend/weather_sources.py
@@ -1,0 +1,258 @@
+"""Central registry for forecast weather sources."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+import config
+from scrapers.met_no import extract_hourly_forecast as extract_met_no
+from scrapers.met_no import fetch_met_no
+from scrapers.meteo_parapente import extract_hourly_forecast as extract_mp
+from scrapers.meteo_parapente import fetch_meteo_parapente
+from scrapers.meteoblue import extract_hourly_forecast as extract_mb
+from scrapers.meteoblue import fetch_meteoblue
+from scrapers.meteociel import extract_hourly_forecast as extract_mc
+from scrapers.meteociel import fetch_meteociel
+from scrapers.open_meteo import extract_hourly_forecast as extract_om
+from scrapers.open_meteo import fetch_open_meteo
+from scrapers.open_meteo import fetch_open_meteo_gfs
+from scrapers.open_meteo import fetch_open_meteo_icon
+from scrapers.openweathermap import extract_hourly_forecast as extract_owm
+from scrapers.openweathermap import fetch_openweathermap
+from scrapers.weatherapi import extract_hourly_forecast as extract_wa
+from scrapers.weatherapi import fetch_weatherapi
+
+FetchFunction = Callable[..., Awaitable[dict[str, Any]]]
+ExtractFunction = Callable[[dict[str, Any], int], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class WeatherSourceDefinition:
+    source_name: str
+    display_name: str
+    description: str
+    is_enabled: bool
+    requires_api_key: bool
+    api_key: str | None
+    priority: int
+    scraper_type: str
+    base_url: str | None
+    documentation_url: str | None
+    fetch: FetchFunction
+    extract: ExtractFunction
+
+    def seed_data(self) -> dict[str, Any]:
+        return {
+            "source_name": self.source_name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "is_enabled": self.is_enabled,
+            "requires_api_key": self.requires_api_key,
+            "api_key": self.api_key,
+            "priority": self.priority,
+            "scraper_type": self.scraper_type,
+            "base_url": self.base_url,
+            "documentation_url": self.documentation_url,
+        }
+
+
+async def fetch_open_meteo_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_open_meteo(lat, lon, days=7)
+
+
+async def fetch_open_meteo_icon_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_open_meteo_icon(lat, lon, days=7)
+
+
+async def fetch_open_meteo_gfs_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_open_meteo_gfs(lat, lon, days=7)
+
+
+async def fetch_weatherapi_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_weatherapi(lat, lon)
+
+
+async def fetch_meteo_parapente_default(
+    lat: float,
+    lon: float,
+    *,
+    site_name: str | None = None,
+    elevation_m: int | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    return await fetch_meteo_parapente(
+        lat,
+        lon,
+        site_name=site_name,
+        elevation_m=elevation_m,
+        days=1,
+    )
+
+
+async def fetch_meteociel_default(
+    lat: float,
+    lon: float,
+    *,
+    site_name: str | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    return await fetch_meteociel(lat, lon, site_name=site_name)
+
+
+async def fetch_meteoblue_default(
+    lat: float,
+    lon: float,
+    *,
+    site_name: str | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    return await fetch_meteoblue(lat, lon, city_name=site_name)
+
+
+async def fetch_met_no_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_met_no(lat, lon, days=7)
+
+
+async def fetch_openweathermap_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
+    return await fetch_openweathermap(lat, lon, days=5)
+
+
+WEATHER_SOURCE_DEFINITIONS: tuple[WeatherSourceDefinition, ...] = (
+    WeatherSourceDefinition(
+        source_name="open-meteo",
+        display_name="Open-Meteo AROME",
+        description="API météo open-source gratuite. Utilise AROME France HD en France et best_match ailleurs.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=10,
+        scraper_type="api",
+        base_url="https://api.open-meteo.com/v1/forecast",
+        documentation_url="https://open-meteo.com/en/docs",
+        fetch=fetch_open_meteo_default,
+        extract=extract_om,
+    ),
+    WeatherSourceDefinition(
+        source_name="open-meteo-icon",
+        display_name="Open-Meteo ICON",
+        description="Modèle ICON exposé séparément via Open-Meteo pour une comparaison traçable des modèles.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=9,
+        scraper_type="api",
+        base_url="https://api.open-meteo.com/v1/forecast",
+        documentation_url="https://open-meteo.com/en/docs",
+        fetch=fetch_open_meteo_icon_default,
+        extract=extract_om,
+    ),
+    WeatherSourceDefinition(
+        source_name="open-meteo-gfs",
+        display_name="Open-Meteo GFS",
+        description="Modèle GFS exposé séparément via Open-Meteo pour une comparaison traçable des modèles.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=8,
+        scraper_type="api",
+        base_url="https://api.open-meteo.com/v1/forecast",
+        documentation_url="https://open-meteo.com/en/docs",
+        fetch=fetch_open_meteo_gfs_default,
+        extract=extract_om,
+    ),
+    WeatherSourceDefinition(
+        source_name="weatherapi",
+        display_name="WeatherAPI.com",
+        description="API météo mondiale avec données détaillées. Clé API requise.",
+        is_enabled=bool(config.WEATHERAPI_KEY),
+        requires_api_key=True,
+        api_key=config.WEATHERAPI_KEY,
+        priority=7,
+        scraper_type="api",
+        base_url="https://api.weatherapi.com/v1/forecast.json",
+        documentation_url="https://www.weatherapi.com/docs/",
+        fetch=fetch_weatherapi_default,
+        extract=extract_wa,
+    ),
+    WeatherSourceDefinition(
+        source_name="met-no",
+        display_name="MET Norway",
+        description="Prévisions MET Norway Locationforecast, gratuites et sans clé API.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=6,
+        scraper_type="api",
+        base_url="https://api.met.no/weatherapi/locationforecast/2.0/complete",
+        documentation_url="https://api.met.no/weatherapi/locationforecast/2.0/documentation",
+        fetch=fetch_met_no_default,
+        extract=extract_met_no,
+    ),
+    WeatherSourceDefinition(
+        source_name="meteo-parapente",
+        display_name="Météo Parapente",
+        description="Prévisions spécialisées parapente avec thermiques et conditions de vol.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=5,
+        scraper_type="playwright",
+        base_url="https://meteo-parapente.com",
+        documentation_url=None,
+        fetch=fetch_meteo_parapente_default,
+        extract=extract_mp,
+    ),
+    WeatherSourceDefinition(
+        source_name="meteociel",
+        display_name="Météociel",
+        description="Prévisions AROME haute résolution pour la France. Scraping de données HTML.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=None,
+        priority=4,
+        scraper_type="playwright",
+        base_url="https://www.meteociel.fr",
+        documentation_url=None,
+        fetch=fetch_meteociel_default,
+        extract=extract_mc,
+    ),
+    WeatherSourceDefinition(
+        source_name="meteoblue",
+        display_name="Meteoblue",
+        description="Prévisions météo professionnelles avec modèles multiples. API key optionnelle.",
+        is_enabled=True,
+        requires_api_key=False,
+        api_key=config.METEOBLUE_API_KEY,
+        priority=3,
+        scraper_type="stealth",
+        base_url="https://www.meteoblue.com",
+        documentation_url="https://docs.meteoblue.com/",
+        fetch=fetch_meteoblue_default,
+        extract=extract_mb,
+    ),
+    WeatherSourceDefinition(
+        source_name="openweathermap",
+        display_name="OpenWeatherMap",
+        description="Prévisions 5 jours par pas de 3 heures. Clé API requise.",
+        is_enabled=bool(config.OPENWEATHERMAP_API_KEY),
+        requires_api_key=True,
+        api_key=config.OPENWEATHERMAP_API_KEY,
+        priority=2,
+        scraper_type="api",
+        base_url="https://api.openweathermap.org/data/2.5/forecast",
+        documentation_url="https://openweathermap.org/forecast5",
+        fetch=fetch_openweathermap_default,
+        extract=extract_owm,
+    ),
+)
+
+WEATHER_SOURCE_REGISTRY = {source.source_name: source for source in WEATHER_SOURCE_DEFINITIONS}
+SYSTEM_WEATHER_SOURCE_NAMES = tuple(WEATHER_SOURCE_REGISTRY.keys())
+
+
+def get_weather_source_definition(source_name: str) -> WeatherSourceDefinition | None:
+    return WEATHER_SOURCE_REGISTRY.get(source_name)
+
+
+def default_weather_source_rows() -> list[dict[str, Any]]:
+    return [source.seed_data() for source in WEATHER_SOURCE_DEFINITIONS]

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -128,14 +128,22 @@ const getSourceUrl = (sourceKey: string): string | null => {
   switch (sourceKey) {
     case 'open-meteo':
       return 'https://open-meteo.com/';
+    case 'open-meteo-icon':
+      return 'https://open-meteo.com/';
+    case 'open-meteo-gfs':
+      return 'https://open-meteo.com/';
     case 'weatherapi':
       return 'https://www.weatherapi.com/';
+    case 'met-no':
+      return 'https://www.met.no/en/free-meteorological-data';
     case 'meteo-parapente':
       return 'https://meteo-parapente.com/';
     case 'meteociel':
       return 'https://www.meteociel.fr/';
     case 'meteoblue':
       return 'https://www.meteoblue.com/';
+    case 'openweathermap':
+      return 'https://openweathermap.org/';
     default:
       return null;
   }
@@ -234,19 +242,27 @@ const formatConsensusValue = (value: number | string | null): string => {
 };
 
 const SOURCE_NAMES: Record<string, string> = {
-  'open-meteo': 'Open-Meteo',
+  'open-meteo': 'Open-Meteo AROME',
+  'open-meteo-icon': 'Open-Meteo ICON',
+  'open-meteo-gfs': 'Open-Meteo GFS',
   weatherapi: 'WeatherAPI',
+  'met-no': 'MET Norway',
   'meteo-parapente': 'Météo-parapente',
   meteociel: 'Meteociel',
   meteoblue: 'Meteoblue',
+  openweathermap: 'OpenWeatherMap',
 };
 
 const SOURCE_ORDER = [
   'open-meteo',
+  'open-meteo-icon',
+  'open-meteo-gfs',
   'weatherapi',
+  'met-no',
   'meteo-parapente',
   'meteociel',
   'meteoblue',
+  'openweathermap',
 ];
 
 export const DEFAULT_UI_THRESHOLDS: UiThresholds = {
@@ -432,6 +448,13 @@ const SourceDataTooltip = ({
   color,
 }: SourceDataTooltipProps) => {
   const { t } = useTranslation();
+  const sourceKeys = [
+    ...SOURCE_ORDER,
+    ...Object.keys(sources).filter(
+      (sourceKey) => !SOURCE_ORDER.includes(sourceKey)
+    ),
+  ];
+
   return (
     <div
       className="bg-white dark:bg-gray-800 border-2 rounded-lg shadow-xl p-4 text-sm max-w-[320px]"
@@ -441,7 +464,7 @@ const SourceDataTooltip = ({
         {label} - {hour}
       </div>
       <div className="space-y-2">
-        {SOURCE_ORDER.map((sourceKey) => {
+        {sourceKeys.map((sourceKey) => {
           const sourceData = sources[sourceKey];
           const sourceName = SOURCE_NAMES[sourceKey] || sourceKey;
 

--- a/docs/adr/0002-weather-source-confidence-and-risk-precedence.md
+++ b/docs/adr/0002-weather-source-confidence-and-risk-precedence.md
@@ -1,0 +1,7 @@
+# Weather Source Confidence and Risk Precedence
+
+The weather model separates **Sources de Prevision** from **Sources d'Observation** because forecasts build the future weather basis while live observations only confirm or contradict the current hour. Adding more sources should improve **Confiance Meteo** and **Decision de Vol**, but source count alone is not precision: confidence must account for freshness, reliability, local resolution, field completeness, and configured priority.
+
+Blocking risks follow the most cautious credible signal instead of being diluted by optimistic averages. Experimental or fragile sources can be enabled and shown to the pilot, but they may only alert or lower confidence until they are considered reliable; they must not create a blocking risk by themselves.
+
+The rejected alternative is a simple average across every enabled source. That would make the system look more precise as source count grows, while allowing weak or stale sources to hide important wind, gust, rain, or live-observation discrepancies.


### PR DESCRIPTION
## Summary
- Add a central weather-source registry and expand the backend to support additional forecast sources, including MET Norway, OpenWeatherMap, and separate Open-Meteo model sources.
- Normalize the consensus pipeline and weather source seeding around dynamic source definitions instead of hardcoded lists.
- Update hourly weather tooltips, docs, and tests to reflect the broader source model and confidence/risk rules.

## Validation
- `TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/unit/test_seed_weather_sources.py tests/scrapers/test_met_no.py tests/scrapers/test_openweathermap.py tests/unit/test_weather_sources_registry.py tests/unit/test_weather_pipeline_sources.py -q --tb=short --no-header`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- CodeRabbit review: passed, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple new weather forecast sources: MET Norway, OpenWeatherMap, and specialized Open-Meteo model variants (ICON and GFS)
  * Enhanced weather source configuration and management system

* **Improvements**
  * Updated weather consensus calculation for improved confidence assessment with dynamic source weighting

* **Documentation**
  * Added reference guidance on weather source confidence calculation and blocking risk assessment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->