### PR TITLE
fix(backend): isolate GoPro overlay rendering

### DIFF
--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -73,6 +73,7 @@ JOB_QUEUE_BACKEND = os.getenv(
     "thread" if IS_TEST_ENV else "rq",
 ).lower()
 JOB_QUEUE_NAME = os.getenv("BACKEND_JOB_QUEUE_NAME", "video_exports")
+GOPRO_OVERLAY_QUEUE_NAME = os.getenv("BACKEND_GOPRO_OVERLAY_QUEUE_NAME", "gopro_overlays")
 JOB_QUEUE_TIMEOUT_SECONDS = int(os.getenv("BACKEND_JOB_QUEUE_TIMEOUT_SECONDS", "21600"))
 
 # ============================================================================
@@ -208,6 +209,8 @@ GOPRO_OVERLAY_FONT = os.getenv(
     "BACKEND_GOPRO_OVERLAY_FONT",
     "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
 )
+GOPRO_OVERLAY_PROCESS_NICE = int(os.getenv("BACKEND_GOPRO_OVERLAY_PROCESS_NICE", "19"))
+GOPRO_OVERLAY_PROCESS_IONICE_CLASS = os.getenv("BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS", "3")
 
 # ============================================================================
 # VALIDATION

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import select
 import shutil
 import subprocess
 import threading
