### PR TITLE
fix(gopro-overlay): clean temp files after render

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1491,6 +1491,9 @@ def _run_job(job_id: str) -> None:
         return
     job = _prepare_queued_job(job_id, job)
     if not job or job.get("status") != _STATUS_QUEUED:
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
         return
 
     prepared_command = job.get("command") if isinstance(job.get("command"), dict) else {}
@@ -1520,6 +1523,9 @@ def _run_job(job_id: str) -> None:
     command.extend([job["video_path"], str(temp_output_path)])
 
     if not _transition_job_to_running(job_id, command):
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
         return
     logger.info("Starting GoPro overlay job %s", job_id)
     _append_job_log(log_path, f"Starting GoPro overlay job {job_id}")
@@ -1535,7 +1541,7 @@ def _run_job(job_id: str) -> None:
         )
     except FileNotFoundError as exc:
         logger.exception("GoPro overlay binary not found for job %s", job_id)
-        _finish_job(
+        finished_job = _finish_job(
             job_id,
             status=_STATUS_FAILED,
             progress=100,
@@ -1543,10 +1549,11 @@ def _run_job(job_id: str) -> None:
             error=str(exc),
             completed_at=_utc_now(),
         )
+        _cleanup_gopro_overlay_temp_files(finished_job)
         return
     except Exception as exc:
         logger.exception("Failed to start GoPro overlay job %s", job_id)
-        _finish_job(
+        finished_job = _finish_job(
             job_id,
             status=_STATUS_FAILED,
             progress=100,
@@ -1554,6 +1561,7 @@ def _run_job(job_id: str) -> None:
             error=str(exc) or exc.__class__.__name__,
             completed_at=_utc_now(),
         )
+        _cleanup_gopro_overlay_temp_files(finished_job)
         return
 
     with _LOCK:
@@ -1671,6 +1679,9 @@ def _run_job(job_id: str) -> None:
     finally:
         with _LOCK:
             _PROCESSES.pop(job_id, None)
+        current_job = get_gopro_overlay_job(job_id)
+        if current_job and current_job.get("status") in _TERMINAL_STATUSES:
+            _cleanup_gopro_overlay_temp_files(current_job)
 
 
 def get_gopro_overlay_job(job_id: str, include_command: bool = False) -> dict[str, Any] | None:
@@ -1754,6 +1765,29 @@ def _can_delete_work_dir(work_dir: Path) -> bool:
     if _is_path_inside(work_dir, _UPLOAD_WORK_ROOT):
         return True
     return work_dir.parent.name == _PATH_WORK_DIR_NAME
+
+
+def _cleanup_gopro_overlay_temp_files(job: dict[str, Any]) -> None:
+    temp_output_path = job.get("temp_output_path")
+    if temp_output_path:
+        _unlink_if_exists(Path(str(temp_output_path)))
+
+    work_dir = _job_work_dir(job)
+    if not work_dir or not work_dir.exists():
+        return
+    if not _can_delete_work_dir(work_dir):
+        logger.warning(
+            "Refusing to clean GoPro overlay work directory outside temp roots: %s", work_dir
+        )
+        return
+
+    try:
+        if work_dir.is_dir() and not work_dir.is_symlink():
+            shutil.rmtree(work_dir)
+        else:
+            work_dir.unlink()
+    except OSError:
+        logger.exception("Failed to clean GoPro overlay work directory %s", work_dir)
 
 
 def _queued_job_ids() -> list[str]:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1899,6 +1899,57 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert Path(command[-2]).parent == work_dir
     assert Path(command[-1]) == Path(job["temp_output_path"])
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
+    assert Path(job["output_path"]).read_bytes() == b"video"
+    assert not Path(job["temp_output_path"]).exists()
+    assert not work_dir.exists()
+
+
+def test_run_job_cleans_temp_files_after_process_failure(
+    tmp_path,
+    monkeypatch,
+    test_db,
+):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_BIN", "gopro-dashboard.py")
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=None,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
+
+    class FailedProcess:
+        def __init__(self, command: list[str]):
+            self.command = command
+            self.stdout = None
+
+        def wait(self) -> int:
+            Path(self.command[-1]).write_bytes(b"partial")
+            return 1
+
+    with patch(
+        "gopro_overlay_export.subprocess.Popen",
+        side_effect=lambda command, **kwargs: FailedProcess(command),
+    ):
+        gopro_overlay_export._run_job(job["job_id"])
+
+    failed_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"])
+    assert failed_job is not None
+    assert failed_job["status"] == "failed"
+    assert not Path(job["temp_output_path"]).exists()
+    assert not work_dir.exists()
 
 
 def test_create_gopro_overlay_job_from_paths_sanitizes_output_filename_in_source_dir(


### PR DESCRIPTION
## Summary\n- clean GoPro overlay work directories and leftover part files when jobs finish terminally\n- add coverage for successful and failed renders\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend\n- targeted pytest/ruff/black checks for apps/backend/gopro_overlay_export.py and tests/api/test_gopro_overlay_endpoints.py\n\n## Review\n- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary files from GoPro overlay exports are now automatically cleaned up when jobs complete, fail, or are cancelled, preventing accumulation of temporary files.

* **Tests**
  * Added tests to verify cleanup behavior during successful job completion and process failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->