### PR TITLE
fix(infrastructure): use git source for gopro overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,8 +151,8 @@ BACKEND_FRONTEND_URL=http://localhost:5173
 
 # Host folders mounted at fixed backend container paths.
 # GOPRO_OVERLAY_DATA_HOST_DIR is mounted at /app/parapente.
-# GOPRO_OVERLAY_HOST_DIR is mounted at /app/gopro-overlay.
-GOPRO_OVERLAY_HOST_DIR=/media/usb/data-m2/developement/gopro-overlay-dasboard
+# GOPRO_OVERLAY_BUILD_CONTEXT is copied into the image at /app/gopro-overlay.
+GOPRO_OVERLAY_BUILD_CONTEXT=https://github.com/capic2/gopro-dashboard-overlay.git#main
 GOPRO_OVERLAY_DATA_HOST_DIR=/media/nas/DS211_Synology_2/parapente
 
 # Deployment version state file (required, no application default).

--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Verify GoPro overlay build context
         env:
-          GOPRO_OVERLAY_BUILD_CONTEXT: ${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT }}
+          GOPRO_OVERLAY_BUILD_CONTEXT: ${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT || 'https://github.com/capic2/gopro-dashboard-overlay.git#main' }}
         run: |
           if [ -z "$GOPRO_OVERLAY_BUILD_CONTEXT" ]; then
             echo "Missing repository variable GOPRO_OVERLAY_BUILD_CONTEXT"
@@ -193,7 +193,7 @@ jobs:
           build-args: |
             VITE_CESIUM_ION_TOKEN=${{ secrets.VITE_CESIUM_ION_TOKEN }}
           build-contexts: |
-            gopro-overlay-src=${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT }}
+            gopro-overlay-src=${{ vars.GOPRO_OVERLAY_BUILD_CONTEXT || 'https://github.com/capic2/gopro-dashboard-overlay.git#main' }}
           tags: |
             ghcr.io/${{ github.repository }}/backend:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/backend:main

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       additional_contexts:
-        gopro-overlay-src: ${GOPRO_OVERLAY_HOST_DIR:?GOPRO_OVERLAY_HOST_DIR is required}
+        gopro-overlay-src: ${GOPRO_OVERLAY_BUILD_CONTEXT:-https://github.com/capic2/gopro-dashboard-overlay.git#main}
       args:
         - VITE_CESIUM_ION_TOKEN=${VITE_CESIUM_ION_TOKEN:?required}
     image: parapente-backend:nx-latest


### PR DESCRIPTION
## Summary\n- Load the GoPro overlay build context from the GitHub repo main branch by default\n- Update the example env file to use GOPRO_OVERLAY_BUILD_CONTEXT\n- Default the CI workflow to the same Git Git source when the repository variable is unset\n\n## Validation\n- VITE_CESIUM_ION_TOKEN=dummy docker compose --env-file .env.example -f docker-compose.yml -f docker-compose.dev.yml config\n- CodeRabbit CLI review: no findings