### PR TITLE
fix(gopro-overlay): rely on absolute osv merge timing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,8 +151,8 @@ BACKEND_FRONTEND_URL=http://localhost:5173
 
 # Host folders mounted at fixed backend container paths.
 # GOPRO_OVERLAY_DATA_HOST_DIR is mounted at /app/parapente.
-# GOPRO_OVERLAY_HOST_DIR is mounted at /app/gopro-overlay.
-GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+# GOPRO_OVERLAY_BUILD_CONTEXT is copied into the image at /app/gopro-overlay.
+GOPRO_OVERLAY_BUILD_CONTEXT=https://github.com/capic2/gopro-dashboard-overlay.git#main
 GOPRO_OVERLAY_DATA_HOST_DIR=/media/nas/DS211_Synology_2/parapente
 
 # Deployment version state file (required, no application default).

--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Verify GoPro overlay build context
         env:
-          GOPRO_OVERLAY_BUILD_CONTEXT: ${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT }}
+          GOPRO_OVERLAY_BUILD_CONTEXT: ${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT || 'https://github.com/capic2/gopro-dashboard-overlay.git#main' }}
         run: |
           if [ -z "$GOPRO_OVERLAY_BUILD_CONTEXT" ]; then
             echo "Missing repository variable GOPRO_OVERLAY_BUILD_CONTEXT"
@@ -193,7 +193,7 @@ jobs:
           build-args: |
             VITE_CESIUM_ION_TOKEN=${{ secrets.VITE_CESIUM_ION_TOKEN }}
           build-contexts: |
