### PR TITLE
fix(gopro-overlay): keep pip visible to the end

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1491,6 +1491,9 @@ def _run_job(job_id: str) -> None:
         return
     job = _prepare_queued_job(job_id, job)
     if not job or job.get("status") != _STATUS_QUEUED:
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
         return
 
     prepared_command = job.get("command") if isinstance(job.get("command"), dict) else {}
@@ -1520,6 +1523,9 @@ def _run_job(job_id: str) -> None:
     command.extend([job["video_path"], str(temp_output_path)])
 
     if not _transition_job_to_running(job_id, command):
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
         return
     logger.info("Starting GoPro overlay job %s", job_id)
     _append_job_log(log_path, f"Starting GoPro overlay job {job_id}")
@@ -1535,7 +1541,7 @@ def _run_job(job_id: str) -> None:
         )
     except FileNotFoundError as exc:
         logger.exception("GoPro overlay binary not found for job %s", job_id)
-        _finish_job(
+        finished_job = _finish_job(
             job_id,
             status=_STATUS_FAILED,
             progress=100,
@@ -1543,10 +1549,11 @@ def _run_job(job_id: str) -> None:
             error=str(exc),
             completed_at=_utc_now(),
         )
+        _cleanup_gopro_overlay_temp_files(finished_job)
         return
     except Exception as exc:
         logger.exception("Failed to start GoPro overlay job %s", job_id)
-        _finish_job(
+        finished_job = _finish_job(
             job_id,
             status=_STATUS_FAILED,
             progress=100,
@@ -1554,6 +1561,7 @@ def _run_job(job_id: str) -> None:
             error=str(exc) or exc.__class__.__name__,
             completed_at=_utc_now(),
         )
+        _cleanup_gopro_overlay_temp_files(finished_job)
         return
 
     with _LOCK:
@@ -1671,6 +1679,9 @@ def _run_job(job_id: str) -> None:
     finally:
         with _LOCK:
             _PROCESSES.pop(job_id, None)
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
 
 
 def get_gopro_overlay_job(job_id: str, include_command: bool = False) -> dict[str, Any] | None:
@@ -1754,6 +1765,29 @@ def _can_delete_work_dir(work_dir: Path) -> bool:
     if _is_path_inside(work_dir, _UPLOAD_WORK_ROOT):
         return True
     return work_dir.parent.name == _PATH_WORK_DIR_NAME
+
+
+def _cleanup_gopro_overlay_temp_files(job: dict[str, Any]) -> None:
+    temp_output_path = job.get("temp_output_path")
+    if temp_output_path:
+        _unlink_if_exists(Path(str(temp_output_path)))
+
+    work_dir = _job_work_dir(job)
+    if not work_dir or not work_dir.exists():
+        return
+    if not _can_delete_work_dir(work_dir):
+        logger.warning(
+            "Refusing to clean GoPro overlay work directory outside temp roots: %s", work_dir
+        )
+        return
+
+    try:
+        if work_dir.is_dir() and not work_dir.is_symlink():
+            shutil.rmtree(work_dir)
+        else:
+            work_dir.unlink()
+    except OSError:
+        logger.exception("Failed to clean GoPro overlay work directory %s", work_dir)
 
 
 def _queued_job_ids() -> list[str]:

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -158,7 +158,12 @@ def _matching_files_by_mtime(directory: Path, pattern: str) -> list[Path]:
     return sorted(matches, key=lambda path: (path.stat().st_mtime, path.name))
 
 
-def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: Path) -> Path:
+def _merge_osv_files_with_gpx(
+    osv_paths: list[Path],
+    gpx_path: Path,
+    input_dir: Path,
+    log_path: Path | None = None,
+) -> Path:
     if not osv_paths:
         return gpx_path
 
@@ -177,6 +182,11 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
         gpx_path,
         merged_gpx_path,
     )
