### PR TITLE
feat: add gpx offset for gopro overlay

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -349,12 +349,28 @@ def _copy_job_input(source: Path, destination: Path, allowed_extensions: set[str
     return destination
 
 
-def _job_preparation_metadata(pin_inputs: bool, requested_layout_id: str | None) -> dict[str, Any]:
+def _job_preparation_metadata(
+    pin_inputs: bool,
+    requested_layout_id: str | None,
+    gpx_offset: float = 0.0,
+) -> dict[str, Any]:
     return {
         "prepare_overlay_inputs": True,
         "pin_inputs": pin_inputs,
         "requested_layout_id": requested_layout_id,
+        "gpx_offset": gpx_offset,
     }
+
+
+def _gpx_offset_from_command_metadata(command: Any) -> float:
+    if isinstance(command, dict):
+        return float(command.get("gpx_offset") or 0.0)
+    if isinstance(command, list) and "--gpx-offset" in command:
+        try:
+            return float(command[command.index("--gpx-offset") + 1])
+        except (IndexError, TypeError, ValueError):
+            return 0.0
+    return 0.0
 
 
 def _append_job_log(log_path: Path, message: str) -> None:
@@ -368,6 +384,7 @@ def _append_job_log(log_path: Path, message: str) -> None:
 
 
 def _job_to_payload(job: GoproOverlayJob, include_command: bool = False) -> dict[str, Any]:
+    command = json.loads(job.command_json) if job.command_json else None
     payload = {
         "job_id": job.id,
         "status": job.status,
@@ -389,12 +406,13 @@ def _job_to_payload(job: GoproOverlayJob, include_command: bool = False) -> dict
         ),
         "video_width": job.video_width,
         "video_height": job.video_height,
+        "gpx_offset": _gpx_offset_from_command_metadata(command),
         "created_at": _to_iso(job.created_at),
         "updated_at": _to_iso(job.updated_at),
         "completed_at": _to_iso(job.completed_at),
     }
     if include_command:
-        payload["command"] = json.loads(job.command_json) if job.command_json else None
+        payload["command"] = command
     return payload
 
 
@@ -1164,6 +1182,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         )
         if not prepared_job or prepared_job.get("status") != _STATUS_QUEUED:
             return None
+        prepared_job["gpx_offset"] = float(command_metadata.get("gpx_offset") or 0.0)
         prepared_job["command"] = command_metadata
         _append_job_log(log_path, "Overlay queued")
         return prepared_job
@@ -1299,6 +1318,7 @@ async def create_gopro_overlay_job(
     fallback_pip_path: Path | None = None,
     output_dir: str | None = None,
     pin_inputs: bool = False,
+    gpx_offset: float = 0.0,
 ) -> dict[str, Any]:
     job_id = str(uuid.uuid4())
     job_upload_dir = _uploaded_job_work_dir(job_id)
@@ -1341,6 +1361,7 @@ async def create_gopro_overlay_job(
             work_dir=job_upload_dir,
             output_dir=output_dir,
             pin_inputs=pin_inputs,
+            gpx_offset=gpx_offset,
         )
     except Exception:
         shutil.rmtree(job_upload_dir, ignore_errors=True)
@@ -1354,6 +1375,7 @@ def create_gopro_overlay_job_from_paths(
     layout_id: str | None,
     output_filename: str | None,
     output_dir: str | None = None,
+    gpx_offset: float = 0.0,
 ) -> dict[str, Any]:
     _validate_file_extension(video_path, _VIDEO_EXTENSIONS)
     _validate_file_extension(gpx_path, _GPX_EXTENSIONS)
@@ -1374,6 +1396,7 @@ def create_gopro_overlay_job_from_paths(
             work_dir=work_dir,
             pin_inputs=True,
             output_dir=output_dir,
+            gpx_offset=gpx_offset,
         )
     except Exception:
         shutil.rmtree(work_dir, ignore_errors=True)
@@ -1390,6 +1413,7 @@ def _create_gopro_overlay_job_from_paths(
     work_dir: Path,
     pin_inputs: bool = False,
     output_dir: str | None = None,
+    gpx_offset: float = 0.0,
 ) -> dict[str, Any]:
     output_name = _safe_filename(output_filename, f"gopro-overlay-{job_id}.mp4")
     if Path(output_name).suffix.lower() != ".mp4":
