### PR TITLE
fix(frontend): keep compact weather day selector

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.mobile.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile.tsx
@@ -12,6 +12,7 @@ type WeatherPageMobileProps = {
   isSearchMode: boolean;
   isAuthenticated: boolean;
   stickySelectionBar: ReactNode;
+  daySelectorPanel?: ReactNode;
   bestSpotSuggestion: ReactNode;
   decisionPanel?: ReactNode;
   searchResultPanel?: ReactNode;
@@ -69,6 +70,7 @@ export default function WeatherPageMobileLayout({
   isSearchMode,
   isAuthenticated,
   stickySelectionBar,
+  daySelectorPanel,
   bestSpotSuggestion,
   decisionPanel,
   searchResultPanel,
@@ -85,7 +87,7 @@ export default function WeatherPageMobileLayout({
   return (
     <div className="mx-auto flex w-full max-w-md flex-col gap-3 pb-24 sm:max-w-lg lg:max-w-xl">
       {stickySelectionBar}
-      {forecastPanel}
+      {daySelectorPanel}
 
       <WeatherPageHero
         activeWeatherName={activeWeatherName}
@@ -106,6 +108,12 @@ export default function WeatherPageMobileLayout({
         summary={t('weather.mobile.liveWindSummary')}
       >
         {liveWindPanel}
+      </ExpandableSection>
+      <ExpandableSection
+        title={t('weather.mobile.forecastTitle')}
+        summary={t('weather.mobile.forecastSummary')}
+      >
+        {forecastPanel}
       </ExpandableSection>
       <ExpandableSection
         title={t('weather.mobile.hourlyTitle')}

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -6,6 +6,7 @@ import CurrentConditions from '../components/weather/CurrentConditions';
 import Forecast7Day from '../components/weather/Forecast7Day';
 import HourlyForecast from '../components/weather/HourlyForecast';
 import EmagramWidget from '../components/dashboard/EmagramWidget';
+import DaySelector from '../components/dashboard/DaySelector';
 import WeatherMultiLanding from '../components/weather/WeatherMultiLanding';
 import { type CityWeatherTarget } from '../components/weather/CityWeatherSearch';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
@@ -382,7 +383,17 @@ export default function WeatherPage() {
     />
   );
 
-  const forecastDaySelector =
+  const daySelectorPanel =
+    !selectedSearchTarget && selectedSiteId ? (
+      <div className="rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/95">
+        <DaySelector
+          selectedDayIndex={selectedDayIndex}
+          onSelectDay={handleSelectForecastDay}
+        />
+      </div>
+    ) : undefined;
+
+  const forecastPanel =
     !selectedSearchTarget && selectedSiteId ? (
       <Forecast7Day
         spotId={selectedSiteId}
@@ -475,7 +486,7 @@ export default function WeatherPage() {
         isSearchMode={Boolean(selectedSearchTarget)}
         isAuthenticated={isAuthenticated}
         stickySelectionBar={stickySelectionBar}
-        forecastPanel={forecastDaySelector}
+        daySelectorPanel={daySelectorPanel}
         bestSpotSuggestion={bestSpotSuggestion}
         decisionPanel={mobileDecisionPanel}
         searchResultPanel={mobileSearchResultPanel}
@@ -483,6 +494,7 @@ export default function WeatherPage() {
         currentConditions={mobileCurrentConditions}
         liveWindPanel={mobileLiveWindPanel}
         landingPanel={mobileLandingPanel}
+        forecastPanel={forecastPanel}
         emagramPanel={mobileEmagramPanel}
         hourlyPanel={mobileHourlyPanel}
       />
@@ -494,7 +506,7 @@ export default function WeatherPage() {
       {stickySelectionBar}
 
       <div className="min-w-0 space-y-4">
-        {forecastDaySelector}
+        {daySelectorPanel}
 
         {bestSpotSuggestion}
 
@@ -551,6 +563,8 @@ export default function WeatherPage() {
             dayIndex={selectedDayIndex}
           />
         )}
+
+        {forecastPanel}
 
         {/* Emagram Analysis (authenticated only) */}
         {isAuthenticated && !selectedSearchTarget && selectedSiteId && (


### PR DESCRIPTION
## Summary
- Restore the compact `DaySelector` under the weather site selection
- Keep the detailed `Forecast7Day` block in the forecast section instead of using it as the day selector

## Context
PR #1098 was merged before the corrective commit was included, so this PR carries only the fix commit.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --files=apps/frontend/src/pages/WeatherPage.tsx,apps/frontend/src/pages/WeatherPage.mobile.tsx --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Reorganized weather page layout with improved day selector positioning on both mobile and desktop
  * Forecast section is now expandable on mobile for better space utilization and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->