### PR TITLE
fix(backend): scope flight decision risks to the active window

### DIFF
--- a/apps/backend/flight_decision.py
+++ b/apps/backend/flight_decision.py
@@ -90,13 +90,13 @@ def build_flight_decision(
         )
         for hour in flyable_hours
     ]
-    global_risks = _global_risks(hourly)
     confidence = _build_confidence(weather_payload, hourly)
     landing_safety = _build_landing_safety(landing_associations or [])
-    global_risks.extend(landing_safety.get("decision_risks", []))
+    global_risks = _global_risks(hourly)
+    decision_risks = list(landing_safety.get("decision_risks", []))
 
     if confidence["level"] in {"low", "very_low"}:
-        global_risks.append(
+        decision_risks.append(
             _diagnostic(
                 "forecast_confidence_low",
                 "vigilance",
@@ -107,9 +107,12 @@ def build_flight_decision(
 
     best_window = _select_best_window(hourly)
     least_unfavorable = None if best_window else _select_least_unfavorable_window(hourly)
+    display_risks = _dedupe_risks(
+        _window_risks(best_window or least_unfavorable, hourly, global_risks) + decision_risks
+    )
     summary_level: DecisionLevel = "unavailable"
     summary_score = 0
-    main_risk_code = global_risks[0]["code"] if global_risks else None
+    main_risk_code = display_risks[0]["code"] if display_risks else None
 
     if best_window:
         summary_level = best_window["level"]
@@ -149,7 +152,7 @@ def build_flight_decision(
         "best_window": best_window,
         "least_unfavorable_window": least_unfavorable,
         "hourly": hourly,
-        "risks": global_risks,
+        "risks": display_risks,
         "confidence": confidence,
         "landing_safety": {
             key: value for key, value in landing_safety.items() if key != "decision_risks"
@@ -667,15 +670,35 @@ def _window_from_hours(hours: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _global_risks(hourly: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    risks = [risk for hour in hourly for risk in hour["risks"]]
+    return sorted(
+        _dedupe_risks(risks), key=lambda risk: _severity_rank(risk["severity"]), reverse=True
+    )
+
+
+def _window_risks(
+    window: dict[str, Any] | None,
+    hourly: list[dict[str, Any]],
+    fallback: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not window:
+        return fallback
+    window_hours = set(window["hours"])
+    risks = [risk for hour in hourly if hour["hour"] in window_hours for risk in hour["risks"]]
+    return sorted(
+        _dedupe_risks(risks), key=lambda risk: _severity_rank(risk["severity"]), reverse=True
+    )
+
+
+def _dedupe_risks(risks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     by_code: dict[str, dict[str, Any]] = {}
-    for hour in hourly:
-        for risk in hour["risks"]:
-            current = by_code.get(risk["code"])
-            if current is None or _severity_rank(risk["severity"]) > _severity_rank(
-                current["severity"]
-            ):
-                by_code[risk["code"]] = risk
-    return sorted(by_code.values(), key=lambda risk: _severity_rank(risk["severity"]), reverse=True)
+    for risk in risks:
+        current = by_code.get(risk["code"])
+        if current is None or _severity_rank(risk["severity"]) > _severity_rank(
+            current["severity"]
+        ):
+            by_code[risk["code"]] = risk
+    return list(by_code.values())
 
 
 def _severity_rank(severity: str) -> int:

--- a/apps/backend/tests/unit/test_flight_decision.py
+++ b/apps/backend/tests/unit/test_flight_decision.py
@@ -113,6 +113,37 @@ def test_tailwind_is_blocking_for_decollage_orientation():
     assert result["best_window"] is None
 
 
+def test_displayed_risks_are_scoped_to_recommended_window():
+    payload = _payload(
+        [
+            _hour(12, wind_speed=8.6, wind_direction=263.8, para_index=80),
+            _hour(13, wind_speed=9.8, wind_direction=266.4, para_index=80),
+            _hour(14, wind_speed=9.7, wind_direction=269.6, para_index=80),
+            _hour(15, wind_speed=8.9, wind_direction=269.7, para_index=80),
+            _hour(16, wind_speed=8.2, wind_direction=277.0, para_index=80),
+            _hour(17, wind_speed=8.0, wind_direction=281.0, para_index=90),
+            _hour(18, wind_speed=6.1, wind_direction=290.1, para_index=90),
+            _hour(19, wind_speed=5.0, wind_direction=296.1, para_index=90),
+            _hour(20, wind_speed=4.4, wind_direction=6.3, para_index=60),
+            _hour(21, wind_speed=4.5, wind_direction=63.9, para_index=60),
+        ]
+    )
+    payload.update({"day_index": 0, "sunrise": "05:00", "sunset": "21:00"})
+
+    result = build_flight_decision(
+        site=_site("SW"),
+        weather_payload=payload,
+        objective="tranquille",
+        now=datetime(2026, 5, 30, 12, tzinfo=ZoneInfo("Europe/Paris")),
+    )
+
+    assert result["best_window"]["hours"] == [12, 13, 14, 15, 16, 17, 18, 19]
+    risk_codes = [risk["code"] for risk in result["risks"]]
+    assert "wind_decollage_travers_fort" in risk_codes
+    assert "wind_decollage_cul" not in risk_codes
+    assert "wind_too_weak" not in risk_codes
+
+
 def test_objective_changes_thermal_score_without_changing_para_index():
     payload = _payload([_hour(11, thermal_strength="fort", cape=700, lifted_index=-1)])
     quiet = build_flight_decision(


### PR DESCRIPTION
## Summary
- Scope the displayed flight-decision risks to the recommended window instead of the whole day.
- Preserve global fallback behavior when no window is available.
- Add a regression test for Planoise SW where tailwind only appears outside the recommended slot.

## Validation
- "/media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest apps/backend/tests/unit/test_flight_decision.py -q --tb=short --no-header"
- "PATH=... NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend -- tests/unit/test_flight_decision.py"
- "PATH=... NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Flight decision recommendations now display weather risks scoped to the recommended time window, providing more contextual and relevant information to users.
  * Duplicate risks are consolidated while preserving the highest severity level, reducing redundancy in risk reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->