### PR TITLE
fix(gopro-overlay): delay merged gpx timeline

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -157,86 +157,6 @@ def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
     return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
-def _xml_local_name(tag: str) -> str:
-    return tag.rsplit("}", 1)[-1].lower()
-
-
-def _register_gpx_namespaces() -> None:
-    ET.register_namespace("", _GPX_NAMESPACE)
-    ET.register_namespace("gpxpx", _GARMIN_GPX_EXTENSION_NAMESPACE)
-    ET.register_namespace("xsi", _XSI_NAMESPACE)
-
-
-def _trkpt_has_osv_sensor_data(point: ET.Element) -> bool:
-    extension_names = {
-        _xml_local_name(element.tag)
-        for extensions in point
-        if _xml_local_name(extensions.tag) == "extensions"
-        for element in extensions.iter()
-    }
-    if extension_names & {
-        "acceleration",
-        "gyroscope",
-        "g_force",
-        "gforce",
-        "accel_x",
-        "accel_y",
-        "accel_z",
-        "gyro_x",
-        "gyro_y",
-        "gyro_z",
-    }:
-        return True
-    return {"x", "y", "z"}.issubset(extension_names)
-
-
-def _trim_gpx_before_first_osv_sensor_point(gpx_path: Path) -> bool:
-    try:
-        tree = ET.parse(gpx_path)
-    except (ET.ParseError, OSError) as exc:
-        logger.warning("Could not parse merged GoPro overlay GPX %s: %s", gpx_path, exc)
-        return False
-
-    root = tree.getroot()
-    trimmed = False
-    removed_count = 0
-
-    for segment in root.iter():
-        if _xml_local_name(segment.tag) != "trkseg":
-            continue
-        points = [child for child in list(segment) if _xml_local_name(child.tag) == "trkpt"]
-        first_osv_index = next(
-            (index for index, point in enumerate(points) if _trkpt_has_osv_sensor_data(point)),
-            None,
-        )
-        if first_osv_index is None or first_osv_index == 0:
-            continue
-        for point in points[:first_osv_index]:
-            segment.remove(point)
-        removed_count += first_osv_index
-        trimmed = True
-
-    if not trimmed:
-        return False
-
-    temp_path = gpx_path.with_name(f".{gpx_path.name}.trimmed")
-    try:
-        _register_gpx_namespaces()
-        tree.write(temp_path, encoding="unicode", xml_declaration=True)
-        temp_path.replace(gpx_path)
-    except OSError as exc:
-        temp_path.unlink(missing_ok=True)
-        logger.warning("Could not write trimmed GoPro overlay GPX %s: %s", gpx_path, exc)
-        return False
-
-    logger.info(
-        "Trimmed %s pre-OSV GPX point(s) from merged GoPro overlay GPX %s",
-        removed_count,
-        gpx_path,
-    )
-    return True
-
-
 def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
     if not osv_paths:
         return gpx_path
@@ -264,6 +184,10 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
         str(merged_gpx_path),
     ]
 