@@ -82,7 +83,6 @@ _LAYOUTS = [
 
 _JOBS: dict[str, dict[str, Any]] = {}
 _PROCESSES: dict[str, subprocess.Popen[str]] = {}
-_ACTIVE_THREADS: set[str] = set()
 _LOCK = threading.Lock()
 _WORKER_THREAD: threading.Thread | None = None
 _WORKER_STOP = threading.Event()
@@ -364,6 +364,58 @@ def _read_process_updates(stream: Any) -> Iterator[str]:
         current += char
     if current.strip():
         yield current.strip()
+
+
+def _is_job_cancelled(job_id: str) -> bool:
+    job = get_gopro_overlay_job(job_id)
+    return bool(job and job.get("status") == _STATUS_CANCELLED)
+
+
+def _read_process_updates_from_process(
+    process: subprocess.Popen[str],
+    job_id: str,
+) -> Iterator[str]:
+    stream = process.stdout
+    if not stream:
+        return
+
+    current = ""
+    while process.poll() is None:
+        if _is_job_cancelled(job_id):
+            process.terminate()
+            return
+
+        ready, _, _ = select.select([stream], [], [], 1)
+        if not ready:
+            continue
+
+        char = stream.read(1)
+        if not char:
+            continue
+        if char in {"\n", "\r"}:
+            if current.strip():
+                yield current.strip()
+            current = ""
+            continue
+        current += char
+
+    if current.strip():
+        yield current.strip()
+
+
+def _background_process_command(command: list[str]) -> list[str]:
+    if config.TESTING:
+        return command.copy()
+
+    wrapped = command.copy()
+    ionice_class = str(config.GOPRO_OVERLAY_PROCESS_IONICE_CLASS).strip()
+    if os.name == "posix" and ionice_class and shutil.which("ionice"):
+        wrapped = ["ionice", "-c", ionice_class, *wrapped]
+
+    nice_value = config.GOPRO_OVERLAY_PROCESS_NICE
+    if os.name == "posix" and nice_value > 0 and shutil.which("nice"):
+        wrapped = ["nice", "-n", str(nice_value), *wrapped]
+    return wrapped
 
 
 def _tail_lines(path: Path, limit: int = 20) -> str:
@@ -837,6 +889,7 @@ def _create_gopro_overlay_job_from_paths(
         selected_layout.id,
         output_path,
     )
+    _enqueue_existing_gopro_overlay_job(job_id)
 
     return job.copy()
 
@@ -879,7 +932,7 @@ def _run_job(job_id: str) -> None:
         if temp_output_path.exists():
             temp_output_path.unlink()
         process = subprocess.Popen(
-            command,
+            _background_process_command(command),
             cwd=config.GOPRO_OVERLAY_ROOT or None,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -920,20 +973,19 @@ def _run_job(job_id: str) -> None:
             log_file.write(f"[{_utc_now()}] Starting GoPro overlay job {job_id}\n")
             log_file.write("Command: " + " ".join(command) + "\n")
             log_file.flush()
-            if process.stdout:
-                for line in _read_process_updates(process.stdout):
-                    log_file.write(line + "\n")
-                    log_file.flush()
-                    output_lines.append(line)
-                    if len(output_lines) > 50:
-                        output_lines = output_lines[-50:]
-                    progress = _progress_from_output_chunk(line)
-                    if progress is None:
-                        _update_job(job_id, message=line or "Rendering overlay")
-                    else:
-                        _update_job(
-                            job_id, progress=progress, message=f"Rendering overlay: {progress}%"
-                        )
+            for line in _read_process_updates_from_process(process, job_id):
+                log_file.write(line + "\n")
+                log_file.flush()
+                output_lines.append(line)
+                if len(output_lines) > 50:
+                    output_lines = output_lines[-50:]
+                progress = _progress_from_output_chunk(line)
+                if progress is None:
+                    _update_job(job_id, message=line or "Rendering overlay")
+                else:
+                    _update_job(
+                        job_id, progress=progress, message=f"Rendering overlay: {progress}%"
+                    )
 
         return_code = process.wait()
         with _LOCK:
@@ -1104,6 +1156,59 @@ def _queued_job_ids() -> list[str]:
             return [job_id for job_id, job in _JOBS.items() if job.get("status") == _STATUS_QUEUED]
 
 
+def _rq_job_id(job_id: str) -> str:
+    return f"gopro-overlay-{job_id}"
+
+
+def _enqueue_gopro_overlay_job_in_rq(job_id: str) -> None:
+    from job_queue import enqueue_once
+
+    enqueue_once(
+        "gopro_overlay_export.process_gopro_overlay_job",
+        job_id,
+        job_id=_rq_job_id(job_id),
+        timeout=config.JOB_QUEUE_TIMEOUT_SECONDS,
+        queue_name=config.GOPRO_OVERLAY_QUEUE_NAME,
+    )
+
+
+def _enqueue_existing_gopro_overlay_job(job_id: str) -> None:
+    from job_queue import is_rq_enabled
+
+    if is_rq_enabled():
+        _enqueue_gopro_overlay_job_in_rq(job_id)
+    elif not config.TESTING:
+        start_gopro_overlay_worker()
+
+
+def _delete_rq_gopro_overlay_job(job_id: str) -> bool:
+    from job_queue import delete_job, is_rq_enabled
+
+    if not is_rq_enabled():
+        return False
+    return delete_job(_rq_job_id(job_id), queue_name=config.GOPRO_OVERLAY_QUEUE_NAME)
+
+
+def enqueue_pending_gopro_overlay_jobs(*, mark_interrupted: bool = False) -> int:
+    """Enqueue queued overlay jobs into the dedicated RQ queue."""
+    from job_queue import is_rq_enabled
+
+    if not is_rq_enabled():
+        return 0
+
+    if mark_interrupted:
+        _mark_interrupted_jobs_failed()
+    job_ids = _queued_job_ids()
+    for job_id in job_ids:
+        _enqueue_gopro_overlay_job_in_rq(job_id)
+    return len(job_ids)
+
+
+def process_gopro_overlay_job(job_id: str) -> None:
+    """RQ job target for one GoPro overlay render."""
+    _run_job(job_id)
+
+
 def _mark_interrupted_jobs_failed() -> None:
     try:
         with SessionLocal() as db:
@@ -1141,30 +1246,24 @@ def _worker_loop() -> None:
     logger.info("GoPro overlay worker started")
     _mark_interrupted_jobs_failed()
     while not _WORKER_STOP.is_set():
-        for job_id in _queued_job_ids():
-            with _LOCK:
-                if job_id in _ACTIVE_THREADS:
-                    continue
-                _ACTIVE_THREADS.add(job_id)
-            thread = threading.Thread(target=_run_job_thread, args=(job_id,), daemon=True)
-            thread.start()
+        job_ids = _queued_job_ids()
+        if job_ids:
+            _run_job(job_ids[0])
+            continue
         _WORKER_STOP.wait(1)
-
-
-def _run_job_thread(job_id: str) -> None:
-    try:
-        _run_job(job_id)
-    finally:
-        with _LOCK:
-            _ACTIVE_THREADS.discard(job_id)
 
 
 def start_gopro_overlay_worker() -> None:
     global _WORKER_THREAD
+    from job_queue import is_rq_enabled
+
     with _WORKER_LOCK:
+        reconcile_gopro_overlay_flight_refs()
+        if is_rq_enabled():
+            enqueue_pending_gopro_overlay_jobs()
+            return
         if _WORKER_THREAD and _WORKER_THREAD.is_alive() is True:
             return
-        reconcile_gopro_overlay_flight_refs()
         _WORKER_STOP.clear()
         _WORKER_THREAD = threading.Thread(
             target=_worker_loop,
@@ -1254,6 +1353,8 @@ def cancel_gopro_overlay_job(job_id: str) -> bool:
 
     if process and process.poll() is None:
         process.terminate()
+    else:
+        _delete_rq_gopro_overlay_job(job_id)
 
     _finish_job(
         job_id,

--- a/apps/backend/gopro_overlay_worker.py
+++ b/apps/backend/gopro_overlay_worker.py
@@ -1,0 +1,35 @@
+"""RQ worker entrypoint for GoPro overlay jobs."""
+
+from __future__ import annotations
+
+import logging
+
+from rq import Worker
+
+import config
+from gopro_overlay_export import enqueue_pending_gopro_overlay_jobs
+from job_queue import get_queue, get_redis_connection, is_rq_enabled
+
+logging.basicConfig(
+    level=getattr(logging, config.LOG_LEVEL, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    if not is_rq_enabled():
+        raise RuntimeError("GoPro overlay RQ worker requires BACKEND_JOB_QUEUE_BACKEND=rq")
+
+    queued_count = enqueue_pending_gopro_overlay_jobs(mark_interrupted=True)
+    if queued_count:
+        logger.info("Enqueued %s pending GoPro overlay job(s)", queued_count)
+
+    queue = get_queue(config.GOPRO_OVERLAY_QUEUE_NAME)
+    worker = Worker([queue], connection=get_redis_connection())
+    logger.info("Starting GoPro overlay RQ worker for queue '%s'", config.GOPRO_OVERLAY_QUEUE_NAME)
+    worker.work(with_scheduler=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1083,6 +1083,148 @@ def test_create_gopro_overlay_job_from_paths_defers_input_copy_to_worker_prepara
     assert prepared["video_height"] == 1080
 
 
+def test_create_gopro_overlay_job_from_paths_enqueues_rq_job(
+    tmp_path,
+    monkeypatch,
+    test_db,
+):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    enqueued_job_ids: list[str] = []
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    monkeypatch.setattr(gopro_overlay_export.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "_enqueue_gopro_overlay_job_in_rq",
+        lambda job_id: enqueued_job_ids.append(job_id),
+    )
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=None,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+
+    assert enqueued_job_ids == [job["job_id"]]
+
+
+def test_enqueue_gopro_overlay_job_uses_dedicated_rq_queue(monkeypatch):
+    enqueued: list[dict[str, object]] = []
+
+    def enqueue_once(function_path: str, *args, **kwargs):
+        enqueued.append({"function_path": function_path, "args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_QUEUE_NAME", "overlay-test-queue")
+    monkeypatch.setattr("job_queue.enqueue_once", enqueue_once)
+
+    gopro_overlay_export._enqueue_gopro_overlay_job_in_rq("job-rq")
+
+    assert enqueued == [
+        {
+            "function_path": "gopro_overlay_export.process_gopro_overlay_job",
+            "args": ("job-rq",),
+            "kwargs": {
+                "job_id": "gopro-overlay-job-rq",
+                "timeout": config.JOB_QUEUE_TIMEOUT_SECONDS,
+                "queue_name": "overlay-test-queue",
+            },
+        }
+    ]
+
+
+def test_start_gopro_overlay_worker_with_rq_does_not_start_local_thread(monkeypatch):
+    enqueued: list[bool] = []
+    monkeypatch.setattr(gopro_overlay_export.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(gopro_overlay_export, "reconcile_gopro_overlay_flight_refs", lambda: 0)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "enqueue_pending_gopro_overlay_jobs",
+        lambda: enqueued.append(True) or 0,
+    )
+    monkeypatch.setattr(
+        gopro_overlay_export.threading,
+        "Thread",
+        lambda *_, **__: pytest.fail("RQ mode must not start a local overlay worker thread"),
+    )
+
+    gopro_overlay_export.start_gopro_overlay_worker()
+
+    assert enqueued == [True]
+
+
+def test_enqueue_pending_gopro_overlay_jobs_does_not_mark_running_failed_by_default(monkeypatch):
+    monkeypatch.setattr(gopro_overlay_export.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(gopro_overlay_export, "_queued_job_ids", lambda: [])
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "_mark_interrupted_jobs_failed",
+        lambda: pytest.fail("API startup must not fail active worker jobs"),
+    )
+
+    assert gopro_overlay_export.enqueue_pending_gopro_overlay_jobs() == 0
+
+
+def test_read_process_updates_from_process_terminates_cancelled_job(monkeypatch):
+    terminated: list[bool] = []
+
+    class FakeProcess:
+        stdout = object()
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            terminated.append(True)
+
+    monkeypatch.setattr(gopro_overlay_export, "_is_job_cancelled", lambda _job_id: True)
+
+    assert list(gopro_overlay_export._read_process_updates_from_process(FakeProcess(), "job")) == []
+    assert terminated == [True]
+
+
+def test_cancel_queued_gopro_overlay_job_removes_rq_job(monkeypatch):
+    job_id = "queued-rq-job"
+    deleted_rq_jobs: list[tuple[str, str | None]] = []
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(gopro_overlay_export.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(
+        gopro_overlay_export.config, "GOPRO_OVERLAY_QUEUE_NAME", "overlay-test-queue"
+    )
+    monkeypatch.setattr(
+        "job_queue.delete_job",
+        lambda rq_job_id, queue_name=None: deleted_rq_jobs.append((rq_job_id, queue_name)) or True,
+    )
+    try:
+        assert cancel_gopro_overlay_job(job_id)
+        assert deleted_rq_jobs == [("gopro-overlay-queued-rq-job", "overlay-test-queue")]
+        assert gopro_overlay_export._JOBS[job_id]["status"] == "cancelled"
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
+
+
 def test_run_job_prepares_inputs_before_starting_process(
     tmp_path,
     monkeypatch,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,3 +11,6 @@ services:
 
   backend-worker:
     image: parapente-backend:nx-latest
+
+  gopro-overlay-worker:
+    image: parapente-backend:nx-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - BACKEND_USE_FAKE_REDIS=${BACKEND_USE_FAKE_REDIS:-false}
       - BACKEND_JOB_QUEUE_BACKEND=${BACKEND_JOB_QUEUE_BACKEND:-rq}
       - BACKEND_JOB_QUEUE_NAME=${BACKEND_JOB_QUEUE_NAME:-video_exports}
+      - BACKEND_GOPRO_OVERLAY_QUEUE_NAME=${BACKEND_GOPRO_OVERLAY_QUEUE_NAME:-gopro_overlays}
 
       # Backend - API
       - BACKEND_API_HOST=${BACKEND_API_HOST:-0.0.0.0}
@@ -116,6 +117,8 @@ services:
       - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay
       - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/parapente
       - BACKEND_GOPRO_OVERLAY_FONT=/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
+      - BACKEND_GOPRO_OVERLAY_PROCESS_NICE=${BACKEND_GOPRO_OVERLAY_PROCESS_NICE:-19}
+      - BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS=${BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS:-3}
 
       # Backend - Deployment metadata
       - BACKEND_DEPLOY_VERSION=${BACKEND_DEPLOY_VERSION}
@@ -155,6 +158,7 @@ services:
       - BACKEND_USE_FAKE_REDIS=${BACKEND_USE_FAKE_REDIS:-false}
       - BACKEND_JOB_QUEUE_BACKEND=${BACKEND_JOB_QUEUE_BACKEND:-rq}
       - BACKEND_JOB_QUEUE_NAME=${BACKEND_JOB_QUEUE_NAME:-video_exports}
+      - BACKEND_GOPRO_OVERLAY_QUEUE_NAME=${BACKEND_GOPRO_OVERLAY_QUEUE_NAME:-gopro_overlays}
       - BACKEND_API_HOST=${BACKEND_API_HOST:-0.0.0.0}
       - BACKEND_API_PORT=${BACKEND_API_PORT:-8001}
       - BACKEND_LOG_LEVEL=${BACKEND_LOG_LEVEL:-INFO}
@@ -173,6 +177,8 @@ services:
       - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay
       - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/parapente
       - BACKEND_GOPRO_OVERLAY_FONT=/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
+      - BACKEND_GOPRO_OVERLAY_PROCESS_NICE=${BACKEND_GOPRO_OVERLAY_PROCESS_NICE:-19}
+      - BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS=${BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS:-3}
       - BACKEND_VERSION_STATE_FILE=${BACKEND_VERSION_STATE_FILE:?BACKEND_VERSION_STATE_FILE is required}
     depends_on:
       redis:
@@ -183,6 +189,64 @@ services:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${VIDEO_EXPORT_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/videos}:${BACKEND_VIDEO_EXPORT_DIR:-/app/video-exports}
       - ${VIDEO_TEMP_IMAGES_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/video-temp-images}:${BACKEND_VIDEO_TEMP_IMAGES_DIR:-/app/video-temp-images}
+      - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'python -c "from job_queue import get_redis_connection; get_redis_connection().ping()"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    networks:
+      - parapente-network
+
+  gopro-overlay-worker:
+    image: ${BACKEND_IMAGE:-ghcr.io/capic2/dashboard-parapente/backend:main}
+    container_name: parapente-gopro-overlay-worker
+    restart: unless-stopped
+    command: ['python', 'gopro_overlay_worker.py']
+    cpus: '${GOPRO_OVERLAY_WORKER_CPUS:-1.0}'
+    mem_limit: ${GOPRO_OVERLAY_WORKER_MEM_LIMIT:-3g}
+    pids_limit: ${GOPRO_OVERLAY_WORKER_PIDS_LIMIT:-256}
+    labels:
+      project: dashboard-parapente
+      service: gopro-overlay-worker
+      env: ${ENVIRONMENT:-production}
+    environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}
+      - BACKEND_DATABASE_URL=${BACKEND_DATABASE_URL:?BACKEND_DATABASE_URL is required}
+      - DATABASE_URL=${DATABASE_URL:?DATABASE_URL is required}
+      - BACKEND_REDIS_HOST=redis
+      - BACKEND_REDIS_PORT=6379
+      - BACKEND_USE_FAKE_REDIS=${BACKEND_USE_FAKE_REDIS:-false}
+      - BACKEND_JOB_QUEUE_BACKEND=${BACKEND_JOB_QUEUE_BACKEND:-rq}
+      - BACKEND_JOB_QUEUE_NAME=${BACKEND_JOB_QUEUE_NAME:-video_exports}
+      - BACKEND_GOPRO_OVERLAY_QUEUE_NAME=${BACKEND_GOPRO_OVERLAY_QUEUE_NAME:-gopro_overlays}
+      - BACKEND_LOG_LEVEL=${BACKEND_LOG_LEVEL:-INFO}
+      - BACKEND_LOG_FILE=${BACKEND_LOG_FILE:?BACKEND_LOG_FILE is required}
+      - BACKEND_METRICS_TOKEN=${BACKEND_METRICS_TOKEN:?required}
+      - BACKEND_JWT_SECRET=${BACKEND_JWT_SECRET:?required}
+      - BACKEND_WEATHERAPI_KEY=${BACKEND_WEATHERAPI_KEY}
+      - BACKEND_METEOBLUE_API_KEY=${BACKEND_METEOBLUE_API_KEY}
+      - BACKEND_STRAVA_VERIFY_TOKEN=${BACKEND_STRAVA_VERIFY_TOKEN:-PARAPENTE_2025}
+      - BACKEND_GOPRO_OVERLAY_ROOT=/app/gopro-overlay
+      - BACKEND_GOPRO_OVERLAY_BIN=/app/gopro-overlay/venv/bin/gopro-dashboard.py
+      - BACKEND_GOPRO_OVERLAY_LAYOUT_DIR=/app/gopro-overlay
+      - BACKEND_GOPRO_OVERLAY_PARAGLIDING_ROOT=/app/parapente
+      - BACKEND_GOPRO_OVERLAY_FONT=/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
+      - BACKEND_GOPRO_OVERLAY_PROCESS_NICE=${BACKEND_GOPRO_OVERLAY_PROCESS_NICE:-19}
+      - BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS=${BACKEND_GOPRO_OVERLAY_PROCESS_IONICE_CLASS:-3}
+      - BACKEND_VERSION_STATE_FILE=${BACKEND_VERSION_STATE_FILE:?BACKEND_VERSION_STATE_FILE is required}
+    depends_on:
+      redis:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+    volumes:
+      - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
- Move GoPro overlay rendering into a dedicated RQ worker and queue.
- Add low-priority process execution plus a separate Docker service with CPU/RAM limits.
- Cover cancellation/restart behavior and queue dispatch with targeted backend tests.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml`
- `docker-compose.yml` / `docker-compose.dev.yml` YAML load check
- CodeRabbit review: passed, no findings