### PR TITLE
fix(frontend): reopen video export logs on remount

### DIFF
--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -54,6 +54,10 @@ vi.mock('react-i18next', () => ({
         'flights.viewer.cancelGenerationShort': 'Cancel generation',
         'flights.viewer.regenerateVideo': 'Restart generation',
         'flights.viewer.regenerateVideoShort': 'Regenerate video',
+        'videoJobs.liveLogs.title': 'Live logs',
+        'videoJobs.liveLogs.empty': 'No logs yet.',
+        'videoJobs.liveLogs.show': 'Show',
+        'videoJobs.liveLogs.hide': 'Hide',
       })[key] ?? key,
   }),
 }));
@@ -166,6 +170,29 @@ describe('FlightVideoExportControls', () => {
     await waitFor(() => {
       expect(apiDelete).toHaveBeenCalledWith('exports/job-running/cancel');
     });
+  });
+
+  it('reopens live logs when remounting with an active export', () => {
+    const { unmount } = render(
+      <FlightVideoExportControls flight={mockFlight} />
+    );
+
+    unmount();
+
+    mockFlight.video_export_status = 'running';
+    mockFlight.video_export_job_id = 'job-running';
+    exportStatusMock.current = {
+      job_id: 'job-running',
+      status: 'processing',
+      internal_status: 'encoding',
+      log_tail: ['Loading export viewer', 'Encoding with FFmpeg'],
+    };
+
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    expect(screen.getByText('Live logs')).toBeInTheDocument();
+    expect(screen.getByText('Hide')).toBeInTheDocument();
+    expect(screen.getByText(/Encoding with FFmpeg/u)).toBeInTheDocument();
   });
 
   it('does not show the download button for completed videos', () => {

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
@@ -116,7 +116,9 @@ export function FlightVideoExportControls({
   const [videoExportMode, setVideoExportMode] =
     useState<VideoExportMode>('manual_fast');
   const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
-  const [isLogsOpen, setIsLogsOpen] = useState(false);
+  const [isLogsOpen, setIsLogsOpen] = useState(() =>
+    hasActiveVideoExport(initialFlight)
+  );
   const [videoExportJobToken, setVideoExportJobToken] = useState<string | null>(
     null
   );
@@ -140,6 +142,12 @@ export function FlightVideoExportControls({
   const canResumeFailedVideoExport = Boolean(
     flight.video_export_status === 'failed' && canResumeVideoExport
   );
+
+  useEffect(() => {
+    if (isExportActive) {
+      setIsLogsOpen(true);
+    }
+  }, [flight.video_export_job_id, isExportActive]);
 
   useEffect(() => {
     if (!flight.id || !exportStatus?.internal_status) {


### PR DESCRIPTION
## Summary\n- reopen live video export logs when returning to an active flight page\n- keep logs panel rehydrated from the active export state\n- add a regression test for remounting with an active export\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightVideoExportControls.test.tsx\n- /home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,build --parallel=5 --exclude=e2e (build passed; lint hit pre-existing repo issues outside the touched files)\n\nCodeRabbit review passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video export live logs panel now automatically opens when an export becomes active
  * Live logs panel correctly initializes based on current export status, improving visibility of export progress

* **Tests**
  * Added coverage to verify live logs UI renders correctly during component remounting while an export is in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->