@@ -1410,6 +1434,7 @@ def _create_gopro_overlay_job_from_paths(
     preparation_metadata = _job_preparation_metadata(
         pin_inputs=pin_inputs,
         requested_layout_id=layout_id,
+        gpx_offset=gpx_offset,
     )
 
     now = _utc_now_dt()
@@ -1465,6 +1490,7 @@ def _create_gopro_overlay_job_from_paths(
             "log_path": str(log_path),
             "video_width": None,
             "video_height": None,
+            "gpx_offset": gpx_offset,
             "created_at": _utc_now(),
             "updated_at": _utc_now(),
             "completed_at": None,
@@ -1489,6 +1515,7 @@ def _create_gopro_overlay_job_from_paths(
         "log_path": str(log_path),
         "video_width": None,
         "video_height": None,
+        "gpx_offset": gpx_offset,
         "created_at": _utc_now(),
         "updated_at": _utc_now(),
         "completed_at": None,
@@ -1536,6 +1563,9 @@ def _run_job(job_id: str) -> None:
         command.extend(["--font", config.GOPRO_OVERLAY_FONT])
     if job.get("video_width") and job.get("video_height"):
         command.extend(["--overlay-size", f"{job['video_width']}x{job['video_height']}"])
+    gpx_offset = float(job.get("gpx_offset") or 0.0)
+    if gpx_offset:
+        command.extend(["--gpx-offset", str(gpx_offset)])
     if job.get("pip_path"):
         command.extend(["--video", f"pip={job['pip_path']}"])
     output_path = Path(job["output_path"])

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -364,7 +364,10 @@ def _job_preparation_metadata(
 
 def _gpx_offset_from_command_metadata(command: Any) -> float:
     if isinstance(command, dict):
-        return float(command.get("gpx_offset") or 0.0)
+        try:
+            return float(command.get("gpx_offset") or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
     if isinstance(command, list) and "--gpx-offset" in command:
         try:
             return float(command[command.index("--gpx-offset") + 1])
@@ -1182,7 +1185,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         )
         if not prepared_job or prepared_job.get("status") != _STATUS_QUEUED:
             return None
-        prepared_job["gpx_offset"] = float(command_metadata.get("gpx_offset") or 0.0)
+        prepared_job["gpx_offset"] = _gpx_offset_from_command_metadata(command_metadata)
         prepared_job["command"] = command_metadata
         _append_job_log(log_path, "Overlay queued")
         return prepared_job

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -339,6 +339,11 @@ def _job_progress(job: dict[str, Any] | None) -> int | None:
     return max(0, min(100, round(progress)))
 
 
+def _validate_gpx_offset(gpx_offset: float) -> None:
+    if not math.isfinite(gpx_offset):
+        raise HTTPException(status_code=422, detail="gpx_offset must be a finite number")
+
+
 def _flight_video_export_progress(flight: Flight) -> int | None:
     return _flight_video_export_state(None, flight)["progress"]
 
@@ -5463,6 +5468,7 @@ async def create_flight_gopro_overlay_job(
     db: Session = Depends(get_db),
 ) -> GoproOverlayJob:
     """Create a GoPro overlay render job from provided media and the flight GPX fallback."""
+    _validate_gpx_offset(gpx_offset)
     dependencies = check_gopro_overlay_dependencies()
     missing = [name for name, available in dependencies.items() if not available]
     if missing:
@@ -5617,6 +5623,7 @@ async def create_gopro_overlay_render_job(
     gpx_offset: float = Form(0.0),
 ) -> GoproOverlayJob:
     """Create a GoPro overlay render job from uploaded video, GPX, and optional PIP video."""
+    _validate_gpx_offset(gpx_offset)
     dependencies = check_gopro_overlay_dependencies()
     missing = [name for name, available in dependencies.items() if not available]
     if missing:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -5459,6 +5459,7 @@ async def create_flight_gopro_overlay_job(
     output_dir: str | None = Form(None),
     layout_id: str | None = Form(None),
     output_filename: str | None = Form(None),
+    gpx_offset: float = Form(0.0),
     db: Session = Depends(get_db),
 ) -> GoproOverlayJob:
     """Create a GoPro overlay render job from provided media and the flight GPX fallback."""
@@ -5533,6 +5534,7 @@ async def create_flight_gopro_overlay_job(
                 layout_id=layout_id,
                 output_filename=resolved_output_filename,
                 output_dir=resolved_output_dir,
+                gpx_offset=gpx_offset,
             )
             _mark_flight_gopro_overlay_job(db, flight, job)
             return _with_gopro_overlay_job_token(job)
@@ -5561,6 +5563,7 @@ async def create_flight_gopro_overlay_job(
             output_filename=resolved_output_filename,
             output_dir=resolved_output_dir,
             pin_inputs=pin_overlay_inputs,
+            gpx_offset=gpx_offset,
         )
         _mark_flight_gopro_overlay_job(db, flight, job)
         return _with_gopro_overlay_job_token(job)
@@ -5611,6 +5614,7 @@ async def create_gopro_overlay_render_job(
     pip_file: UploadFile | None = File(None),
     layout_id: str | None = Form(None),
     output_filename: str | None = Form(None),
+    gpx_offset: float = Form(0.0),
 ) -> GoproOverlayJob:
     """Create a GoPro overlay render job from uploaded video, GPX, and optional PIP video."""
     dependencies = check_gopro_overlay_dependencies()
@@ -5628,6 +5632,7 @@ async def create_gopro_overlay_render_job(
             pip_file=pip_file,
             layout_id=layout_id,
             output_filename=output_filename,
+            gpx_offset=gpx_offset,
         )
         return _with_gopro_overlay_job_token(job)
     except ValueError as exc:

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -61,6 +61,7 @@ class GoproOverlayJob(BaseModel):
     output_filename: str
     video_width: int | None = None
     video_height: int | None = None
+    gpx_offset: float = 0.0
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None = None

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -82,7 +82,11 @@ def test_create_gopro_overlay_job_passes_uploaded_files(client: TestClient):
                 "gpx_file": ("flight.gpx", b"<gpx />", "application/gpx+xml"),
                 "pip_file": ("pip.mp4", b"pip", "video/mp4"),
             },
-            data={"layout_id": "parapente-1080", "output_filename": "flight-overlay.mp4"},
+            data={
+                "layout_id": "parapente-1080",
+                "output_filename": "flight-overlay.mp4",
+                "gpx_offset": "2.5",
+            },
         )
 
     assert response.status_code == 200
@@ -91,6 +95,7 @@ def test_create_gopro_overlay_job_passes_uploaded_files(client: TestClient):
     assert response.json()["job_token"]
     assert create_job.call_args.kwargs["layout_id"] == "parapente-1080"
     assert create_job.call_args.kwargs["output_filename"] == "flight-overlay.mp4"
+    assert create_job.call_args.kwargs["gpx_offset"] == 2.5
     assert create_job.call_args.kwargs["pip_file"] is not None
 
 
@@ -1972,6 +1977,7 @@ def test_run_job_prepares_inputs_before_starting_process(
         pip_path=None,
         layout_id="parapente-1080",
         output_filename="overlay.mp4",
+        gpx_offset=-1.5,
     )
     work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
 
@@ -1995,6 +2001,7 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
     assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
     assert command[command.index("--overlay-size") + 1] == "1920x1080"
+    assert command[command.index("--gpx-offset") + 1] == "-1.5"
     assert Path(command[-2]) == video_path
     assert Path(command[-1]) == Path(job["temp_output_path"])
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -99,6 +99,28 @@ def test_create_gopro_overlay_job_passes_uploaded_files(client: TestClient):
     assert create_job.call_args.kwargs["pip_file"] is not None
 
 
+@pytest.mark.parametrize("gpx_offset", ["nan", "inf", "-inf"])
+def test_create_gopro_overlay_job_rejects_non_finite_gpx_offset(
+    client: TestClient, gpx_offset: str
+):
+    response = client.post(
+        f"{API_PREFIX}/gopro-overlays/jobs",
+        files={
+            "video_file": ("flight.mp4", b"video", "video/mp4"),
+            "gpx_file": ("flight.gpx", b"<gpx />", "application/gpx+xml"),
+        },
+        data={"gpx_offset": gpx_offset},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "gpx_offset must be a finite number"
+
+
+def test_gpx_offset_from_command_metadata_defaults_malformed_values():
+    assert gopro_overlay_export._gpx_offset_from_command_metadata({"gpx_offset": "bad"}) == 0.0
+    assert gopro_overlay_export._gpx_offset_from_command_metadata({"gpx_offset": None}) == 0.0
+
+
 def test_gopro_overlay_job_access_status_accepts_job_token(client: TestClient):
     token = create_job_token(purpose="gopro_overlay", job_id="job-gopro")
     expected = {
@@ -185,6 +207,21 @@ def test_create_flight_gopro_overlay_job_uses_flight_files(
     assert create_job.call_args.kwargs["pip_file"] is not None
     assert create_job.call_args.kwargs["output_filename"] == "Arguel test-overlay.mp4"
     assert create_job.call_args.kwargs["output_dir"] == str(output_dir)
+
+
+@pytest.mark.parametrize("gpx_offset", ["nan", "inf", "-inf"])
+def test_create_flight_gopro_overlay_job_rejects_non_finite_gpx_offset(
+    client: TestClient,
+    sample_flight,
+    gpx_offset: str,
+):
+    response = client.post(
+        f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay",
+        data={"gpx_offset": gpx_offset},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "gpx_offset must be a finite number"
 
 
 def test_create_flight_gopro_overlay_job_resolves_paragliding_root_paths(

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -82,6 +82,8 @@ vi.mock('react-i18next', () => ({
         'flights.goproOverlayRegenerateShort': 'Regenerate overlay',
         'flights.goproOverlayGenerate': 'Generate overlay',
         'flights.goproOverlayGenerateShort': 'Generate overlay',
+        'flights.goproOverlayGpxOffsetLabel': 'GPX offset (seconds)',
+        'flights.goproOverlayGpxOffsetHint': 'Offset hint',
         'flights.goproOverlayStarted': 'Overlay started',
         'flights.goproOverlayCancelled': 'Overlay cancelled',
         'flights.goproOverlayStartError': 'Overlay start error',
@@ -198,6 +200,27 @@ describe('FlightDetails GoPro overlay action', () => {
     });
   });
 
+
+  it('passes the GPX offset when starting overlay generation', async () => {
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('GPX offset (seconds)'), {
+      target: { value: '2.5' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Generate overlay/u }));
+
+    await waitFor(() => {
+      expect(createOverlayMock).toHaveBeenCalled();
+    });
+    const formData = createOverlayMock.mock.calls[0][0] as FormData;
+    expect(formData.get('gpx_offset')).toBe('2.5');
+  });
   it('regenerates overlay after cancellation', async () => {
     mockFlight.gopro_overlay_job_id = 'job-overlay';
     mockFlight.gopro_overlay_status = 'cancelled';

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -468,8 +468,11 @@ export function FlightDetails({
                 onChange={(event) =>
                   setGoproOverlayGpxOffset(event.currentTarget.value)
                 }
-                disabled={isGoproOverlayRunning || createGoproOverlayJob.isPending}
+                disabled={
+                  isGoproOverlayRunning || createGoproOverlayJob.isPending
+                }
                 className="min-h-10 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                aria-label={t('flights.goproOverlayGpxOffsetLabel')}
                 aria-describedby="gopro-overlay-gpx-offset-hint"
               />
               <span

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -77,6 +77,7 @@ export function FlightDetails({
   >(null);
   const [isCancellingGoproOverlay, setIsCancellingGoproOverlay] =
     useState(false);
+  const [goproOverlayGpxOffset, setGoproOverlayGpxOffset] = useState('0');
   const [downloadingMedia, setDownloadingMedia] =
     useState<DownloadableFlightMedia | null>(null);
 
@@ -138,6 +139,7 @@ export function FlightDetails({
     setGoproOverlayJobId(null);
     setGoproOverlayJobToken(null);
     setIsCancellingGoproOverlay(false);
+    setGoproOverlayGpxOffset('0');
     setDownloadingMedia(null);
     resetGoproOverlayJob();
   }, [flight.id, resetGoproOverlayJob]);
@@ -245,6 +247,10 @@ export function FlightDetails({
 
     const requestedFlightId = flight.id;
     const formData = new FormData();
+    const normalizedGpxOffset = goproOverlayGpxOffset.trim();
+    if (normalizedGpxOffset) {
+      formData.append('gpx_offset', normalizedGpxOffset);
+    }
 
     try {
       const job = await createGoproOverlayJob.mutateAsync(formData);
@@ -450,25 +456,50 @@ export function FlightDetails({
             />
           </div>
 
-          <div className="flex flex-wrap gap-2 border-t border-gray-200 pt-3 dark:border-gray-700">
-            <Button
-              variant="ghost"
-              className="min-h-10 rounded-lg px-3 py-2 text-sm"
-              onPress={() => setEditingMode(true)}
-              aria-label={t('flights.editFlight')}
-            >
-              <Edit3 className="h-4 w-4" aria-hidden="true" />
-              {t('flights.editButton')}
-            </Button>
-            <Button
-              variant="ghost"
-              className="min-h-10 rounded-lg px-3 py-2 text-sm"
-              onPress={() => fileInputRef.current?.click()}
-              isDisabled={uploadGPXMutation.isPending}
-            >
-              <FileUp className="h-4 w-4" aria-hidden="true" />
-              {gpxUploadLabel}
-            </Button>
+          <div className="border-t border-gray-200 pt-3 dark:border-gray-700">
+            <label className="mb-3 flex max-w-xs flex-col gap-1 text-sm text-gray-700 dark:text-gray-200">
+              <span className="font-medium">
+                {t('flights.goproOverlayGpxOffsetLabel')}
+              </span>
+              <input
+                type="number"
+                step="0.1"
+                value={goproOverlayGpxOffset}
+                onChange={(event) =>
+                  setGoproOverlayGpxOffset(event.currentTarget.value)
+                }
+                disabled={isGoproOverlayRunning || createGoproOverlayJob.isPending}
+                className="min-h-10 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                aria-describedby="gopro-overlay-gpx-offset-hint"
+              />
+              <span
+                id="gopro-overlay-gpx-offset-hint"
+                className="text-xs text-gray-500 dark:text-gray-400"
+              >
+                {t('flights.goproOverlayGpxOffsetHint')}
+              </span>
+            </label>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="ghost"
+                className="min-h-10 rounded-lg px-3 py-2 text-sm"
+                onPress={() => setEditingMode(true)}
+                aria-label={t('flights.editFlight')}
+              >
+                <Edit3 className="h-4 w-4" aria-hidden="true" />
+                {t('flights.editButton')}
+              </Button>
+              <Button
+                variant="ghost"
+                className="min-h-10 rounded-lg px-3 py-2 text-sm"
+                onPress={() => fileInputRef.current?.click()}
+                isDisabled={uploadGPXMutation.isPending}
+              >
+                <FileUp className="h-4 w-4" aria-hidden="true" />
+                {gpxUploadLabel}
+              </Button>
+            </div>
           </div>
 
           <input

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -942,6 +942,8 @@
     "goproOverlayDownload": "Download overlay",
     "goproOverlayDownloadShort": "Download",
     "goproOverlayGenerateTitle": "Generate a GoPro overlay video for this flight",
+    "goproOverlayGpxOffsetLabel": "GPX offset (seconds)",
+    "goproOverlayGpxOffsetHint": "Positive values delay the GPX track; negative values advance it.",
     "goproOverlayCanProvideGpx": "Provide a GPX in the next step or add one to the flight",
     "goproOverlayNeedsGpx": "Add a GPX to this flight before generating the overlay",
     "goproOverlayNeedsVideo": "Generate the flight video before adding the overlay",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -947,7 +947,7 @@
     "goproOverlayDownloadShort": "Télécharger",
     "goproOverlayGenerateTitle": "Générer une vidéo avec overlay GoPro pour ce vol",
     "goproOverlayGpxOffsetLabel": "Offset GPX (secondes)",
-    "goproOverlayGpxOffsetHint": "Une valeur positive retarde le GPX ; une valeur n�gative l'avance.",
+    "goproOverlayGpxOffsetHint": "Une valeur positive retarde le GPX ; une valeur négative l'avance.",
     "goproOverlayCanProvideGpx": "Fournissez un GPX dans l'étape suivante ou ajoutez-en un au vol",
     "goproOverlayNeedsGpx": "Ajoutez un GPX à ce vol pour générer l'overlay",
     "goproOverlayNeedsVideo": "Générez d'abord la vidéo du vol pour ajouter l'overlay",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -946,6 +946,8 @@
     "goproOverlayDownload": "Télécharger overlay",
     "goproOverlayDownloadShort": "Télécharger",
     "goproOverlayGenerateTitle": "Générer une vidéo avec overlay GoPro pour ce vol",
+    "goproOverlayGpxOffsetLabel": "Offset GPX (secondes)",
+    "goproOverlayGpxOffsetHint": "Une valeur positive retarde le GPX ; une valeur n�gative l'avance.",
     "goproOverlayCanProvideGpx": "Fournissez un GPX dans l'étape suivante ou ajoutez-en un au vol",
     "goproOverlayNeedsGpx": "Ajoutez un GPX à ce vol pour générer l'overlay",
     "goproOverlayNeedsVideo": "Générez d'abord la vidéo du vol pour ajouter l'overlay",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPX time offset support to GoPro overlay exports, including a new “GPX offset (seconds)” input in flight details.
  * Updated GoPro overlay backend endpoints and job creation flow to accept, store, and apply the GPX offset to the overlay command.
  * Added English and French translations for the GPX offset label and hint.
* **Tests**
  * Extended end-to-end coverage to confirm GPX offset propagation and worker command arguments.
  * Added validation tests to reject non-finite offset values with a 422 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->