### PR TITLE
feat(frontend): move weather day selector under site selection

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.mobile.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile.tsx
@@ -85,6 +85,7 @@ export default function WeatherPageMobileLayout({
   return (
     <div className="mx-auto flex w-full max-w-md flex-col gap-3 pb-24 sm:max-w-lg lg:max-w-xl">
       {stickySelectionBar}
+      {forecastPanel}
 
       <WeatherPageHero
         activeWeatherName={activeWeatherName}
@@ -105,12 +106,6 @@ export default function WeatherPageMobileLayout({
         summary={t('weather.mobile.liveWindSummary')}
       >
         {liveWindPanel}
-      </ExpandableSection>
-      <ExpandableSection
-        title={t('weather.mobile.forecastTitle')}
-        summary={t('weather.mobile.forecastSummary')}
-      >
-        {forecastPanel}
       </ExpandableSection>
       <ExpandableSection
         title={t('weather.mobile.hourlyTitle')}

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -382,6 +382,15 @@ export default function WeatherPage() {
     />
   );
 
+  const forecastDaySelector =
+    !selectedSearchTarget && selectedSiteId ? (
+      <Forecast7Day
+        spotId={selectedSiteId}
+        selectedDayIndex={selectedDayIndex}
+        onSelectDay={handleSelectForecastDay}
+      />
+    ) : undefined;
+
   const mobileEmptyPanel =
     !selectedSearchTarget && !selectedSiteId ? (
       <WeatherEmptyState />
@@ -440,15 +449,6 @@ export default function WeatherPage() {
       />
     ) : undefined;
 
-  const mobileForecastPanel =
-    !selectedSearchTarget && selectedSiteId ? (
-      <Forecast7Day
-        spotId={selectedSiteId}
-        selectedDayIndex={selectedDayIndex}
-        onSelectDay={handleSelectForecastDay}
-      />
-    ) : undefined;
-
   const mobileEmagramPanel =
     isAuthenticated && !selectedSearchTarget && selectedSiteId ? (
       <EmagramWidget siteId={selectedSiteId} dayIndex={selectedDayIndex} />
@@ -475,6 +475,7 @@ export default function WeatherPage() {
         isSearchMode={Boolean(selectedSearchTarget)}
         isAuthenticated={isAuthenticated}
         stickySelectionBar={stickySelectionBar}
+        forecastPanel={forecastDaySelector}
         bestSpotSuggestion={bestSpotSuggestion}
         decisionPanel={mobileDecisionPanel}
         searchResultPanel={mobileSearchResultPanel}
@@ -482,7 +483,6 @@ export default function WeatherPage() {
         currentConditions={mobileCurrentConditions}
         liveWindPanel={mobileLiveWindPanel}
         landingPanel={mobileLandingPanel}
-        forecastPanel={mobileForecastPanel}
         emagramPanel={mobileEmagramPanel}
         hourlyPanel={mobileHourlyPanel}
       />
@@ -494,6 +494,8 @@ export default function WeatherPage() {
       {stickySelectionBar}
 
       <div className="min-w-0 space-y-4">
+        {forecastDaySelector}
+
         {bestSpotSuggestion}
 
         {!selectedSearchTarget && !selectedSiteId && <WeatherEmptyState />}
@@ -547,15 +549,6 @@ export default function WeatherPage() {
           <WeatherMultiLanding
             spotId={selectedSiteId}
             dayIndex={selectedDayIndex}
-          />
-        )}
-
-        {/* 7-Day Forecast + Day Selector */}
-        {!selectedSearchTarget && selectedSiteId && (
-          <Forecast7Day
-            spotId={selectedSiteId}
-            selectedDayIndex={selectedDayIndex}
-            onSelectDay={handleSelectForecastDay}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Move the 7-day weather selector directly under site selection on desktop and mobile
- Remove the duplicated forecast block lower in the weather page layout

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --files=apps/frontend/src/pages/WeatherPage.tsx,apps/frontend/src/pages/WeatherPage.mobile.tsx --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mobile Experience**
  * Weather forecast on mobile is now displayed directly in the main page flow without requiring expansion, providing immediate access to forecast information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->