+    if log_path:
+        _append_job_log(
+            log_path,
+            f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
+        )
     command = [
         "python3",
         str(merge_script),
@@ -200,15 +210,23 @@ def _merge_osv_files_with_gpx(osv_paths: list[Path], gpx_path: Path, input_dir: 
         )
     except subprocess.TimeoutExpired as exc:
         detail = exc.stderr or exc.stdout or "OSV merge timed out"
+        if log_path:
+            _append_job_log(log_path, f"OSV merge timed out: {detail}")
         raise ValueError(detail) from exc
 
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "OSV merge failed"
+        if log_path:
+            _append_job_log(log_path, f"OSV merge failed: {detail}")
         raise ValueError(detail)
     if not merged_gpx_path.exists():
+        if log_path:
+            _append_job_log(log_path, "OSV merge did not create a GPX file")
         raise ValueError("OSV merge did not create a GPX file")
 
     logger.info("Created merged GoPro overlay GPX: %s", merged_gpx_path)
+    if log_path:
+        _append_job_log(log_path, f"Created merged GPX: {merged_gpx_path.name}")
     return merged_gpx_path
 
 
@@ -333,6 +351,16 @@ def _job_preparation_metadata(pin_inputs: bool, requested_layout_id: str | None)
         "pin_inputs": pin_inputs,
         "requested_layout_id": requested_layout_id,
     }
+
+
+def _append_job_log(log_path: Path, message: str) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        with log_path.open("a", encoding="utf-8") as log_file:
+            log_file.write(f"[{timestamp}] {message}\n")
+    except OSError:
+        pass
 
 
 def _job_to_payload(job: GoproOverlayJob, include_command: bool = False) -> dict[str, Any]:
@@ -767,11 +795,15 @@ def _prepare_pip_video_for_overlay(
     gpx_path: Path,
     pip_path: Path,
     work_dir: Path,
+    log_path: Path | None = None,
 ) -> Path:
     video_duration = probe_video_duration(video_path)
     pip_width, pip_height = probe_video_resolution(pip_path)
     if video_duration is None or not pip_width or not pip_height:
         return pip_path
+
+    if log_path:
+        _append_job_log(log_path, f"Preparing PIP video: {pip_path.name}")
 
     pip_duration = probe_video_duration(pip_path)
     gpx_start = _first_gpx_timestamp(gpx_path)
@@ -860,14 +892,22 @@ def _prepare_pip_video_for_overlay(
         )
     except (FileNotFoundError, subprocess.SubprocessError, TimeoutError) as exc:
         _unlink_if_exists(prepared_path)
+        if log_path:
+            _append_job_log(log_path, f"PIP preparation failed: {exc}")
         raise ValueError(str(exc) or exc.__class__.__name__) from exc
 
     if result.returncode != 0:
         _unlink_if_exists(prepared_path)
         detail = result.stderr.strip() or result.stdout.strip() or "ffmpeg pip preparation failed"
+        if log_path:
+            _append_job_log(log_path, f"PIP preparation failed: {detail}")
         raise ValueError(detail)
     if not prepared_path.exists():
+        if log_path:
+            _append_job_log(log_path, "ffmpeg did not create the prepared PIP video")
         raise ValueError("ffmpeg did not create the prepared PIP video")
+    if log_path:
+        _append_job_log(log_path, f"Prepared PIP video: {prepared_path.name}")
     return prepared_path
 
 
@@ -999,7 +1039,10 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
     if not isinstance(metadata, dict) or not metadata.get("prepare_overlay_inputs"):
         return job
 
+    log_path = Path(str(job.get("log_path") or Path(str(job["output_path"])).with_suffix(".log")))
+
     try:
