### PR TITLE
fix(gopro-overlay): sync pip with gpx timeline

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -588,6 +588,220 @@ def _verify_video_output(path: Path) -> tuple[bool, str | None]:
     return True, None
 
 
+def probe_video_duration(video_path: Path) -> float | None:
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "json",
+                str(video_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+
+    try:
+        duration = float((json.loads(result.stdout or "{}").get("format") or {}).get("duration", 0))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return duration if duration > 0 else None
+
+
+def _parse_utc_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def probe_video_start_time(video_path: Path) -> datetime | None:
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format_tags=creation_time:stream_tags=creation_time",
+                "-of",
+                "json",
+                str(video_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+    candidates = [
+        ((payload.get("format") or {}).get("tags") or {}).get("creation_time"),
+        *[
+            ((stream.get("tags") or {}).get("creation_time"))
+            for stream in payload.get("streams") or []
+        ],
+    ]
+    return next(
+        (parsed for candidate in candidates if (parsed := _parse_utc_datetime(candidate))),
+        None,
+    )
+
+
+def _first_gpx_timestamp(gpx_path: Path) -> datetime | None:
+    try:
+        root = ET.parse(gpx_path).getroot()
+    except (ET.ParseError, OSError):
+        return None
+
+    for element in root.iter():
+        if element.tag.rsplit("}", 1)[-1] == "time" and element.text:
+            parsed = _parse_utc_datetime(element.text)
+            if parsed:
+                return parsed
+    return None
+
+
+def _pip_timeline_offsets(
+    video_start: datetime | None,
+    gpx_start: datetime | None,
+) -> tuple[float, float]:
+    if video_start is None or gpx_start is None:
+        return 0.0, 0.0
+    offset = (gpx_start - video_start).total_seconds()
+    if offset >= 0:
+        return offset, 0.0
+    return 0.0, abs(offset)
+
+
+def _prepared_pip_path(work_dir: Path, job_id: str) -> Path:
+    return work_dir / f"pip-prepared-{job_id}.mp4"
+
+
+def _ffmpeg_timeout_for_duration(duration: float) -> int:
+    return max(600, min(int(duration * 20), 6 * 60 * 60))
+
+
+def _prepare_pip_video_for_overlay(
+    job_id: str,
+    video_path: Path,
+    gpx_path: Path,
+    pip_path: Path,
+    work_dir: Path,
+) -> Path:
+    video_duration = probe_video_duration(video_path)
+    pip_width, pip_height = probe_video_resolution(pip_path)
+    if video_duration is None or not pip_width or not pip_height:
+        return pip_path
+
+    pip_duration = probe_video_duration(pip_path)
+    video_start = probe_video_start_time(video_path)
+    gpx_start = _first_gpx_timestamp(gpx_path)
+    pip_delay, pip_trim = _pip_timeline_offsets(video_start, gpx_start)
+    prepared_path = _prepared_pip_path(work_dir, job_id)
+    _unlink_if_exists(prepared_path)
+
+    base_input = f"color=c=black:s={pip_width}x{pip_height}:r=30:d={video_duration:.3f}"
+    if pip_delay >= video_duration or (pip_duration is not None and pip_trim >= pip_duration):
+        command = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            base_input,
+            "-t",
+            f"{video_duration:.3f}",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "18",
+            "-movflags",
+            "+faststart",
+            str(prepared_path),
+        ]
+    else:
+        command = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            base_input,
+        ]
+        if pip_trim > 0:
+            command.extend(["-ss", f"{pip_trim:.3f}"])
+        command.extend(
+            [
+                "-i",
+                str(pip_path),
+                "-filter_complex",
+                f"[1:v]setpts=PTS-STARTPTS+{pip_delay:.3f}/TB[pip];"
+                "[0:v][pip]overlay=0:0:eof_action=pass:shortest=0[v]",
+                "-map",
+                "[v]",
+                "-t",
+                f"{video_duration:.3f}",
+                "-an",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-preset",
+                "veryfast",
+                "-crf",
+                "18",
+                "-movflags",
+                "+faststart",
+                str(prepared_path),
+            ]
+        )
+
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_ffmpeg_timeout_for_duration(video_duration),
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError) as exc:
+        _unlink_if_exists(prepared_path)
+        raise ValueError(str(exc) or exc.__class__.__name__) from exc
+
+    if result.returncode != 0:
+        _unlink_if_exists(prepared_path)
+        detail = result.stderr.strip() or result.stdout.strip() or "ffmpeg pip preparation failed"
+        raise ValueError(detail)
+    if not prepared_path.exists():
+        raise ValueError("ffmpeg did not create the prepared PIP video")
+    return prepared_path
+
+
 def _scaled_video_path(path: Path) -> Path:
     return path.with_name(f".{path.stem}.scaled{path.suffix or '.mp4'}")
 
@@ -757,6 +971,15 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             )
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
+
+        if pip_path:
+            pip_path = _prepare_pip_video_for_overlay(
+                job_id,
+                video_path,
+                gpx_path,
+                pip_path,
+                work_dir,
+            )
 
         width, height = probe_video_resolution(video_path)
         requested_layout_id = metadata.get("requested_layout_id")

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1166,6 +1166,136 @@ def test_gopro_overlay_process_updates_split_carriage_returns():
     ]
 
 
+def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text(
+        "<gpx><trk><trkseg><trkpt><time>2026-03-15T10:00:05Z</time></trkpt></trkseg></trk></gpx>"
+    )
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 10.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:00Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result()
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert prepared == work_dir / "pip-prepared-job-pip.mp4"
+    assert prepared.read_bytes() == b"prepared"
+    command = commands[0]
+    assert "-ss" not in command
+    assert "setpts=PTS-STARTPTS+5.000/TB" in command[command.index("-filter_complex") + 1]
+
+
+def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monkeypatch):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text("<gpx><time>2026-03-15T10:00:00Z</time></gpx>")
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 20.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:05Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result()
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert prepared.exists()
+    command = commands[0]
+    assert command[command.index("-ss") + 1] == "5.000"
+    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
+
+
+def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_db):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    prepared_pip_path = tmp_path / "prepared-pip.mp4"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    pip_path.write_bytes(b"pip")
+    prepared_pip_path.write_bytes(b"prepared")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "_prepare_pip_video_for_overlay",
+        lambda *_args: prepared_pip_path,
+    )
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=pip_path,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
+    assert queued_job is not None
+
+    prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
+
+    assert prepared is not None
+    assert Path(prepared["pip_path"]) == prepared_pip_path
+
+
 @pytest.mark.asyncio
 async def test_create_gopro_overlay_job_cleans_uploads_after_validation_failure(
     tmp_path,


### PR DESCRIPTION
## Summary\n- prepare a synced intermediate PIP video before invoking gopro-dashboard\n- align PIP timing against GPX start and camera creation time\n- add backend coverage for delay/trim/prepared PIP usage\n\n## Validation\n- ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic video metadata detection for overlay rendering, including duration and timestamp identification.
  * Overlay videos are now prepared with intelligent timing adjustments to synchronize with GPS track data, automatically applying delays or trims as needed.

* **Tests**
  * Added comprehensive test coverage for overlay video preparation and timing synchronization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->