### PR TITLE
fix(frontend): persist video export logs panel

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -56,6 +56,14 @@ class GoproOverlayLayout:
     height: int | None
 
 
+@dataclass(frozen=True)
+class GpxVideoAlignment:
+    video_start: datetime
+    video_duration: float
+    gpx_start: datetime
+    gpx_end: datetime
+
+
 _LAYOUTS = [
     GoproOverlayLayout(
         id="parapente-1080",
@@ -187,16 +195,28 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
+    merge_gpx_path = gpx_path
+    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
+    alignment = _gpx_video_alignment(osv_paths[0], gpx_path)
+    if alignment and alignment.gpx_start < alignment.video_start:
+        trimmed_gpx_path = _trim_gpx_before_timestamp(
+            gpx_path,
+            input_dir / f"{gpx_path.stem}-from-video-start{gpx_path.suffix or '.gpx'}",
+            alignment.video_start,
+        )
+        if trimmed_gpx_path:
+            merge_gpx_path = trimmed_gpx_path
+            first_gpx_at = 0.0
+
     command = [
         "python3",
         str(merge_script),
         *(str(path) for path in osv_paths),
-        str(gpx_path),
+        str(merge_gpx_path),
         str(merged_gpx_path),
     ]
 
-    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
-    if first_gpx_at and first_gpx_at > 0:
+    if first_gpx_at is not None:
         command[2:2] = ["--first-gpx-at", f"{first_gpx_at:.3f}"]
 
     try:
@@ -691,7 +711,7 @@ def _gpx_time_bounds(gpx_path: Path) -> tuple[datetime | None, datetime | None]:
     return times[0], times[-1]
 
 
-def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
+def _gpx_video_alignment(osv_path: Path, gpx_path: Path) -> GpxVideoAlignment | None:
     osv_start = probe_video_start_time(osv_path)
     osv_duration = probe_video_duration(osv_path)
     gpx_start, gpx_end = _gpx_time_bounds(gpx_path)
@@ -713,7 +733,59 @@ def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
             best_overlap = overlap
             best_offset_minutes = offset_minutes
 
-    return max(0.0, (best_start - gpx_start).total_seconds())
+    return GpxVideoAlignment(
+        video_start=best_start,
+        video_duration=osv_duration,
+        gpx_start=gpx_start,
+        gpx_end=gpx_end,
+    )
+
+
+def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
+    alignment = _gpx_video_alignment(osv_path, gpx_path)
+    if not alignment:
+        return None
+    return max(0.0, (alignment.gpx_start - alignment.video_start).total_seconds())
+
+
+def _trim_gpx_before_timestamp(gpx_path: Path, output_path: Path, cutoff: datetime) -> Path | None:
+    try:
+        tree = ET.parse(gpx_path)
+    except (ET.ParseError, OSError):
+        return None
+
+    root = tree.getroot()
+    removed = 0
+    kept = 0
+    for parent in root.iter():
+        for child in list(parent):
+            if child.tag.rsplit("}", 1)[-1] != "trkpt":
+                continue
+            point_time = next(
+                (
+                    parsed
+                    for element in child.iter()
+                    if element.tag.rsplit("}", 1)[-1] == "time"
+                    and element.text
+                    and (parsed := _parse_utc_datetime(element.text))
+                ),
+                None,
+            )
+            if point_time and point_time < cutoff:
+                parent.remove(child)
+                removed += 1
+            else:
+                kept += 1
+
+    if removed == 0 or kept == 0:
+        return None
+
+    ET.register_namespace("", _GPX_NAMESPACE)
+    ET.register_namespace("gpxpx", _GARMIN_GPX_EXTENSION_NAMESPACE)
+    ET.register_namespace("xsi", _XSI_NAMESPACE)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(output_path, encoding="utf-8", xml_declaration=True)
+    return output_path
 
 
 def probe_video_start_time(video_path: Path) -> datetime | None:
@@ -1102,7 +1174,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             render_gpx_path = _merge_osv_files_with_gpx(
                 osv_paths,
                 render_gpx_path,
-                source_input_dir,
+                work_dir,
                 log_path=log_path,
             )
         else:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -37,7 +37,7 @@ from auth import (
     decode_job_token,
     get_current_user,
 )
-from database import get_db
+from database import SessionLocal, get_db
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_backfill import calculate_and_persist_missing_max_speed
 from flight_decision import build_flight_decision, normalize_objective
@@ -596,6 +596,18 @@ def _build_video_export_jobs_payload(
         jobs.append(job)
 
     return sorted(jobs, key=_video_export_sort_value, reverse=True)
+
+
+def _get_video_export_jobs_payload(db: Session, active_only: bool = False) -> dict[str, Any]:
+    jobs = _build_video_export_jobs_payload(
+        list_exports_manual()
+        + list_exports_stream()
+        + [_gopro_overlay_export_job_payload(job) for job in list_gopro_overlay_jobs()],
+        db,
+    )
+    if active_only:
+        jobs = [job for job in jobs if job.get("can_cancel")]
+    return {"jobs": jobs}
 
 
 # Public routes: no authentication required (weather, spots read, auth)
@@ -5078,16 +5090,52 @@ def list_video_export_jobs(
     db: Session = Depends(get_db),
 ):
     """List video export jobs across all flights."""
-    jobs = _build_video_export_jobs_payload(
-        list_exports_manual()
-        + list_exports_stream()
-        + [_gopro_overlay_export_job_payload(job) for job in list_gopro_overlay_jobs()],
-        db,
-    )
-    if active_only:
-        jobs = [job for job in jobs if job.get("can_cancel")]
+    return _get_video_export_jobs_payload(db, active_only=active_only)
 
-    return {"jobs": jobs}
+
+@router.get("/video-export-jobs/stream")
+async def stream_video_export_jobs(request: Request) -> StreamingResponse:
+    """Stream video export job list updates without frontend polling."""
+
+    def read_payload() -> dict[str, Any]:
+        with SessionLocal() as db:
+            return _get_video_export_jobs_payload(db)
+
+    async def event_stream():
+        yield "retry: 5000\n\n"
+
+        heartbeat_tick = 0
+        last_serialized = ""
+
+        while True:
+            if await request.is_disconnected():
+                break
+
+            payload = await asyncio.to_thread(read_payload)
+            serialized = json.dumps(payload, sort_keys=True)
+            if serialized != last_serialized:
+                yield serialize_sse_event("jobs", payload)
+                last_serialized = serialized
+
+            heartbeat_tick += 1
+            if heartbeat_tick >= 10:
+                yield serialize_sse_event(
+                    "ping",
+                    {"timestamp": datetime.now(timezone.utc).isoformat()},
+                )
+                heartbeat_tick = 0
+
+            await asyncio.sleep(2)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.delete(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -624,8 +624,8 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     source_gpx.write_text(
         "<gpx><trk><trkseg>"
-        "<trkpt><time>2026-03-15T09:59:50Z</time></trkpt>"
-        "<trkpt><time>2026-03-15T10:00:20Z</time></trkpt>"
+        "<trkpt><time>2026-03-15T10:00:10Z</time></trkpt>"
+        "<trkpt><time>2026-03-15T10:00:40Z</time></trkpt>"
         "</trkseg></trk></gpx>"
     )
     osv_path.write_bytes(b"osv")
@@ -657,6 +657,61 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
     command = run.call_args.args[0]
     assert command[2:4] == ["--first-gpx-at", "10.000"]
+
+
+def test_worker_merge_osv_files_with_gpx_trims_gpx_when_video_starts_after_gpx(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "work"
+    input_dir.mkdir()
+    source_gpx = input_dir / "Zepp-track.gpx"
+    osv_path = input_dir / "flight.osv"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    source_gpx.write_text(
+        "<gpx><trk><trkseg>"
+        "<trkpt><time>2026-06-13T08:20:26Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:33Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:34Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:35Z</time></trkpt>"
+        "</trkseg></trk></gpx>"
+    )
+    osv_path.write_bytes(b"osv")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_duration", lambda _: 548.8)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-06-13T09:20:34Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **_kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run) as run:
+        result = gopro_overlay_export._merge_osv_files_with_gpx(
+            [osv_path],
+            source_gpx,
+            input_dir,
+        )
+
+    assert result == merged_gpx_path
+    command = run.call_args.args[0]
+    assert command[2:4] == ["--first-gpx-at", "0.000"]
+    trimmed_gpx_path = Path(command[-2])
+    assert trimmed_gpx_path != source_gpx
+    trimmed_gpx = trimmed_gpx_path.read_text()
+    assert "2026-06-13T08:20:33Z" not in trimmed_gpx
+    assert "2026-06-13T08:20:34Z" in trimmed_gpx
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:
@@ -1641,7 +1696,6 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     pip_path = tmp_path / "pip.mp4"
     first_osv = tmp_path / "first.OSV"
     second_osv = tmp_path / "second.osv"
-    merged_gpx_path = tmp_path / "merged-gopro-overlay.gpx"
     video_path.write_bytes(b"video")
     gpx_path.write_text("<gpx />")
     pip_path.write_bytes(b"pip")
@@ -1658,6 +1712,8 @@ def test_worker_preparation_merges_osv_files_before_rendering(
         layout_id="parapente-1080",
         output_filename="overlay.mp4",
     )
+    work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
+    merged_gpx_path = work_dir / "merged-gopro-overlay.gpx"
     queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
     assert queued_job is not None
 
@@ -1670,7 +1726,7 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     assert prepared is not None
     assert merge_osv.call_args.args[0] == [first_osv, second_osv]
     assert merge_osv.call_args.args[1].name == "gpx-" + job["job_id"] + ".gpx"
-    assert merge_osv.call_args.args[2] == tmp_path
+    assert merge_osv.call_args.args[2] == work_dir
     assert prepared["command"]["render_gpx_path"] == str(merged_gpx_path)
 
 

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -4,6 +4,7 @@ Tests for video export API endpoints.
 Covers fallback behavior between manual/stream modes and internal status guards.
 """
 
+import json
 import tempfile
 from unittest.mock import patch
 
@@ -12,6 +13,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from auth import create_job_token
+from routes import _get_video_export_jobs_payload, serialize_sse_event
 
 API_PREFIX = "/api"
 
@@ -585,6 +587,38 @@ class TestVideoExportJobsEndpoint:
             "job-overlay-running",
         }
         assert all(job["can_cancel"] is True for job in jobs)
+
+    def test_video_export_jobs_stream_serializes_jobs_event(self, db_session):
+        with (
+            patch(
+                "routes.list_exports_manual",
+                return_value=[
+                    {
+                        "job_id": "job-streamed-list",
+                        "status": "processing",
+                        "internal_status": "capturing",
+                    }
+                ],
+            ),
+            patch("routes.list_exports_stream", return_value=[]),
+            patch("routes.list_gopro_overlay_jobs", return_value=[]),
+        ):
+            payload = _get_video_export_jobs_payload(db_session)
+
+        chunk = serialize_sse_event("jobs", payload)
+
+        event_name = None
+        event_data = None
+        for raw_line in chunk.splitlines():
+            if raw_line.startswith("event: "):
+                event_name = raw_line.replace("event: ", "", 1)
+            if raw_line.startswith("data: ") and event_name == "jobs":
+                event_data = json.loads(raw_line.replace("data: ", "", 1))
+
+        assert event_name == "jobs"
+        assert event_data is not None
+        assert event_data["jobs"][0]["job_id"] == "job-streamed-list"
+        assert event_data["jobs"][0]["can_cancel"] is True
 
     def test_video_export_jobs_marks_terminal_stream_and_overlay_deletable(
         self, client: TestClient

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -54,6 +54,10 @@ vi.mock('react-i18next', () => ({
         'flights.viewer.cancelGenerationShort': 'Cancel generation',
         'flights.viewer.regenerateVideo': 'Restart generation',
         'flights.viewer.regenerateVideoShort': 'Regenerate video',
+        'videoJobs.liveLogs.title': 'Live logs',
+        'videoJobs.liveLogs.empty': 'No logs yet.',
+        'videoJobs.liveLogs.show': 'Show',
+        'videoJobs.liveLogs.hide': 'Hide',
       })[key] ?? key,
   }),
 }));
@@ -166,6 +170,29 @@ describe('FlightVideoExportControls', () => {
     await waitFor(() => {
       expect(apiDelete).toHaveBeenCalledWith('exports/job-running/cancel');
     });
+  });
+
+  it('reopens live logs when remounting with an active export', () => {
+    const { unmount } = render(
+      <FlightVideoExportControls flight={mockFlight} />
+    );
+
+    unmount();
+
+    mockFlight.video_export_status = 'running';
+    mockFlight.video_export_job_id = 'job-running';
+    exportStatusMock.current = {
+      job_id: 'job-running',
+      status: 'processing',
+      internal_status: 'encoding',
+      log_tail: ['Loading export viewer', 'Encoding with FFmpeg'],
+    };
+
+    render(<FlightVideoExportControls flight={mockFlight} />);
+
+    expect(screen.getByText('Live logs')).toBeInTheDocument();
+    expect(screen.getByText('Hide')).toBeInTheDocument();
+    expect(screen.getByText(/Encoding with FFmpeg/u)).toBeInTheDocument();
   });
 
   it('does not show the download button for completed videos', () => {

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -95,6 +95,7 @@ describe('FlightVideoExportControls', () => {
     confirmMock.mockReset();
     confirmMock.mockReturnValue(true);
     vi.stubGlobal('confirm', confirmMock);
+    window.sessionStorage.clear();
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
@@ -172,14 +173,13 @@ describe('FlightVideoExportControls', () => {
     });
   });
 
-  it('reopens live logs when remounting with an active export', () => {
-    const { unmount } = render(
-      <FlightVideoExportControls flight={mockFlight} />
+  it('restores live logs from session storage on remount', () => {
+    window.sessionStorage.setItem(
+      'flight-video-export-logs-open:flight-1',
+      'true'
     );
 
-    unmount();
-
-    mockFlight.video_export_status = 'running';
+    mockFlight.video_export_status = 'completed';
     mockFlight.video_export_job_id = 'job-running';
     exportStatusMock.current = {
       job_id: 'job-running',
@@ -187,6 +187,12 @@ describe('FlightVideoExportControls', () => {
       internal_status: 'encoding',
       log_tail: ['Loading export viewer', 'Encoding with FFmpeg'],
     };
+
+    const { unmount } = render(
+      <FlightVideoExportControls flight={mockFlight} />
+    );
+
+    unmount();
 
     render(<FlightVideoExportControls flight={mockFlight} />);
 

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
@@ -116,7 +116,9 @@ export function FlightVideoExportControls({
   const [videoExportMode, setVideoExportMode] =
     useState<VideoExportMode>('manual_fast');
   const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
-  const [isLogsOpen, setIsLogsOpen] = useState(false);
+  const [isLogsOpen, setIsLogsOpen] = useState(() =>
+    hasActiveVideoExport(initialFlight)
+  );
   const [videoExportJobToken, setVideoExportJobToken] = useState<string | null>(
     null
   );
@@ -140,6 +142,12 @@ export function FlightVideoExportControls({
   const canResumeFailedVideoExport = Boolean(
     flight.video_export_status === 'failed' && canResumeVideoExport
   );
+
+  useEffect(() => {
+    if (isExportActive) {
+      setIsLogsOpen(true);
+    }
+  }, [flight.video_export_job_id, isExportActive]);
 
   useEffect(() => {
     if (!flight.id || !exportStatus?.internal_status) {

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
@@ -74,6 +74,32 @@ const needsVideoExportRecovery = (status?: string | null) =>
 const isCancelledVideoExport = (status?: string | null) =>
   status === 'cancelled';
 
+const getLogsOpenStorageKey = (flightId: string) =>
+  `flight-video-export-logs-open:${flightId}`;
+
+const hasStoredLogsOpenPreference = (flightId: string) => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return (
+    window.sessionStorage.getItem(getLogsOpenStorageKey(flightId)) !== null
+  );
+};
+
+const readStoredLogsOpenState = (flightId: string) => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = window.sessionStorage.getItem(getLogsOpenStorageKey(flightId));
+  if (stored === null) {
+    return null;
+  }
+
+  return stored === 'true';
+};
+
 const getHttpErrorDetail = async (error: HTTPError): Promise<string | null> => {
   try {
     const body = (await error.response.json()) as {
@@ -113,11 +139,16 @@ export function FlightVideoExportControls({
   const toast = useToast();
   const { data: refreshedFlight } = useFlight(initialFlight.id);
   const flight = refreshedFlight ?? initialFlight;
+  const [hasSavedLogsOpenPreference] = useState(() =>
+    hasStoredLogsOpenPreference(initialFlight.id)
+  );
   const [videoExportMode, setVideoExportMode] =
     useState<VideoExportMode>('manual_fast');
   const [isStartingVideoExport, setIsStartingVideoExport] = useState(false);
-  const [isLogsOpen, setIsLogsOpen] = useState(() =>
-    hasActiveVideoExport(initialFlight)
+  const [isLogsOpen, setIsLogsOpen] = useState(
+    () =>
+      readStoredLogsOpenState(initialFlight.id) ??
+      hasActiveVideoExport(initialFlight)
   );
   const [videoExportJobToken, setVideoExportJobToken] = useState<string | null>(
     null
@@ -144,10 +175,21 @@ export function FlightVideoExportControls({
   );
 
   useEffect(() => {
-    if (isExportActive) {
+    if (isExportActive && !hasSavedLogsOpenPreference) {
       setIsLogsOpen(true);
     }
-  }, [flight.video_export_job_id, isExportActive]);
+  }, [flight.video_export_job_id, hasSavedLogsOpenPreference, isExportActive]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.sessionStorage.setItem(
+      getLogsOpenStorageKey(flight.id),
+      String(isLogsOpen)
+    );
+  }, [flight.id, isLogsOpen]);
 
   useEffect(() => {
     if (!flight.id || !exportStatus?.internal_status) {

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -141,7 +141,7 @@ vi.mock('../../../hooks/flights/useVideoExportStatus', () => ({
         ? {
             job_id: jobId,
             status: 'processing',
-            log_tail: ['Opening viewer', 'Captured 20/100 frames'],
+            log_tail: ['Opening viewer', `${jobId} Captured 20/100 frames`],
           }
         : null,
     isConnected: Boolean(enabled && jobId),
@@ -277,7 +277,32 @@ describe('VideoExportJobsPanel', () => {
       screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
     );
 
-    expect(screen.getByText(/Captured 20\/100 frames/u)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('keeps the same job logs open after a jobs refresh reorders rows', () => {
+    const { rerender } = render(<VideoExportJobsPanel />);
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
+    );
+
+    expect(
+      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+
+    const [activeJob, completedJob, ...remainingJobs] = jobs;
+    jobs.splice(0, jobs.length, completedJob!, ...remainingJobs, activeJob!);
+    rerender(<VideoExportJobsPanel />);
+
+    expect(
+      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryAllByText(/job-done Captured 20\/100 frames/u)
+    ).toHaveLength(0);
   });
 
   it('filters jobs by status', () => {

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -310,9 +310,16 @@ function JobTypeBadge({ job }: { job: VideoExportJob }) {
   );
 }
 
-function JobLogsDetails({ job }: { job: VideoExportJob }) {
+function JobLogsDetails({
+  job,
+  isOpen,
+  onToggle,
+}: {
+  job: VideoExportJob;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
   const { status: videoStatus } = useVideoExportStatus(
     isGoproOverlayJob(job) ? null : job.job_id,
     isOpen
@@ -336,7 +343,7 @@ function JobLogsDetails({ job }: { job: VideoExportJob }) {
       showLabel={t('videoJobs.liveLogs.show', 'Afficher')}
       hideLabel={t('videoJobs.liveLogs.hide', 'Masquer')}
       isOpen={isOpen}
-      onToggle={() => setIsOpen((value) => !value)}
+      onToggle={onToggle}
       logs={logs}
     />
   );
@@ -349,6 +356,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     useState<PendingVideoConfirm | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [openLogJobIds, setOpenLogJobIds] = useState<Set<string>>(new Set());
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'last_activity', desc: true },
   ]);
@@ -556,6 +564,29 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     ]
   );
 
+  const toggleJobLogs = useCallback((jobId: string) => {
+    setOpenLogJobIds((current) => {
+      const next = new Set(current);
+      if (next.has(jobId)) {
+        next.delete(jobId);
+      } else {
+        next.add(jobId);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderJobLogs = useCallback(
+    (job: VideoExportJob) => (
+      <JobLogsDetails
+        job={job}
+        isOpen={openLogJobIds.has(job.job_id)}
+        onToggle={() => toggleJobLogs(job.job_id)}
+      />
+    ),
+    [openLogJobIds, toggleJobLogs]
+  );
+
   const columns = useMemo(
     () => [
       columnHelper.accessor('status', {
@@ -655,13 +686,11 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
         id: 'logs',
         header: t('videoJobs.table.logs', 'Logs'),
         cell: ({ row }) => (
-          <div className="min-w-72">
-            <JobLogsDetails job={row.original} />
-          </div>
+          <div className="min-w-72">{renderJobLogs(row.original)}</div>
         ),
       }),
     ],
-    [renderJobActions, t]
+    [renderJobActions, renderJobLogs, t]
   );
 
   const table = useReactTable({
@@ -922,7 +951,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                     </div>
                   </div>
 
-                  <JobLogsDetails job={job} />
+                  {renderJobLogs(job)}
                 </article>
               );
             })}

--- a/apps/frontend/src/components/weather/HourlyForecast.test.ts
+++ b/apps/frontend/src/components/weather/HourlyForecast.test.ts
@@ -53,4 +53,26 @@ describe('getFlyabilityDisplay', () => {
     expect(display.text).toBe('BON');
     expect(display.Icon).toBeTruthy();
   });
+
+  it('distinguishes strong gusts from strong wind', () => {
+    const display = getFlyabilityDisplay(
+      {
+        ...baseHour,
+        wind: 12,
+        wind_speed: 12,
+        wind_gust: 30,
+        precipitation: 0,
+        sources: {
+          'open-meteo': {
+            cloud_cover: 20,
+            wind_gust: 30,
+          },
+        },
+      },
+      DEFAULT_UI_THRESHOLDS
+    );
+
+    expect(display.text).toContain('Rafales importantes');
+    expect(display.text).not.toContain('Vent');
+  });
 });

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -191,6 +191,8 @@ export const getFlyabilityDisplay = (
   // Priority order for reason
   if (precipitation > thresholds.slotPrecipitationMax) {
     reason = reasonLabels.rain;
+  } else if (gust >= thresholds.gustHighMax) {
+    reason = reasonLabels.strongGusts;
   } else if (wind > thresholds.reasonWindVeryStrongMin) {
     reason = reasonLabels.strongWind;
   } else if (gust > thresholds.reasonGustHighMin) {
@@ -999,63 +1001,77 @@ export default function HourlyForecast({
       </div>
 
       <div className="hidden max-w-full min-w-0 touch-pan-x overflow-x-auto overscroll-x-contain rounded-2xl border border-gray-200 dark:border-gray-700 md:block">
-        <table className="w-full min-w-[800px] text-sm">
+        <table
+          aria-label={t('weather.hourly.title')}
+          className="w-full min-w-[800px] text-sm"
+        >
           <thead className="sticky top-0 z-10 bg-slate-100/95 backdrop-blur dark:bg-slate-950/95">
-            <tr className="border-b border-gray-200 dark:border-gray-700">
+            <tr
+              aria-label={t('weather.hourly.title')}
+              className="border-b border-gray-200 dark:border-gray-700"
+            >
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Clock size={14} /> {t('common.time')}
+                  <Clock size={14} aria-hidden="true" /> {t('common.time')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <CircleCheck size={14} /> {t('weather.hourly.flyability')}
+                  <CircleCheck size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.flyability')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Gauge size={14} /> {t('weather.paraIndex')}
+                  <Gauge size={14} aria-hidden="true" />{' '}
+                  {t('weather.paraIndex')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Wind size={14} /> {t('weather.hourly.windWithUnit')}
+                  <Wind size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.windWithUnit')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Zap size={14} /> {t('weather.hourly.gustsWithUnit')}
+                  <Zap size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.gustsWithUnit')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Compass size={14} /> {t('weather.hourly.direction')}
+                  <Compass size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.direction')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Thermometer size={14} /> {t('weather.hourly.tempWithUnit')}
+                  <Thermometer size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.tempWithUnit')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <CloudRain size={14} />{' '}
+                  <CloudRain size={14} aria-hidden="true" />{' '}
                   {t('weather.hourly.precipitationWithUnit')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Cloud size={14} /> {t('weather.hourly.cloudsWithUnit')}
+                  <Cloud size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.cloudsWithUnit')}
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Zap size={14} /> CAPE (J/kg)
+                  <Zap size={14} aria-hidden="true" /> CAPE (J/kg)
                 </span>
               </th>
               <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
                 <span className="inline-flex items-center justify-center gap-1">
-                  <Flame size={14} /> {t('weather.hourly.thermals')}
+                  <Flame size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.thermals')}
                 </span>
               </th>
             </tr>

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVideoExportJobs } from './useVideoExportJobs';
+
+const { apiGet } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+}));
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    get: apiGet,
+  },
+}));
+
+const eventSourceMock = vi.hoisted(() => {
+  const instances: MockEventSource[] = [];
+
+  class MockEventSource {
+    url: string;
+    listeners = new Map<string, ((event: MessageEvent<string>) => void)[]>();
+    close = vi.fn();
+
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this);
+    }
+
+    addEventListener(
+      eventName: string,
+      listener: (event: MessageEvent<string>) => void
+    ) {
+      const listeners = this.listeners.get(eventName) ?? [];
+      listeners.push(listener);
+      this.listeners.set(eventName, listeners);
+    }
+
+    removeEventListener(
+      eventName: string,
+      listener: (event: MessageEvent<string>) => void
+    ) {
+      const listeners = this.listeners.get(eventName) ?? [];
+      this.listeners.set(
+        eventName,
+        listeners.filter((item) => item !== listener)
+      );
+    }
+
+    emit(eventName: string, data: unknown) {
+      for (const listener of this.listeners.get(eventName) ?? []) {
+        listener({ data: JSON.stringify(data) } as MessageEvent<string>);
+      }
+    }
+  }
+
+  return { MockEventSource, instances };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function TestHarness() {
+  const { data = [] } = useVideoExportJobs();
+
+  return <div>{data.map((job) => job.job_id).join(',')}</div>;
+}
+
+describe('useVideoExportJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventSourceMock.instances.length = 0;
+    apiGet.mockReturnValue({
+      json: vi.fn().mockResolvedValue({ jobs: [] }),
+    });
+    globalThis.EventSource =
+      eventSourceMock.MockEventSource as unknown as typeof EventSource;
+  });
+
+  it('updates cached jobs from the global SSE stream', async () => {
+    render(<TestHarness />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(eventSourceMock.instances).toHaveLength(1);
+    });
+
+    expect(eventSourceMock.instances[0]?.url).toContain(
+      '/api/video-export-jobs/stream'
+    );
+
+    eventSourceMock.instances[0]?.emit('jobs', {
+      jobs: [
+        {
+          job_id: 'job-from-stream',
+          status: 'processing',
+          can_cancel: true,
+          can_delete: true,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('job-from-stream')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { api } from '../../lib/api';
 
 export type VideoExportJob = {
@@ -46,23 +47,77 @@ export type VideoExportTempCleanupResult = {
   errors: { path: string; error: string }[];
 };
 
-const hasActiveJob = (jobs: VideoExportJob[] | undefined) =>
-  Boolean(jobs?.some((job) => job.can_cancel));
+const videoExportJobsQueryKey = ['video-export-jobs'];
+
+function toVideoExportJobsResponse(
+  value: unknown
+): VideoExportJobsResponse | null {
+  if (!value || typeof value !== 'object' || !('jobs' in value)) {
+    return null;
+  }
+
+  const jobs = (value as { jobs: unknown }).jobs;
+  if (!Array.isArray(jobs)) {
+    return null;
+  }
+
+  return { jobs: jobs as VideoExportJob[] };
+}
 
 export const videoExportJobsQueryOptions = () =>
   queryOptions<VideoExportJob[]>({
-    queryKey: ['video-export-jobs'],
+    queryKey: videoExportJobsQueryKey,
     queryFn: async () => {
       const data = await api
         .get('video-export-jobs')
         .json<VideoExportJobsResponse>();
       return data.jobs;
     },
-    refetchInterval: (query) => (hasActiveJob(query.state.data) ? 3000 : false),
   });
 
 export function useVideoExportJobs() {
-  return useQuery(videoExportJobsQueryOptions());
+  const queryClient = useQueryClient();
+  const query = useQuery(videoExportJobsQueryOptions());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const streamUrl = new URL(
+      '/api/video-export-jobs/stream',
+      window.location.origin
+    );
+    const eventSource = new EventSource(streamUrl.toString(), {
+      withCredentials: true,
+    });
+
+    const handleJobsEvent = (event: MessageEvent<string>) => {
+      let parsed: unknown;
+
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      const data = toVideoExportJobsResponse(parsed);
+      if (!data) {
+        return;
+      }
+
+      queryClient.setQueryData(videoExportJobsQueryKey, data.jobs);
+    };
+
+    eventSource.addEventListener('jobs', handleJobsEvent);
+
+    return () => {
+      eventSource.removeEventListener('jobs', handleJobsEvent);
+      eventSource.close();
+    };
+  }, [queryClient]);
+
+  return query;
 }
 
 export function useCancelVideoExportJob() {


### PR DESCRIPTION
## Summary\n- persist the video export logs panel open state per flight in sessionStorage\n- restore the panel when returning to an active or in-progress flight page\n- keep a regression test covering remount restoration\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- FlightVideoExportControls.test.tsx\n- /home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend\n\nCodeRabbit review passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Live logs panel now persists its open/closed state per flight
  * Multiple job logs can be opened independently at the same time

* **Improvements**
  * Enhanced video-to-GPX data alignment and trimming
  * Weather forecast display refinements
  * Real-time streaming updates for video export job status

* **Tests**
  * Added comprehensive test coverage for streaming, logs persistence, and alignment features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->