### PR TITLE
fix(gopro-overlay): preserve trimmed GPX namespace

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -35,6 +35,10 @@ _ACTIVE_STATUSES = {_STATUS_QUEUED, _STATUS_PREPARING, _STATUS_RUNNING}
 _INTERRUPTIBLE_STATUSES = {_STATUS_PREPARING, _STATUS_RUNNING}
 _TERMINAL_STATUSES = {_STATUS_COMPLETED, _STATUS_FAILED, _STATUS_CANCELLED}
 
+_GPX_NAMESPACE = "http://www.topografix.com/GPX/1/1"
+_GARMIN_GPX_EXTENSION_NAMESPACE = "http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+_XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance"
+
 _VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v"}
 _GPX_EXTENSIONS = {".gpx", ".fit"}
 _UPLOAD_WORK_ROOT = Path("/tmp/dashboard-parapente/gopro-overlays")
@@ -157,6 +161,12 @@ def _xml_local_name(tag: str) -> str:
     return tag.rsplit("}", 1)[-1].lower()
 
 
+def _register_gpx_namespaces() -> None:
+    ET.register_namespace("", _GPX_NAMESPACE)
+    ET.register_namespace("gpxpx", _GARMIN_GPX_EXTENSION_NAMESPACE)
+    ET.register_namespace("xsi", _XSI_NAMESPACE)
+
+
 def _trkpt_has_osv_sensor_data(point: ET.Element) -> bool:
     extension_names = {
         _xml_local_name(element.tag)
@@ -211,6 +221,7 @@ def _trim_gpx_before_first_osv_sensor_point(gpx_path: Path) -> bool:
 
     temp_path = gpx_path.with_name(f".{gpx_path.name}.trimmed")
     try:
+        _register_gpx_namespaces()
         tree.write(temp_path, encoding="unicode", xml_declaration=True)
         temp_path.replace(gpx_path)
     except OSError as exc:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1629,6 +1629,56 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     assert prepared["command"]["render_gpx_path"] == str(merged_gpx_path)
 
 
+def test_trim_gpx_preserves_default_gpx_namespace(tmp_path: Path) -> None:
+    gpx_path = tmp_path / "merged-gopro-overlay.gpx"
+    gpx_path.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1"
+     creator="OSV+GPX Merger v2.0"
+     xmlns="http://www.topografix.com/GPX/1/1"
+     xmlns:ns1="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+     xmlns:gpxpx="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+    <name>Merged OSV + GPX Track</name>
+    <trk>
+    <trkseg>
+      <trkpt lat="47.1" lon="5.1">
+        <ele>491.57</ele>
+        <time>2026-06-07T12:54:49Z</time>
+        <extensions>
+          <ns1:TrackPointExtension>
+            <ns1:speed>0.0</ns1:speed>
+          </ns1:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="47.2" lon="5.2">
+        <ele>491.86</ele>
+        <time>2026-06-07T12:54:58+00:00</time>
+        <extensions>
+          <ns1:TrackPointExtension>
+            <ns1:speed>0.0</ns1:speed>
+          </ns1:TrackPointExtension>
+          <gpxpx:Acceleration>
+            <gpxpx:x>-0.338608</gpxpx:x>
+            <gpxpx:y>-0.869588</gpxpx:y>
+            <gpxpx:z>-0.784719</gpxpx:z>
+          </gpxpx:Acceleration>
+        </extensions>
+      </trkpt>
+    </trkseg>
+    </trk>
+</gpx>""")
+
+    assert gopro_overlay_export._trim_gpx_before_first_osv_sensor_point(gpx_path)
+
+    trimmed_gpx = gpx_path.read_text()
+    assert "<gpx " in trimmed_gpx
+    assert "<ns0:gpx" not in trimmed_gpx
+    assert "<trkpt " in trimmed_gpx
+    assert "2026-06-07T12:54:49Z" not in trimmed_gpx
+    assert "2026-06-07T12:54:58+00:00" in trimmed_gpx
+
+
 def test_worker_preparation_uses_exact_video_size_for_non_standard_source(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary\n- Preserve the default GPX namespace when trimming merged GoPro overlay GPX files\n- Add a regression test to keep trimmed GPX files parseable\n\n## Validation\n- /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/python -m pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header\n- /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/ruff check . --output-format=github\n- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPX namespace handling during file trimming to ensure proper XML namespace declarations are preserved and consistent in the output.

* **Tests**
  * Added test coverage for GPX namespace preservation during trim operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->