### PR TITLE
feat(frontend): prefix flight sites with location

### DIFF
--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
@@ -4,6 +4,21 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { http, HttpResponse, delay } from 'msw';
 import { fn } from 'storybook/test';
 import { CreateFlightModal } from './CreateFlightModal';
+import type { Site } from '../../../types';
+
+const mockSites: Site[] = [
+  {
+    id: 'site-mont-poupet',
+    name: 'Mont Poupet',
+    latitude: 46.98,
+    longitude: 5.88,
+    country: 'FR',
+    region: 'Besançon',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+];
 
 const meta = preview.meta({
   title: 'Components/Forms/CreateFlightModal',
@@ -38,6 +53,7 @@ const meta = preview.meta({
 const mockFlightResult = {
   flight: {
     id: 'new-flight-1',
+    site_id: 'site-mont-poupet',
     name: 'Vol Mont Poupet',
     flight_date: '2024-03-15',
     site_name: 'Mont Poupet',
@@ -52,6 +68,7 @@ export const FlightModal = meta.story({
   name: 'Flight Modal',
   args: {
     isOpen: true,
+    sites: mockSites,
     onClose: fn(),
     onCreateComplete: fn(),
   },
@@ -89,7 +106,7 @@ FlightModal.test('It can upload a file', async ({ args }) => {
 
   // Upload the file
   await userEvent.upload(input, file);
-  await expect(await screen.findByText(/test-flight.gpx/)).toBeInTheDocument();
+  await expect(await screen.findByText(/test-flight.gpx/u)).toBeInTheDocument();
 
   // Click the upload button
   const uploadButton = await screen.findByText('📤 Créer le vol');
@@ -98,6 +115,9 @@ FlightModal.test('It can upload a file', async ({ args }) => {
   // Verify success message appears
   await expect(
     await screen.findByText('✅ Vol créé avec succès')
+  ).toBeInTheDocument();
+  await expect(
+    await screen.findByText(/Besançon - Mont Poupet/u)
   ).toBeInTheDocument();
 
   await expect(args.onCreateComplete).toHaveBeenCalled();
@@ -129,14 +149,16 @@ FlightModal.test(
     // Upload the file
     await userEvent.upload(input, file);
     await expect(
-      await screen.findByText(/test-flight.gpx/)
+      await screen.findByText(/test-flight.gpx/u)
     ).toBeInTheDocument();
 
     // Click the upload button
     const cancelButton = screen.getByText('Annuler');
     await userEvent.click(cancelButton);
 
-    await expect(screen.queryByText(/test-flight.gpx/)).not.toBeInTheDocument();
+    await expect(
+      screen.queryByText(/test-flight.gpx/u)
+    ).not.toBeInTheDocument();
   }
 );
 
@@ -152,7 +174,7 @@ FlightModal.test(
   await userEvent.click(uploadButton);
 
 
-    await expect(await screen.findByText(/Création en cours.../)).toBeInTheDocument();
+    await expect(await screen.findByText(/Création en cours.../u)).toBeInTheDocument();
 })*/
 
 FlightModal.test(
@@ -199,7 +221,7 @@ FlightModal.test(
 
     // Verify file is selected
     await expect(
-      await screen.findByText(/invalid-flight.gpx/)
+      await screen.findByText(/invalid-flight.gpx/u)
     ).toBeInTheDocument();
 
     // Click the upload button
@@ -239,7 +261,7 @@ FlightModal.test(
 FlightModal.test(
   'it calls onClose when click on close button',
   async ({ args }) => {
-    await userEvent.click(screen.getByRole('button', { name: /fermer/i }));
+    await userEvent.click(screen.getByRole('button', { name: /fermer/iu }));
     await expect(args.onClose).toHaveBeenCalled();
   }
 );

--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
@@ -3,15 +3,19 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Modal, Button } from '@dashboard-parapente/design-system';
 import { useCreateFlightFromGPX } from '../../../hooks/flights/useFlights';
 import { useToast } from '../../../hooks/useToast';
+import type { Site } from '../../../types';
+import { formatFlightSiteLabel } from '../siteDisplay';
 
 interface CreateFlightModalProps {
   isOpen: boolean;
+  sites: Site[];
   onClose: () => void;
   onCreateComplete: () => void;
 }
 
 export function CreateFlightModal({
   isOpen,
+  sites,
   onClose,
   onCreateComplete,
 }: CreateFlightModalProps) {
@@ -22,6 +26,13 @@ export function CreateFlightModal({
 
   const { mutate: createFlight, isPending, data } = useCreateFlightFromGPX();
   const toast = useToast();
+  const createdFlightSiteLabel = data
+    ? formatFlightSiteLabel({
+        siteId: data.flight.site_id,
+        siteName: data.flight.site_name,
+        sites,
+      })
+    : '';
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -58,7 +69,6 @@ export function CreateFlightModal({
         setTimeout(() => onClose(), 2000); // Fermer après 2s
       },
       onError: (error: Error) => {
-        console.log({ error });
         const errorMessage = error.message || t('flights.createGenericError');
         setError(errorMessage);
         toast.error(t('flights.createFailure') + ` ${errorMessage}`);
@@ -103,6 +113,7 @@ export function CreateFlightModal({
               ref={fileInputRef}
               type="file"
               accept=".gpx,.igc"
+              aria-label={t('flights.gpxFile')}
               onChange={handleFileChange}
               disabled={isPending}
               className="block w-full text-sm text-gray-500 dark:text-gray-400
@@ -147,9 +158,10 @@ export function CreateFlightModal({
               <li>
                 • <strong>{t('flights.date')}</strong> {data.flight.flight_date}
               </li>
-              {data.flight.site_name && (
+              {createdFlightSiteLabel && (
                 <li>
-                  • <strong>{t('flights.site')}</strong> {data.flight.site_name}
+                  • <strong>{t('flights.site')}</strong>{' '}
+                  {createdFlightSiteLabel}
                 </li>
               )}
               {data.flight.duration_minutes && (

--- a/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
@@ -20,6 +20,7 @@ const mockSites: Site[] = [
     flight_count: 12,
     is_active: true,
     camera_distance: null,
+    region: 'Besançon',
   },
   {
     id: 'site-chalais',
@@ -33,6 +34,7 @@ const mockSites: Site[] = [
     flight_count: 5,
     is_active: true,
     camera_distance: null,
+    region: 'Besançon',
   },
 ];
 

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -104,6 +104,12 @@ export function FlightDetails({
   const canRegenerateGoproOverlay =
     hasPersistedGoproOverlay || isGoproOverlayCancelled;
   const isDownloadingAnyMedia = downloadingMedia !== null;
+  let gpxUploadLabel = t('flights.addGpx');
+  if (uploadGPXMutation.isPending) {
+    gpxUploadLabel = t('flights.uploadInProgress');
+  } else if (flight.gpx_file_path) {
+    gpxUploadLabel = t('flights.replaceGpx');
+  }
   const videoProcessingLabel = formatMediaProgressLabel(
     t('flights.videoProcessingBadge'),
     flight.video_export_progress
@@ -170,8 +176,8 @@ export function FlightDetails({
         notes: notesText,
       });
       setEditingNotes(false);
-    } catch (err) {
-      console.error('Failed to update notes:', err);
+    } catch {
+      toast.error(t('flights.updateError'));
     }
   };
 
@@ -204,7 +210,7 @@ export function FlightDetails({
     }
   };
 
-  const handleGPXUpload = async (e: ChangeEvent<HTMLInputElement>) => {
+  const handleGPXUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
@@ -461,11 +467,7 @@ export function FlightDetails({
               isDisabled={uploadGPXMutation.isPending}
             >
               <FileUp className="h-4 w-4" aria-hidden="true" />
-              {uploadGPXMutation.isPending
-                ? t('flights.uploadInProgress')
-                : flight.gpx_file_path
-                  ? t('flights.replaceGpx')
-                  : t('flights.addGpx')}
+              {gpxUploadLabel}
             </Button>
           </div>
 
@@ -485,7 +487,7 @@ export function FlightDetails({
               onDownload={handleDownloadGoproOverlay}
             />
           )}
-          <FlightStatsGrid flight={flight} />
+          <FlightStatsGrid flight={flight} sites={sites} />
           <FlightNotesSection
             notes={flight.notes}
             editingNotes={editingNotes}

--- a/apps/frontend/src/components/flights/details/FlightStatsGrid.tsx
+++ b/apps/frontend/src/components/flights/details/FlightStatsGrid.tsx
@@ -1,25 +1,53 @@
 import { useTranslation } from 'react-i18next';
-import type { Flight } from '../../../types';
+import type { Flight, Site } from '../../../types';
 import {
   formatAltitudeMeters,
   formatDistanceKm,
   formatSpeedKmh,
   useAppSettingsStore,
 } from '../../../stores/appSettingsStore';
+import { formatFlightSiteLabel } from '../siteDisplay';
 
 interface FlightStatsGridProps {
   flight: Flight;
+  sites: Site[];
 }
 
 const labelClass = 'text-xs text-gray-600 dark:text-gray-300';
 const valueClass =
   'block text-sm font-medium text-gray-900 dark:text-white mt-1';
 
-export function FlightStatsGrid({ flight }: FlightStatsGridProps) {
+export function FlightStatsGrid({ flight, sites }: FlightStatsGridProps) {
   const { t, i18n } = useTranslation();
   const units = useAppSettingsStore((state) => state.settings.units);
   const [year, month, day] = flight.flight_date.split('-');
   const localDate = new Date(Number(year), Number(month) - 1, Number(day));
+  const siteLabel = formatFlightSiteLabel({
+    siteId: flight.site_id,
+    siteName: flight.site_name,
+    sites,
+    fallback: t('flights.notSpecified'),
+  });
+  const durationLabel =
+    flight.duration_minutes == null
+      ? 'N/A'
+      : `${Math.floor(flight.duration_minutes / 60)}h ${flight.duration_minutes % 60}m`;
+  const distanceLabel =
+    flight.distance_km == null
+      ? 'N/A'
+      : formatDistanceKm(flight.distance_km, units.distance);
+  const maxAltitudeLabel =
+    flight.max_altitude_m == null
+      ? 'N/A'
+      : formatAltitudeMeters(flight.max_altitude_m, units.altitude);
+  const elevationGainLabel =
+    flight.elevation_gain_m == null
+      ? 'N/A'
+      : formatAltitudeMeters(flight.elevation_gain_m, units.altitude);
+  const maxSpeedLabel =
+    flight.max_speed_kmh == null
+      ? 'N/A'
+      : formatSpeedKmh(flight.max_speed_kmh, units.speed);
 
   return (
     <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-3">
@@ -47,54 +75,27 @@ export function FlightStatsGrid({ flight }: FlightStatsGridProps) {
       </div>
       <div className="col-span-2 md:col-span-3">
         <span className={labelClass}>{t('flights.siteLabel')}</span>
-        <span className={valueClass}>
-          {flight.site_name ?? flight.site_id ?? t('flights.notSpecified')}
-        </span>
+        <span className={valueClass}>{siteLabel}</span>
       </div>
       <div>
         <span className={labelClass}>{t('flights.durationLabel')}</span>
-        <span className={valueClass}>
-          {flight.duration_minutes != null ? (
-            <>
-              {Math.floor(flight.duration_minutes / 60)}h{' '}
-              {flight.duration_minutes % 60}m
-            </>
-          ) : (
-            'N/A'
-          )}
-        </span>
+        <span className={valueClass}>{durationLabel}</span>
       </div>
       <div>
         <span className={labelClass}>{t('flights.distanceLabel')}</span>
-        <span className={valueClass}>
-          {flight.distance_km != null
-            ? formatDistanceKm(flight.distance_km, units.distance)
-            : 'N/A'}
-        </span>
+        <span className={valueClass}>{distanceLabel}</span>
       </div>
       <div>
         <span className={labelClass}>{t('flights.maxAltitudeLabel')}</span>
-        <span className={valueClass}>
-          {flight.max_altitude_m != null
-            ? formatAltitudeMeters(flight.max_altitude_m, units.altitude)
-            : 'N/A'}
-        </span>
+        <span className={valueClass}>{maxAltitudeLabel}</span>
       </div>
       <div>
         <span className={labelClass}>{t('flights.elevationGainLabel')}</span>
-        <span className={valueClass}>
-          {flight.elevation_gain_m != null
-            ? formatAltitudeMeters(flight.elevation_gain_m, units.altitude)
-            : 'N/A'}
-        </span>
+        <span className={valueClass}>{elevationGainLabel}</span>
       </div>
       <div>
         <span className={labelClass}>{t('flights.maxSpeedLabel')}</span>
-        <span className={valueClass}>
-          {flight.max_speed_kmh != null
-            ? formatSpeedKmh(flight.max_speed_kmh, units.speed)
-            : 'N/A'}
-        </span>
+        <span className={valueClass}>{maxSpeedLabel}</span>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/flights/siteDisplay.ts
+++ b/apps/frontend/src/components/flights/siteDisplay.ts
@@ -1,0 +1,27 @@
+import type { Site } from '../../types';
+
+interface FormatFlightSiteLabelOptions {
+  siteId: string | null | undefined;
+  siteName: string | null | undefined;
+  sites: Site[];
+  fallback?: string;
+}
+
+export function formatFlightSiteLabel({
+  siteId,
+  siteName,
+  sites,
+  fallback,
+}: FormatFlightSiteLabelOptions): string {
+  const site =
+    sites.find((candidate) => siteId != null && candidate.id === siteId) ??
+    sites.find((candidate) => siteName != null && candidate.name === siteName);
+  const displayedName = site?.name ?? siteName ?? siteId ?? fallback;
+  if (!displayedName) return '';
+
+  const region = site?.region?.trim();
+
+  if (!region || region === displayedName) return displayedName;
+
+  return `${region} - ${displayedName}`;
+}

--- a/apps/frontend/src/components/flights/table/Flight.stories.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.stories.tsx
@@ -1,6 +1,6 @@
 import preview from '../../../../.storybook/preview';
 import { Flight } from './Flight';
-import type { Flight as FlightRecord } from '../../../types';
+import type { Flight as FlightRecord, Site } from '../../../types';
 import { fn } from 'storybook/test';
 
 const mockFlight: FlightRecord = {
@@ -20,6 +20,20 @@ const mockFlight: FlightRecord = {
   notes: null,
 };
 
+const mockSites: Site[] = [
+  {
+    id: 'site-1',
+    name: 'Puy de Dome',
+    latitude: 45.77,
+    longitude: 2.96,
+    country: 'FR',
+    region: 'Besançon',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+];
+
 const meta = preview.meta({
   title: 'Components/Flights/Flight',
   component: Flight,
@@ -35,6 +49,7 @@ export const Default = meta.story({
     <div className="max-w-sm">
       <Flight
         flight={mockFlight}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -55,6 +70,7 @@ export const Active = meta.story({
     <div className="max-w-sm">
       <Flight
         flight={mockFlight}
+        sites={mockSites}
         isActive
         isSelected={false}
         selectionMode={false}
@@ -80,6 +96,7 @@ export const NoFile = meta.story({
           video_file_path: null,
           gopro_overlay_file_path: null,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -104,6 +121,7 @@ export const WithGpx = meta.story({
           video_file_path: null,
           gopro_overlay_file_path: null,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -124,6 +142,7 @@ export const WithGpxVideo = meta.story({
     <div className="max-w-sm">
       <Flight
         flight={{ ...mockFlight, gopro_overlay_file_path: null }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -144,6 +163,7 @@ export const WithOverlay = meta.story({
     <div className="max-w-sm">
       <Flight
         flight={mockFlight}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -171,6 +191,7 @@ export const VideoProcessing = meta.story({
           video_export_progress: 42,
           gopro_overlay_file_path: null,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -196,6 +217,7 @@ export const OverlayProcessing = meta.story({
           gopro_overlay_status: 'running',
           gopro_overlay_progress: 42,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -223,6 +245,7 @@ export const VideoError = meta.story({
           video_export_progress: 42,
           gopro_overlay_file_path: null,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}
@@ -249,6 +272,7 @@ export const OverlayError = meta.story({
           gopro_overlay_progress: 42,
           gopro_overlay_file_path: null,
         }}
+        sites={mockSites}
         isActive={false}
         isSelected={false}
         selectionMode={false}

--- a/apps/frontend/src/components/flights/table/Flight.test.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import type React from 'react';
 import { expect, test, vi } from 'vitest';
-import type { Flight as FlightRecord } from '../../../types';
+import type { Flight as FlightRecord, Site } from '../../../types';
 
 vi.mock('@dashboard-parapente/design-system', () => ({
   Button: ({
@@ -52,10 +52,25 @@ const flight = {
   site_id: 'site-1',
 } as FlightRecord;
 
+const sites = [
+  {
+    id: 'site-1',
+    name: 'Puy de Dôme',
+    latitude: 45.77,
+    longitude: 2.96,
+    country: 'FR',
+    region: 'Besançon',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+] as Site[];
+
 test('does not render the selected flight badge', () => {
   render(
     <Flight
       flight={flight}
+      sites={sites}
       isActive={true}
       isSelected={false}
       selectionMode={false}
@@ -77,4 +92,5 @@ test('does not render the selected flight badge', () => {
     'data-selected',
     'true'
   );
+  expect(screen.getByText('Besançon - Puy de Dôme')).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -13,7 +13,7 @@ import {
   Wand2,
 } from 'lucide-react';
 import { formatMediaProgressLabel } from './mediaProgress';
-import type { Flight as FlightRecord } from '../../../types';
+import type { Flight as FlightRecord, Site } from '../../../types';
 import {
   formatAltitudeMeters,
   formatDistanceKm,
@@ -24,6 +24,7 @@ import {
   hasFlightVideo,
   isGoproOverlayInProgress,
 } from '../../../lib/flightMediaState';
+import { formatFlightSiteLabel } from '../siteDisplay';
 
 export interface DownloadingMedia {
   flightId: string;
@@ -32,6 +33,7 @@ export interface DownloadingMedia {
 
 interface FlightProps {
   flight: FlightRecord;
+  sites: Site[];
   isActive: boolean;
   isSelected: boolean;
   selectionMode: boolean;
@@ -64,6 +66,7 @@ function formatDepartureTime(date: string, language: string) {
 // oxlint-disable-next-line max-lines-per-function
 export function Flight({
   flight,
+  sites,
   isActive,
   isSelected,
   selectionMode,
@@ -121,6 +124,11 @@ export function Flight({
     hasPersistedGoproOverlay ||
     isGoproOverlayRunning ||
     isGoproOverlayFailed;
+  const siteLabel = formatFlightSiteLabel({
+    siteId: flight.site_id,
+    siteName: flight.site_name,
+    sites,
+  });
 
   return (
     <Card
@@ -282,12 +290,12 @@ export function Flight({
           </div>
         )}
       </div>
-      {flight.site_id && (
+      {siteLabel && (
         <div
           className={`mt-2 flex items-center gap-1 pl-1.5 text-xs ${metaColor}`}
         >
           <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-          <span className="truncate">{flight.site_name || flight.site_id}</span>
+          <span className="truncate">{siteLabel}</span>
         </div>
       )}
     </Card>

--- a/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 import { useState } from 'react';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { FlightsTable } from './FlightsTable';
-import type { Flight } from '../../../types';
+import type { Flight, Site } from '../../../types';
 
 const mockFlights: Flight[] = [
   {
@@ -89,6 +89,53 @@ const mockFlights: Flight[] = [
   },
 ];
 
+const mockSites: Site[] = [
+  {
+    id: 'site-1',
+    name: 'Puy de Dôme',
+    latitude: 45.77,
+    longitude: 2.96,
+    country: 'FR',
+    region: 'Besançon',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+  {
+    id: 'site-2',
+    name: 'Col de la Forclaz',
+    latitude: 45.86,
+    longitude: 6.24,
+    country: 'FR',
+    region: 'Annecy',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+  {
+    id: 'site-3',
+    name: 'Planfait',
+    latitude: 45.84,
+    longitude: 6.21,
+    country: 'FR',
+    region: 'Annecy',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+  {
+    id: 'site-4',
+    name: 'Sancy',
+    latitude: 45.53,
+    longitude: 2.81,
+    country: 'FR',
+    region: 'Besançon',
+    camera_distance: null,
+    flight_count: 1,
+    is_active: true,
+  },
+];
+
 function FlightsTableWrapper({
   flights,
   selectionMode = false,
@@ -107,6 +154,7 @@ function FlightsTableWrapper({
     <div style={{ maxWidth: '400px' }}>
       <FlightsTable
         flights={flights}
+        sites={mockSites}
         selectedFlightId={selectedFlightId}
         selectionMode={selectionMode}
         onSelectFlight={(flight) => setSelectedFlightId(flight.id)}

--- a/apps/frontend/src/components/flights/table/FlightsTable.tsx
+++ b/apps/frontend/src/components/flights/table/FlightsTable.tsx
@@ -5,10 +5,11 @@ import type { Selection } from 'react-aria-components';
 import { DataList } from '@dashboard-parapente/design-system';
 import { Flight, type DownloadingMedia } from './Flight';
 import { useFlightsTable, FLIGHT_SORTABLE_COLUMNS } from './useFlightsTable';
-import type { Flight as FlightRecord } from '../../../types';
+import type { Flight as FlightRecord, Site } from '../../../types';
 
 interface FlightsTableProps {
   flights: FlightRecord[];
+  sites: Site[];
   selectedFlightId: string | null;
   selectionMode: boolean;
   onSelectFlight: (flight: FlightRecord) => void;
@@ -23,6 +24,7 @@ interface FlightsTableProps {
 
 export function FlightsTable({
   flights,
+  sites,
   selectedFlightId,
   selectionMode,
   onSelectFlight,
@@ -75,6 +77,7 @@ export function FlightsTable({
       return (
         <Flight
           flight={flight}
+          sites={sites}
           isActive={selectedFlightId === flight.id}
           isSelected={isSelected}
           selectionMode={selectionMode}
@@ -90,6 +93,7 @@ export function FlightsTable({
     [
       selectionMode,
       selectedFlightId,
+      sites,
       onSelectFlight,
       onDeleteFlight,
       onDownloadGpx,
@@ -110,7 +114,12 @@ export function FlightsTable({
       className="flex h-full flex-col lg:min-h-[calc(100vh-22rem)]"
       itemsClassName="min-h-72 flex-1 overflow-y-auto pr-1"
       virtualizedLayoutOptions={{ estimatedRowSize: 136, gap: 8 }}
-      renderDependencies={[selectedFlightId, selectionMode, rowSelection]}
+      renderDependencies={[
+        selectedFlightId,
+        selectionMode,
+        rowSelection,
+        sites,
+      ]}
       selectionMode={selectionMode ? 'multiple' : 'none'}
       selectedKeys={selectedKeys}
       onSelectionChange={handleSelectionChange}

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -171,15 +171,13 @@ export default function FlightHistory() {
         let successCount = 0;
         let failCount = 0;
 
-        for (const flightId of selectedFlightIds) {
-          try {
-            await api.delete(`flights/${flightId}`);
-            successCount++;
-          } catch (err) {
-            console.error(`Failed to delete flight ${flightId}:`, err);
-            failCount++;
-          }
-        }
+        const deleteResults = await Promise.allSettled(
+          selectedFlightIds.map((flightId) => api.delete(`flights/${flightId}`))
+        );
+        successCount = deleteResults.filter(
+          (result) => result.status === 'fulfilled'
+        ).length;
+        failCount = deleteResults.length - successCount;
 
         queryClient.invalidateQueries({ queryKey: ['flights'] });
         queryClient.invalidateQueries({ queryKey: ['flights', 'stats'] });
@@ -210,7 +208,6 @@ export default function FlightHistory() {
         setFlightToDelete(null);
       }
     } catch (err) {
-      console.error('Failed to delete flight:', err);
       let errorMessage = t('flights.unknownError');
       if (err instanceof HTTPError) {
         try {
@@ -460,6 +457,7 @@ export default function FlightHistory() {
           <div className={isMobile ? '' : 'lg:col-span-1 lg:h-full'}>
             <FlightsTable
               flights={filteredFlights}
+              sites={sites}
               selectedFlightId={selectedFlightId}
               selectionMode={selectionMode}
               onSelectFlight={handleSelectFlight}
@@ -529,6 +527,7 @@ export default function FlightHistory() {
       {/* Modal Créer un vol depuis GPX */}
       <CreateFlightModal
         isOpen={showCreateFlightModal}
+        sites={sites}
         onClose={() => setShowCreateFlightModal(false)}
         onCreateComplete={() => {
           void queryClient.invalidateQueries({ queryKey: ['flights'] });


### PR DESCRIPTION
## Summary
- Prefix flight site labels with the site location/region, e.g. `Besançon - Arguel`
- Apply the label in flight list cards, flight details, and GPX creation summary
- Add shared frontend formatting helper and update stories/tests
- Clean lint issues in touched frontend files so pre-commit hooks pass

## Validation
- PASS: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- --run src/components/flights/table/Flight.test.tsx src/components/flights/details/FlightDetails.test.tsx`
- PASS: `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend`
- PASS: touched-file oxlint via pre-commit hook
- PASS: CodeRabbit CLI review, no findings before ship
- WARN: `nx affected -t lint frontend` fails on pre-existing repo-wide lint issues outside this change
- WARN: `nx affected -t test frontend --parallel=5` was not clean due unrelated affected backend pytest availability and Vitest timeout/port contention

Shipping proceeded best-effort after explicit confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Flight sites now display with formatted region and name together (e.g., "Besançon - Mont Poupet").
  * Multi-delete operations now execute in parallel for faster performance.
  * Enhanced accessibility with improved form labeling.

* **Tests**
  * Updated test data with regional site information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->