### PR TITLE
fix(gopro-overlay): avoid copying large video inputs

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1138,6 +1138,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         current_job = _update_job(
             job_id,
             status=_STATUS_PREPARING,
+            progress=5,
             message="Preparing overlay files",
         )
         if not current_job or current_job.get("status") != _STATUS_PREPARING:
@@ -1150,27 +1151,18 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         render_gpx_path = gpx_path
 
         if metadata.get("pin_inputs"):
-            _append_job_log(log_path, "Pinning overlay input files")
-            video_path = _copy_job_input(
-                video_path,
-                work_dir / f"input{video_path.suffix.lower()}",
-                _VIDEO_EXTENSIONS,
-            )
+            _append_job_log(log_path, "Pinning GPX input file")
+            _update_job(job_id, progress=7, message="Preparing GPX input")
             render_gpx_path = _copy_job_input(
                 gpx_path,
                 work_dir / f"gpx-{job_id}{gpx_path.suffix.lower()}",
                 _GPX_EXTENSIONS,
             )
-            if pip_path:
-                pip_path = _copy_job_input(
-                    pip_path,
-                    work_dir / f"pip{pip_path.suffix.lower()}",
-                    _VIDEO_EXTENSIONS,
-                )
 
         source_input_dir = Path(str(job["output_path"])).parent
         osv_paths = _matching_files_by_mtime(source_input_dir, "*.osv")
         if osv_paths:
+            _update_job(job_id, progress=10, message="Merging OSV telemetry")
             render_gpx_path = _merge_osv_files_with_gpx(
                 osv_paths,
                 render_gpx_path,
@@ -1184,6 +1176,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         _append_job_log(log_path, f"Render GPX: {render_gpx_path.name}")
 
         if pip_path:
+            _update_job(job_id, progress=15, message="Preparing PIP video")
             pip_path = _prepare_pip_video_for_overlay(
                 job_id,
                 video_path,
@@ -1196,6 +1189,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
             _append_job_log(log_path, "No PIP video configured")
 
         width, height = probe_video_resolution(video_path)
+        _update_job(job_id, progress=20, message="Preparing overlay layout")
         requested_layout_id = metadata.get("requested_layout_id")
         selected_layout = (
             _find_layout(str(requested_layout_id))

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1619,10 +1619,9 @@ def test_create_gopro_overlay_job_from_paths_defers_input_copy_to_worker_prepara
 
     assert prepared is not None
     assert prepared["status"] == "queued"
-    assert Path(prepared["video_path"]).parent == work_dir
+    assert Path(prepared["video_path"]) == video_path
     assert Path(prepared["gpx_path"]) == gpx_path
     assert Path(prepared["command"]["render_gpx_path"]).parent == work_dir
-    assert Path(prepared["video_path"]).read_bytes() == b"video"
     assert Path(prepared["command"]["render_gpx_path"]).read_text() == "<gpx />"
     assert prepared["video_width"] == 1920
     assert prepared["video_height"] == 1080
@@ -2000,7 +1999,7 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
     assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
     assert command[command.index("--overlay-size") + 1] == "1920x1080"
-    assert Path(command[-2]).parent == work_dir
+    assert Path(command[-2]) == video_path
     assert Path(command[-1]) == Path(job["temp_output_path"])
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
     assert Path(job["output_path"]).read_bytes() == b"video"


### PR DESCRIPTION
## What\n- stop copying large MP4/PIP inputs into the GoPro overlay workdir during preparation\n- keep pinning the small GPX input only\n- add preparation progress updates before GPX copy, OSV merge, PIP prep, and layout prep\n\n## Why\nRecent overlay jobs appeared stuck at 0% because preparation was copying multi-GB video files before rendering started. On the 2026-06-13 flight, a workdir had only a partial 2.8GB input.mp4 and no render progress yet.\n\n## Validation\n- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend --skip-nx-cache\n- CodeRabbit: no findings