+    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
+    if first_gpx_at and first_gpx_at > 0:
+        command[2:2] = ["--first-gpx-at", f"{first_gpx_at:.3f}"]
+
     try:
         result = subprocess.run(
             command,
@@ -283,7 +207,6 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
     if not merged_gpx_path.exists():
         raise ValueError("OSV merge did not create a GPX file")
 
-    _trim_gpx_before_first_osv_sensor_point(merged_gpx_path)
     logger.info("Created merged GoPro overlay GPX: %s", merged_gpx_path)
     return merged_gpx_path
 
@@ -713,6 +636,49 @@ def _parse_utc_datetime(value: str | None) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _gpx_time_bounds(gpx_path: Path) -> tuple[datetime | None, datetime | None]:
+    try:
+        root = ET.parse(gpx_path).getroot()
+    except (ET.ParseError, OSError):
+        return None, None
+
+    times = [
+        parsed
+        for element in root.iter()
+        if element.tag.rsplit("}", 1)[-1] == "time"
+        and element.text
+        and (parsed := _parse_utc_datetime(element.text))
+    ]
+    if not times:
+        return None, None
+    return times[0], times[-1]
+
+
+def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
+    osv_start = probe_video_start_time(osv_path)
+    osv_duration = probe_video_duration(osv_path)
+    gpx_start, gpx_end = _gpx_time_bounds(gpx_path)
+    if not osv_start or not osv_duration or not gpx_start or not gpx_end:
+        return None
+
+    best_start = osv_start
+    best_overlap = -1.0
+    best_offset_minutes = 0
+    for offset_minutes in range(-12 * 60, 14 * 60 + 1, 15):
+        shift = timedelta(minutes=-offset_minutes)
+        candidate_start = osv_start + shift
+        candidate_end = candidate_start + timedelta(seconds=osv_duration)
+        overlap = max(
+            0.0, (min(candidate_end, gpx_end) - max(candidate_start, gpx_start)).total_seconds()
+        )
+        if (overlap, -abs(offset_minutes)) > (best_overlap, -abs(best_offset_minutes)):
+            best_start = candidate_start
+            best_overlap = overlap
+            best_offset_minutes = offset_minutes
+
+    return max(0.0, (best_start - gpx_start).total_seconds())
+
+
 def probe_video_start_time(video_path: Path) -> datetime | None:
     try:
         result = subprocess.run(
@@ -778,32 +744,6 @@ def _pip_timeline_offsets(
     return 0.0, abs(offset)
 
 
-def _align_video_start_time_to_gpx(
-    video_start: datetime | None,
-    gpx_start: datetime | None,
-) -> datetime | None:
-    if video_start is None or gpx_start is None:
-        return video_start
-
-    aligned_start = video_start
-    aligned_gap = abs((video_start - gpx_start).total_seconds())
-    for shift_minutes in range(-12 * 60, 14 * 60 + 1, 15):
-        candidate_start = video_start + timedelta(minutes=shift_minutes)
-        candidate_gap = abs((candidate_start - gpx_start).total_seconds())
-        if candidate_gap < aligned_gap:
-            aligned_start = candidate_start
-            aligned_gap = candidate_gap
-
-    if aligned_start != video_start:
-        logger.info(
-            "Adjusted video start time %s -> %s to better align with GPX %s",
-            video_start,
-            aligned_start,
-            gpx_start,
-        )
-    return aligned_start
-
-
 def _prepared_pip_path(work_dir: Path, job_id: str) -> Path:
     return work_dir / f"pip-prepared-{job_id}.mp4"
 
@@ -826,7 +766,7 @@ def _prepare_pip_video_for_overlay(
 
     pip_duration = probe_video_duration(pip_path)
     gpx_start = _first_gpx_timestamp(gpx_path)
-    video_start = _align_video_start_time_to_gpx(probe_video_start_time(video_path), gpx_start)
+    video_start = probe_video_start_time(video_path)
     pip_delay, pip_trim = _pip_timeline_offsets(video_start, gpx_start)
     visible_pip_duration = max(0.0, pip_duration - pip_trim) if pip_duration is not None else None
     pip_tail_duration = (

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
@@ -569,50 +568,53 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert run.call_args.kwargs["timeout"] == 456
 
 
-def test_worker_merge_osv_files_with_gpx_trims_gpx_preroll_before_osv_sensor_data(
+def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     tmp_path,
     monkeypatch,
 ) -> None:
     gopro_root = tmp_path / "gopro-overlay"
     gopro_root.mkdir()
     (gopro_root / "osv_merge.py").write_text("# merge")
-    input_dir = tmp_path / "20260607" / "01"
+    input_dir = tmp_path / "20260315" / "01"
     input_dir.mkdir(parents=True)
-    source_gpx = input_dir / "strava.gpx"
+    source_gpx = input_dir / "Zepp-track.gpx"
     osv_path = input_dir / "flight.osv"
-    source_gpx.write_text("<gpx />")
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    source_gpx.write_text(
+        "<gpx><trk><trkseg>"
+        "<trkpt><time>2026-03-15T09:59:50Z</time></trkpt>"
+        "<trkpt><time>2026-03-15T10:00:20Z</time></trkpt>"
+        "</trkseg></trk></gpx>"
+    )
     osv_path.write_bytes(b"osv")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_duration", lambda _: 30.0)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:00Z"),
+    )
 
     class Result:
         returncode = 0
         stderr = ""
         stdout = ""
 
-    def fake_run(command, **kwargs):
-        Path(command[-1]).write_text("""<?xml version="1.0" encoding="UTF-8"?>
-<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxpx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
-  <trk><trkseg>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:49Z</time></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:50Z</time></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:58Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.1</gpxpx:x><gpxpx:y>0.2</gpxpx:y><gpxpx:z>0.3</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
-    <trkpt lat="46.0" lon="6.0"><time>2026-06-07T12:54:59Z</time><extensions><gpxpx:Acceleration><gpxpx:x>0.2</gpxpx:x><gpxpx:y>0.3</gpxpx:y><gpxpx:z>0.4</gpxpx:z></gpxpx:Acceleration></extensions></trkpt>
-  </trkseg></trk>
-</gpx>""")
+    def fake_run(command, **_kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
         return Result()
 
-    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run):
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run) as run:
         result = gopro_overlay_export._merge_osv_files_with_gpx(
             [osv_path],
             source_gpx,
             input_dir,
         )
 
-    root = ET.parse(result).getroot()
-    times = [
-        element.text for element in root.iter() if element.tag.rsplit("}", 1)[-1].lower() == "time"
-    ]
-    assert times == ["2026-06-07T12:54:58Z", "2026-06-07T12:54:59Z"]
+    assert result == merged_gpx_path
+    assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
+    command = run.call_args.args[0]
+    assert command[2:4] == ["--first-gpx-at", "10.000"]
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:
@@ -1308,53 +1310,6 @@ def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monk
     assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
 
 
-def test_prepare_pip_video_auto_aligns_start_time_by_timezone_offset(tmp_path, monkeypatch):
-    video_path = tmp_path / "camera.mp4"
-    gpx_path = tmp_path / "track.gpx"
-    pip_path = tmp_path / "pip.mp4"
-    work_dir = tmp_path / "work"
-    video_path.write_bytes(b"video")
-    pip_path.write_bytes(b"pip")
-    gpx_path.write_text(
-        "<gpx><trk><trkseg><trkpt><time>2026-03-15T10:00:00Z</time></trkpt></trkseg></trk></gpx>"
-    )
-    work_dir.mkdir()
-    commands: list[list[str]] = []
-
-    monkeypatch.setattr(
-        gopro_overlay_export,
-        "probe_video_duration",
-        lambda path: 30.0 if path == video_path else 10.0,
-    )
-    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
-    monkeypatch.setattr(
-        gopro_overlay_export,
-        "probe_video_start_time",
-        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T11:00:00Z"),
-    )
-
-    class Result:
-        returncode = 0
-        stderr = ""
-        stdout = ""
-
-    def run(command, **_kwargs):
-        commands.append(command)
-        Path(command[-1]).write_bytes(b"prepared")
-        return Result()
-
-    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
-
-    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
-        "job-pip", video_path, gpx_path, pip_path, work_dir
-    )
-
-    assert prepared == work_dir / "pip-prepared-job-pip.mp4"
-    assert prepared.read_bytes() == b"prepared"
-    command = commands[0]
-    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
-
-
 def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_db):
     layout_dir = tmp_path / "layouts"
     layout_dir.mkdir()
