### PR TITLE
fix(frontend): remove weather site selector from weather panel

### DIFF
--- a/apps/frontend/src/components/weather/WeatherSelectionPanel.tsx
+++ b/apps/frontend/src/components/weather/WeatherSelectionPanel.tsx
@@ -1,18 +1,10 @@
 import { useTranslation } from 'react-i18next';
-import { MapPin, Search } from 'lucide-react';
-import {
-  Button,
-  Tab,
-  TabList,
-  TabPanel,
-  Tabs,
-} from '@dashboard-parapente/design-system';
+import { Search } from 'lucide-react';
 import type {
   BestSpotResult,
   HourlyBestSpotsResult,
   Site,
 } from '@dashboard-parapente/shared-types';
-import SiteSelector from '../dashboard/SiteSelector';
 import CityWeatherSearch, { type CityWeatherTarget } from './CityWeatherSearch';
 import { BestSpotSuggestion } from './BestSpotSuggestion';
 import {
@@ -23,37 +15,27 @@ import {
 export type WeatherSelectionTab = 'favorites' | 'search';
 
 type WeatherSelectionPanelProps = {
-  selectionTab: WeatherSelectionTab;
   sites: Site[];
   selectedSearchTarget: CityWeatherTarget | null;
-  selectedSiteId: string;
   selectedDayIndex: number;
-  weatherData: Map<string, Record<string, unknown>>;
   bestSpot: BestSpotResult | null;
   hourlyBestSpots?: HourlyBestSpotsResult['hours'];
   hourlyStartHour?: number;
-  onSelectionTabChange: (tab: WeatherSelectionTab) => void;
   onSelectSite: (siteId: string) => void;
   onSelectSearchTarget: (target: CityWeatherTarget | null) => void;
   onFavoriteCreated: (siteId: string) => void;
-  onAddSite: () => void;
 };
 
 export default function WeatherSelectionPanel({
-  selectionTab,
   sites,
   selectedSearchTarget,
-  selectedSiteId,
   selectedDayIndex,
-  weatherData,
   bestSpot,
   hourlyBestSpots = [],
   hourlyStartHour,
-  onSelectionTabChange,
   onSelectSite,
   onSelectSearchTarget,
   onFavoriteCreated,
-  onAddSite,
 }: WeatherSelectionPanelProps) {
   const { t } = useTranslation();
 
@@ -76,59 +58,18 @@ export default function WeatherSelectionPanel({
           </div>
         </div>
         <div className="p-3 sm:p-4">
-          <Tabs
-            selectedKey={selectionTab}
-            onSelectionChange={(key) =>
-              onSelectionTabChange(key as WeatherSelectionTab)
-            }
-          >
-            <TabList className="grid-cols-2 gap-1 rounded-2xl bg-slate-100 p-1 shadow-none dark:bg-slate-950/70">
-              <Tab id="favorites">
-                <span className="inline-flex items-center gap-2">
-                  <MapPin className="h-4 w-4" aria-hidden="true" />
-                  {t('weather.selection.favorites')}
-                </span>
-              </Tab>
-              <Tab id="search">
-                <span className="inline-flex items-center gap-2">
-                  <Search className="h-4 w-4" aria-hidden="true" />
-                  {t('weather.selection.search')}
-                </span>
-              </Tab>
-            </TabList>
-            <TabPanel id="favorites">
-              {sites.length > 0 ? (
-                <SiteSelector
-                  selectedSiteId={selectedSearchTarget ? '' : selectedSiteId}
-                  onSelectSite={onSelectSite}
-                  weatherData={weatherData}
-                />
-              ) : (
-                <div className="rounded-xl bg-gray-50 p-4 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
-                  <p className="font-semibold text-gray-900 dark:text-white">
-                    {t('dashboard.noSites')}
-                  </p>
-                  <p className="mt-1">{t('dashboard.noSitesDescription')}</p>
-                  <Button
-                    onPress={onAddSite}
-                    className="mt-3 rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-700"
-                  >
-                    {t('dashboard.addSite')}
-                  </Button>
-                </div>
-              )}
-            </TabPanel>
-            <TabPanel id="search">
-              <CityWeatherSearch
-                dayIndex={selectedDayIndex}
-                selectedTarget={selectedSearchTarget}
-                favoriteSites={sites}
-                isEmbedded
-                onSelectTarget={onSelectSearchTarget}
-                onFavoriteCreated={onFavoriteCreated}
-              />
-            </TabPanel>
-          </Tabs>
+          <div className="mb-3 inline-flex items-center gap-2 text-sm font-black text-slate-950 dark:text-white">
+            <Search className="h-4 w-4 text-sky-600" aria-hidden="true" />
+            {t('weather.selection.search')}
+          </div>
+          <CityWeatherSearch
+            dayIndex={selectedDayIndex}
+            selectedTarget={selectedSearchTarget}
+            favoriteSites={sites}
+            isEmbedded
+            onSelectTarget={onSelectSearchTarget}
+            onFavoriteCreated={onFavoriteCreated}
+          />
         </div>
       </section>
 

--- a/apps/frontend/src/pages/WeatherPage.stories.tsx
+++ b/apps/frontend/src/pages/WeatherPage.stories.tsx
@@ -631,7 +631,7 @@ const defaultHandlersWithoutSpotsAndDetails = defaultHandlers.filter(
   (handler) => handler !== spotsHandler && handler !== spotDetailsHandler
 );
 
-const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_SEARCH_DATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const parseLocalDate = (value: string) => {
@@ -717,7 +717,7 @@ export const Default = meta.story({
 });
 
 Default.test(
-  'renders weather page with site selector and conditions',
+  'renders weather page with sticky selector and conditions',
   async ({ canvas, userEvent }) => {
     await canvas.findAllByText(/Arguel/u);
     await canvas.findAllByText(/Chalais/u);
@@ -813,18 +813,14 @@ export const WithCitySearch = meta.story({
 WithCitySearch.test(
   'selects a searched spot, displays hourly details, and adds it to favorites',
   async ({ canvas, userEvent }) => {
-    const searchTab = await canvas.findByRole('tab', {
-      name: i18n.t('weather.selection.search'),
-    });
-    await userEvent.click(searchTab);
-    const input = await canvas.findByPlaceholderText(/Besançon/);
+    const input = await canvas.findByPlaceholderText(/Besançon/u);
     await userEvent.type(input, 'Besan');
-    const suggestion = await canvas.findByRole('option', { name: /Besançon/ });
+    const suggestion = await canvas.findByRole('option', { name: /Besançon/u });
     await userEvent.click(suggestion);
     const searchedSpotButton = await canvas.findByRole('button', {
-      name: /Arguel déco/,
+      name: /Arguel déco/u,
     });
-    await canvas.findByRole('button', { name: /Plaine d'Arguel/ });
+    await canvas.findByRole('button', { name: /Plaine d'Arguel/u });
 
     await userEvent.click(searchedSpotButton);
     await canvas.findByText(i18n.t('weather.page.selectedSearchResult'));
@@ -862,7 +858,7 @@ export const NoSites = meta.story({
 });
 
 NoSites.test('shows no sites message', async ({ canvas }) => {
-  await canvas.findByText(/Aucun site configuré/);
+  await canvas.findByText(/Aucun site configuré/u);
 });
 
 export const Loading = meta.story({
@@ -927,7 +923,7 @@ export const WeatherError = meta.story({
 });
 
 WeatherError.test(
-  'renders site selector even when weather fails',
+  'renders sticky selector even when weather fails',
   async ({ canvas }) => {
     await canvas.findAllByText(/Arguel/u);
     await canvas.findAllByText(/Chalais/u);

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -270,9 +270,6 @@ export default function WeatherPage() {
     : false;
 
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const [weatherDataMap] = useState<Map<string, Record<string, unknown>>>(
-    new Map()
-  );
   const weatherSearch = {
     siteId: selectedSiteId,
     day: getForecastDaySearch(selectedDayIndex),
@@ -360,20 +357,15 @@ export default function WeatherPage() {
 
   const selectionPanel = (
     <WeatherSelectionPanel
-      selectionTab={selectionTab}
       sites={sites}
       selectedSearchTarget={selectedSearchTarget}
-      selectedSiteId={selectedSiteId}
       selectedDayIndex={selectedDayIndex}
-      weatherData={weatherDataMap}
       bestSpot={bestSpot ?? null}
       hourlyBestSpots={hourlyBestSpots?.hours}
       hourlyStartHour={hourlyBestSpots?.startHour}
-      onSelectionTabChange={handleSelectionTabChange}
       onSelectSite={handleSelectSite}
       onSelectSearchTarget={handleSelectSearchTarget}
       onFavoriteCreated={handleSelectSite}
-      onAddSite={() => void navigate({ to: '/sites' })}
     />
   );
 


### PR DESCRIPTION
## Summary
- Remove the redundant site selector from the weather left panel.
- Keep weather search and best-spot suggestions in the panel; the sticky bar remains the site chooser.
- Update weather story tests to match the always-visible search UI.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- CodeRabbit review ✅

## Notes
- `nx affected -t lint --projects=frontend` and `nx affected -t test --projects=frontend --parallel=5` expanded to backend/shared-type targets in this repo and hit unrelated environment issues (`ruff`/`pytest` missing, `--projects` passthrough invalid for `vitest`).
- Targeted Vitest runs for the weather story file timed out in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the weather selection panel by consolidating the tabbed interface (favorites/search) into a unified, search-focused layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->