### PR TITLE
fix(frontend): group sites by locality

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -439,6 +439,12 @@
     "fromDate": "From {{date}}",
     "toDate": "To {{date}}"
   },
+  "dataList": {
+    "sortOptions": "Sort options",
+    "sortBy": "Sort by {{column}}",
+    "sortByAsc": "Sort by {{column}} ascending",
+    "sortByDesc": "Sort by {{column}} descending"
+  },
   "sites": {
     "management": "Site Management",
     "newSite": "New site",
@@ -467,6 +473,9 @@
     "orientation": "Orientation:",
     "editSite": "Edit site",
     "viewFlights": "View flights",
+    "locationUnknown": "No locality",
+    "locationGroupCount_one": "{{count}} site",
+    "locationGroupCount_other": "{{count}} sites",
     "deleteSite": "Delete site"
   },
   "settings": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -439,6 +439,12 @@
     "fromDate": "Du {{date}}",
     "toDate": "Au {{date}}"
   },
+  "dataList": {
+    "sortOptions": "Options de tri",
+    "sortBy": "Trier par {{column}}",
+    "sortByAsc": "Trier par {{column}} croissant",
+    "sortByDesc": "Trier par {{column}} décroissant"
+  },
   "sites": {
     "management": "Gestion des Sites",
     "newSite": "Nouveau site",
@@ -467,6 +473,9 @@
     "orientation": "Orientation:",
     "editSite": "Éditer le site",
     "viewFlights": "Voir les vols",
+    "locationUnknown": "Sans localité",
+    "locationGroupCount_one": "{{count}} site",
+    "locationGroupCount_other": "{{count}} sites",
     "deleteSite": "Supprimer le site"
   },
   "settings": {

--- a/apps/frontend/src/pages/Sites.tsx
+++ b/apps/frontend/src/pages/Sites.tsx
@@ -2,8 +2,8 @@ import { useDeferredValue, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
 import { Input, Label, TextField } from 'react-aria-components';
-import { Button, DataList, Modal } from '@dashboard-parapente/design-system';
-import { Plus, Search, Trash2 } from 'lucide-react';
+import { Button, Modal } from '@dashboard-parapente/design-system';
+import { ArrowDown, ArrowUp, Plus, Search, Trash2 } from 'lucide-react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
   useReactTable,
@@ -50,6 +50,11 @@ const SITE_SORTABLE_COLUMNS = [
   { id: 'region', label: 'Localité' },
   { id: 'elevation_m', label: 'Altitude' },
 ];
+
+interface SiteGroup {
+  location: string;
+  rows: Row<Site>[];
+}
 
 export const Sites: React.FC = () => {
   const { t } = useTranslation();
@@ -110,6 +115,20 @@ export const Sites: React.FC = () => {
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
+
+  const sortedSiteRows = table.getSortedRowModel().rows;
+  const siteGroups = sortedSiteRows.reduce<SiteGroup[]>((groups, row) => {
+    const location = row.original.region?.trim() || t('sites.locationUnknown');
+    const existingGroup = groups.find((group) => group.location === location);
+
+    if (existingGroup) {
+      existingGroup.rows.push(row);
+    } else {
+      groups.push({ location, rows: [row] });
+    }
+
+    return groups;
+  }, []);
 
   // Handlers
   const handleEdit = (site: Site) => {
@@ -244,17 +263,93 @@ export const Sites: React.FC = () => {
         {t('common.siteFound', { count: filteredSites.length })}
       </p>
 
-      {/* Sites Grid with DataList sort buttons */}
-      <DataList
-        table={table}
-        sortableColumns={SITE_SORTABLE_COLUMNS}
-        emptyMessage={t('sites.noSiteFound')}
-        renderItem={renderSiteCard}
-        ariaLabel="Liste des sites"
-        layout="grid"
-        itemsClassName="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-        getTextValue={(row) => getSiteDisplayName(row.original)}
-      />
+      <div>
+        <fieldset className="mb-4 flex flex-wrap gap-1.5">
+          <legend className="sr-only">{t('dataList.sortOptions')}</legend>
+          {SITE_SORTABLE_COLUMNS.map((col) => {
+            const currentSort = sorting.find((sort) => sort.id === col.id);
+            const isActive = !!currentSort;
+
+            return (
+              <Button
+                key={col.id}
+                className={`inline-flex items-center rounded-md px-3 py-2 text-xs font-medium transition-colors sm:px-2 sm:py-1 ${
+                  isActive
+                    ? 'bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600'
+                }`}
+                aria-label={
+                  currentSort
+                    ? t(
+                        currentSort.desc
+                          ? 'dataList.sortByDesc'
+                          : 'dataList.sortByAsc',
+                        { column: col.label }
+                      )
+                    : t('dataList.sortBy', { column: col.label })
+                }
+                aria-pressed={isActive}
+                onPress={() => table.getColumn(col.id)?.toggleSorting()}
+              >
+                {col.label}
+                {currentSort &&
+                  (currentSort.desc ? (
+                    <ArrowDown
+                      className="ml-1 h-3.5 w-3.5 shrink-0"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <ArrowUp
+                      className="ml-1 h-3.5 w-3.5 shrink-0"
+                      aria-hidden="true"
+                    />
+                  ))}
+              </Button>
+            );
+          })}
+        </fieldset>
+
+        {siteGroups.length > 0 ? (
+          <div className="space-y-8">
+            {siteGroups.map((group, index) => {
+              const headingId = `site-location-${index}`;
+
+              return (
+                <section key={group.location} aria-labelledby={headingId}>
+                  <div className="mb-3 flex flex-col gap-1 border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex-row sm:items-end sm:justify-between">
+                    <h2
+                      id={headingId}
+                      className="text-xl font-semibold text-gray-900 dark:text-white"
+                    >
+                      {group.location}
+                    </h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      {t('sites.locationGroupCount', {
+                        count: group.rows.length,
+                      })}
+                    </p>
+                  </div>
+                  <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {group.rows.map((row) => (
+                      <div key={row.id}>
+                        {renderSiteCard(row, { isSelected: false })}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        ) : (
+          <output aria-label={t('sites.noSiteFound')}>
+            <div className="rounded-xl bg-white p-8 text-center shadow-md dark:bg-gray-800">
+              <p className="font-medium text-gray-700 dark:text-gray-300">
+                {t('sites.noSiteFound')}
+              </p>
+            </div>
+          </output>
+        )}
+      </div>
 
       {filteredSites.length === 0 && hasActiveFilters && (
         <div className="mt-4 text-center">


### PR DESCRIPTION
## Summary
- Group sites on the Sites page by locality/region with a fallback group for missing locality
- Keep the existing sort controls and add the needed i18n strings

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- CodeRabbit review passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sites view now organizes results by geographic location with counts displayed for each location grouping
  * Sorting controls added to the sites view with visual direction indicators for sorting by available columns and better data organization

* **Localization**
  * Updated translation strings for new sorting controls and location-based grouping features across supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->