### PR TITLE
fix frontend stale flight decision on site switch

### DIFF
--- a/apps/frontend/src/components/weather/FlightDecisionCockpit.test.tsx
+++ b/apps/frontend/src/components/weather/FlightDecisionCockpit.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ComponentProps } from 'react';
+import type { FlightDecisionResponse } from '@dashboard-parapente/shared-types';
+import FlightDecisionCockpit from './FlightDecisionCockpit';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@dashboard-parapente/design-system', () => ({
+  Button: ({ children, ...props }: ComponentProps<'button'>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+const createDecision = (siteId: string): FlightDecisionResponse => ({
+  site: {
+    id: siteId,
+    name: `Site ${siteId}`,
+    usage_type: 'takeoff',
+    orientation: 'W',
+  },
+  objective: 'tranquille',
+  timezone: 'Europe/Paris',
+  day_index: 0,
+  summary: {
+    level: 'favorable',
+    translation_key: 'decision-level',
+    score_objectif: 82,
+    title_key: `decision-title-${siteId}`,
+    message_key: `decision-message-${siteId}`,
+    message_params: {},
+    main_risk_code: null,
+    has_recommended_window: true,
+  },
+  best_window: {
+    start_hour: 10,
+    end_hour: 12,
+    level: 'favorable',
+    score_objectif: 82,
+    min_score_objectif: 78,
+    hours: [10, 11, 12],
+    main_risk_codes: [],
+    translation_key: 'window-level',
+    summary_key: 'window-summary',
+    summary_params: {},
+  },
+  least_unfavorable_window: null,
+  hourly: [],
+  risks: [],
+  confidence: {
+    level: 'high',
+    score: 90,
+    translation_key: 'confidence-high',
+    source_count: 4,
+    expected_source_count: 5,
+    freshness: {
+      cached_at: null,
+      age_minutes: null,
+      status: 'fresh',
+    },
+    diagnostics: [],
+  },
+  landing_safety: {
+    status: 'not_configured',
+    level: 'vigilance',
+    translation_key: 'landing-not-configured',
+    summary_key: 'landing-summary',
+    summary_params: {},
+    landings: [],
+  },
+  live_wind: {
+    status: 'not_evaluated',
+    influences_confidence: false,
+    stations: [],
+    diagnostics: [],
+  },
+  alternatives: [],
+  cached_at: null,
+});
+
+describe('FlightDecisionCockpit', () => {
+  it('does not display a decision for a previous selected site', () => {
+    render(
+      <FlightDecisionCockpit
+        decision={createDecision('site-a')}
+        expectedSiteId="site-b"
+        objective="tranquille"
+        onObjectiveChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('common.loading')).toBeInTheDocument();
+    expect(screen.queryByText('decision-title-site-a')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('decision-message-site-a')
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays the decision when it matches the selected site', () => {
+    render(
+      <FlightDecisionCockpit
+        decision={createDecision('site-b')}
+        expectedSiteId="site-b"
+        objective="tranquille"
+        onObjectiveChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('decision-title-site-b')).toBeInTheDocument();
+    expect(screen.getByText('82')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/weather/FlightDecisionCockpit.tsx
+++ b/apps/frontend/src/components/weather/FlightDecisionCockpit.tsx
@@ -23,6 +23,7 @@ import {
 
 type FlightDecisionCockpitProps = {
   decision?: FlightDecisionResponse;
+  expectedSiteId?: string;
   objective: FlightObjective;
   isLoading?: boolean;
   isError?: boolean;
@@ -42,6 +43,7 @@ const formatHourWindow = (start: number, end: number) =>
 
 export default function FlightDecisionCockpit({
   decision,
+  expectedSiteId,
   objective,
   isLoading = false,
   isError = false,
@@ -52,6 +54,9 @@ export default function FlightDecisionCockpit({
   const activeObjective = objective ?? DEFAULT_FLIGHT_OBJECTIVE;
   const translate = (key: string, params?: Record<string, unknown>) =>
     String(t(key, params));
+  const hasStaleDecision = Boolean(
+    expectedSiteId && decision && decision.site.id !== expectedSiteId
+  );
 
   if (isCityContext) {
     return (
@@ -66,7 +71,7 @@ export default function FlightDecisionCockpit({
     );
   }
 
-  if (isLoading) {
+  if (isLoading || (hasStaleDecision && !isError)) {
     return (
       <section
         className={`${weatherCardClassName} p-4 sm:p-5`}
@@ -82,7 +87,7 @@ export default function FlightDecisionCockpit({
     );
   }
 
-  if (isError || !decision) {
+  if (isError || !decision || hasStaleDecision) {
     return (
       <section className={`${weatherCardClassName} p-4 sm:p-5`} role="alert">
         <p className={weatherSectionTitleClassName}>

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -425,6 +425,7 @@ export default function WeatherPage() {
     selectedSearchTarget || selectedSiteId ? (
       <FlightDecisionCockpit
         decision={flightDecision.data}
+        expectedSiteId={selectedSearchTarget ? undefined : selectedSiteId}
         objective={selectedObjective}
         isLoading={flightDecision.isLoading}
         isError={flightDecision.isError}
@@ -512,6 +513,7 @@ export default function WeatherPage() {
         {(selectedSearchTarget || selectedSiteId) && (
           <FlightDecisionCockpit
             decision={flightDecision.data}
+            expectedSiteId={selectedSearchTarget ? undefined : selectedSiteId}
             objective={selectedObjective}
             isLoading={flightDecision.isLoading}
             isError={flightDecision.isError}


### PR DESCRIPTION
## Summary
- Prevents the flight-decision card from showing a decision that belongs to a previous site while the selected site changes.
- Threads the expected site id from WeatherPage into the cockpit and adds a regression test for the stale-decision case.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/weather/FlightDecisionCockpit.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- CodeRabbit CLI: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of weather decision data from mismatched flight planning sites to prevent displaying stale or incorrect information.
  * Enhanced loading and error state display when weather data is unavailable or outdated.

* **Tests**
  * Added comprehensive test coverage for the flight decision display component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->