### PR TITLE
fix(frontend): correct flight trace placement

### DIFF
--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
@@ -54,6 +54,10 @@ import {
   computeCursorTelemetryLabel,
   type ViewerUnits,
 } from './flightViewerTelemetry';
+import {
+  getBearingRadians,
+  getRenderedTrackElevation,
+} from './flightViewerTrackPlacement';
 import { useAppSettingsStore } from '../../../stores/appSettingsStore';
 
 declare global {
@@ -301,6 +305,9 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   const [terrainReady, setTerrainReady] = useState(false);
   const [elevationOffset, setElevationOffset] = useState(0);
   const [autoOffset, setAutoOffset] = useState(0);
+  const [landingElevationOffset, setLandingElevationOffset] = useState<
+    number | null
+  >(null);
   const [isCalculatingOffset, setIsCalculatingOffset] = useState(false);
   const [currentProgress, setCurrentProgress] = useState(0);
   const [isPanelCollapsed, setIsPanelCollapsed] = useState(compact);
@@ -657,6 +664,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
   useEffect(() => {
     setElevationOffset(0);
     setAutoOffset(0);
+    setLandingElevationOffset(null);
     setTerrainReady(false); // Reset terrain ready state on flight change
   }, [flightId]);
 
@@ -713,11 +721,17 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
     try {
       // Convert GPX coordinates to Cartesian3 avec offset d'élévation
-      const positions = gpxData.coordinates.map((point) =>
+      const positions = gpxData.coordinates.map((point, index) =>
         Cartesian3.fromDegrees(
           point.lon,
           point.lat,
-          point.elevation + elevationOffset
+          getRenderedTrackElevation(
+            point,
+            index,
+            gpxData.coordinates.length,
+            elevationOffset,
+            landingElevationOffset
+          )
         )
       );
 
@@ -826,21 +840,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
         // Calculate heading from reference point BACK to takeoff
         // This makes the camera look toward the takeoff/launch site
-        const deltaLon = takeoffCoord.lon - referenceCoord.lon;
-
-        // Calculate angle in radians
-        // We need to convert lon/lat differences to proper bearing
-        // Using standard bearing formula
-        const y =
-          Math.sin(deltaLon) * Math.cos((takeoffCoord.lat * Math.PI) / 180);
-        const x =
-          Math.cos((referenceCoord.lat * Math.PI) / 180) *
-            Math.sin((takeoffCoord.lat * Math.PI) / 180) -
-          Math.sin((referenceCoord.lat * Math.PI) / 180) *
-            Math.cos((takeoffCoord.lat * Math.PI) / 180) *
-            Math.cos(deltaLon);
-
-        return Math.atan2(y, x);
+        return getBearingRadians(referenceCoord, takeoffCoord);
       };
 
       // Position camera - MUST happen after elevation offset is calculated
@@ -951,6 +951,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     elevationOffset,
     gpxData,
     isActiveViewer,
+    landingElevationOffset,
     viewerReady,
   ]);
 