@@ -1627,56 +1582,6 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     assert merge_osv.call_args.args[1].name == "gpx-" + job["job_id"] + ".gpx"
     assert merge_osv.call_args.args[2] == tmp_path
     assert prepared["command"]["render_gpx_path"] == str(merged_gpx_path)
-
-
-def test_trim_gpx_preserves_default_gpx_namespace(tmp_path: Path) -> None:
-    gpx_path = tmp_path / "merged-gopro-overlay.gpx"
-    gpx_path.write_text("""<?xml version="1.0" encoding="UTF-8"?>
-<gpx version="1.1"
-     creator="OSV+GPX Merger v2.0"
-     xmlns="http://www.topografix.com/GPX/1/1"
-     xmlns:ns1="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
-     xmlns:gpxpx="http://www.garmin.com/xmlschemas/GpxExtensions/v3"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
-    <name>Merged OSV + GPX Track</name>
-    <trk>
-    <trkseg>
-      <trkpt lat="47.1" lon="5.1">
-        <ele>491.57</ele>
-        <time>2026-06-07T12:54:49Z</time>
-        <extensions>
-          <ns1:TrackPointExtension>
-            <ns1:speed>0.0</ns1:speed>
-          </ns1:TrackPointExtension>
-        </extensions>
-      </trkpt>
-      <trkpt lat="47.2" lon="5.2">
-        <ele>491.86</ele>
-        <time>2026-06-07T12:54:58+00:00</time>
-        <extensions>
-          <ns1:TrackPointExtension>
-            <ns1:speed>0.0</ns1:speed>
-          </ns1:TrackPointExtension>
-          <gpxpx:Acceleration>
-            <gpxpx:x>-0.338608</gpxpx:x>
-            <gpxpx:y>-0.869588</gpxpx:y>
-            <gpxpx:z>-0.784719</gpxpx:z>
-          </gpxpx:Acceleration>
-        </extensions>
-      </trkpt>
-    </trkseg>
-    </trk>
-</gpx>""")
-
-    assert gopro_overlay_export._trim_gpx_before_first_osv_sensor_point(gpx_path)
-
-    trimmed_gpx = gpx_path.read_text()
-    assert "<gpx " in trimmed_gpx
-    assert "<ns0:gpx" not in trimmed_gpx
-    assert "<trkpt " in trimmed_gpx
-    assert "2026-06-07T12:54:49Z" not in trimmed_gpx
-    assert "2026-06-07T12:54:58+00:00" in trimmed_gpx
 
 
 def test_worker_preparation_uses_exact_video_size_for_non_standard_source(


### PR DESCRIPTION
## What\n- delay merged GPX timeline from the video/OSV start alignment\n- keep PIP visibility aligned with the GPX start\n- resolve the rebase on origin/main\n\n## Validation\n- pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py -k 'merge_osv_files_with_gpx or prepare_pip_video'\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic GPX timestamp alignment during OSV file merging for improved synchronization.

* **Improvements**
  * Simplified video start time detection for PIP overlay preparation.

* **Tests**
  * Updated test coverage to validate GPX timestamp alignment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->