### PR TITLE
fix(frontend): keep video export camera stable

### DIFF
--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
@@ -1350,12 +1350,16 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           lastIndex > 0
             ? (scenePosition.previousIndex + scenePosition.ratio) / lastIndex
             : 0;
-        const distance = getFlightCameraDistance({
-          progress,
-          baseDistance: cameraDistanceRef.current,
-          closeZoomPercent: cameraCloseZoomPercentRef.current,
-          transitionPercent: cameraTransitionPercentRef.current,
-        });
+        const isExportMode =
+          typeof window !== 'undefined' && Boolean(window._exportMode);
+        const distance = isExportMode
+          ? cameraDistanceRef.current
+          : getFlightCameraDistance({
+              progress,
+              baseDistance: cameraDistanceRef.current,
+              closeZoomPercent: cameraCloseZoomPercentRef.current,
+              transitionPercent: cameraTransitionPercentRef.current,
+            });
         const pitch = -0.05;
 
         if (!smoothCamera || !cameraTargetRef.current) {

--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
@@ -16,6 +16,9 @@ const {
     destroy: () => void;
     isDestroyed: () => boolean;
     useDefaultRenderLoop: boolean;
+    camera: {
+      moveBackward: ReturnType<typeof vi.fn>;
+    };
     scene?: {
       requestRender: ReturnType<typeof vi.fn>;
       render: ReturnType<typeof vi.fn>;
@@ -370,6 +373,26 @@ describe('FlightViewer3D video export mode', () => {
     expect(frameState).toMatchObject({ progress: 100, tilesLoaded: true });
     expect(viewer.scene?.requestRender).toHaveBeenCalled();
     expect(viewer.render).toHaveBeenCalled();
+  });
+
+  it('keeps the export camera distance constant across frames', async () => {
+    window._exportMode = 'manual_render';
+
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(window._setExportFrame).toBeTypeOf('function');
+    });
+
+    const viewer = viewerInstances[viewerInstances.length - 1];
+
+    window._setExportFrame?.(0, 3);
+    window._setExportFrame?.(1, 3);
+    window._setExportFrame?.(2, 3);
+
+    expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(1, 500);
+    expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(2, 500);
+    expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(3, 500);
   });
 
   it('draws the replay track only as a volume plus curtain', async () => {


### PR DESCRIPTION
## Summary
- Keep the video export camera distance fixed so the replay track does not visibly zoom in and out during frame capture.
- Add a regression test for constant export camera distance.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightViewer3D.video-export.test.tsx` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5` ⚠️ blocked by `backend:test` because `pytest` is missing in the worktree environment

## Review
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved camera behavior during flight path video exports by ensuring the camera maintains a consistent, fixed distance throughout the entire export process, preventing unwanted camera adjustments that could affect video quality.

* **Tests**
  * Added test coverage to verify camera distance consistency is maintained across all frames during video export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->