### PR TITLE
fix(gopro-overlay): align merged gpx to video start

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -56,6 +56,14 @@ class GoproOverlayLayout:
     height: int | None
 
 
+@dataclass(frozen=True)
+class GpxVideoAlignment:
+    video_start: datetime
+    video_duration: float
+    gpx_start: datetime
+    gpx_end: datetime
+
+
 _LAYOUTS = [
     GoproOverlayLayout(
         id="parapente-1080",
@@ -187,16 +195,28 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
+    merge_gpx_path = gpx_path
+    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
+    alignment = _gpx_video_alignment(osv_paths[0], gpx_path)
+    if alignment and alignment.gpx_start < alignment.video_start:
+        trimmed_gpx_path = _trim_gpx_before_timestamp(
+            gpx_path,
+            input_dir / f"{gpx_path.stem}-from-video-start{gpx_path.suffix or '.gpx'}",
+            alignment.video_start,
+        )
+        if trimmed_gpx_path:
+            merge_gpx_path = trimmed_gpx_path
+            first_gpx_at = 0.0
+
     command = [
         "python3",
         str(merge_script),
         *(str(path) for path in osv_paths),
-        str(gpx_path),
+        str(merge_gpx_path),
         str(merged_gpx_path),
     ]
 
-    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
-    if first_gpx_at and first_gpx_at > 0:
+    if first_gpx_at is not None:
         command[2:2] = ["--first-gpx-at", f"{first_gpx_at:.3f}"]
 
     try:
@@ -691,7 +711,7 @@ def _gpx_time_bounds(gpx_path: Path) -> tuple[datetime | None, datetime | None]:
     return times[0], times[-1]
 
 
-def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
+def _gpx_video_alignment(osv_path: Path, gpx_path: Path) -> GpxVideoAlignment | None:
     osv_start = probe_video_start_time(osv_path)
     osv_duration = probe_video_duration(osv_path)
     gpx_start, gpx_end = _gpx_time_bounds(gpx_path)
@@ -713,7 +733,59 @@ def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
             best_overlap = overlap
             best_offset_minutes = offset_minutes
 
-    return max(0.0, (best_start - gpx_start).total_seconds())
+    return GpxVideoAlignment(
+        video_start=best_start,
+        video_duration=osv_duration,
+        gpx_start=gpx_start,
+        gpx_end=gpx_end,
+    )
+
+
+def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
+    alignment = _gpx_video_alignment(osv_path, gpx_path)
+    if not alignment:
+        return None
+    return max(0.0, (alignment.gpx_start - alignment.video_start).total_seconds())
+
+
+def _trim_gpx_before_timestamp(gpx_path: Path, output_path: Path, cutoff: datetime) -> Path | None:
+    try:
+        tree = ET.parse(gpx_path)
+    except (ET.ParseError, OSError):
+        return None
+
+    root = tree.getroot()
+    removed = 0
+    kept = 0
+    for parent in root.iter():
+        for child in list(parent):
+            if child.tag.rsplit("}", 1)[-1] != "trkpt":
+                continue
+            point_time = next(
+                (
+                    parsed
+                    for element in child.iter()
+                    if element.tag.rsplit("}", 1)[-1] == "time"
+                    and element.text
+                    and (parsed := _parse_utc_datetime(element.text))
+                ),
+                None,
+            )
+            if point_time and point_time < cutoff:
+                parent.remove(child)
+                removed += 1
+            else:
+                kept += 1
+
+    if removed == 0 or kept == 0:
+        return None
+
+    ET.register_namespace("", _GPX_NAMESPACE)
+    ET.register_namespace("gpxpx", _GARMIN_GPX_EXTENSION_NAMESPACE)
+    ET.register_namespace("xsi", _XSI_NAMESPACE)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(output_path, encoding="utf-8", xml_declaration=True)
+    return output_path
 
 
 def probe_video_start_time(video_path: Path) -> datetime | None:
@@ -1102,7 +1174,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             render_gpx_path = _merge_osv_files_with_gpx(
                 osv_paths,
                 render_gpx_path,
-                source_input_dir,
+                work_dir,
                 log_path=log_path,
             )
         else:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -624,8 +624,8 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
     source_gpx.write_text(
         "<gpx><trk><trkseg>"
-        "<trkpt><time>2026-03-15T09:59:50Z</time></trkpt>"
-        "<trkpt><time>2026-03-15T10:00:20Z</time></trkpt>"
+        "<trkpt><time>2026-03-15T10:00:10Z</time></trkpt>"
+        "<trkpt><time>2026-03-15T10:00:40Z</time></trkpt>"
         "</trkseg></trk></gpx>"
     )
     osv_path.write_bytes(b"osv")
@@ -657,6 +657,61 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
     command = run.call_args.args[0]
     assert command[2:4] == ["--first-gpx-at", "10.000"]
+
+
+def test_worker_merge_osv_files_with_gpx_trims_gpx_when_video_starts_after_gpx(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "work"
+    input_dir.mkdir()
+    source_gpx = input_dir / "Zepp-track.gpx"
+    osv_path = input_dir / "flight.osv"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    source_gpx.write_text(
+        "<gpx><trk><trkseg>"
+        "<trkpt><time>2026-06-13T08:20:26Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:33Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:34Z</time></trkpt>"
+        "<trkpt><time>2026-06-13T08:20:35Z</time></trkpt>"
+        "</trkseg></trk></gpx>"
+    )
+    osv_path.write_bytes(b"osv")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_duration", lambda _: 548.8)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-06-13T09:20:34Z"),
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **_kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run) as run:
+        result = gopro_overlay_export._merge_osv_files_with_gpx(
+            [osv_path],
+            source_gpx,
+            input_dir,
+        )
+
+    assert result == merged_gpx_path
+    command = run.call_args.args[0]
+    assert command[2:4] == ["--first-gpx-at", "0.000"]
+    trimmed_gpx_path = Path(command[-2])
+    assert trimmed_gpx_path != source_gpx
+    trimmed_gpx = trimmed_gpx_path.read_text()
+    assert "2026-06-13T08:20:33Z" not in trimmed_gpx
+    assert "2026-06-13T08:20:34Z" in trimmed_gpx
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:
@@ -1641,7 +1696,6 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     pip_path = tmp_path / "pip.mp4"
     first_osv = tmp_path / "first.OSV"
     second_osv = tmp_path / "second.osv"
-    merged_gpx_path = tmp_path / "merged-gopro-overlay.gpx"
     video_path.write_bytes(b"video")
     gpx_path.write_text("<gpx />")
     pip_path.write_bytes(b"pip")
@@ -1658,6 +1712,8 @@ def test_worker_preparation_merges_osv_files_before_rendering(
         layout_id="parapente-1080",
         output_filename="overlay.mp4",
     )
+    work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
+    merged_gpx_path = work_dir / "merged-gopro-overlay.gpx"
     queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
     assert queued_job is not None
 
@@ -1670,7 +1726,7 @@ def test_worker_preparation_merges_osv_files_before_rendering(
     assert prepared is not None
     assert merge_osv.call_args.args[0] == [first_osv, second_osv]
     assert merge_osv.call_args.args[1].name == "gpx-" + job["job_id"] + ".gpx"
-    assert merge_osv.call_args.args[2] == tmp_path
+    assert merge_osv.call_args.args[2] == work_dir
     assert prepared["command"]["render_gpx_path"] == str(merged_gpx_path)
 
 


### PR DESCRIPTION
## What\n- trim the merged GPX when the GPX starts before the rendered video timeline\n- keep the merged GPX and temporary prep files inside the job workdir\n- add regression coverage for the 13/06 flight offset case\n\n## Validation\n- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py -k 'merge_osv_files_with_gpx or preparation_merges_osv_files or run_job_cleans_temp_files'\n- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend --skip-nx-cache\n- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic alignment detection between GPX data and video timestamps for improved overlay accuracy.
  * GPX points occurring before video start are now automatically trimmed during merge operations to eliminate unnecessary data.

* **Tests**
  * Extended test coverage for new GPX trimming and alignment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->