-            gopro-overlay-src=${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT }}
+            gopro-overlay-src=${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT || 'https://github.com/capic2/gopro-dashboard-overlay.git#main' }}
           tags: |
             ghcr.io/${{ github.repository }}/backend:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/backend:main

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -195,7 +195,6 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
-    first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
     command = [
         "python3",
         str(merge_script),
@@ -203,9 +202,6 @@ def _merge_osv_files_with_gpx(
         str(gpx_path),
         str(merged_gpx_path),
     ]
-
-    if first_gpx_at is not None:
-        command[2:2] = ["--first-gpx-at", f"{first_gpx_at:.3f}"]
 
     try:
         result = subprocess.run(
@@ -727,13 +723,6 @@ def _gpx_video_alignment(osv_path: Path, gpx_path: Path) -> GpxVideoAlignment | 
         gpx_start=gpx_start,
         gpx_end=gpx_end,
     )
-
-
-def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
-    alignment = _gpx_video_alignment(osv_path, gpx_path)
-    if not alignment:
-        return None
-    return abs((alignment.video_start - alignment.gpx_start).total_seconds())
 
 
 def probe_video_start_time(video_path: Path) -> datetime | None:

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -195,24 +195,12 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
-    merge_gpx_path = gpx_path
     first_gpx_at = _first_gpx_at_seconds(osv_paths[0], gpx_path)
-    alignment = _gpx_video_alignment(osv_paths[0], gpx_path)
-    if alignment and alignment.gpx_start < alignment.video_start:
-        trimmed_gpx_path = _trim_gpx_before_timestamp(
-            gpx_path,
-            input_dir / f"{gpx_path.stem}-from-video-start{gpx_path.suffix or '.gpx'}",
-            alignment.video_start,
-        )
-        if trimmed_gpx_path:
-            merge_gpx_path = trimmed_gpx_path
-            first_gpx_at = 0.0
-
     command = [
         "python3",
         str(merge_script),
         *(str(path) for path in osv_paths),
-        str(merge_gpx_path),
+        str(gpx_path),
         str(merged_gpx_path),
     ]
 
@@ -745,47 +733,7 @@ def _first_gpx_at_seconds(osv_path: Path, gpx_path: Path) -> float | None:
     alignment = _gpx_video_alignment(osv_path, gpx_path)
     if not alignment:
         return None
-    return max(0.0, (alignment.gpx_start - alignment.video_start).total_seconds())
-
-
-def _trim_gpx_before_timestamp(gpx_path: Path, output_path: Path, cutoff: datetime) -> Path | None:
-    try:
-        tree = ET.parse(gpx_path)
-    except (ET.ParseError, OSError):
-        return None
-
-    root = tree.getroot()
-    removed = 0
-    kept = 0
-    for parent in root.iter():
-        for child in list(parent):
-            if child.tag.rsplit("}", 1)[-1] != "trkpt":
-                continue
-            point_time = next(
-                (
-                    parsed
-                    for element in child.iter()
-                    if element.tag.rsplit("}", 1)[-1] == "time"
-                    and element.text
-                    and (parsed := _parse_utc_datetime(element.text))
-                ),
-                None,
-            )
-            if point_time and point_time < cutoff:
-                parent.remove(child)
-                removed += 1
-            else:
-                kept += 1
-
-    if removed == 0 or kept == 0:
-        return None
-
-    ET.register_namespace("", _GPX_NAMESPACE)
-    ET.register_namespace("gpxpx", _GARMIN_GPX_EXTENSION_NAMESPACE)
-    ET.register_namespace("xsi", _XSI_NAMESPACE)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tree.write(output_path, encoding="utf-8", xml_declaration=True)
-    return output_path
+    return abs((alignment.video_start - alignment.gpx_start).total_seconds())
 
 
 def probe_video_start_time(video_path: Path) -> datetime | None:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -610,7 +610,7 @@ def test_worker_merge_osv_files_with_gpx_writes_log_steps(
     assert any("Created merged GPX" in line for line in log_lines)
 
 
-def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
+def test_worker_merge_osv_files_with_gpx_uses_absolute_timestamps_without_forced_offset(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -656,7 +656,7 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     assert result == merged_gpx_path
     assert merged_gpx_path.read_text() == "<gpx>merged</gpx>"
     command = run.call_args.args[0]
-    assert command[2:4] == ["--first-gpx-at", "10.000"]
+    assert "--first-gpx-at" not in command
 
 
 def test_worker_merge_osv_files_with_gpx_keeps_source_gpx_when_video_starts_after_gpx(
@@ -706,7 +706,7 @@ def test_worker_merge_osv_files_with_gpx_keeps_source_gpx_when_video_starts_afte
 
     assert result == merged_gpx_path
     command = run.call_args.args[0]
-    assert command[2:4] == ["--first-gpx-at", "8.000"]
+    assert "--first-gpx-at" not in command
     assert Path(command[-2]) == source_gpx
 
 

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -659,7 +659,7 @@ def test_worker_merge_osv_files_with_gpx_passes_first_gpx_at_from_osv_start(
     assert command[2:4] == ["--first-gpx-at", "10.000"]
 
 
-def test_worker_merge_osv_files_with_gpx_trims_gpx_when_video_starts_after_gpx(
+def test_worker_merge_osv_files_with_gpx_keeps_source_gpx_when_video_starts_after_gpx(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -706,12 +706,8 @@ def test_worker_merge_osv_files_with_gpx_trims_gpx_when_video_starts_after_gpx(
 
     assert result == merged_gpx_path
     command = run.call_args.args[0]
-    assert command[2:4] == ["--first-gpx-at", "0.000"]
-    trimmed_gpx_path = Path(command[-2])
-    assert trimmed_gpx_path != source_gpx
-    trimmed_gpx = trimmed_gpx_path.read_text()
-    assert "2026-06-13T08:20:33Z" not in trimmed_gpx
-    assert "2026-06-13T08:20:34Z" in trimmed_gpx
+    assert command[2:4] == ["--first-gpx-at", "8.000"]
+    assert Path(command[-2]) == source_gpx
 
 
 def test_gopro_overlay_output_resolution_is_rescaled_when_needed(tmp_path, monkeypatch) -> None:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       additional_contexts:
-        gopro-overlay-src: ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}
+        gopro-overlay-src: ${GOPRO_OVERLAY_BUILD_CONTEXT:-https://github.com/capic2/gopro-dashboard-overlay.git#main}
       args:
         - VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN:?required}
     image: parapente-backend:nx-latest


### PR DESCRIPTION
## Summary
- stop passing --first-gpx-at from dashboard-parapente to osv_merge.py
- let the fixed OSV merge script use absolute OSV/GPX timestamps and its automatic video window
- update tests to assert no forced GPX offset is injected

## Dependencies
- gopro-dashboard-overlay PR #2: https://github.com/capic2/gopro-dashboard-overlay/pull/2
- gopro-dashboard-overlay PR #3: https://github.com/capic2/gopro-dashboard-overlay/pull/3

## Validation
- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py -k 'merge_osv_files_with_gpx'
- .venv/bin/pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend --skip-nx-cache
- /home/capic/.local/bin/coderabbit review: No findings