### PR TITLE
fix(gopro-overlay): keep visible gpx and 4k layout

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -717,6 +717,7 @@ async def create_gopro_overlay_job(
     fallback_gpx_path: Path | None = None,
     fallback_pip_path: Path | None = None,
     output_dir: str | None = None,
+    pin_inputs: bool = False,
 ) -> dict[str, Any]:
     job_id = str(uuid.uuid4())
     job_upload_dir = _uploaded_job_work_dir(job_id)
@@ -758,6 +759,7 @@ async def create_gopro_overlay_job(
             output_filename=output_filename,
             work_dir=job_upload_dir,
             output_dir=output_dir,
+            pin_inputs=pin_inputs,
         )
     except Exception:
         shutil.rmtree(job_upload_dir, ignore_errors=True)

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -520,6 +520,8 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         video_path = Path(str(job["video_path"]))
         gpx_path = Path(str(job["gpx_path"]))
         pip_path = Path(str(job["pip_path"])) if job.get("pip_path") else None
+        command_metadata = dict(metadata)
+        render_gpx_path = gpx_path
 
         if metadata.get("pin_inputs"):
             video_path = _copy_job_input(
@@ -527,9 +529,9 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 work_dir / f"input{video_path.suffix.lower()}",
                 _VIDEO_EXTENSIONS,
             )
-            gpx_path = _copy_job_input(
+            render_gpx_path = _copy_job_input(
                 gpx_path,
-                work_dir / f"track{gpx_path.suffix.lower()}",
+                work_dir / f"gpx-{job_id}{gpx_path.suffix.lower()}",
                 _GPX_EXTENSIONS,
             )
             if pip_path:
@@ -538,6 +540,8 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                     work_dir / f"pip{pip_path.suffix.lower()}",
                     _VIDEO_EXTENSIONS,
                 )
+
+        command_metadata["render_gpx_path"] = str(render_gpx_path)
 
         width, height = probe_video_resolution(video_path)
         requested_layout_id = metadata.get("requested_layout_id")
@@ -571,11 +575,12 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             layout_path=str(layout_path),
             video_width=render_width,
             video_height=render_height,
-            command_json=None,
+            command_json=json.dumps(command_metadata),
             message="Overlay queued",
         )
         if not prepared_job or prepared_job.get("status") != _STATUS_QUEUED:
             return None
+        prepared_job["command"] = command_metadata
         return prepared_job
     except Exception as exc:
         logger.exception("Failed to prepare GoPro overlay job %s", job_id)
@@ -609,17 +614,7 @@ def _find_layout(layout_id: str) -> GoproOverlayLayout | None:
 
 
 def _nearest_layout(width: int | None, height: int | None) -> GoproOverlayLayout:
-    max_width = config.GOPRO_OVERLAY_MAX_AUTO_LAYOUT_WIDTH
-    max_height = config.GOPRO_OVERLAY_MAX_AUTO_LAYOUT_HEIGHT
-    layouts = [
-        layout
-        for layout in _LAYOUTS
-        if (
-            layout.width is None
-            or layout.height is None
-            or (layout.width <= max_width and layout.height <= max_height)
-        )
-    ] or _LAYOUTS
+    layouts = _LAYOUTS
 
     if width is None or height is None:
         return layouts[0]
@@ -935,11 +930,14 @@ def _run_job(job_id: str) -> None:
     if not job or job.get("status") != _STATUS_QUEUED:
         return
 
