### PR TITLE
fix(gopro-overlay): auto-align pip timestamps

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -12,7 +12,7 @@ import uuid
 import xml.etree.ElementTree as ET
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -153,79 +153,6 @@ def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
     return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
-def _xml_local_name(tag: str) -> str:
-    return tag.rsplit("}", 1)[-1].lower()
-
-
-def _trkpt_has_osv_sensor_data(point: ET.Element) -> bool:
-    extension_names = {
-        _xml_local_name(element.tag)
-        for extensions in point
-        if _xml_local_name(extensions.tag) == "extensions"
-        for element in extensions.iter()
-    }
-    if extension_names & {
-        "acceleration",
-        "gyroscope",
-        "g_force",
-        "gforce",
-        "accel_x",
-        "accel_y",
-        "accel_z",
-        "gyro_x",
-        "gyro_y",
-        "gyro_z",
-    }:
-        return True
-    return {"x", "y", "z"}.issubset(extension_names)
-
-
-def _trim_gpx_before_first_osv_sensor_point(gpx_path: Path) -> bool:
-    try:
-        tree = ET.parse(gpx_path)
-    except (ET.ParseError, OSError) as exc:
-        logger.warning("Could not parse merged GoPro overlay GPX %s: %s", gpx_path, exc)
-        return False
-
-    root = tree.getroot()
-    trimmed = False
-    removed_count = 0
-
-    for segment in root.iter():
-        if _xml_local_name(segment.tag) != "trkseg":
-            continue
-        points = [child for child in list(segment) if _xml_local_name(child.tag) == "trkpt"]
-        first_osv_index = next(
-            (index for index, point in enumerate(points) if _trkpt_has_osv_sensor_data(point)),
-            None,
-        )
-        if first_osv_index is None or first_osv_index == 0:
-            continue
-        for point in points[:first_osv_index]:
-            segment.remove(point)
-        removed_count += first_osv_index
-        trimmed = True
-
-    if not trimmed:
-        return False
-
-    temp_path = gpx_path.with_name(f".{gpx_path.name}.trimmed")
-    try:
-        tree.write(temp_path, encoding="unicode", xml_declaration=True)
-        temp_path.replace(gpx_path)
-    except OSError as exc:
-        temp_path.unlink(missing_ok=True)
-        logger.warning("Could not write trimmed GoPro overlay GPX %s: %s", gpx_path, exc)
-        return False
-
-    logger.info(
-        "Trimmed %s pre-OSV GPX point(s) from merged GoPro overlay GPX %s",
-        removed_count,
-        gpx_path,
-    )
-    return True
-
-
 def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
     if not osv_paths:
         return gpx_path
@@ -272,7 +199,6 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
     if not merged_gpx_path.exists():
         raise ValueError("OSV merge did not create a GPX file")
 
-    _trim_gpx_before_first_osv_sensor_point(merged_gpx_path)
     logger.info("Created merged GoPro overlay GPX: %s", merged_gpx_path)
     return merged_gpx_path
 
