### PR TITLE
fix(frontend): show 7-day forecast under weather site selection

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.mobile.tsx
+++ b/apps/frontend/src/pages/WeatherPage.mobile.tsx
@@ -12,7 +12,6 @@ type WeatherPageMobileProps = {
   isSearchMode: boolean;
   isAuthenticated: boolean;
   stickySelectionBar: ReactNode;
-  daySelectorPanel?: ReactNode;
   bestSpotSuggestion: ReactNode;
   decisionPanel?: ReactNode;
   searchResultPanel?: ReactNode;
@@ -70,7 +69,6 @@ export default function WeatherPageMobileLayout({
   isSearchMode,
   isAuthenticated,
   stickySelectionBar,
-  daySelectorPanel,
   bestSpotSuggestion,
   decisionPanel,
   searchResultPanel,
@@ -87,7 +85,7 @@ export default function WeatherPageMobileLayout({
   return (
     <div className="mx-auto flex w-full max-w-md flex-col gap-3 pb-24 sm:max-w-lg lg:max-w-xl">
       {stickySelectionBar}
-      {daySelectorPanel}
+      {forecastPanel}
 
       <WeatherPageHero
         activeWeatherName={activeWeatherName}
@@ -108,12 +106,6 @@ export default function WeatherPageMobileLayout({
         summary={t('weather.mobile.liveWindSummary')}
       >
         {liveWindPanel}
-      </ExpandableSection>
-      <ExpandableSection
-        title={t('weather.mobile.forecastTitle')}
-        summary={t('weather.mobile.forecastSummary')}
-      >
-        {forecastPanel}
       </ExpandableSection>
       <ExpandableSection
         title={t('weather.mobile.hourlyTitle')}

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -6,7 +6,6 @@ import CurrentConditions from '../components/weather/CurrentConditions';
 import Forecast7Day from '../components/weather/Forecast7Day';
 import HourlyForecast from '../components/weather/HourlyForecast';
 import EmagramWidget from '../components/dashboard/EmagramWidget';
-import DaySelector from '../components/dashboard/DaySelector';
 import WeatherMultiLanding from '../components/weather/WeatherMultiLanding';
 import { type CityWeatherTarget } from '../components/weather/CityWeatherSearch';
 import { sitesQueryOptions } from '../hooks/sites/useSites';
@@ -383,17 +382,7 @@ export default function WeatherPage() {
     />
   );
 
-  const daySelectorPanel =
-    !selectedSearchTarget && selectedSiteId ? (
-      <div className="rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/95">
-        <DaySelector
-          selectedDayIndex={selectedDayIndex}
-          onSelectDay={handleSelectForecastDay}
-        />
-      </div>
-    ) : undefined;
-
-  const forecastPanel =
+  const forecastDaySelector =
     !selectedSearchTarget && selectedSiteId ? (
       <Forecast7Day
         spotId={selectedSiteId}
@@ -486,7 +475,7 @@ export default function WeatherPage() {
         isSearchMode={Boolean(selectedSearchTarget)}
         isAuthenticated={isAuthenticated}
         stickySelectionBar={stickySelectionBar}
-        daySelectorPanel={daySelectorPanel}
+        forecastPanel={forecastDaySelector}
         bestSpotSuggestion={bestSpotSuggestion}
         decisionPanel={mobileDecisionPanel}
         searchResultPanel={mobileSearchResultPanel}
@@ -494,7 +483,6 @@ export default function WeatherPage() {
         currentConditions={mobileCurrentConditions}
         liveWindPanel={mobileLiveWindPanel}
         landingPanel={mobileLandingPanel}
-        forecastPanel={forecastPanel}
         emagramPanel={mobileEmagramPanel}
         hourlyPanel={mobileHourlyPanel}
       />
@@ -506,7 +494,7 @@ export default function WeatherPage() {
       {stickySelectionBar}
 
       <div className="min-w-0 space-y-4">
-        {daySelectorPanel}
+        {forecastDaySelector}
 
         {bestSpotSuggestion}
 
@@ -563,8 +551,6 @@ export default function WeatherPage() {
             dayIndex={selectedDayIndex}
           />
         )}
-
-        {forecastPanel}
 
         {/* Emagram Analysis (authenticated only) */}
         {isAuthenticated && !selectedSearchTarget && selectedSiteId && (


### PR DESCRIPTION
## Summary
- Remove the compact day selector from the weather page
- Show the 7-day forecast block directly under the site selection instead
- Keep the forecast block from being duplicated lower in the mobile/desktop layouts

## Context
PR #1099 restored the compact day selector, but the desired behavior is to keep the 7-day forecast at that location. This PR reverts that change.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --files=apps/frontend/src/pages/WeatherPage.tsx,apps/frontend/src/pages/WeatherPage.mobile.tsx --parallel=5 --exclude=e2e
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test:unit frontend
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized mobile weather forecast layout, consolidating day selector and forecast panel into a unified display
  * Removed collapsible forecast section from mobile view for streamlined navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->