+    prepared_command = job.get("command") if isinstance(job.get("command"), dict) else {}
+    render_gpx_path = Path(str(prepared_command.get("render_gpx_path") or job["gpx_path"]))
+
     command = [
         config.GOPRO_OVERLAY_BIN,
         "--use-gpx-only",
         "--gpx",
-        job["gpx_path"],
+        str(render_gpx_path),
         "--layout",
         "xml",
         "--layout-xml",

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -280,6 +280,7 @@ def _flight_gopro_camera_file_exists(db: Session, flight: Flight) -> bool:
 
 
 _GOPRO_OVERLAY_IN_PROGRESS_STATUSES = {"queued", "preparing", "running"}
+_GOPRO_OVERLAY_MERGED_GPX_FILENAME = "merged-gopro-overlay.gpx"
 
 
 def _flight_gopro_overlay_file_path(
@@ -408,9 +409,10 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
     if not merge_script.exists():
         raise ValueError(f"OSV merge script not found: {merge_script}")
 
-    work_dir = input_dir / ".gopro-overlay-work"
-    work_dir.mkdir(parents=True, exist_ok=True)
-    merged_gpx_path = work_dir / f"merged-{uuid.uuid4()}.gpx"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    merged_gpx_path = input_dir / _GOPRO_OVERLAY_MERGED_GPX_FILENAME
+    if merged_gpx_path.exists():
+        merged_gpx_path.unlink()
     command = [
         "python3",
         str(merge_script),
@@ -504,6 +506,7 @@ def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "progress": job.get("progress"),
         "message": job.get("message"),
         "error": job.get("error"),
+        "gpx_path": job.get("gpx_path"),
         "mode": "gopro_overlay",
         "flight_title": job.get("output_filename") or job.get("layout_label"),
         "flight_name": job.get("layout_label"),
@@ -5387,6 +5390,7 @@ async def create_flight_gopro_overlay_job(
         )
         fallback_pip_path = resolved_pip_path or auto_pip_path or generated_video_path
         gpx_file_for_job = gpx_file
+        pin_overlay_inputs = False
         if gpx_file and gpx_file.filename and auto_osv_paths:
             uploaded_gpx_path = await save_uploaded_file(
                 gpx_file,
@@ -5402,6 +5406,7 @@ async def create_flight_gopro_overlay_job(
                 input_dir,
             )
             gpx_file_for_job = None
+            pin_overlay_inputs = True
         elif fallback_gpx_path and fallback_gpx_path.exists() and auto_osv_paths:
             fallback_gpx_path = await asyncio.to_thread(
                 _merge_osv_files_with_gpx,
@@ -5409,6 +5414,7 @@ async def create_flight_gopro_overlay_job(
                 fallback_gpx_path,
                 input_dir,
             )
+            pin_overlay_inputs = True
 
         if resolved_video_path:
             if not resolved_video_path.exists():
@@ -5455,6 +5461,7 @@ async def create_flight_gopro_overlay_job(
             layout_id=layout_id,
             output_filename=resolved_output_filename,
             output_dir=resolved_output_dir,
+            pin_inputs=pin_overlay_inputs,
         )
         _mark_flight_gopro_overlay_job(db, flight, job)
         return _with_gopro_overlay_job_token(job)

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -55,6 +55,7 @@ class GoproOverlayJob(BaseModel):
     progress: int
     message: str
     error: str | None = None
+    gpx_path: str | None = None
     layout_id: str
     layout_label: str
     output_filename: str

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -403,7 +403,7 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     pip_path = input_dir / "flight-pip.mp4"
     first_osv = input_dir / "first.osv"
     second_osv = input_dir / "second.osv"
-    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     camera_path.write_bytes(b"camera")
     gpx_path.write_text("<gpx />")
     pip_path.write_bytes(b"pip")
@@ -411,7 +411,6 @@ def test_create_flight_gopro_overlay_job_merges_all_auto_osv_files(
     second_osv.write_bytes(b"second")
     sample_flight.video_file_path = str(pip_path)
     db_session.commit()
-    merged_gpx_path.parent.mkdir(parents=True)
     merged_gpx_path.write_text("<gpx>merged</gpx>")
     os.utime(first_osv, (1, 1))
     os.utime(second_osv, (2, 2))
@@ -456,13 +455,12 @@ def test_create_flight_gopro_overlay_job_uses_merged_uploaded_gpx_when_osv_exist
     input_dir.mkdir(parents=True)
     pip_path = input_dir / "flight-pip.mp4"
     osv_path = input_dir / "flight.osv"
-    merged_gpx_path = input_dir / ".gopro-overlay-work" / "merged.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     pip_path.write_bytes(b"pip")
     osv_path.write_bytes(b"osv")
     sample_flight.gpx_file_path = None
     sample_flight.video_file_path = str(pip_path)
     db_session.commit()
-    merged_gpx_path.parent.mkdir(parents=True)
     merged_gpx_path.write_text("<gpx>merged</gpx>")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
 
@@ -503,6 +501,45 @@ def test_create_flight_gopro_overlay_job_uses_merged_uploaded_gpx_when_osv_exist
     assert merge_osv.call_args.args[2] == input_dir
     assert create_job.call_args.kwargs["gpx_file"] is None
     assert create_job.call_args.kwargs["fallback_gpx_path"] == merged_gpx_path
+    assert create_job.call_args.kwargs["pin_inputs"] is True
+
+
+def test_merge_osv_files_with_gpx_writes_stable_file_in_flight_directory(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "20260315" / "01"
+    input_dir.mkdir(parents=True)
+    first_osv = input_dir / "first.osv"
+    second_osv = input_dir / "second.osv"
+    source_gpx = input_dir / "Zepp-track.gpx"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    first_osv.write_bytes(b"first")
+    second_osv.write_bytes(b"second")
+    source_gpx.write_text("<gpx>source</gpx>")
+    merged_gpx_path.write_text("stale")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("routes.subprocess.run", side_effect=fake_run) as run:
+        result = routes._merge_osv_files_with_gpx([first_osv, second_osv], source_gpx, input_dir)
+
+    assert result == merged_gpx_path
+    assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
+    command = run.call_args.args[0]
+    assert command[-2:] == [str(source_gpx), str(merged_gpx_path)]
+    assert str(input_dir / ".gopro-overlay-work") not in command[-1]
 
 
 def test_create_flight_gopro_overlay_job_rejects_paths_outside_paragliding_root(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1125,20 +1125,18 @@ def test_create_gopro_overlay_job_from_paths_defers_input_copy_to_worker_prepara
     assert prepared is not None
     assert prepared["status"] == "queued"
     assert Path(prepared["video_path"]).parent == work_dir
-    assert Path(prepared["gpx_path"]).parent == work_dir
+    assert Path(prepared["gpx_path"]) == gpx_path
+    assert Path(prepared["command"]["render_gpx_path"]).parent == work_dir
     assert Path(prepared["video_path"]).read_bytes() == b"video"
-    assert Path(prepared["gpx_path"]).read_text() == "<gpx />"
+    assert Path(prepared["command"]["render_gpx_path"]).read_text() == "<gpx />"
     assert prepared["video_width"] == 1920
     assert prepared["video_height"] == 1080
 
 
-def test_auto_layout_selection_caps_4k_sources_to_1080_by_default(monkeypatch):
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_MAX_AUTO_LAYOUT_WIDTH", 1920)
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_MAX_AUTO_LAYOUT_HEIGHT", 1080)
-
+def test_auto_layout_selection_uses_4k_layout_for_4k_source():
     selected = gopro_overlay_export._nearest_layout(3840, 2160)
 
-    assert selected.id == "parapente-1080"
+    assert selected.id == "parapente-3840"
 
 
 def test_worker_preparation_uses_video_render_size_for_4k_source(
@@ -1173,7 +1171,7 @@ def test_worker_preparation_uses_video_render_size_for_4k_source(
     prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
 
     assert prepared is not None
-    assert prepared["layout_id"] == "parapente-1080"
+    assert prepared["layout_id"] == "parapente-3840"
     assert prepared["video_width"] == 3840
     assert prepared["video_height"] == 2160
     prepared_layout = Path(prepared["layout_path"]).read_text()

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -16,6 +16,7 @@ export type VideoExportJob = {
   progress?: number | null;
   message?: string | null;
   error?: string | null;
+  gpx_path?: string | null;
   mode?: string | null;
   started_at?: string | null;
   completed_at?: string | null;

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -14,6 +14,7 @@ export type GoproOverlayJob = {
   progress: number;
   message: string;
   error?: string | null;
+  gpx_path?: string | null;
   layout_id: string;
   layout_label: string;
   output_filename: string;


### PR DESCRIPTION
## Summary\n- keep the merged GPX visible in the flight directory as merged-gopro-overlay.gpx\n- render from a job-specific GPX snapshot while preserving the visible file\n- auto-select the best layout for the source resolution, including 4k sources\n\n## Validation\n- ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video export jobs now display the GPX file path used for overlays
  * Improved automatic layout selection with expanded layout detection

* **Improvements**
  * Enhanced GPX file handling for more reliable merging with overlay data
  * Deterministic naming and storage for merged GPX files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->