### PR TITLE
feat(frontend): add sticky weather selector

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: Site, spot
 A real paragliding place that can be added to the user's list. A **Site** can be a **Decollage**, an **Atterrissage**, or both.
 _Avoid_: Ville, generic location
 
+**Site Enregistre**:
+A **Site** already present in the user's list and available for direct selection on the weather page.
+_Avoid_: Site Existant, Ville, search result
+
 **Localité de Site**:
 The geographic attachment displayed with a **Site** to help the pilot locate it. It may come from the **Ville** searched by the pilot and is not necessarily the exact administrative municipality.
 _Avoid_: Région, administrative city

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -35,20 +35,14 @@ import {
 interface EmagramWidgetProps {
   siteId: string;
   dayIndex?: number;
-  siteName?: string;
 }
 
-function EmagramHeaderTitle({ siteName }: { siteName?: string }) {
+function EmagramHeaderTitle() {
   return (
     <div className="min-w-0">
       <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
         🌡️ Analyse Thermique (Émagramme)
       </h2>
-      {siteName && (
-        <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
-          {siteName}
-        </p>
-      )}
     </div>
   );
 }
@@ -271,7 +265,6 @@ function HourSlider({
 export default function EmagramWidget({
   siteId,
   dayIndex = 0,
-  siteName,
 }: EmagramWidgetProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lightboxOpen, setLightboxOpen] = useState(false);
@@ -395,7 +388,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
         <div className="flex items-center justify-between mb-3">
-          <EmagramHeaderTitle siteName={siteName} />
+          <EmagramHeaderTitle />
         </div>
         {hourSlider}
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
@@ -415,7 +408,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
         <div className="mb-3.5">
-          <EmagramHeaderTitle siteName={siteName} />
+          <EmagramHeaderTitle />
         </div>
         {hourSlider}
         <AnalysisProgress elapsedSeconds={elapsedAnalysisSeconds} />
@@ -427,7 +420,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-red-500">
         <div className="flex items-center justify-between mb-3">
-          <EmagramHeaderTitle siteName={siteName} />
+          <EmagramHeaderTitle />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing || !siteId}
@@ -455,7 +448,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600">
         <div className="flex items-center justify-between mb-3">
-          <EmagramHeaderTitle siteName={siteName} />
+          <EmagramHeaderTitle />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing || !siteId}
@@ -489,7 +482,7 @@ export default function EmagramWidget({
     return (
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-orange-500">
         <div className="flex items-center justify-between mb-3">
-          <EmagramHeaderTitle siteName={siteName} />
+          <EmagramHeaderTitle />
           <Button
             onPress={handleRefresh}
             isDisabled={isRefreshing}
@@ -564,7 +557,7 @@ export default function EmagramWidget({
     <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border-l-4 border-purple-600 flex-1 flex flex-col">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
-        <EmagramHeaderTitle siteName={siteName} />
+        <EmagramHeaderTitle />
         <div className="flex items-center gap-2">
           <EmagramExplanationTooltip emagram={emagram} compact />
           <Button

--- a/apps/frontend/src/components/weather/CurrentConditions.tsx
+++ b/apps/frontend/src/components/weather/CurrentConditions.tsx
@@ -79,9 +79,6 @@ export default function CurrentConditions({
             <p className={weatherSectionTitleClassName}>
               {t('weather.currentConditions')}
             </p>
-            <h2 className="mt-1 truncate text-xl font-black text-slate-950 dark:text-white">
-              {weather.spot_name}
-            </h2>
           </div>
           <div
             className={`inline-flex w-fit items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-bold whitespace-nowrap ${verdictVisual.badgeClassName}`}

--- a/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
@@ -7,7 +7,6 @@ vi.mock('react-i18next', () => ({
     t: (key: string, options?: Record<string, string>) => {
       const labels: Record<string, string> = {
         'weather.paraIndex': 'Para-Index',
-        'weather.hourly.site': `Site : ${options?.siteName}`,
         'weather.hourly.paraIndexAt': `Para-Index ${options?.hour}`,
         'weather.hourly.verdictAt': `Verdict ${options?.hour}`,
         'weather.metricsUsed': 'Metriques utilisees',
@@ -136,9 +135,7 @@ describe('HourlyForecast tooltip behavior', () => {
   });
 
   it('shows para-index tooltip content on hover', () => {
-    render(<HourlyForecast spotId="site-1" dayIndex={0} siteName="Arguel" />);
-
-    expect(screen.getByText('Site : Arguel')).toBeTruthy();
+    render(<HourlyForecast spotId="site-1" dayIndex={0} />);
 
     fireEvent.mouseOver(
       screen.getByRole('button', { name: 'Para-Index 10:00' })

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -30,7 +30,6 @@ interface HourlyForecastProps {
   weatherData?: WeatherData;
   isLoading?: boolean;
   isError?: boolean;
-  siteName?: string;
 }
 
 // ============================================================================
@@ -613,7 +612,6 @@ export default function HourlyForecast({
   weatherData,
   isLoading: isOverrideLoading,
   isError: isOverrideError,
-  siteName,
 }: HourlyForecastProps) {
   const { t } = useTranslation();
   const {
@@ -689,11 +687,6 @@ export default function HourlyForecast({
           <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
             {t('weather.hourly.title')}
           </h2>
-          {siteName && (
-            <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
-              {t('weather.hourly.site', { siteName })}
-            </p>
-          )}
         </div>
         <div className="py-5 text-center text-gray-500 dark:text-gray-400 text-sm">
           {t('common.loading')}
@@ -709,11 +702,6 @@ export default function HourlyForecast({
           <h2 className="text-sm text-gray-600 dark:text-gray-300 font-semibold">
             {t('weather.hourly.title')}
           </h2>
-          {siteName && (
-            <p className="mt-1 truncate text-sm font-bold text-gray-900 dark:text-white">
-              {t('weather.hourly.site', { siteName })}
-            </p>
-          )}
         </div>
         <div className="py-5 text-center text-red-500 dark:text-red-400 text-sm">
           {t('common.dataUnavailable')}
@@ -859,11 +847,6 @@ export default function HourlyForecast({
           <h2 className={weatherSectionTitleClassName}>
             {t('weather.hourly.title')}
           </h2>
-          {siteName && (
-            <p className="mt-1 truncate text-sm font-bold text-slate-950 dark:text-white">
-              {t('weather.hourly.site', { siteName })}
-            </p>
-          )}
           <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
             {t('weather.hourly.description')}
           </p>

--- a/apps/frontend/src/components/weather/WeatherStickySelectionBar.tsx
+++ b/apps/frontend/src/components/weather/WeatherStickySelectionBar.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, ChevronDown, MapPin, Search, X } from 'lucide-react';
+import {
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from '@dashboard-parapente/design-system';
+import type { Site } from '@dashboard-parapente/shared-types';
+import { getSiteDisplayName } from '../../lib/siteDisplay';
+import CityWeatherSearch, { type CityWeatherTarget } from './CityWeatherSearch';
+import type { WeatherSelectionTab } from './WeatherSelectionPanel';
+
+type WeatherStickySelectionBarProps = {
+  activeWeatherName?: string;
+  selectedDayLabel: string;
+  selectionTab: WeatherSelectionTab;
+  allSites: Site[];
+  sites: Site[];
+  selectedSearchTarget: CityWeatherTarget | null;
+  selectedSiteId: string;
+  selectedDayIndex: number;
+  onSelectionTabChange: (tab: WeatherSelectionTab) => void;
+  onSelectSite: (siteId: string) => void;
+  onSelectSearchTarget: (target: CityWeatherTarget | null) => void;
+  onFavoriteCreated: (siteId: string) => void;
+};
+
+const getSearchText = (site: Site) =>
+  [
+    getSiteDisplayName(site),
+    site.name,
+    site.code,
+    site.region,
+    site.orientation,
+    site.elevation_m?.toString(),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+const getSiteMeta = (site: Site) =>
+  [site.orientation, site.elevation_m ? `${site.elevation_m}m` : null]
+    .filter(Boolean)
+    .join(' · ');
+
+export default function WeatherStickySelectionBar({
+  activeWeatherName,
+  selectedDayLabel,
+  selectionTab,
+  allSites,
+  sites,
+  selectedSearchTarget,
+  selectedSiteId,
+  selectedDayIndex,
+  onSelectionTabChange,
+  onSelectSite,
+  onSelectSearchTarget,
+  onFavoriteCreated,
+}: WeatherStickySelectionBarProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [siteQuery, setSiteQuery] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDialogElement>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const activeTab: WeatherSelectionTab =
+    sites.length === 0 ? 'search' : selectionTab;
+  const hasActiveTarget = Boolean(activeWeatherName);
+  let targetKind = t('weather.sticky.target.none');
+  if (selectedSearchTarget) {
+    targetKind = t(`weather.sticky.target.${selectedSearchTarget.type}`);
+  } else if (hasActiveTarget) {
+    targetKind = t('weather.sticky.target.savedSite');
+  }
+  let contextLabel = t('weather.sticky.noContext');
+  if (selectedSearchTarget) {
+    contextLabel = t('flightDecision.context.title');
+  } else if (hasActiveTarget) {
+    contextLabel = t('flightDecision.title');
+  }
+  const filteredSites = useMemo(() => {
+    const query = siteQuery.trim().toLowerCase();
+    if (!query) return sites;
+
+    return sites.filter((site) => getSearchText(site).includes(query));
+  }, [siteQuery, sites]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previouslyFocused = document.activeElement;
+    const getFocusableElements = () =>
+      Array.from(
+        popoverRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        ) ?? []
+      ).filter((element) => element.offsetParent !== null);
+
+    window.requestAnimationFrame(() => {
+      getFocusableElements()[0]?.focus();
+    });
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        toggleButtonRef.current?.focus();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) {
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+      if (previouslyFocused instanceof HTMLElement) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [isOpen]);
+
+  const handleSelectSite = (siteId: string) => {
+    onSelectSite(siteId);
+    setSiteQuery('');
+    setIsOpen(false);
+  };
+
+  const handleSelectSearchTarget = (target: CityWeatherTarget | null) => {
+    onSelectSearchTarget(target);
+    if (target) {
+      setIsOpen(false);
+    }
+  };
+
+  const handleFavoriteCreated = (siteId: string) => {
+    onFavoriteCreated(siteId);
+    setIsOpen(false);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="sticky top-0 z-40 mb-4 rounded-2xl border border-slate-200 bg-white/95 shadow-xl shadow-slate-200/70 backdrop-blur dark:border-slate-700 dark:bg-slate-900/95 dark:shadow-black/30"
+    >
+      <div className="flex items-center justify-between gap-3 p-3 sm:p-4">
+        <div className="min-w-0">
+          <p className="flex items-center gap-1.5 text-xs font-bold uppercase tracking-[0.16em] text-sky-700 dark:text-sky-300">
+            <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span className="truncate">{targetKind}</span>
+          </p>
+          <h2 className="mt-0.5 truncate text-base font-black text-slate-950 dark:text-white sm:text-lg">
+            {activeWeatherName ?? t('weather.sticky.noTarget')}
+          </h2>
+          <p className="mt-0.5 truncate text-xs font-semibold text-slate-500 dark:text-slate-400 sm:text-sm">
+            {contextLabel} · {selectedDayLabel}
+          </p>
+        </div>
+
+        <button
+          ref={toggleButtonRef}
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          aria-expanded={isOpen}
+          className="inline-flex shrink-0 cursor-pointer items-center gap-2 rounded-xl bg-sky-600 px-3 py-2 text-sm font-bold text-white shadow-sm shadow-sky-900/20 transition-colors hover:bg-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 sm:px-4"
+        >
+          {hasActiveTarget
+            ? t('weather.sticky.change')
+            : t('weather.sticky.choose')}
+          <ChevronDown
+            className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+
+      {isOpen && (
+        <dialog
+          ref={popoverRef}
+          open
+          aria-labelledby="weather-selection-panel-title"
+          aria-modal="true"
+          className="absolute left-0 right-0 top-full z-50 mt-2 max-h-[70vh] w-auto max-w-none overflow-y-auto overscroll-contain rounded-2xl border border-slate-200 bg-white p-3 text-left text-slate-950 shadow-2xl shadow-slate-900/20 backdrop:bg-transparent dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:shadow-black/50 sm:p-4"
+        >
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <p
+              id="weather-selection-panel-title"
+              className="text-sm font-black text-slate-950 dark:text-white"
+            >
+              {t('weather.sticky.panelTitle')}
+            </p>
+            <button
+              type="button"
+              onClick={() => setIsOpen(false)}
+              aria-label={t('common.close')}
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-white"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+
+          <Tabs
+            selectedKey={activeTab}
+            onSelectionChange={(key) =>
+              onSelectionTabChange(key as WeatherSelectionTab)
+            }
+          >
+            <TabList className="grid-cols-2 gap-1 rounded-2xl bg-slate-100 p-1 shadow-none dark:bg-slate-950/70">
+              <Tab id="favorites" isDisabled={sites.length === 0}>
+                <span className="inline-flex items-center gap-2">
+                  <MapPin className="h-4 w-4" aria-hidden="true" />
+                  {t('weather.sticky.savedSites')}
+                </span>
+              </Tab>
+              <Tab id="search">
+                <span className="inline-flex items-center gap-2">
+                  <Search className="h-4 w-4" aria-hidden="true" />
+                  {t('weather.selection.search')}
+                </span>
+              </Tab>
+            </TabList>
+
+            <TabPanel id="favorites">
+              <div className="space-y-3">
+                <label className="block text-sm font-semibold text-slate-700 dark:text-slate-200">
+                  {t('weather.sticky.filterSites')}
+                  <input
+                    type="search"
+                    value={siteQuery}
+                    onChange={(event) => setSiteQuery(event.target.value)}
+                    placeholder={t('weather.sticky.filterPlaceholder')}
+                    className="mt-1.5 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-slate-950 outline-none transition-colors placeholder:text-slate-400 focus:border-sky-500 focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+                  />
+                </label>
+
+                <div className="grid max-h-[42vh] gap-2 overflow-y-auto pr-1 sm:grid-cols-2 xl:grid-cols-3">
+                  {filteredSites.map((site) => {
+                    const isActive =
+                      site.id === selectedSiteId && !selectedSearchTarget;
+                    const meta = getSiteMeta(site);
+
+                    return (
+                      <button
+                        key={site.id}
+                        type="button"
+                        onClick={() => handleSelectSite(site.id)}
+                        className={`flex min-w-0 cursor-pointer items-center justify-between gap-3 rounded-xl border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 ${
+                          isActive
+                            ? 'border-sky-500 bg-sky-600 text-white shadow-sm shadow-sky-900/20'
+                            : 'border-slate-200 bg-white text-slate-900 hover:border-sky-300 hover:bg-sky-50/70 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:hover:border-sky-700 dark:hover:bg-sky-950/30'
+                        }`}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm font-bold">
+                            {getSiteDisplayName(site)}
+                          </span>
+                          {meta && (
+                            <span
+                              className={`mt-0.5 block truncate text-xs ${
+                                isActive
+                                  ? 'text-sky-100'
+                                  : 'text-slate-500 dark:text-slate-400'
+                              }`}
+                            >
+                              {meta}
+                            </span>
+                          )}
+                        </span>
+                        {isActive && (
+                          <Check
+                            className="h-4 w-4 shrink-0"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {filteredSites.length === 0 && (
+                  <div className="rounded-xl bg-slate-50 px-3 py-5 text-center text-sm text-slate-500 dark:bg-slate-950 dark:text-slate-400">
+                    {t('weather.sticky.noSavedSiteFound')}
+                  </div>
+                )}
+              </div>
+            </TabPanel>
+
+            <TabPanel id="search">
+              <CityWeatherSearch
+                dayIndex={selectedDayIndex}
+                selectedTarget={selectedSearchTarget}
+                favoriteSites={allSites}
+                isEmbedded
+                onSelectTarget={handleSelectSearchTarget}
+                onFavoriteCreated={handleFavoriteCreated}
+              />
+            </TabPanel>
+          </Tabs>
+        </dialog>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -221,6 +221,24 @@
       "favorites": "Favorites",
       "search": "Search"
     },
+    "sticky": {
+      "change": "Change",
+      "choose": "Choose",
+      "filterPlaceholder": "Name, orientation, altitude...",
+      "filterSites": "Filter saved sites",
+      "noContext": "No weather context",
+      "noSavedSiteFound": "No saved site found.",
+      "noTarget": "No weather target",
+      "panelTitle": "Change active weather",
+      "savedSites": "Saved sites",
+      "target": {
+        "city": "City",
+        "landing": "Landing",
+        "none": "Weather",
+        "savedSite": "Saved site",
+        "takeoff": "Takeoff"
+      }
+    },
     "page": {
       "badge": "Flight weather",
       "defaultTitle": "Weather forecast",
@@ -278,7 +296,6 @@
     },
     "hourly": {
       "title": "Hourly Forecast",
-      "site": "Site: {{siteName}}",
       "description": "Flight windows, source consensus and watch points.",
       "direction": "Direction",
       "cloudCover": "Cloud cover",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -221,6 +221,24 @@
       "favorites": "Favoris",
       "search": "Recherche"
     },
+    "sticky": {
+      "change": "Changer",
+      "choose": "Choisir",
+      "filterPlaceholder": "Nom, orientation, altitude...",
+      "filterSites": "Filtrer les sites enregistrés",
+      "noContext": "Aucun contexte météo",
+      "noSavedSiteFound": "Aucun site enregistré trouvé.",
+      "noTarget": "Aucune cible météo",
+      "panelTitle": "Changer la météo active",
+      "savedSites": "Sites enregistrés",
+      "target": {
+        "city": "Ville",
+        "landing": "Atterrissage",
+        "none": "Météo",
+        "savedSite": "Site enregistré",
+        "takeoff": "Décollage"
+      }
+    },
     "page": {
       "badge": "Météo de vol",
       "defaultTitle": "Prévisions météo",
@@ -278,7 +296,6 @@
     },
     "hourly": {
       "title": "Prévisions Horaires",
-      "site": "Site : {{siteName}}",
       "description": "Créneaux de vol, consensus des sources et points de vigilance.",
       "direction": "Direction",
       "cloudCover": "Couverture nuageuse",

--- a/apps/frontend/src/pages/WeatherPage.mobile.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile.tsx
@@ -11,6 +11,7 @@ type WeatherPageMobileProps = {
   selectedSiteId?: string;
   isSearchMode: boolean;
   isAuthenticated: boolean;
+  stickySelectionBar: ReactNode;
   selectionPanel: ReactNode;
   decisionPanel?: ReactNode;
   searchResultPanel?: ReactNode;
@@ -67,6 +68,7 @@ export default function WeatherPageMobileLayout({
   selectedSiteId,
   isSearchMode,
   isAuthenticated,
+  stickySelectionBar,
   selectionPanel,
   decisionPanel,
   searchResultPanel,
@@ -82,10 +84,11 @@ export default function WeatherPageMobileLayout({
 
   return (
     <div className="mx-auto flex w-full max-w-md flex-col gap-3 pb-24 sm:max-w-lg lg:max-w-xl">
+      {stickySelectionBar}
+
       <ExpandableSection
         title={t('weather.selection.title')}
         summary={t('weather.mobile.selectionSummary')}
-        defaultOpen
       >
         {selectionPanel}
       </ExpandableSection>

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -24,6 +24,7 @@ import WeatherSearchResultPanel from '../components/weather/WeatherSearchResultP
 import WeatherSelectionPanel, {
   type WeatherSelectionTab,
 } from '../components/weather/WeatherSelectionPanel';
+import WeatherStickySelectionBar from '../components/weather/WeatherStickySelectionBar';
 import FlightDecisionCockpit from '../components/weather/FlightDecisionCockpit';
 import {
   DEFAULT_FLIGHT_OBJECTIVE,
@@ -376,6 +377,23 @@ export default function WeatherPage() {
     />
   );
 
+  const stickySelectionBar = (
+    <WeatherStickySelectionBar
+      activeWeatherName={activeWeatherName}
+      selectedDayLabel={selectedDayLabel}
+      selectionTab={selectionTab}
+      allSites={sites}
+      sites={favoriteSites}
+      selectedSearchTarget={selectedSearchTarget}
+      selectedSiteId={selectedSiteId}
+      selectedDayIndex={selectedDayIndex}
+      onSelectionTabChange={handleSelectionTabChange}
+      onSelectSite={handleSelectSite}
+      onSelectSearchTarget={handleSelectSearchTarget}
+      onFavoriteCreated={handleSelectSite}
+    />
+  );
+
   const mobileEmptyPanel =
     !selectedSearchTarget && !selectedSiteId ? (
       <WeatherEmptyState />
@@ -445,11 +463,7 @@ export default function WeatherPage() {
 
   const mobileEmagramPanel =
     isAuthenticated && !selectedSearchTarget && selectedSiteId ? (
-      <EmagramWidget
-        siteId={selectedSiteId}
-        dayIndex={selectedDayIndex}
-        siteName={selectedSiteDisplayName}
-      />
+      <EmagramWidget siteId={selectedSiteId} dayIndex={selectedDayIndex} />
     ) : undefined;
 
   const mobileHourlyPanel =
@@ -460,7 +474,6 @@ export default function WeatherPage() {
         weatherData={selectedSearchWeatherData}
         isLoading={selectedSearchTarget ? isSearchWeatherLoading : undefined}
         isError={selectedSearchTarget ? isSearchWeatherError : undefined}
-        siteName={activeWeatherName}
       />
     ) : undefined;
 
@@ -473,6 +486,7 @@ export default function WeatherPage() {
         selectedSiteId={selectedSiteId}
         isSearchMode={Boolean(selectedSearchTarget)}
         isAuthenticated={isAuthenticated}
+        stickySelectionBar={stickySelectionBar}
         selectionPanel={selectionPanel}
         decisionPanel={mobileDecisionPanel}
         searchResultPanel={mobileSearchResultPanel}
@@ -488,97 +502,97 @@ export default function WeatherPage() {
   }
 
   return (
-    <div className="grid w-full min-w-0 gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
-      <aside className="min-w-0 space-y-4 xl:sticky xl:top-4 xl:self-start">
-        {selectionPanel}
-      </aside>
+    <div className="w-full min-w-0">
+      {stickySelectionBar}
 
-      <div className="min-w-0 space-y-4">
-        {!selectedSearchTarget && !selectedSiteId && <WeatherEmptyState />}
+      <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(340px,420px)_minmax(0,1fr)]">
+        <aside className="min-w-0 space-y-4">{selectionPanel}</aside>
 
-        {selectedSearchTarget && (
-          <WeatherSearchResultPanel
-            selectedSearchTitle={selectedSearchTitle}
-            selectedDayIndex={selectedDayIndex}
-            getDayLabel={(day) => getSearchDayLabel(day, t)}
-            onSelectDay={handleSelectSearchDay}
-          />
-        )}
+        <div className="min-w-0 space-y-4">
+          {!selectedSearchTarget && !selectedSiteId && <WeatherEmptyState />}
 
-        {(selectedSearchTarget || selectedSiteId) && (
-          <FlightDecisionCockpit
-            decision={flightDecision.data}
-            objective={selectedObjective}
-            isLoading={flightDecision.isLoading}
-            isError={flightDecision.isError}
-            isCityContext={Boolean(selectedSearchTarget)}
-            onObjectiveChange={handleObjectiveChange}
-          />
-        )}
+          {selectedSearchTarget && (
+            <WeatherSearchResultPanel
+              selectedSearchTitle={selectedSearchTitle}
+              selectedDayIndex={selectedDayIndex}
+              getDayLabel={(day) => getSearchDayLabel(day, t)}
+              onSelectDay={handleSelectSearchDay}
+            />
+          )}
 
-        {(selectedSearchTarget || selectedSiteId) && (
-          <CurrentConditions
-            spotId={selectedSearchTarget ? undefined : selectedSiteId}
-            dayIndex={selectedDayIndex}
-            weatherData={selectedSearchWeatherData}
-            isLoading={
-              selectedSearchTarget ? isSearchWeatherLoading : undefined
-            }
-            isError={selectedSearchTarget ? isSearchWeatherError : undefined}
-            siteOrientation={
-              isSpotSearchTarget(selectedSearchTarget)
-                ? selectedSearchTarget.spot.orientation
-                : undefined
-            }
-          />
-        )}
+          {(selectedSearchTarget || selectedSiteId) && (
+            <FlightDecisionCockpit
+              decision={flightDecision.data}
+              objective={selectedObjective}
+              isLoading={flightDecision.isLoading}
+              isError={flightDecision.isError}
+              isCityContext={Boolean(selectedSearchTarget)}
+              onObjectiveChange={handleObjectiveChange}
+            />
+          )}
 
-        {!selectedSearchTarget && selectedSiteId && (
-          <WeatherLiveWindPanel
-            latitude={selectedSite?.latitude}
-            longitude={selectedSite?.longitude}
-          />
-        )}
+          {(selectedSearchTarget || selectedSiteId) && (
+            <CurrentConditions
+              spotId={selectedSearchTarget ? undefined : selectedSiteId}
+              dayIndex={selectedDayIndex}
+              weatherData={selectedSearchWeatherData}
+              isLoading={
+                selectedSearchTarget ? isSearchWeatherLoading : undefined
+              }
+              isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+              siteOrientation={
+                isSpotSearchTarget(selectedSearchTarget)
+                  ? selectedSearchTarget.spot.orientation
+                  : undefined
+              }
+            />
+          )}
 
-        {/* Landing Sites Weather */}
-        {!selectedSearchTarget && selectedSiteId && (
-          <WeatherMultiLanding
-            spotId={selectedSiteId}
-            dayIndex={selectedDayIndex}
-          />
-        )}
+          {!selectedSearchTarget && selectedSiteId && (
+            <WeatherLiveWindPanel
+              latitude={selectedSite?.latitude}
+              longitude={selectedSite?.longitude}
+            />
+          )}
 
-        {/* 7-Day Forecast + Day Selector */}
-        {!selectedSearchTarget && selectedSiteId && (
-          <Forecast7Day
-            spotId={selectedSiteId}
-            selectedDayIndex={selectedDayIndex}
-            onSelectDay={handleSelectForecastDay}
-          />
-        )}
+          {/* Landing Sites Weather */}
+          {!selectedSearchTarget && selectedSiteId && (
+            <WeatherMultiLanding
+              spotId={selectedSiteId}
+              dayIndex={selectedDayIndex}
+            />
+          )}
 
-        {/* Emagram Analysis (authenticated only) */}
-        {isAuthenticated && !selectedSearchTarget && selectedSiteId && (
-          <EmagramWidget
-            siteId={selectedSiteId}
-            dayIndex={selectedDayIndex}
-            siteName={selectedSiteDisplayName}
-          />
-        )}
+          {/* 7-Day Forecast + Day Selector */}
+          {!selectedSearchTarget && selectedSiteId && (
+            <Forecast7Day
+              spotId={selectedSiteId}
+              selectedDayIndex={selectedDayIndex}
+              onSelectDay={handleSelectForecastDay}
+            />
+          )}
 
-        {/* Hourly Forecast */}
-        {(selectedSearchTarget || selectedSiteId) && (
-          <HourlyForecast
-            spotId={selectedSearchTarget ? undefined : selectedSiteId}
-            dayIndex={selectedDayIndex}
-            weatherData={selectedSearchWeatherData}
-            isLoading={
-              selectedSearchTarget ? isSearchWeatherLoading : undefined
-            }
-            isError={selectedSearchTarget ? isSearchWeatherError : undefined}
-            siteName={activeWeatherName}
-          />
-        )}
+          {/* Emagram Analysis (authenticated only) */}
+          {isAuthenticated && !selectedSearchTarget && selectedSiteId && (
+            <EmagramWidget
+              siteId={selectedSiteId}
+              dayIndex={selectedDayIndex}
+            />
+          )}
+
+          {/* Hourly Forecast */}
+          {(selectedSearchTarget || selectedSiteId) && (
+            <HourlyForecast
+              spotId={selectedSearchTarget ? undefined : selectedSiteId}
+              dayIndex={selectedDayIndex}
+              weatherData={selectedSearchWeatherData}
+              isLoading={
+                selectedSearchTarget ? isSearchWeatherLoading : undefined
+              }
+              isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+            />
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a sticky weather selection bar with tabs for saved sites and search.
- Remove repeated site names from key weather cards to reduce redundancy.
- Update weather page integrations and locale strings for the new selection flow.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend`
- `vitest run src/components/weather/HourlyForecast.behavior.test.tsx --config vitest.config.ts`
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced sticky weather selection bar to switch between sites and forecasts with favorites filtering and search capabilities.

* **Improvements**
  * Consolidated site name display in the selection bar; removed from individual weather cards for a cleaner interface.

* **Documentation**
  * Added glossary entry for "Site Enregistre".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->