### PR TITLE
feat(weather): expand forecast sources and keep settings in sync

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -299,9 +299,15 @@ def seed_weather_sources():
                     continue
 
                 configured_api_key = source_data.get("api_key")
-                if configured_api_key and source.api_key != configured_api_key:
+                previous_api_key = source.api_key
+                if configured_api_key and previous_api_key != configured_api_key:
                     source.api_key = configured_api_key
                     logger.info(f"✓ Updated API key for {source.display_name}")
+                    if source.requires_api_key and not source.is_enabled and not previous_api_key:
+                        source.is_enabled = True
+                        logger.info(
+                            f"✓ Re-enabled {source.display_name} after API key configuration"
+                        )
 
             db.commit()
             db.close()

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -117,6 +117,7 @@ from video_export_manual import start_video_export_manual
 from video_export_manual import start_video_export_manual_fast
 from versioning import get_version_payload
 from weather_pipeline import get_daily_aggregate, get_normalized_forecast
+from weather_sources import ensure_weather_source_configs
 
 logger = logging.getLogger(__name__)
 
@@ -5656,6 +5657,8 @@ def get_weather_sources(enabled_only: bool = False, db: Session = Depends(get_db
     Returns:
         List of WeatherSourceConfig with stats
     """
+    ensure_weather_source_configs(db)
+
     query = db.query(WeatherSourceConfig)
 
     if enabled_only:
@@ -5675,6 +5678,7 @@ def get_weather_sources_stats(db: Session = Depends(get_db)):
     Returns:
         WeatherSourceStats with aggregations
     """
+    ensure_weather_source_configs(db)
     sources = db.query(WeatherSourceConfig).all()
 
     total = len(sources)

--- a/apps/backend/scrapers/openweathermap.py
+++ b/apps/backend/scrapers/openweathermap.py
@@ -23,12 +23,13 @@ async def fetch_openweathermap(lat: float, lon: float, days: int = 5) -> dict[st
         }
 
     try:
+        forecast_days = max(1, days)
         params = {
             "lat": lat,
             "lon": lon,
             "appid": OPENWEATHERMAP_API_KEY,
             "units": "metric",
-            "cnt": min(days * 8, 40),
+            "cnt": min(forecast_days * 8, 40),
         }
 
         async with httpx.AsyncClient(timeout=10.0) as client:

--- a/apps/backend/tests/api/test_routes_weather_simple.py
+++ b/apps/backend/tests/api/test_routes_weather_simple.py
@@ -5,6 +5,9 @@ Tests HTTP endpoints respond correctly without mocking external dependencies.
 Tests may fail if weather APIs are down, which is expected behavior.
 """
 
+from models import WeatherSourceConfig
+from weather_sources import SYSTEM_WEATHER_SOURCE_NAMES
+
 # API prefix for all routes
 API_PREFIX = "/api"
 
@@ -91,10 +94,28 @@ class TestWeatherSourcesEndpoints:
     """Tests for /weather-sources configuration endpoints"""
 
     def test_get_weather_sources(self, client, db_session):
-        """GET /weather-sources lists all weather sources"""
+        """GET /weather-sources lists all registered weather sources"""
+        db_session.query(WeatherSourceConfig).delete()
+        db_session.commit()
+
         response = client.get(f"{API_PREFIX}/weather-sources")
-        # Should return list of sources
-        assert response.status_code in [200, 500]
+        assert response.status_code == 200
+
+        data = response.json()
+        returned_names = {source["source_name"] for source in data}
+
+        assert set(SYSTEM_WEATHER_SOURCE_NAMES).issubset(returned_names)
+
+    def test_get_weather_sources_stats_synchronizes_missing_sources(self, client, db_session):
+        """GET /weather-sources/stats should reflect registry-backed sources."""
+        db_session.query(WeatherSourceConfig).delete()
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/weather-sources/stats")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["total_sources"] >= len(SYSTEM_WEATHER_SOURCE_NAMES)
 
     def test_get_weather_sources_stats(self, client, db_session):
         """GET /weather-sources/stats returns usage statistics"""

--- a/apps/backend/tests/scrapers/test_open_meteo.py
+++ b/apps/backend/tests/scrapers/test_open_meteo.py
@@ -4,6 +4,8 @@ Live tests for Open-Meteo scraper
 
 import pytest
 
+import scrapers.open_meteo as open_meteo
+
 from scrapers.open_meteo import fetch_open_meteo
 
 ARGUEL_LAT = 47.2
@@ -31,3 +33,51 @@ async def test_fetch_open_meteo_timeout():
     duration = time.time() - start
     assert duration < 15.0
     assert "success" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_open_meteo_icon_uses_icon_model(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    async def fake_fetch_open_meteo_model(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "source": kwargs["source"]}
+
+    monkeypatch.setattr(open_meteo, "_fetch_open_meteo_model", fake_fetch_open_meteo_model)
+
+    result = await open_meteo.fetch_open_meteo_icon(ARGUEL_LAT, ARGUEL_LON, days=4)
+
+    assert result == {"success": True, "source": "open-meteo-icon"}
+    assert calls == [
+        {
+            "lat": ARGUEL_LAT,
+            "lon": ARGUEL_LON,
+            "days": 4,
+            "model": "icon_seamless",
+            "source": "open-meteo-icon",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_open_meteo_gfs_uses_gfs_model(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    async def fake_fetch_open_meteo_model(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "source": kwargs["source"]}
+
+    monkeypatch.setattr(open_meteo, "_fetch_open_meteo_model", fake_fetch_open_meteo_model)
+
+    result = await open_meteo.fetch_open_meteo_gfs(ARGUEL_LAT, ARGUEL_LON)
+
+    assert result == {"success": True, "source": "open-meteo-gfs"}
+    assert calls == [
+        {
+            "lat": ARGUEL_LAT,
+            "lon": ARGUEL_LON,
+            "days": 7,
+            "model": "gfs_seamless",
+            "source": "open-meteo-gfs",
+        }
+    ]

--- a/apps/backend/tests/scrapers/test_openweathermap.py
+++ b/apps/backend/tests/scrapers/test_openweathermap.py
@@ -1,3 +1,6 @@
+import pytest
+
+from scrapers import openweathermap
 from scrapers.openweathermap import extract_hourly_forecast
 
 
@@ -40,3 +43,35 @@ def test_extract_openweathermap_returns_empty_when_dt_txt_is_missing():
     result = extract_hourly_forecast({"success": True, "data": {"list": [{"main": {}}]}})
 
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_openweathermap_clamps_days_to_minimum_of_one(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"list": []}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params):
+            captured["url"] = url
+            captured["params"] = params
+            return _FakeResponse()
+
+    monkeypatch.setattr(openweathermap, "OPENWEATHERMAP_API_KEY", "test-key")
+    monkeypatch.setattr(openweathermap.httpx, "AsyncClient", lambda **kwargs: _FakeClient())
+
+    result = await openweathermap.fetch_openweathermap(47.2, 6.0, days=0)
+
+    assert result["success"] is True
+    assert captured["params"]["cnt"] == 8

--- a/apps/backend/tests/unit/test_seed_weather_sources.py
+++ b/apps/backend/tests/unit/test_seed_weather_sources.py
@@ -44,3 +44,42 @@ def test_seed_weather_sources_adds_missing_sources_and_updates_api_keys(db_sessi
     assert weatherapi.api_key == "test_weather_key"
     assert weatherapi.is_enabled is False
     assert met_no.is_enabled is True
+
+
+def test_seed_weather_sources_reenables_api_key_sources_that_were_only_disabled_for_missing_keys(
+    db_session, monkeypatch
+):
+    import main
+
+    weatherapi_without_key = WeatherSourceConfig(
+        id=str(uuid.uuid4()),
+        source_name="weatherapi",
+        display_name="WeatherAPI.com",
+        description="Existing source",
+        is_enabled=False,
+        requires_api_key=True,
+        api_key=None,
+        priority=9,
+        scraper_type="api",
+        base_url="https://www.weatherapi.com/",
+        documentation_url="https://www.weatherapi.com/docs/",
+    )
+    db_session.add(weatherapi_without_key)
+    db_session.commit()
+
+    class TestSessionLocal:
+        def __call__(self):
+            return db_session
+
+    monkeypatch.setattr(main, "SessionLocal", TestSessionLocal())
+
+    assert main.seed_weather_sources() is True
+
+    weatherapi = (
+        db_session.query(WeatherSourceConfig)
+        .filter(WeatherSourceConfig.source_name == "weatherapi")
+        .one()
+    )
+
+    assert weatherapi.api_key == "test_weather_key"
+    assert weatherapi.is_enabled is True

--- a/apps/backend/weather_pipeline.py
+++ b/apps/backend/weather_pipeline.py
@@ -142,9 +142,8 @@ async def fetch_from_enabled_sources(
         )
 
         # Create instrumented tasks
-        async def instrumented_fetch(src_name: str):
+        async def instrumented_fetch(src_name: str) -> dict[str, Any]:
             """Wrapper to instrument each fetch call"""
-            result = None
             try:
                 source_definition = WEATHER_SOURCE_REGISTRY[src_name]
                 result = await source_definition.fetch(
@@ -153,27 +152,6 @@ async def fetch_from_enabled_sources(
                     site_name=site_name,
                     elevation_m=elevation_m,
                 )
-
-                # Update stats based on result
-                from models import WeatherSourceConfig
-
-                source = (
-                    db.query(WeatherSourceConfig)
-                    .filter(WeatherSourceConfig.source_name == src_name)
-                    .first()
-                )
-
-                if source and result:
-                    if result.get("success"):
-                        source.success_count += 1
-                        source.last_success_at = datetime.utcnow()
-                    else:
-                        source.error_count += 1
-                        source.last_error_at = datetime.utcnow()
-                        source.last_error_message = result.get("error", "Unknown error")[:500]
-
-                    source.updated_at = datetime.utcnow()
-                    db.commit()
 
                 # CRITICAL FIX: Transform raw data to hourly format
                 # Scrapers return {'success': True, 'data': {...}}
@@ -185,22 +163,6 @@ async def fetch_from_enabled_sources(
 
             except Exception as e:
                 logger.error(f"Error fetching from {src_name}: {e}")
-                # Update error stats
-                from models import WeatherSourceConfig
-
-                source = (
-                    db.query(WeatherSourceConfig)
-                    .filter(WeatherSourceConfig.source_name == src_name)
-                    .first()
-                )
-
-                if source:
-                    source.error_count += 1
-                    source.last_error_at = datetime.utcnow()
-                    source.last_error_message = str(e)[:500]
-                    source.updated_at = datetime.utcnow()
-                    db.commit()
-
                 return {
                     "success": False,
                     "source": src_name,
@@ -230,13 +192,38 @@ async def fetch_from_enabled_sources(
             "sources": {},
         }
 
+        from models import WeatherSourceConfig
+
         for i, result in enumerate(results):
             source_name = source_names[i]
 
             if isinstance(result, Exception):
-                aggregated["sources"][source_name] = {"success": False, "error": str(result)}
-            else:
-                aggregated["sources"][source_name] = result
+                result = {"success": False, "error": str(result)}
+
+            aggregated["sources"][source_name] = result
+
+            source = (
+                db.query(WeatherSourceConfig)
+                .filter(WeatherSourceConfig.source_name == source_name)
+                .first()
+            )
+
+            if source:
+                if result.get("success"):
+                    source.success_count += 1
+                    source.last_success_at = datetime.utcnow()
+                else:
+                    source.error_count += 1
+                    source.last_error_at = datetime.utcnow()
+                    source.last_error_message = result.get("error", "Unknown error")[:500]
+
+                source.updated_at = datetime.utcnow()
+
+        try:
+            db.commit()
+        except Exception as commit_error:
+            logger.error(f"Failed to update weather source stats: {commit_error}")
+            db.rollback()
 
         return aggregated
 

--- a/apps/backend/weather_sources.py
+++ b/apps/backend/weather_sources.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+import uuid
 from typing import Any
 
 import config
@@ -256,3 +257,27 @@ def get_weather_source_definition(source_name: str) -> WeatherSourceDefinition |
 
 def default_weather_source_rows() -> list[dict[str, Any]]:
     return [source.seed_data() for source in WEATHER_SOURCE_DEFINITIONS]
+
+
+def ensure_weather_source_configs(db_session) -> list[str]:
+    """Ensure every registered source has a row in the database.
+
+    Returns the list of source names that were added.
+    """
+
+    from models import WeatherSourceConfig
+
+    existing_names = {row.source_name for row in db_session.query(WeatherSourceConfig).all()}
+    added_sources: list[str] = []
+
+    for source_data in default_weather_source_rows():
+        if source_data["source_name"] in existing_names:
+            continue
+
+        db_session.add(WeatherSourceConfig(id=str(uuid.uuid4()), **source_data))
+        added_sources.append(source_data["source_name"])
+
+    if added_sources:
+        db_session.commit()
+
+    return added_sources


### PR DESCRIPTION
## Summary
- Expand the weather source registry with additional forecast models and normalize their hourly extraction.
- Keep Settings/API output synchronized with the registry so newly added sources appear even before manual seeding.
- Harden seeding, scraper edge cases, and weather pipeline stats updates.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend
- Targeted backend pytest for weather sources, scrapers, and settings routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MET Norway, OpenWeatherMap, and additional Open-Meteo model variants (ICON, GFS) as available weather forecast sources for improved data coverage.
  * Enhanced weather source configuration and management, enabling dynamic source registration and enablement based on API key availability.

* **Documentation**
  * Added architectural guidance on weather source credibility, forecast confidence calculation, and risk precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->