### PR TITLE
fix(frontend): show wind direction on mobile hourly cards

### DIFF
--- a/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
@@ -156,4 +156,10 @@ describe('HourlyForecast tooltip behavior', () => {
     expect(screen.getByText('✓ Verdict - 10:00')).toBeTruthy();
     expect(screen.getByText(/Criteres evalues/iu)).toBeTruthy();
   });
+
+  it('shows wind direction on mobile hourly cards', () => {
+    render(<HourlyForecast spotId="site-1" dayIndex={0} />);
+
+    expect(screen.getByText('NW (315°)')).toBeTruthy();
+  });
 });

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -950,6 +950,33 @@ export default function HourlyForecast({
                   </div>
                   <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
                     <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <Compass
+                        className="h-3.5 w-3.5 text-violet-500"
+                        aria-hidden="true"
+                      />
+                      {t('weather.hourly.direction')}
+                    </span>
+                    <div className="flex items-center gap-1.5 font-bold text-slate-950 dark:text-white">
+                      {hour.wind_direction_deg === null ||
+                      typeof hour.wind_direction_deg === 'undefined' ? (
+                        '—'
+                      ) : (
+                        <>
+                          <WindArrow
+                            degrees={hour.wind_direction_deg}
+                            className="text-violet-600 dark:text-violet-400"
+                          />
+                          <span>
+                            {formatWindDirectionWithDegrees(
+                              hour.wind_direction_deg
+                            )}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                       <CloudRain
                         className="h-3.5 w-3.5 text-cyan-500"
                         aria-hidden="true"


### PR DESCRIPTION
## Summary
- Add wind direction to the mobile hourly weather cards.
- Reuse the existing wind arrow and direction formatting from the desktop view.
- Cover the new mobile display with a behavior test.

## Validation
- `vitest run --config vitest.config.ts src/components/weather/HourlyForecast.behavior.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- CodeRabbit review: passed, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile hourly weather cards now display wind direction using compass bearing and degrees (e.g., NW 315°).

* **Tests**
  * Added test for wind direction rendering on mobile hourly forecast cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->