@@ -767,6 +693,32 @@ def _pip_timeline_offsets(
     return 0.0, abs(offset)
 
 
+def _align_video_start_time_to_gpx(
+    video_start: datetime | None,
+    gpx_start: datetime | None,
+) -> datetime | None:
+    if video_start is None or gpx_start is None:
+        return video_start
+
+    aligned_start = video_start
+    aligned_gap = abs((video_start - gpx_start).total_seconds())
+    for shift_minutes in range(-12 * 60, 14 * 60 + 1, 15):
+        candidate_start = video_start + timedelta(minutes=shift_minutes)
+        candidate_gap = abs((candidate_start - gpx_start).total_seconds())
+        if candidate_gap < aligned_gap:
+            aligned_start = candidate_start
+            aligned_gap = candidate_gap
+
+    if aligned_start != video_start:
+        logger.info(
+            "Adjusted video start time %s -> %s to better align with GPX %s",
+            video_start,
+            aligned_start,
+            gpx_start,
+        )
+    return aligned_start
+
+
 def _prepared_pip_path(work_dir: Path, job_id: str) -> Path:
     return work_dir / f"pip-prepared-{job_id}.mp4"
 
@@ -788,8 +740,11 @@ def _prepare_pip_video_for_overlay(
         return pip_path
 
     pip_duration = probe_video_duration(pip_path)
-    video_start = probe_video_start_time(video_path)
     gpx_start = _first_gpx_timestamp(gpx_path)
+    video_start = _align_video_start_time_to_gpx(
+        probe_video_start_time(video_path),
+        gpx_start,
+    )
     pip_delay, pip_trim = _pip_timeline_offsets(video_start, gpx_start)
     prepared_path = _prepared_pip_path(work_dir, job_id)
     _unlink_if_exists(prepared_path)

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -153,6 +153,79 @@ def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
     return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
+def _xml_local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _trkpt_has_osv_sensor_data(point: ET.Element) -> bool:
+    extension_names = {
+        _xml_local_name(element.tag)
+        for extensions in point
+        if _xml_local_name(extensions.tag) == "extensions"
+        for element in extensions.iter()
+    }
+    if extension_names & {
+        "acceleration",
+        "gyroscope",
+        "g_force",
+        "gforce",
+        "accel_x",
+        "accel_y",
+        "accel_z",
+        "gyro_x",
+        "gyro_y",
+        "gyro_z",
+    }:
+        return True
+    return {"x", "y", "z"}.issubset(extension_names)
+
+
+def _trim_gpx_before_first_osv_sensor_point(gpx_path: Path) -> bool:
+    try:
+        tree = ET.parse(gpx_path)
+    except (ET.ParseError, OSError) as exc:
+        logger.warning("Could not parse merged GoPro overlay GPX %s: %s", gpx_path, exc)
+        return False
+
+    root = tree.getroot()
+    trimmed = False
+    removed_count = 0
+
+    for segment in root.iter():
+        if _xml_local_name(segment.tag) != "trkseg":
+            continue
+        points = [child for child in list(segment) if _xml_local_name(child.tag) == "trkpt"]
+        first_osv_index = next(
+            (index for index, point in enumerate(points) if _trkpt_has_osv_sensor_data(point)),
+            None,
+        )
+        if first_osv_index is None or first_osv_index == 0:
+            continue
+        for point in points[:first_osv_index]:
+            segment.remove(point)
+        removed_count += first_osv_index
+        trimmed = True
+
+    if not trimmed:
+        return False
+
+    temp_path = gpx_path.with_name(f".{gpx_path.name}.trimmed")
+    try:
+        tree.write(temp_path, encoding="unicode", xml_declaration=True)
+        temp_path.replace(gpx_path)
+    except OSError as exc:
+        temp_path.unlink(missing_ok=True)
+        logger.warning("Could not write trimmed GoPro overlay GPX %s: %s", gpx_path, exc)
+        return False
+
+    logger.info(
+        "Trimmed %s pre-OSV GPX point(s) from merged GoPro overlay GPX %s",
+        removed_count,
+        gpx_path,
+    )
+    return True
+
+
 def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
     if not osv_paths:
         return gpx_path
@@ -199,6 +272,7 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
     if not merged_gpx_path.exists():
         raise ValueError("OSV merge did not create a GPX file")
 
+    _trim_gpx_before_first_osv_sensor_point(merged_gpx_path)
     logger.info("Created merged GoPro overlay GPX: %s", merged_gpx_path)
     return merged_gpx_path
 

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
@@ -566,6 +567,52 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert result == merged_gpx_path
     assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
     assert run.call_args.kwargs["timeout"] == 456
+
+
+def test_worker_merge_osv_files_with_gpx_trims_gpx_preroll_before_osv_sensor_data(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "20260607" / "01"
+    input_dir.mkdir(parents=True)
+    source_gpx = input_dir / "strava.gpx"
+    osv_path = input_dir / "flight.osv"
+    source_gpx.write_text("<gpx />")
+    osv_path.write_bytes(b"osv")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxpx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+  <trk><trkseg>
+    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:49Z</time></trkpt>
+    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:50Z</time></trkpt>
+    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:58Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.1</gpxpx:x><gpxpx:y>0.2</gpxpx:y><gpxpx:z>0.3</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
+    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:59Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.2</gpxpx:x><gpxpx:y>0.3</gpxpx:y><gpxpx:z>0.4</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
+  </trkseg></trk>
+</gpx>""")
+        return Result()
+
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run):
+        result = gopro_overlay_export._merge_osv_files_with_gpx(
+            [osv_path],
+            source_gpx,
+            input_dir,
+        )
+
+    root = ET.parse(result).getroot()
+    times = [
+        element.text for element in root.iter() if element.tag.rsplit("}", 1)[-1].lower() == "time"
+    ]
+    assert times == ["2026-06-07T12:54:58Z", "2026-06-07T12:54:59Z"]
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
@@ -567,52 +566,6 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert result == merged_gpx_path
     assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
     assert run.call_args.kwargs["timeout"] == 456
-
-
-def test_worker_merge_osv_files_with_gpx_trims_gpx_preroll_before_osv_sensor_data(
-    tmp_path,
-    monkeypatch,
-) -> None:
-    gopro_root = tmp_path / "gopro-overlay"
-    gopro_root.mkdir()
-    (gopro_root / "osv_merge.py").write_text("# merge")
-    input_dir = tmp_path / "20260607" / "01"
-    input_dir.mkdir(parents=True)
-    source_gpx = input_dir / "strava.gpx"
-    osv_path = input_dir / "flight.osv"
-    source_gpx.write_text("<gpx />")
-    osv_path.write_bytes(b"osv")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
-
-    class Result:
-        returncode = 0
-        stderr = ""
-        stdout = ""
-
-    def fake_run(command, **kwargs):
-        Path(command[-1]).write_text("""<?xml version="1.0" encoding="UTF-8"?>
-<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxpx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
-  <trk><trkseg>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:49Z</time></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:50Z</time></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:58Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.1</gpxpx:x><gpxpx:y>0.2</gpxpx:y><gpxpx:z>0.3</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:59Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.2</gpxpx:x><gpxpx:y>0.3</gpxpx:y><gpxpx:z>0.4</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
-  </trkseg></trk>
-</gpx>""")
-        return Result()
-
-    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run):
-        result = gopro_overlay_export._merge_osv_files_with_gpx(
-            [osv_path],
-            source_gpx,
-            input_dir,
-        )
-
-    root = ET.parse(result).getroot()
-    times = [
-        element.text for element in root.iter() if element.tag.rsplit("}", 1)[-1].lower() == "time"
-    ]
-    assert times == ["2026-06-07T12:54:58Z", "2026-06-07T12:54:59Z"]
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:
@@ -1303,6 +1256,53 @@ def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monk
     assert prepared.exists()
     command = commands[0]
     assert command[command.index("-ss") + 1] == "5.000"
+    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
+
+
+def test_prepare_pip_video_auto_aligns_start_time_by_timezone_offset(tmp_path, monkeypatch):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text(
+        "<gpx><trk><trkseg><trkpt><time>2026-03-15T10:00:00Z</time></trkpt></trkseg></trk></gpx>"
+    )
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 10.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T11:00:00Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result()
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert prepared == work_dir / "pip-prepared-job-pip.mp4"
+    assert prepared.read_bytes() == b"prepared"
+    command = commands[0]
     assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
 
 


### PR DESCRIPTION
## Summary\n- auto-align video creation time against GPX before preparing the PIP overlay\n- keep GPX preroll intact and avoid advancing the rendered timeline\n- add regression coverage for the timezone-offset case\n\n## Validation\n- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py -k 'merge_osv_files_with_gpx or prepare_pip_video'\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --base=origin/main --head=HEAD\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --base=origin/main --head=HEAD --parallel=5\n- CodeRabbit review: no findings\n\n## Notes\n- The full backend affected test run completed with the usual slow scraper/browser suite; the targeted overlay tests passed.