@@ -1059,15 +1060,22 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
     try {
       const firstPoint = gpxData.coordinates[0];
+      const lastPoint = gpxData.coordinates[gpxData.coordinates.length - 1];
 
       // Créer une position cartographique pour le premier point
-      const position = Cartesian3.fromDegrees(firstPoint.lon, firstPoint.lat);
-      const cartographic = Cartographic.fromCartesian(position);
+      const firstPosition = Cartesian3.fromDegrees(
+        firstPoint.lon,
+        firstPoint.lat
+      );
+      const firstCartographic = Cartographic.fromCartesian(firstPosition);
+      const lastPosition = Cartesian3.fromDegrees(lastPoint.lon, lastPoint.lat);
+      const lastCartographic = Cartographic.fromCartesian(lastPosition);
 
       // Échantillonner le terrain pour obtenir la hauteur réelle du sol
       const terrainProvider = viewer.terrainProvider;
       const samples = await sampleTerrainMostDetailed(terrainProvider, [
-        cartographic,
+        firstCartographic,
+        lastCartographic,
       ]);
 
       if (!isMountedRef.current || !isActiveViewer(viewer)) {
@@ -1085,6 +1093,12 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
         setAutoOffset(offset);
         setElevationOffset(offset);
+        const landingTerrainHeight = samples[1]?.height;
+        if (landingTerrainHeight === undefined) {
+          setLandingElevationOffset(null);
+        } else {
+          setLandingElevationOffset(landingTerrainHeight - lastPoint.elevation);
+        }
         // Le flyTo se fera automatiquement via le useEffect qui dépend de elevationOffset
       }
     } catch (error) {

--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
@@ -5,11 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   invalidateQueries,
   mockFlight,
+  cartesianFromDegreesCalls,
   entityOptions,
   viewerInstances,
   viewerOptions,
 } = vi.hoisted(() => ({
   invalidateQueries: vi.fn(),
+  cartesianFromDegreesCalls: [] as unknown[][],
   entityOptions: [] as unknown[],
   viewerInstances: [] as {
     render: ReturnType<typeof vi.fn>;
@@ -42,7 +44,8 @@ vi.mock('cesium', () => {
       public z = 0
     ) {}
 
-    static fromDegrees() {
+    static fromDegrees(...args: unknown[]) {
+      cartesianFromDegreesCalls.push(args);
       return new Cartesian3();
     }
 
@@ -282,6 +285,7 @@ describe('FlightViewer3D video export mode', () => {
     invalidateQueries.mockClear();
     viewerInstances.length = 0;
     viewerOptions.length = 0;
+    cartesianFromDegreesCalls.length = 0;
     entityOptions.length = 0;
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
@@ -393,6 +397,21 @@ describe('FlightViewer3D video export mode', () => {
     expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(1, 500);
     expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(2, 500);
     expect(viewer.camera.moveBackward).toHaveBeenNthCalledWith(3, 500);
+  });
+
+  it('passes GPX longitude, latitude and rendered elevation to Cesium', async () => {
+    window._exportMode = 'manual_render';
+
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(window._setExportFrame).toBeTypeOf('function');
+    });
+
+    await waitFor(() => {
+      expect(cartesianFromDegreesCalls[0]).toEqual([6, 45, 1000]);
+      expect(cartesianFromDegreesCalls[1]).toEqual([6.1, 45.1, 1100]);
+    });
   });
 
   it('draws the replay track only as a volume plus curtain', async () => {

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.test.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getBearingRadians,
+  getInterpolatedElevationOffset,
+  getRenderedTrackElevation,
+} from './flightViewerTrackPlacement';
+
+describe('flightViewerTrackPlacement', () => {
+  it('keeps a single takeoff offset when no landing offset is known', () => {
+    expect(getInterpolatedElevationOffset(2, 5, 40, null)).toBe(40);
+  });
+
+  it('interpolates elevation offsets from takeoff to landing', () => {
+    expect(getInterpolatedElevationOffset(0, 5, 40, -20)).toBe(40);
+    expect(getInterpolatedElevationOffset(2, 5, 40, -20)).toBe(10);
+    expect(getInterpolatedElevationOffset(4, 5, 40, -20)).toBe(-20);
+  });
+
+  it('adjusts only rendered elevation, not latitude or longitude', () => {
+    const point = { lat: 45.12, lon: 6.34, elevation: 800 };
+
+    expect(getRenderedTrackElevation(point, 1, 3, 100, -50)).toBe(825);
+    expect(point).toEqual({ lat: 45.12, lon: 6.34, elevation: 800 });
+  });
+
+  it('computes bearings with radians, not degree deltas', () => {
+    expect(
+      getBearingRadians(
+        { lat: 45, lon: 6, elevation: 0 },
+        { lat: 46, lon: 6, elevation: 0 }
+      )
+    ).toBeCloseTo(0, 6);
+    expect(
+      getBearingRadians(
+        { lat: 45, lon: 6, elevation: 0 },
+        { lat: 45, lon: 7, elevation: 0 }
+      )
+    ).toBeCloseTo(1.564626, 6);
+  });
+});

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.ts
@@ -1,0 +1,51 @@
+export type TrackPoint = {
+  lat: number;
+  lon: number;
+  elevation: number;
+};
+
+export const getInterpolatedElevationOffset = (
+  pointIndex: number,
+  totalPoints: number,
+  takeoffOffset: number,
+  landingOffset: number | null | undefined
+) => {
+  if (
+    landingOffset === null ||
+    landingOffset === undefined ||
+    totalPoints <= 1
+  ) {
+    return takeoffOffset;
+  }
+
+  const progress = Math.min(Math.max(pointIndex / (totalPoints - 1), 0), 1);
+  return takeoffOffset + (landingOffset - takeoffOffset) * progress;
+};
+
+export const getRenderedTrackElevation = (
+  point: TrackPoint,
+  pointIndex: number,
+  totalPoints: number,
+  takeoffOffset: number,
+  landingOffset: number | null | undefined
+) =>
+  point.elevation +
+  getInterpolatedElevationOffset(
+    pointIndex,
+    totalPoints,
+    takeoffOffset,
+    landingOffset
+  );
+
+export const getBearingRadians = (from: TrackPoint, to: TrackPoint) => {
+  const fromLat = (from.lat * Math.PI) / 180;
+  const toLat = (to.lat * Math.PI) / 180;
+  const deltaLon = ((to.lon - from.lon) * Math.PI) / 180;
+
+  const y = Math.sin(deltaLon) * Math.cos(toLat);
+  const x =
+    Math.cos(fromLat) * Math.sin(toLat) -
+    Math.sin(fromLat) * Math.cos(toLat) * Math.cos(deltaLon);
+
+  return Math.atan2(y, x);
+};


### PR DESCRIPTION
## Summary
- Interpolate the replay track altitude between takeoff and landing terrain heights so the trace stays anchored through the full flight.
- Fix the automatic camera bearing calculation to use radians.
- Add unit and integration coverage for the track placement helper and Cesium coordinate usage.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/viewer/flightViewerTrackPlacement.test.ts src/components/flights/viewer/FlightViewer3D.video-export.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --base=origin/main --head=HEAD --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --base=origin/main --head=HEAD --parallel=5 --exclude=e2e` timed out while running the full frontend suite; the targeted frontend tests above passed.

## Review
- CodeRabbit review passed with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced 3D flight visualization with improved elevation handling at takeoff and landing points
  * Refined camera positioning using more accurate bearing calculations for initial flight view setup

* **Tests**
  * Added comprehensive test coverage for elevation offset interpolation between flight phases and bearing angle calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->