### PR TITLE
fix(gopro-overlay): persist merged GPX snapshots

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -717,6 +717,7 @@ async def create_gopro_overlay_job(
     fallback_gpx_path: Path | None = None,
     fallback_pip_path: Path | None = None,
     output_dir: str | None = None,
+    pin_inputs: bool = False,
 ) -> dict[str, Any]:
     job_id = str(uuid.uuid4())
     job_upload_dir = _uploaded_job_work_dir(job_id)
@@ -758,6 +759,7 @@ async def create_gopro_overlay_job(
             output_filename=output_filename,
             work_dir=job_upload_dir,
             output_dir=output_dir,
+            pin_inputs=pin_inputs,
         )
     except Exception:
         shutil.rmtree(job_upload_dir, ignore_errors=True)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -280,6 +280,7 @@ def _flight_gopro_camera_file_exists(db: Session, flight: Flight) -> bool:
 
 
 _GOPRO_OVERLAY_IN_PROGRESS_STATUSES = {"queued", "preparing", "running"}
+_GOPRO_OVERLAY_MERGED_GPX_FILENAME = "merged-gopro-overlay.gpx"
 
 
 def _flight_gopro_overlay_file_path(
@@ -408,9 +409,10 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
     if not merge_script.exists():
         raise ValueError(f"OSV merge script not found: {merge_script}")
 
-    work_dir = input_dir / ".gopro-overlay-work"
-    work_dir.mkdir(parents=True, exist_ok=True)
-    merged_gpx_path = work_dir / f"merged-{uuid.uuid4()}.gpx"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    merged_gpx_path = input_dir / _GOPRO_OVERLAY_MERGED_GPX_FILENAME
+    if merged_gpx_path.exists():
+        merged_gpx_path.unlink()
     command = [
         "python3",
         str(merge_script),
@@ -504,6 +506,7 @@ def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "progress": job.get("progress"),
         "message": job.get("message"),
         "error": job.get("error"),
+        "gpx_path": job.get("gpx_path"),
         "mode": "gopro_overlay",
         "flight_title": job.get("output_filename") or job.get("layout_label"),
         "flight_name": job.get("layout_label"),
@@ -5387,6 +5390,7 @@ async def create_flight_gopro_overlay_job(
         )
         fallback_pip_path = resolved_pip_path or auto_pip_path or generated_video_path
         gpx_file_for_job = gpx_file
+        pin_overlay_inputs = False
         if gpx_file and gpx_file.filename and auto_osv_paths:
             uploaded_gpx_path = await save_uploaded_file(
                 gpx_file,
@@ -5402,6 +5406,7 @@ async def create_flight_gopro_overlay_job(
                 input_dir,
             )
             gpx_file_for_job = None
+            pin_overlay_inputs = True
         elif fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
             fallback_gpx_path = await asyncio.to_thread(
                 _merge_osv_files_with_gpx,
@@ -5409,6 +5414,7 @@ async def create_flight_gopro_overlay_job(
                 fallback_gpx_path,
                 input_dir,
             )
+            pin_overlay_inputs = True
 
         if resolved_video_path:
             if not resolved_video_path.exists():
@@ -5455,6 +5461,7 @@ async def create_flight_gopro_overlay_job(
             layout_id=layout_id,
             output_filename=resolved_output_filename,
             output_dir=resolved_output_dir,
+            pin_inputs=pin_overlay_inputs,
         )
         _mark_flight_gopro_overlay_job(db, flight, job)
         return _with_gopro_overlay_job_token(job)

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -55,6 +55,7 @@ class GoproOverlayJob(BaseModel):
     progress: int
     message: str
     error: str | None = None
+    gpx_path: str | None = None
     layout_id: str
     layout_label: str
     output_filename: str

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -403,7 +403,7 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     pip_path = input_dir / "flight-pip.mp4"
     first_osv = input_dir / "first.osv"
     second_osv = input_dir / "second.osv"
-    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     camera_path.write_bytes(b"camera")
     gpx_path.write_text("<gpx />")
     pip_path.write_bytes(b"pip")
@@ -411,7 +411,6 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     second_osv.write_bytes(b"second")
     sample_flight.video_file_path = str(pip_path)
     db_session.commit()
-    merged_gpx_path.parent.mkdir(parents=True)
     merged_gpx_path.write_text("<gpx>merged</gpx>")
     os.utime(first_osv, (1, 1))
     os.utime(second_osv, (2, 2))
@@ -456,13 +455,12 @@ def test_create_flight_gopro_overlay_job_uses_merged_uploaded_gpx_when_osv_exist
     input_dir.mkdir(parents=True)
     pip_path = input_dir / "flight-pip.mp4"
     osv_path = input_dir / "flight.osv"
-    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     pip_path.write_bytes(b"pip")
     osv_path.write_bytes(b"osv")
     sample_flight.gpx_file_path = None
     sample_flight.video_file_path = str(pip_path)
     db_session.commit()
-    merged_gpx_path.parent.mkdir(parents=True)
     merged_gpx_path.write_text("<gpx>merged</gpx>")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
 
@@ -503,6 +501,45 @@ def test_create_flight_gopro_overlay_job_uses_merged_uploaded_gpx_when_osv_exist
     assert merge_osv.call_args.args[2] == input_dir
     assert create_job.call_args.kwargs["gpx_file"] is None
     assert create_job.call_args.kwargs["fallback_gpx_path"] == merged_gpx_path
+    assert create_job.call_args.kwargs["pin_inputs"] is True
+
+
+def test_merge_osv_files_with_gpx_writes_stable_file_in_flight_directory(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "20260315" / "01"
+    input_dir.mkdir(parents=True)
+    first_osv = input_dir / "first.osv"
+    second_osv = input_dir / "second.osv"
+    source_gpx = input_dir / "Zepp-track.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    first_osv.write_bytes(b"first")
+    second_osv.write_bytes(b"second")
+    source_gpx.write_text("<gpx>source</gpx>")
+    merged_gpx_path.write_text("stale")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("routes.subprocess.run", side_effect=fake_run) as run:
+        result = routes._merge_osv_files_with_gpx([first_osv, second_osv], source_gpx, input_dir)
+
+    assert result == merged_gpx_path
+    assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
+    command = run.call_args.args[0]
+    assert command[-2:] == [str(source_gpx), str(merged_gpx_path)]
+    assert str(input_dir / ".gopro-overlay-work") not in command[-1]
 
 
 def test_create_flight_gopro_overlay_job_rejects_paths_outside_paragliding_root(

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -16,6 +16,7 @@ export type VideoExportJob = {
   progress?: number | null;
   message?: string | null;
   error?: string | null;
+  gpx_path?: string | null;
   mode?: string | null;
   started_at?: string | null;
   completed_at?: string | null;

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -14,6 +14,7 @@ export type GoproOverlayJob = {
   progress: number;
   message: string;
   error?: string | null;
+  gpx_path?: string | null;
   layout_id: string;
   layout_label: string;
   output_filename: string;


### PR DESCRIPTION
## Summary\n- persist merged GoPro GPX files in the flight directory as merged-gopro-overlay.gpx\n- make overlay jobs use a stable GPX snapshot and expose gpx_path in job payloads\n- add/adjust backend tests and frontend job types\n\n## Validation\n- ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t type-check --parallel=5 --exclude=e2e\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPX file path tracking to GoPro overlay export jobs, allowing the system to reference merged GPS data during video rendering.
  * Improved handling of overlay input files when merging GPS data from auto-detected sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->