+        _append_job_log(log_path, "Preparing overlay files")
         current_job = _update_job(
             job_id,
             status=_STATUS_PREPARING,
@@ -1015,6 +1058,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         render_gpx_path = gpx_path
 
         if metadata.get("pin_inputs"):
+            _append_job_log(log_path, "Pinning overlay input files")
             video_path = _copy_job_input(
                 video_path,
                 work_dir / f"input{video_path.suffix.lower()}",
@@ -1036,10 +1080,16 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         osv_paths = _matching_files_by_mtime(source_input_dir, "*.osv")
         if osv_paths:
             render_gpx_path = _merge_osv_files_with_gpx(
-                osv_paths, render_gpx_path, source_input_dir
+                osv_paths,
+                render_gpx_path,
+                source_input_dir,
+                log_path=log_path,
             )
+        else:
+            _append_job_log(log_path, "No OSV files found; using GPX directly")
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
+        _append_job_log(log_path, f"Render GPX: {render_gpx_path.name}")
 
         if pip_path:
             pip_path = _prepare_pip_video_for_overlay(
@@ -1048,7 +1098,10 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 gpx_path,
                 pip_path,
                 work_dir,
+                log_path=log_path,
             )
+        else:
+            _append_job_log(log_path, "No PIP video configured")
 
         width, height = probe_video_resolution(video_path)
         requested_layout_id = metadata.get("requested_layout_id")
@@ -1062,6 +1115,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         source_layout_path = _layout_path(selected_layout)
         if not source_layout_path.exists():
             raise ValueError(f"Layout file not found: {source_layout_path}")
+        _append_job_log(log_path, f"Using layout {selected_layout.label}")
         layout_path = _prepare_layout_file(
             source_layout_path,
             work_dir / source_layout_path.name,
@@ -1088,8 +1142,10 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         if not prepared_job or prepared_job.get("status") != _STATUS_QUEUED:
             return None
         prepared_job["command"] = command_metadata
+        _append_job_log(log_path, "Overlay queued")
         return prepared_job
     except Exception as exc:
+        _append_job_log(log_path, f"Overlay preparation failed: {exc}")
         logger.exception("Failed to prepare GoPro overlay job %s", job_id)
         _finish_job(
             job_id,
@@ -1466,6 +1522,7 @@ def _run_job(job_id: str) -> None:
     if not _transition_job_to_running(job_id, command):
         return
     logger.info("Starting GoPro overlay job %s", job_id)
+    _append_job_log(log_path, f"Starting GoPro overlay job {job_id}")
     try:
         if temp_output_path.exists():
             temp_output_path.unlink()

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -717,6 +717,12 @@ def _prepare_pip_video_for_overlay(
     video_start = probe_video_start_time(video_path)
     gpx_start = _first_gpx_timestamp(gpx_path)
     pip_delay, pip_trim = _pip_timeline_offsets(video_start, gpx_start)
+    visible_pip_duration = max(0.0, pip_duration - pip_trim) if pip_duration is not None else None
+    pip_tail_duration = (
+        max(0.0, video_duration - pip_delay - visible_pip_duration)
+        if visible_pip_duration is not None
+        else None
+    )
     prepared_path = _prepared_pip_path(work_dir, job_id)
     _unlink_if_exists(prepared_path)
 
@@ -755,12 +761,15 @@ def _prepare_pip_video_for_overlay(
         ]
         if pip_trim > 0:
             command.extend(["-ss", f"{pip_trim:.3f}"])
+        pip_filters = [f"setpts=PTS-STARTPTS+{pip_delay:.3f}/TB"]
+        if pip_tail_duration and pip_tail_duration > 0:
+            pip_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
         command.extend(
             [
                 "-i",
                 str(pip_path),
                 "-filter_complex",
-                f"[1:v]setpts=PTS-STARTPTS+{pip_delay:.3f}/TB[pip];"
+                f"[1:v]{','.join(pip_filters)}[pip];"
                 "[0:v][pip]overlay=0:0:eof_action=pass:shortest=0[v]",
                 "-map",
                 "[v]",

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -826,7 +826,6 @@ def _prepare_pip_video_for_overlay(
     prepared_path = _prepared_pip_path(work_dir, job_id)
     _unlink_if_exists(prepared_path)
 
-    base_input = f"color=c=black:s={pip_width}x{pip_height}:r=30:d={video_duration:.3f}"
     if pip_delay >= video_duration or (pip_duration is not None and pip_trim >= pip_duration):
         command = [
             "ffmpeg",
@@ -834,7 +833,7 @@ def _prepare_pip_video_for_overlay(
             "-f",
             "lavfi",
             "-i",
-            base_input,
+            f"color=c=black:s={pip_width}x{pip_height}:r=30:d={video_duration:.3f}",
             "-t",
             f"{video_duration:.3f}",
             "-an",
@@ -851,28 +850,23 @@ def _prepare_pip_video_for_overlay(
             str(prepared_path),
         ]
     else:
+        pip_filters = ["setpts=PTS-STARTPTS"]
+        if pip_delay > 0:
+            pip_filters.append(f"tpad=start_mode=add:start_duration={pip_delay:.3f}")
+        if pip_tail_duration and pip_tail_duration > 0:
+            pip_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
         command = [
             "ffmpeg",
             "-y",
-            "-f",
-            "lavfi",
-            "-i",
-            base_input,
         ]
         if pip_trim > 0:
             command.extend(["-ss", f"{pip_trim:.3f}"])
-        pip_filters = [f"setpts=PTS-STARTPTS+{pip_delay:.3f}/TB"]
-        if pip_tail_duration and pip_tail_duration > 0:
-            pip_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
         command.extend(
             [
                 "-i",
                 str(pip_path),
-                "-filter_complex",
-                f"[1:v]{','.join(pip_filters)}[pip];"
-                "[0:v][pip]overlay=0:0:eof_action=pass:shortest=0[v]",
-                "-map",
-                "[v]",
+                "-vf",
+                ",".join(pip_filters),
                 "-t",
                 f"{video_duration:.3f}",
                 "-an",

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -588,6 +588,220 @@ def _verify_video_output(path: Path) -> tuple[bool, str | None]:
     return True, None
 
 
+def probe_video_duration(video_path: Path) -> float | None:
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "json",
+                str(video_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+
+    try:
+        duration = float((json.loads(result.stdout or "{}").get("format") or {}).get("duration", 0))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return duration if duration > 0 else None
+
+
+def _parse_utc_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def probe_video_start_time(video_path: Path) -> datetime | None:
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format_tags=creation_time:stream_tags=creation_time",
+                "-of",
+                "json",
+                str(video_path),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return None
+
+    try:
+        payload = json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+    candidates = [
+        ((payload.get("format") or {}).get("tags") or {}).get("creation_time"),
+        *[
+            ((stream.get("tags") or {}).get("creation_time"))
+            for stream in payload.get("streams") or []
+        ],
+    ]
+    return next(
+        (parsed for candidate in candidates if (parsed := _parse_utc_datetime(candidate))),
+        None,
+    )
+
+
+def _first_gpx_timestamp(gpx_path: Path) -> datetime | None:
+    try:
+        root = ET.parse(gpx_path).getroot()
+    except (ET.ParseError, OSError):
+        return None
+
+    for element in root.iter():
+        if element.tag.rsplit("}", 1)[-1] == "time" and element.text:
+            parsed = _parse_utc_datetime(element.text)
+            if parsed:
+                return parsed
+    return None
+
+
+def _pip_timeline_offsets(
+    video_start: datetime | None,
+    gpx_start: datetime | None,
+) -> tuple[float, float]:
+    if video_start is None or gpx_start is None:
+        return 0.0, 0.0
+    offset = (gpx_start - video_start).total_seconds()
+    if offset >= 0:
+        return offset, 0.0
+    return 0.0, abs(offset)
+
+
+def _prepared_pip_path(work_dir: Path, job_id: str) -> Path:
+    return work_dir / f"pip-prepared-{job_id}.mp4"
+
+
+def _ffmpeg_timeout_for_duration(duration: float) -> int:
+    return max(600, min(int(duration * 20), 6 * 60 * 60))
+
+
+def _prepare_pip_video_for_overlay(
+    job_id: str,
+    video_path: Path,
+    gpx_path: Path,
+    pip_path: Path,
+    work_dir: Path,
+) -> Path:
+    video_duration = probe_video_duration(video_path)
+    pip_width, pip_height = probe_video_resolution(pip_path)
+    if video_duration is None or not pip_width or not pip_height:
+        return pip_path
+
+    pip_duration = probe_video_duration(pip_path)
+    video_start = probe_video_start_time(video_path)
+    gpx_start = _first_gpx_timestamp(gpx_path)
+    pip_delay, pip_trim = _pip_timeline_offsets(video_start, gpx_start)
+    prepared_path = _prepared_pip_path(work_dir, job_id)
+    _unlink_if_exists(prepared_path)
+
+    base_input = f"color=c=black:s={pip_width}x{pip_height}:r=30:d={video_duration:.3f}"
+    if pip_delay >= video_duration or (pip_duration is not None and pip_trim >= pip_duration):
+        command = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            base_input,
+            "-t",
+            f"{video_duration:.3f}",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "18",
+            "-movflags",
+            "+faststart",
+            str(prepared_path),
+        ]
+    else:
+        command = [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            base_input,
+        ]
+        if pip_trim > 0:
+            command.extend(["-ss", f"{pip_trim:.3f}"])
+        command.extend(
+            [
+                "-i",
+                str(pip_path),
+                "-filter_complex",
+                f"[1:v]setpts=PTS-STARTPTS+{pip_delay:.3f}/TB[pip];"
+                "[0:v][pip]overlay=0:0:eof_action=pass:shortest=0[v]",
+                "-map",
+                "[v]",
+                "-t",
+                f"{video_duration:.3f}",
+                "-an",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-preset",
+                "veryfast",
+                "-crf",
+                "18",
+                "-movflags",
+                "+faststart",
+                str(prepared_path),
+            ]
+        )
+
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_ffmpeg_timeout_for_duration(video_duration),
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError) as exc:
+        _unlink_if_exists(prepared_path)
+        raise ValueError(str(exc) or exc.__class__.__name__) from exc
+
+    if result.returncode != 0:
+        _unlink_if_exists(prepared_path)
+        detail = result.stderr.strip() or result.stdout.strip() or "ffmpeg pip preparation failed"
+        raise ValueError(detail)
+    if not prepared_path.exists():
+        raise ValueError("ffmpeg did not create the prepared PIP video")
+    return prepared_path
+
+
 def _scaled_video_path(path: Path) -> Path:
     return path.with_name(f".{path.stem}.scaled{path.suffix or '.mp4'}")
 
@@ -757,6 +971,15 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             )
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
+
+        if pip_path:
+            pip_path = _prepare_pip_video_for_overlay(
+                job_id,
+                video_path,
+                gpx_path,
+                pip_path,
+                work_dir,
+            )
 
         width, height = probe_video_resolution(video_path)
         requested_layout_id = metadata.get("requested_layout_id")

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1258,9 +1258,10 @@ def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
     assert prepared.read_bytes() == b"prepared"
     command = commands[0]
     assert "-ss" not in command
-    filter_complex = command[command.index("-filter_complex") + 1]
-    assert "setpts=PTS-STARTPTS+5.000/TB" in filter_complex
-    assert "tpad=stop_mode=clone:stop_duration=15.000" in filter_complex
+    video_filter = command[command.index("-vf") + 1]
+    assert "setpts=PTS-STARTPTS" in video_filter
+    assert "tpad=start_mode=add:start_duration=5.000" in video_filter
+    assert "tpad=stop_mode=clone:stop_duration=15.000" in video_filter
 
 
 def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monkeypatch):
@@ -1305,7 +1306,7 @@ def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monk
     assert prepared.exists()
     command = commands[0]
     assert command[command.index("-ss") + 1] == "5.000"
-    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
+    assert "tpad=stop_mode=clone:stop_duration=15.000" in command[command.index("-vf") + 1]
 
 
 def test_prepare_pip_video_auto_aligns_start_time_by_timezone_offset(tmp_path, monkeypatch):
@@ -1352,7 +1353,7 @@ def test_prepare_pip_video_auto_aligns_start_time_by_timezone_offset(tmp_path, m
     assert prepared == work_dir / "pip-prepared-job-pip.mp4"
     assert prepared.read_bytes() == b"prepared"
     command = commands[0]
-    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
+    assert "tpad=stop_mode=clone:stop_duration=20.000" in command[command.index("-vf") + 1]
 
 
 def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_db):

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1166,6 +1166,136 @@ def test_gopro_overlay_process_updates_split_carriage_returns():
     ]
 
 
+def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text(
+        "<gpx><trk><trkseg><trkpt><time>2026-03-15T10:00:05Z</time></trkpt></trkseg></trk></gpx>"
+    )
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 10.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:00Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result()
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert prepared == work_dir / "pip-prepared-job-pip.mp4"
+    assert prepared.read_bytes() == b"prepared"
+    command = commands[0]
+    assert "-ss" not in command
+    assert "setpts=PTS-STARTPTS+5.000/TB" in command[command.index("-filter_complex") + 1]
+
+
+def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monkeypatch):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text("<gpx><time>2026-03-15T10:00:00Z</time></gpx>")
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 20.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:05Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result()
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert prepared.exists()
+    command = commands[0]
+    assert command[command.index("-ss") + 1] == "5.000"
+    assert "setpts=PTS-STARTPTS+0.000/TB" in command[command.index("-filter_complex") + 1]
+
+
+def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_db):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    prepared_pip_path = tmp_path / "prepared-pip.mp4"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    pip_path.write_bytes(b"pip")
+    prepared_pip_path.write_bytes(b"prepared")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "_prepare_pip_video_for_overlay",
+        lambda *_args: prepared_pip_path,
+    )
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=pip_path,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
+    assert queued_job is not None
+
+    prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
+
+    assert prepared is not None
+    assert Path(prepared["pip_path"]) == prepared_pip_path
+
+
 @pytest.mark.asyncio
 async def test_create_gopro_overlay_job_cleans_uploads_after_validation_failure(
     tmp_path,

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1899,6 +1899,57 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert Path(command[-2]).parent == work_dir
     assert Path(command[-1]) == Path(job["temp_output_path"])
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
+    assert Path(job["output_path"]).read_bytes() == b"video"
+    assert not Path(job["temp_output_path"]).exists()
+    assert not work_dir.exists()
+
+
+def test_run_job_cleans_temp_files_after_process_failure(
+    tmp_path,
+    monkeypatch,
+    test_db,
+):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_BIN", "gopro-dashboard.py")
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=None,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
+
+    class FailedProcess:
+        def __init__(self, command: list[str]):
+            self.command = command
+            self.stdout = None
+
+        def wait(self) -> int:
+            Path(self.command[-1]).write_bytes(b"partial")
+            return 1
+
+    with patch(
+        "gopro_overlay_export.subprocess.Popen",
+        side_effect=lambda command, **kwargs: FailedProcess(command),
+    ):
+        gopro_overlay_export._run_job(job["job_id"])
+
+    failed_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"])
+    assert failed_job is not None
+    assert failed_job["status"] == "failed"
+    assert not Path(job["temp_output_path"]).exists()
+    assert not work_dir.exists()
 
 
 def test_create_gopro_overlay_job_from_paths_sanitizes_output_filename_in_source_dir(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -570,6 +570,46 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert run.call_args.kwargs["timeout"] == 456
 
 
+def test_worker_merge_osv_files_with_gpx_writes_log_steps(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "20260315" / "01"
+    input_dir.mkdir(parents=True)
+    source_gpx = input_dir / "Zepp-track.gpx"
+    osv_path = input_dir / "flight.osv"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    log_path = input_dir / "overlay.log"
+    source_gpx.write_text("<gpx>source</gpx>")
+    osv_path.write_bytes(b"osv")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run):
+        result = gopro_overlay_export._merge_osv_files_with_gpx(
+            [osv_path],
+            source_gpx,
+            input_dir,
+            log_path=log_path,
+        )
+
+    assert result == merged_gpx_path
+    log_lines = log_path.read_text().splitlines()
+    assert any("Merging 1 OSV file(s)" in line for line in log_lines)
+    assert any("Created merged GPX" in line for line in log_lines)
+
+
 def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     tmp_path,
     monkeypatch,
@@ -1330,7 +1370,7 @@ def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_d
     monkeypatch.setattr(
         gopro_overlay_export,
         "_prepare_pip_video_for_overlay",
-        lambda *_args: prepared_pip_path,
+        lambda *_args, **_kwargs: prepared_pip_path,
     )
 
     job = create_gopro_overlay_job_from_paths(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1211,7 +1211,9 @@ def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
     assert prepared.read_bytes() == b"prepared"
     command = commands[0]
     assert "-ss" not in command
-    assert "setpts=PTS-STARTPTS+5.000/TB" in command[command.index("-filter_complex") + 1]
+    filter_complex = command[command.index("-filter_complex") + 1]
+    assert "setpts=PTS-STARTPTS+5.000/TB" in filter_complex
+    assert "tpad=stop_mode=clone:stop_duration=15.000" in filter_complex
 
 
 def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n- prepare the PIP as a single filtered stream with GPX-aligned delay\n- keep the last visible frame cloned until the end instead of falling back to black\n- preserve the timezone alignment logic from origin/main\n\n## Validation\n- ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GoPro picture-in-picture overlay timing with more accurate start alignment and tail padding.
  * Refined overlay video generation to better handle cases where overlay processing isn’t needed.

* **New Features**
  * Added optional per-job logging to make overlay/merge preparation easier to diagnose.

* **Tests**
  * Updated overlay processing tests to match the revised filter behavior and timing logic.
  * Added coverage for job log output and cleanup behavior on both success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->