### PR TITLE
fix weather best-spot reason localization

### DIFF
--- a/apps/frontend/src/components/weather/BestSpotSuggestion.test.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentType } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { BestSpotSuggestion } from './BestSpotSuggestion';
+import type { BestSpotResult } from '@dashboard-parapente/shared-types';
+
+vi.mock('react-i18next', () => ({
+  withTranslation: () => (Component: ComponentType) => Component,
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const labels: Record<string, string> = {
+        'common.today': 'Aujourd’hui',
+        'weather.bestSpotFor': `Meilleur spot pour ${options?.date}`,
+        'weather.bestSpot.reasonCodes.windDecollageCul':
+          'vent de cul au décollage',
+        'weather.byHour': 'H -> fin de journée',
+        'weather.calculating': 'Calcul en cours...',
+        'weather.flyableSlot': 'Créneau',
+        'weather.paraIndex': 'Conditions de vol',
+        'weather.score': 'Score',
+        'weather.thermalCeiling': 'Plafond',
+        'weather.viewForecast': 'Voir les prévisions',
+        'weather.windOrientation': 'Vent / Orientation',
+        'weather.favorabilityPoor': 'Défavorable',
+      };
+      return labels[key] ?? key;
+    },
+    i18n: {
+      language: 'fr',
+    },
+  }),
+}));
+
+const bestSpotWithTechnicalReason: BestSpotResult = {
+  site: {
+    id: 'site-arguel',
+    code: 'arguel',
+    name: 'Arguel',
+    orientation: 'W',
+  },
+  paraIndex: 35,
+  score: 35,
+  windDirection: 'E',
+  windSpeed: 12,
+  windFavorability: 'bad',
+  reason:
+    'Les conditions restent limites. Le moment le moins défavorable est autour de 7h-7h, principalement à cause de wind_decollage_cul.',
+  flyableSlot: '7h',
+  thermalCeiling: null,
+  verdict: 'LIMITE',
+};
+
+describe('BestSpotSuggestion', () => {
+  it('localizes technical reason codes returned by the API', () => {
+    render(
+      <BestSpotSuggestion
+        bestSpot={bestSpotWithTechnicalReason}
+        onSelectSite={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/wind_decollage_cul/u)).not.toBeInTheDocument();
+    expect(screen.getByText(/vent de cul au décollage/u)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
+++ b/apps/frontend/src/components/weather/BestSpotSuggestion.tsx
@@ -30,6 +30,12 @@ import { getSiteDisplayName } from '../../lib/siteDisplay';
 
 type HourlyBestSpot = BestSpotResult & { hour: number };
 
+type ReasonTranslator = (key: string) => string;
+
+const BEST_SPOT_REASON_CODE_KEYS: Record<string, string> = {
+  wind_decollage_cul: 'weather.bestSpot.reasonCodes.windDecollageCul',
+};
+
 interface BestSpotSuggestionProps {
   bestSpot: BestSpotResult | null;
   hourlyBestSpots?: HourlyBestSpot[];
@@ -171,6 +177,17 @@ function getWindFavorabilityLabel(
   return t('weather.favorabilityPoor');
 }
 
+function localizeBestSpotReason(reason: string, t: ReasonTranslator) {
+  return Object.entries(BEST_SPOT_REASON_CODE_KEYS).reduce(
+    (localizedReason, [code, translationKey]) =>
+      localizedReason.replace(
+        new RegExp(`\\b${code}\\b`, 'gu'),
+        t(translationKey)
+      ),
+    reason.replace(/Para-Index/gu, t('weather.paraIndex'))
+  );
+}
+
 export const BestSpotSuggestion = ({
   bestSpot,
   hourlyBestSpots = [],
@@ -228,10 +245,7 @@ export const BestSpotSuggestion = ({
     100,
     Math.max(0, Math.round(score ?? paraIndex))
   );
-  const localizedReason = reason.replace(
-    /Para-Index/gu,
-    t('weather.paraIndex')
-  );
+  const localizedReason = localizeBestSpotReason(reason, t);
   const scoreColor = getScoreColor(adjustedScore);
   const verdictInfo = getVerdict(adjustedScore, verdict ?? undefined);
   const hourlyRows = hourlyBestSpots.map((hourlySpot) => {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -156,6 +156,11 @@
     "notCached": "Not cached",
     "forecast7Days": "7-Day Forecast",
     "bestSpotFor": "Best spot for {{date}}",
+    "bestSpot": {
+      "reasonCodes": {
+        "windDecollageCul": "tailwind at takeoff"
+      }
+    },
     "bestSpotTimeline": "Best spot hour by hour",
     "byHour": "H -> end of day",
     "calculating": "Calculating...",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -156,6 +156,11 @@
     "notCached": "Non mis en cache",
     "forecast7Days": "Prévisions 7 Jours",
     "bestSpotFor": "Meilleur spot pour {{date}}",
+    "bestSpot": {
+      "reasonCodes": {
+        "windDecollageCul": "vent de cul au décollage"
+      }
+    },
     "bestSpotTimeline": "Meilleur spot heure par heure",
     "byHour": "H -> fin de journée",
     "calculating": "Calcul en cours...",


### PR DESCRIPTION
## Summary
- Localize technical best-spot reason codes so weather cards no longer show raw identifiers like `wind_decollage_cul`.
- Add FR/EN translations for the new reason code and cover the display with a targeted unit test.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts src/components/weather/BestSpotSuggestion.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json apps/frontend/src/components/weather/BestSpotSuggestion.tsx apps/frontend/src/components/weather/BestSpotSuggestion.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`

## Notes
- CodeRabbit review ran and returned no findings.