### PR TITLE
fix(frontend): fade replay wall trail

### DIFF
--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
@@ -57,6 +57,7 @@ import {
   getBearingRadians,
   getRenderedTrackElevation,
 } from './flightViewerTrackPlacement';
+import { getReplayTrackTrailPositions } from './flightViewerTrackTrail';
 import { useAppSettingsStore } from '../../../stores/appSettingsStore';
 
 declare global {
@@ -1305,16 +1306,11 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
           ? scenePosition.nextIndex
           : scenePosition.previousIndex;
       currentTimestampRef.current = scenePosition.timestamp;
-      visiblePositionsRef.current = allPositionsRef.current.slice(
-        0,
-        scenePosition.previousIndex + 1
+      visiblePositionsRef.current = getReplayTrackTrailPositions(
+        allPositionsRef.current,
+        scenePosition.previousIndex,
+        scenePosition.ratio > 0 ? scenePosition.position : undefined
       );
-      if (scenePosition.ratio > 0) {
-        visiblePositionsRef.current = [
-          ...visiblePositionsRef.current,
-          scenePosition.position,
-        ];
-      }
 
       if (timestampsRef.current.length > 0) {
         const startTimestamp = timestampsRef.current[0];

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackTrail.test.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackTrail.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { getReplayTrackTrailPositions } from './flightViewerTrackTrail';
+
+describe('flightViewerTrackTrail', () => {
+  it('keeps the full track while it is shorter than the trail window', () => {
+    const positions = [1, 2, 3];
+
+    expect(getReplayTrackTrailPositions(positions, 2, undefined, 5)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('drops old positions as the replay advances', () => {
+    const positions = [1, 2, 3, 4, 5, 6];
+
+    expect(getReplayTrackTrailPositions(positions, 5, undefined, 3)).toEqual([
+      4, 5, 6,
+    ]);
+  });
+
+  it('reserves one trail slot for the interpolated current position', () => {
+    const positions = [1, 2, 3, 4, 5, 6];
+
+    expect(getReplayTrackTrailPositions(positions, 5, 6.5, 3)).toEqual([
+      5, 6, 6.5,
+    ]);
+  });
+});

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackTrail.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackTrail.ts
@@ -1,0 +1,25 @@
+export const REPLAY_TRACK_TRAIL_POINT_COUNT = 80;
+
+export const getReplayTrackTrailPositions = <T>(
+  positions: T[],
+  previousIndex: number,
+  currentPosition: T | undefined,
+  maxPointCount = REPLAY_TRACK_TRAIL_POINT_COUNT
+) => {
+  if (positions.length === 0 || maxPointCount <= 0) return [];
+
+  const safePreviousIndex = Math.min(
+    Math.max(previousIndex, 0),
+    positions.length - 1
+  );
+  const hasCurrentPosition = currentPosition !== undefined;
+  const historicalPointCount = hasCurrentPosition
+    ? Math.max(maxPointCount - 1, 0)
+    : maxPointCount;
+  const startIndex = Math.max(0, safePreviousIndex - historicalPointCount + 1);
+  const trailPositions = positions.slice(startIndex, safePreviousIndex + 1);
+
+  return hasCurrentPosition
+    ? [...trailPositions, currentPosition]
+    : trailPositions;
+};


### PR DESCRIPTION
## Summary
- Make the replay wall fade out by keeping only a sliding window of recent track points.
- Add a focused helper and unit tests for the trail-window logic.

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/viewer/flightViewerTrackTrail.test.ts src/components/flights/viewer/FlightViewer3D.video-export.test.tsx`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend`
- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored flight replay track trail position computation to use a dedicated helper function for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for track trail position calculations during flight replay, including window boundary handling and interpolation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->