### PR TITLE
fix frontend overlay disabled reason

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -154,6 +154,26 @@ describe('FlightDetails GoPro overlay action', () => {
     mockFlight.gopro_overlay_status = null;
     mockFlight.gopro_overlay_file_path = null;
     mockFlight.gopro_overlay_file_exists = undefined;
+    mockFlight.video_file_path = '/exports/flight.mp4';
+    mockFlight.video_file_exists = true;
+    mockFlight.gopro_camera_file_exists = true;
+  });
+
+  it('shows why overlay generation is unavailable', () => {
+    mockFlight.gopro_camera_file_exists = false;
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Needs camera video')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Generate overlay/u })
+    ).toBeDisabled();
   });
 
   it('turns the overlay button into cancel while generation is running', async () => {

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -382,6 +382,12 @@ export function FlightDetails({
   } else if (!hasVideo) {
     goproOverlayTitle = t('flights.goproOverlayNeedsVideo');
   }
+  let goproOverlayUnavailableReason: string | null = null;
+  if (!isGoproOverlayRunning && !hasGoproCameraVideo) {
+    goproOverlayUnavailableReason = t('flights.goproOverlayNeedsCameraVideo');
+  } else if (!isGoproOverlayRunning && !hasVideo) {
+    goproOverlayUnavailableReason = t('flights.goproOverlayNeedsVideo');
+  }
   const canUseGoproOverlayAction =
     (isGoproOverlayRunning && Boolean(effectiveGoproOverlayJobId)) ||
     (hasGoproCameraVideo && hasVideo && !isGoproOverlayRunning);
@@ -433,6 +439,7 @@ export function FlightDetails({
               goproOverlayLabel={goproOverlayLabel}
               goproOverlayCompactLabel={goproOverlayCompactLabel}
               goproOverlayTitle={goproOverlayTitle}
+              goproOverlayUnavailableReason={goproOverlayUnavailableReason}
               onGoproOverlayAction={goproOverlayAction}
             />
           </div>

--- a/apps/frontend/src/components/flights/details/FlightMediaExportActions.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaExportActions.tsx
@@ -16,6 +16,7 @@ interface FlightMediaExportActionsProps {
   goproOverlayLabel: string;
   goproOverlayCompactLabel: string;
   goproOverlayTitle: string;
+  goproOverlayUnavailableReason: string | null;
   onGoproOverlayAction: () => void;
 }
 
@@ -31,6 +32,7 @@ export function FlightMediaExportActions({
   goproOverlayLabel,
   goproOverlayCompactLabel,
   goproOverlayTitle,
+  goproOverlayUnavailableReason,
   onGoproOverlayAction,
 }: FlightMediaExportActionsProps) {
   const { t } = useTranslation();
@@ -95,6 +97,11 @@ export function FlightMediaExportActions({
           {goproOverlayCompactLabel}
         </Button>
       </div>
+      {goproOverlayUnavailableReason && (
+        <p className="mt-2 rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-2 text-xs font-medium text-amber-900 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100">
+          {goproOverlayUnavailableReason}
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show the GoPro overlay disable reason directly under the media action buttons.
- Cover the unavailable state in FlightDetails tests.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e
- /home/capic/.local/share/pnpm/pnpm exec vitest run src/components/flights/details/FlightDetails.test.tsx --config vitest.config.ts
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build --parallel=5 --exclude=e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GoPro overlay action now displays specific unavailability reasons to users when the feature cannot be used, such as when camera video is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->