### PR TITLE
fix(infrastructure): replace video export polling with SSE

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -37,7 +37,7 @@ from auth import (
     decode_job_token,
     get_current_user,
 )
-from database import get_db
+from database import SessionLocal, get_db
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_backfill import calculate_and_persist_missing_max_speed
 from flight_decision import build_flight_decision, normalize_objective
@@ -596,6 +596,18 @@ def _build_video_export_jobs_payload(
         jobs.append(job)
 
     return sorted(jobs, key=_video_export_sort_value, reverse=True)
+
+
+def _get_video_export_jobs_payload(db: Session, active_only: bool = False) -> dict[str, Any]:
+    jobs = _build_video_export_jobs_payload(
+        list_exports_manual()
+        + list_exports_stream()
+        + [_gopro_overlay_export_job_payload(job) for job in list_gopro_overlay_jobs()],
+        db,
+    )
+    if active_only:
+        jobs = [job for job in jobs if job.get("can_cancel")]
+    return {"jobs": jobs}
 
 
 # Public routes: no authentication required (weather, spots read, auth)
@@ -5078,16 +5090,52 @@ def list_video_export_jobs(
     db: Session = Depends(get_db),
 ):
     """List video export jobs across all flights."""
-    jobs = _build_video_export_jobs_payload(
-        list_exports_manual()
-        + list_exports_stream()
-        + [_gopro_overlay_export_job_payload(job) for job in list_gopro_overlay_jobs()],
-        db,
-    )
-    if active_only:
-        jobs = [job for job in jobs if job.get("can_cancel")]
+    return _get_video_export_jobs_payload(db, active_only=active_only)
 
-    return {"jobs": jobs}
+
+@router.get("/video-export-jobs/stream")
+async def stream_video_export_jobs(request: Request) -> StreamingResponse:
+    """Stream video export job list updates without frontend polling."""
+
+    def read_payload() -> dict[str, Any]:
+        with SessionLocal() as db:
+            return _get_video_export_jobs_payload(db)
+
+    async def event_stream():
+        yield "retry: 5000\n\n"
+
+        heartbeat_tick = 0
+        last_serialized = ""
+
+        while True:
+            if await request.is_disconnected():
+                break
+
+            payload = await asyncio.to_thread(read_payload)
+            serialized = json.dumps(payload, sort_keys=True)
+            if serialized != last_serialized:
+                yield serialize_sse_event("jobs", payload)
+                last_serialized = serialized
+
+            heartbeat_tick += 1
+            if heartbeat_tick >= 10:
+                yield serialize_sse_event(
+                    "ping",
+                    {"timestamp": datetime.now(timezone.utc).isoformat()},
+                )
+                heartbeat_tick = 0
+
+            await asyncio.sleep(2)
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.delete(

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -4,6 +4,7 @@ Tests for video export API endpoints.
 Covers fallback behavior between manual/stream modes and internal status guards.
 """
 
+import json
 import tempfile
 from unittest.mock import patch
 
@@ -12,6 +13,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from auth import create_job_token
+from routes import _get_video_export_jobs_payload, serialize_sse_event
 
 API_PREFIX = "/api"
 
@@ -585,6 +587,38 @@ class TestVideoExportJobsEndpoint:
             "job-overlay-running",
         }
         assert all(job["can_cancel"] is True for job in jobs)
+
+    def test_video_export_jobs_stream_serializes_jobs_event(self, db_session):
+        with (
+            patch(
+                "routes.list_exports_manual",
+                return_value=[
+                    {
+                        "job_id": "job-streamed-list",
+                        "status": "processing",
+                        "internal_status": "capturing",
+                    }
+                ],
+            ),
+            patch("routes.list_exports_stream", return_value=[]),
+            patch("routes.list_gopro_overlay_jobs", return_value=[]),
+        ):
+            payload = _get_video_export_jobs_payload(db_session)
+
+        chunk = serialize_sse_event("jobs", payload)
+
+        event_name = None
+        event_data = None
+        for raw_line in chunk.splitlines():
+            if raw_line.startswith("event: "):
+                event_name = raw_line.replace("event: ", "", 1)
+            if raw_line.startswith("data: ") and event_name == "jobs":
+                event_data = json.loads(raw_line.replace("data: ", "", 1))
+
+        assert event_name == "jobs"
+        assert event_data is not None
+        assert event_data["jobs"][0]["job_id"] == "job-streamed-list"
+        assert event_data["jobs"][0]["can_cancel"] is True
 
     def test_video_export_jobs_marks_terminal_stream_and_overlay_deletable(
         self, client: TestClient

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -141,7 +141,7 @@ vi.mock('../../../hooks/flights/useVideoExportStatus', () => ({
         ? {
             job_id: jobId,
             status: 'processing',
-            log_tail: ['Opening viewer', 'Captured 20/100 frames'],
+            log_tail: ['Opening viewer', `${jobId} Captured 20/100 frames`],
           }
         : null,
     isConnected: Boolean(enabled && jobId),
@@ -277,7 +277,32 @@ describe('VideoExportJobsPanel', () => {
       screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
     );
 
-    expect(screen.getByText(/Captured 20\/100 frames/u)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('keeps the same job logs open after a jobs refresh reorders rows', () => {
+    const { rerender } = render(<VideoExportJobsPanel />);
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
+    );
+
+    expect(
+      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+
+    const [activeJob, completedJob, ...remainingJobs] = jobs;
+    jobs.splice(0, jobs.length, completedJob!, ...remainingJobs, activeJob!);
+    rerender(<VideoExportJobsPanel />);
+
+    expect(
+      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryAllByText(/job-done Captured 20\/100 frames/u)
+    ).toHaveLength(0);
   });
 
   it('filters jobs by status', () => {

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -310,9 +310,16 @@ function JobTypeBadge({ job }: { job: VideoExportJob }) {
   );
 }
 
-function JobLogsDetails({ job }: { job: VideoExportJob }) {
+function JobLogsDetails({
+  job,
+  isOpen,
+  onToggle,
+}: {
+  job: VideoExportJob;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
   const { status: videoStatus } = useVideoExportStatus(
     isGoproOverlayJob(job) ? null : job.job_id,
     isOpen
@@ -336,7 +343,7 @@ function JobLogsDetails({ job }: { job: VideoExportJob }) {
       showLabel={t('videoJobs.liveLogs.show', 'Afficher')}
       hideLabel={t('videoJobs.liveLogs.hide', 'Masquer')}
       isOpen={isOpen}
-      onToggle={() => setIsOpen((value) => !value)}
+      onToggle={onToggle}
       logs={logs}
     />
   );
@@ -349,6 +356,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     useState<PendingVideoConfirm | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [openLogJobIds, setOpenLogJobIds] = useState<Set<string>>(new Set());
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'last_activity', desc: true },
   ]);
@@ -556,6 +564,29 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     ]
   );
 
+  const toggleJobLogs = useCallback((jobId: string) => {
+    setOpenLogJobIds((current) => {
+      const next = new Set(current);
+      if (next.has(jobId)) {
+        next.delete(jobId);
+      } else {
+        next.add(jobId);
+      }
+      return next;
+    });
+  }, []);
+
+  const renderJobLogs = useCallback(
+    (job: VideoExportJob) => (
+      <JobLogsDetails
+        job={job}
+        isOpen={openLogJobIds.has(job.job_id)}
+        onToggle={() => toggleJobLogs(job.job_id)}
+      />
+    ),
+    [openLogJobIds, toggleJobLogs]
+  );
+
   const columns = useMemo(
     () => [
       columnHelper.accessor('status', {
@@ -655,13 +686,11 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
         id: 'logs',
         header: t('videoJobs.table.logs', 'Logs'),
         cell: ({ row }) => (
-          <div className="min-w-72">
-            <JobLogsDetails job={row.original} />
-          </div>
+          <div className="min-w-72">{renderJobLogs(row.original)}</div>
         ),
       }),
     ],
-    [renderJobActions, t]
+    [renderJobActions, renderJobLogs, t]
   );
 
   const table = useReactTable({
@@ -922,7 +951,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                     </div>
                   </div>
 
-                  <JobLogsDetails job={job} />
+                  {renderJobLogs(job)}
                 </article>
               );
             })}

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVideoExportJobs } from './useVideoExportJobs';
+
+const { apiGet } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+}));
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    get: apiGet,
+  },
+}));
+
+const eventSourceMock = vi.hoisted(() => {
+  const instances: MockEventSource[] = [];
+
+  class MockEventSource {
+    url: string;
+    listeners = new Map<string, ((event: MessageEvent<string>) => void)[]>();
+    close = vi.fn();
+
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this);
+    }
+
+    addEventListener(
+      eventName: string,
+      listener: (event: MessageEvent<string>) => void
+    ) {
+      const listeners = this.listeners.get(eventName) ?? [];
+      listeners.push(listener);
+      this.listeners.set(eventName, listeners);
+    }
+
+    removeEventListener(
+      eventName: string,
+      listener: (event: MessageEvent<string>) => void
+    ) {
+      const listeners = this.listeners.get(eventName) ?? [];
+      this.listeners.set(
+        eventName,
+        listeners.filter((item) => item !== listener)
+      );
+    }
+
+    emit(eventName: string, data: unknown) {
+      for (const listener of this.listeners.get(eventName) ?? []) {
+        listener({ data: JSON.stringify(data) } as MessageEvent<string>);
+      }
+    }
+  }
+
+  return { MockEventSource, instances };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function TestHarness() {
+  const { data = [] } = useVideoExportJobs();
+
+  return <div>{data.map((job) => job.job_id).join(',')}</div>;
+}
+
+describe('useVideoExportJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    eventSourceMock.instances.length = 0;
+    apiGet.mockReturnValue({
+      json: vi.fn().mockResolvedValue({ jobs: [] }),
+    });
+    globalThis.EventSource =
+      eventSourceMock.MockEventSource as unknown as typeof EventSource;
+  });
+
+  it('updates cached jobs from the global SSE stream', async () => {
+    render(<TestHarness />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(eventSourceMock.instances).toHaveLength(1);
+    });
+
+    expect(eventSourceMock.instances[0]?.url).toContain(
+      '/api/video-export-jobs/stream'
+    );
+
+    eventSourceMock.instances[0]?.emit('jobs', {
+      jobs: [
+        {
+          job_id: 'job-from-stream',
+          status: 'processing',
+          can_cancel: true,
+          can_delete: true,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('job-from-stream')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -4,6 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { api } from '../../lib/api';
 
 export type VideoExportJob = {
@@ -46,23 +47,77 @@ export type VideoExportTempCleanupResult = {
   errors: { path: string; error: string }[];
 };
 
-const hasActiveJob = (jobs: VideoExportJob[] | undefined) =>
-  Boolean(jobs?.some((job) => job.can_cancel));
+const videoExportJobsQueryKey = ['video-export-jobs'];
+
+function toVideoExportJobsResponse(
+  value: unknown
+): VideoExportJobsResponse | null {
+  if (!value || typeof value !== 'object' || !('jobs' in value)) {
+    return null;
+  }
+
+  const jobs = (value as { jobs: unknown }).jobs;
+  if (!Array.isArray(jobs)) {
+    return null;
+  }
+
+  return { jobs: jobs as VideoExportJob[] };
+}
 
 export const videoExportJobsQueryOptions = () =>
   queryOptions<VideoExportJob[]>({
-    queryKey: ['video-export-jobs'],
+    queryKey: videoExportJobsQueryKey,
     queryFn: async () => {
       const data = await api
         .get('video-export-jobs')
         .json<VideoExportJobsResponse>();
       return data.jobs;
     },
-    refetchInterval: (query) => (hasActiveJob(query.state.data) ? 3000 : false),
   });
 
 export function useVideoExportJobs() {
-  return useQuery(videoExportJobsQueryOptions());
+  const queryClient = useQueryClient();
+  const query = useQuery(videoExportJobsQueryOptions());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const streamUrl = new URL(
+      '/api/video-export-jobs/stream',
+      window.location.origin
+    );
+    const eventSource = new EventSource(streamUrl.toString(), {
+      withCredentials: true,
+    });
+
+    const handleJobsEvent = (event: MessageEvent<string>) => {
+      let parsed: unknown;
+
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+
+      const data = toVideoExportJobsResponse(parsed);
+      if (!data) {
+        return;
+      }
+
+      queryClient.setQueryData(videoExportJobsQueryKey, data.jobs);
+    };
+
+    eventSource.addEventListener('jobs', handleJobsEvent);
+
+    return () => {
+      eventSource.removeEventListener('jobs', handleJobsEvent);
+      eventSource.close();
+    };
+  }, [queryClient]);
+
+  return query;
 }
 
 export function useCancelVideoExportJob() {


### PR DESCRIPTION
## Summary\n- Replace video export polling with a global SSE stream\n- Preserve live log panels by job id across refreshes\n- Add backend/frontend tests for the stream and UI persistence\n\n## Validation\n- nx test frontend -- src/hooks/flights/useVideoExportJobs.test.tsx src/components/flights/video-export/VideoExportJobsPanel.test.tsx\n- ../../.venv/bin/pytest tests/api/test_video_export_endpoints.py -q --tb=short --no-header\n- nx lint backend\n- nx build frontend\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time video export job status updates via server-sent events, replacing interval-based polling for more responsive and efficient refreshes.

* **Improvements**
  * Job logs panel state (open/collapsed) is now preserved when the job list refreshes, enhancing user experience.

* **Tests**
  * Added comprehensive test coverage for video export streaming functionality and UI state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->