### PR TITLE
fix(frontend): place weather panels side by side

### DIFF
--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -511,47 +511,47 @@ export default function WeatherPage() {
         )}
 
         {(selectedSearchTarget || selectedSiteId) && (
-          <FlightDecisionCockpit
-            decision={flightDecision.data}
-            expectedSiteId={selectedSearchTarget ? undefined : selectedSiteId}
-            objective={selectedObjective}
-            isLoading={flightDecision.isLoading}
-            isError={flightDecision.isError}
-            isCityContext={Boolean(selectedSearchTarget)}
-            onObjectiveChange={handleObjectiveChange}
-          />
-        )}
+          <div className="flex min-w-0 flex-col gap-4 lg:flex-row lg:[&>*]:min-w-0 lg:[&>*]:flex-1">
+            <FlightDecisionCockpit
+              decision={flightDecision.data}
+              expectedSiteId={selectedSearchTarget ? undefined : selectedSiteId}
+              objective={selectedObjective}
+              isLoading={flightDecision.isLoading}
+              isError={flightDecision.isError}
+              isCityContext={Boolean(selectedSearchTarget)}
+              onObjectiveChange={handleObjectiveChange}
+            />
 
-        {(selectedSearchTarget || selectedSiteId) && (
-          <CurrentConditions
-            spotId={selectedSearchTarget ? undefined : selectedSiteId}
-            dayIndex={selectedDayIndex}
-            weatherData={selectedSearchWeatherData}
-            isLoading={
-              selectedSearchTarget ? isSearchWeatherLoading : undefined
-            }
-            isError={selectedSearchTarget ? isSearchWeatherError : undefined}
-            siteOrientation={
-              isSpotSearchTarget(selectedSearchTarget)
-                ? selectedSearchTarget.spot.orientation
-                : undefined
-            }
-          />
+            <CurrentConditions
+              spotId={selectedSearchTarget ? undefined : selectedSiteId}
+              dayIndex={selectedDayIndex}
+              weatherData={selectedSearchWeatherData}
+              isLoading={
+                selectedSearchTarget ? isSearchWeatherLoading : undefined
+              }
+              isError={selectedSearchTarget ? isSearchWeatherError : undefined}
+              siteOrientation={
+                isSpotSearchTarget(selectedSearchTarget)
+                  ? selectedSearchTarget.spot.orientation
+                  : undefined
+              }
+            />
+          </div>
         )}
 
         {!selectedSearchTarget && selectedSiteId && (
-          <WeatherLiveWindPanel
-            latitude={selectedSite?.latitude}
-            longitude={selectedSite?.longitude}
-          />
-        )}
+          <div className="flex min-w-0 flex-col gap-4 lg:flex-row lg:[&>*]:min-w-0 lg:[&>*]:flex-1">
+            <WeatherLiveWindPanel
+              latitude={selectedSite?.latitude}
+              longitude={selectedSite?.longitude}
+            />
 
-        {/* Landing Sites Weather */}
-        {!selectedSearchTarget && selectedSiteId && (
-          <WeatherMultiLanding
-            spotId={selectedSiteId}
-            dayIndex={selectedDayIndex}
-          />
+            {/* Landing Sites Weather */}
+            <WeatherMultiLanding
+              spotId={selectedSiteId}
+              dayIndex={selectedDayIndex}
+            />
+          </div>
         )}
 
         {/* Emagram Analysis (authenticated only) */}


### PR DESCRIPTION
## Summary
- Put the main weather decision and current conditions cards side by side on wide screens.
- Put live wind and landing weather cards side by side on wide screens.
- Keep the mobile layout unchanged.

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- CI=true NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:test:unit
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the desktop weather display layout by reorganizing related weather information panels into logical visual groups. This enhancement provides better visual hierarchy and structure, making it easier for users to scan, locate, and understand correlated weather data at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->