### PR TITLE
fix(gopro-overlay): pass gpx offset to merge step

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -171,6 +171,7 @@ def _merge_osv_files_with_gpx(
     gpx_path: Path,
     input_dir: Path,
     log_path: Path | None = None,
+    gpx_offset: float = 0.0,
 ) -> Path:
     if not osv_paths:
         return gpx_path
@@ -198,6 +199,7 @@ def _merge_osv_files_with_gpx(
     command = [
         "python3",
         str(merge_script),
+        *(["--gpx-offset", str(gpx_offset)] if gpx_offset else []),
         *(str(path) for path in osv_paths),
         str(gpx_path),
         str(merged_gpx_path),
@@ -1126,6 +1128,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 render_gpx_path,
                 work_dir,
                 log_path=log_path,
+                gpx_offset=_gpx_offset_from_command_metadata(command_metadata),
             )
         else:
             _append_job_log(log_path, "No OSV files found; using GPX directly")
@@ -1566,9 +1569,6 @@ def _run_job(job_id: str) -> None:
         command.extend(["--font", config.GOPRO_OVERLAY_FONT])
     if job.get("video_width") and job.get("video_height"):
         command.extend(["--overlay-size", f"{job['video_width']}x{job['video_height']}"])
-    gpx_offset = float(job.get("gpx_offset") or 0.0)
-    if gpx_offset:
-        command.extend(["--gpx-offset", str(gpx_offset)])
     if job.get("pip_path"):
         command.extend(["--video", f"pip={job['pip_path']}"])
     output_path = Path(job["output_path"])

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -612,6 +612,45 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert run.call_args.kwargs["timeout"] == 456
 
 
+def test_worker_merge_osv_files_with_gpx_passes_gpx_offset_to_merge_tool(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gopro_root = tmp_path / "gopro-overlay"
+    gopro_root.mkdir()
+    (gopro_root / "osv_merge.py").write_text("# merge")
+    input_dir = tmp_path / "20260315" / "01"
+    input_dir.mkdir(parents=True)
+    source_gpx = input_dir / "Zepp-track.gpx"
+    osv_path = input_dir / "flight.osv"
+    merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
+    source_gpx.write_text("<gpx>source</gpx>")
+    osv_path.write_bytes(b"osv")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(command, **kwargs):
+        Path(command[-1]).write_text("<gpx>merged</gpx>")
+        return Result()
+
+    with patch("gopro_overlay_export.subprocess.run", side_effect=fake_run) as run:
+        result = gopro_overlay_export._merge_osv_files_with_gpx(
+            [osv_path],
+            source_gpx,
+            input_dir,
+            gpx_offset=-1.5,
+        )
+
+    assert result == merged_gpx_path
+    command = run.call_args.args[0]
+    assert command[command.index("--gpx-offset") + 1] == "-1.5"
+    assert command[-3:] == [str(osv_path), str(source_gpx), str(merged_gpx_path)]
+
+
 def test_worker_merge_osv_files_with_gpx_writes_log_steps(
     tmp_path,
     monkeypatch,
@@ -1999,14 +2038,23 @@ def test_run_job_prepares_inputs_before_starting_process(
     (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
     video_path = tmp_path / "source.mp4"
     gpx_path = tmp_path / "source.gpx"
+    osv_path = tmp_path / "source.osv"
     video_path.write_bytes(b"video")
     gpx_path.write_text("<gpx />")
+    osv_path.write_bytes(b"osv")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
     monkeypatch.setattr(config, "GOPRO_OVERLAY_BIN", "gopro-dashboard.py")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(tmp_path / "runner-root"))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     monkeypatch.setattr(gopro_overlay_export, "_verify_video_output", lambda _: (True, None))
+    merge_calls = []
+
+    def fake_merge(osv_paths, gpx_path, input_dir, **kwargs):
+        merge_calls.append((osv_paths, gpx_path, input_dir, kwargs))
+        return gpx_path
+
+    monkeypatch.setattr(gopro_overlay_export, "_merge_osv_files_with_gpx", fake_merge)
 
     job = create_gopro_overlay_job_from_paths(
         video_path=video_path,
@@ -2038,9 +2086,12 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
     assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
     assert command[command.index("--overlay-size") + 1] == "1920x1080"
-    assert command[command.index("--gpx-offset") + 1] == "-1.5"
+    assert "--gpx-offset" not in command
     assert Path(command[-2]) == video_path
     assert Path(command[-1]) == Path(job["temp_output_path"])
+    assert len(merge_calls) == 1
+    assert merge_calls[0][0] == [osv_path]
+    assert merge_calls[0][3]["gpx_offset"] == -1.5
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
     assert Path(job["output_path"]).read_bytes() == b"video"
     assert not Path(job["temp_output_path"]).exists()


### PR DESCRIPTION
## Summary\n- Pass gpx_offset to the OSV/GPX merge step instead of gopro-dashboard.py\n- Remove the unsupported flag from the render command\n- Add regression tests for merge and render behavior\n\n## Validation\n- ../../.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py -m 'not integration and not slow' -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal processing of GPS offset parameter in GoPro overlay export pipeline for improved code structure and maintainability.

* **Tests**
  * Updated test coverage to reflect changes in GPS offset parameter handling during overlay export processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->