### PR TITLE
fix(backend): discover AZBA auth signature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,14 @@ BACKEND_METEOBLUE_API_KEY=your_meteoblue_key_here
 # Request access from SpotAiR / balises data provider
 BACKEND_SPOTAIR_BALISES_API_KEY=your_spotair_balises_key_here
 
+# SIA AZBA / RTBA official activity API
+# The public SIA AZBA web app uses the v3 endpoints and a signed AUTH header.
+BACKEND_AZBA_API_BASE_URL=https://bo-prod-sofia-vac.sia-france.fr/api/
+BACKEND_AZBA_API_VERSION=v3/
+BACKEND_AZBA_API_AUTH_SECRET=your_sia_azba_auth_secret_here
+BACKEND_AZBA_CACHE_TTL_SECONDS=900
+BACKEND_AZBA_SITE_RADIUS_KM=10
+
 # Authentication (JWT)
 # Generate secret: openssl rand -hex 32
 BACKEND_JWT_SECRET=__GENERATE_WITH_openssl_rand_-hex_32__

--- a/.env.example
+++ b/.env.example
@@ -62,10 +62,10 @@ BACKEND_METEOBLUE_API_KEY=your_meteoblue_key_here
 BACKEND_SPOTAIR_BALISES_API_KEY=your_spotair_balises_key_here
 
 # SIA AZBA / RTBA official activity API
-# The public SIA AZBA web app uses the v3 endpoints and a signed AUTH header.
+# The backend auto-discovers the public app signature when no override is set.
 BACKEND_AZBA_API_BASE_URL=https://bo-prod-sofia-vac.sia-france.fr/api/
 BACKEND_AZBA_API_VERSION=v3/
-BACKEND_AZBA_API_AUTH_SECRET=your_sia_azba_auth_secret_here
+BACKEND_AZBA_API_AUTH_SECRET=
 BACKEND_AZBA_CACHE_TTL_SECONDS=900
 BACKEND_AZBA_SITE_RADIUS_KM=10
 

--- a/apps/backend/azba_airspace.py
+++ b/apps/backend/azba_airspace.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from typing import Any
@@ -14,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 AZBA_OFFICIAL_URL = "https://www.sia.aviation-civile.gouv.fr/schedules"
 _CACHE: dict[str, tuple[datetime, dict[str, Any]]] = {}
+_DMS_RE = re.compile(
+    r"^(?P<degrees>\d{2,3})(?P<minutes>\d{2})(?P<seconds>\d{2}(?:\.\d+)?)(?P<hemisphere>[NSEW])$"
+)
 
 
 @dataclass(frozen=True)
@@ -67,6 +71,12 @@ def _to_iso_utc(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _to_sia_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
 def _parse_datetime(value: str) -> datetime:
     normalized = value.replace("Z", "+00:00")
     parsed = datetime.fromisoformat(normalized)
@@ -83,6 +93,31 @@ def _first_text(payload: dict[str, Any], keys: tuple[str, ...]) -> str | None:
         if isinstance(value, int | float):
             return str(value)
     return None
+
+
+def _coordinate_to_decimal(value: Any) -> float | None:
+    if isinstance(value, int | float):
+        return float(value)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    match = _DMS_RE.match(stripped)
+    if match is None:
+        return None
+    decimal = (
+        int(match.group("degrees"))
+        + int(match.group("minutes")) / 60
+        + float(match.group("seconds")) / 3600
+    )
+    if match.group("hemisphere") in {"S", "W"}:
+        decimal *= -1
+    return decimal
 
 
 def _iter_nested_dicts(value: Any):
@@ -112,8 +147,10 @@ def _extract_coordinates(payload: dict[str, Any]) -> list[tuple[float, float]]:
     for item in _iter_nested_dicts(payload):
         lat = item.get("lat", item.get("latitude"))
         lon = item.get("lon", item.get("lng", item.get("longitude")))
-        if isinstance(lat, int | float) and isinstance(lon, int | float):
-            coords.append((float(lat), float(lon)))
+        decimal_lat = _coordinate_to_decimal(lat)
+        decimal_lon = _coordinate_to_decimal(lon)
+        if decimal_lat is not None and decimal_lon is not None:
+            coords.append((decimal_lat, decimal_lon))
     return coords
 
 
@@ -203,9 +240,8 @@ async def _get_active_zones(
     params = urlencode(
         {
             "itemsPerPage": "600",
-            "date": latest_azba_date,
-            "timeSlots.startTime[before]": _to_iso_utc(end),
-            "timeSlots.endTime[after]": _to_iso_utc(start),
+            "debutIntervalTemps": _to_sia_utc(start),
+            "finIntervalTemps": _to_sia_utc(end),
         }
     )
     path = f"{config.AZBA_API_VERSION.rstrip('/')}/r_t_b_as?{params}"

--- a/apps/backend/azba_airspace.py
+++ b/apps/backend/azba_airspace.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 import httpx
 
@@ -14,10 +14,16 @@ import config
 logger = logging.getLogger(__name__)
 
 AZBA_OFFICIAL_URL = "https://www.sia.aviation-civile.gouv.fr/schedules"
+AZBA_PUBLIC_APP_URL = "https://www.sia.aviation-civile.gouv.fr/azbaEx/?lang=fr"
 _CACHE: dict[str, tuple[datetime, dict[str, Any]]] = {}
+_AZBA_API_AUTH_SECRET_CACHE: str | None = None
 _DMS_RE = re.compile(
     r"^(?P<degrees>\d{2,3})(?P<minutes>\d{2})(?P<seconds>\d{2}(?:\.\d+)?)(?P<hemisphere>[NSEW])$"
 )
+_AZBA_MAIN_SCRIPT_RE = re.compile(
+    r'<script\s+src="(?P<src>main\.[^"]+\.js)"\s+type="module"></script>'
+)
+_AZBA_SHARE_SECRET_RE = re.compile(r'share_secret:"(?P<secret>[^"]+)"')
 
 
 @dataclass(frozen=True)
@@ -51,12 +57,51 @@ def _cache_set(key: str, payload: dict[str, Any]) -> None:
     _CACHE[key] = (datetime.now(timezone.utc), payload)
 
 
-def _build_auth_header(path_with_query: str) -> dict[str, str]:
-    if not config.AZBA_API_AUTH_SECRET:
+def _extract_azba_public_app_script_url(html: str) -> str | None:
+    match = _AZBA_MAIN_SCRIPT_RE.search(html)
+    if match is None:
+        return None
+    return urljoin(AZBA_PUBLIC_APP_URL, match.group("src"))
+
+
+def _extract_azba_public_auth_secret(script: str) -> str | None:
+    match = _AZBA_SHARE_SECRET_RE.search(script)
+    if match is None:
+        return None
+    return match.group("secret")
+
+
+async def _get_azba_api_auth_secret(client: httpx.AsyncClient) -> str:
+    global _AZBA_API_AUTH_SECRET_CACHE
+
+    if config.AZBA_API_AUTH_SECRET:
+        return config.AZBA_API_AUTH_SECRET
+    if _AZBA_API_AUTH_SECRET_CACHE:
+        return _AZBA_API_AUTH_SECRET_CACHE
+
+    try:
+        app_response = await client.get(AZBA_PUBLIC_APP_URL)
+        app_response.raise_for_status()
+        script_url = _extract_azba_public_app_script_url(app_response.text)
+        if script_url is None:
+            raise AzbaClientError("Unable to locate SIA AZBA public app script")
+
+        script_response = await client.get(script_url)
+        script_response.raise_for_status()
+        auth_secret = _extract_azba_public_auth_secret(script_response.text)
+        if auth_secret is None:
+            raise AzbaClientError("Unable to locate SIA AZBA public auth signature")
+    except httpx.HTTPError as exc:
+        raise AzbaClientError("Unable to retrieve SIA AZBA public app signature") from exc
+
+    _AZBA_API_AUTH_SECRET_CACHE = auth_secret
+    return auth_secret
+
+
+def _build_auth_header(path_with_query: str, auth_secret: str | None) -> dict[str, str]:
+    if not auth_secret:
         return {}
-    token_uri = hashlib.sha512(
-        f"{config.AZBA_API_AUTH_SECRET}/api/{path_with_query}".encode()
-    ).hexdigest()
+    token_uri = hashlib.sha512(f"{auth_secret}/api/{path_with_query}".encode()).hexdigest()
     token = base64.b64encode(f'{{"tokenUri":"{token_uri}"}}'.encode()).decode("ascii")
     return {"AUTH": token}
 
@@ -216,17 +261,33 @@ def _zone_matches_site(zone: AzbaActiveZone, radius_km: float) -> bool:
 
 
 async def _get_json(path_with_query: str) -> dict[str, Any]:
+    global _AZBA_API_AUTH_SECRET_CACHE
+
     url = _join_api_path(path_with_query)
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
-            response = await client.get(url, headers=_build_auth_header(path_with_query))
-            response.raise_for_status()
+            try:
+                response = await _get_json_response(client, url, path_with_query)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code not in {401, 403} or config.AZBA_API_AUTH_SECRET:
+                    raise
+                _AZBA_API_AUTH_SECRET_CACHE = None
+                response = await _get_json_response(client, url, path_with_query)
             payload = response.json()
     except (httpx.HTTPError, ValueError) as exc:
         raise AzbaClientError(f"Unable to retrieve SIA AZBA data from {url}") from exc
     if not isinstance(payload, dict):
         return {"items": payload}
     return payload
+
+
+async def _get_json_response(
+    client: httpx.AsyncClient, url: str, path_with_query: str
+) -> httpx.Response:
+    auth_secret = await _get_azba_api_auth_secret(client)
+    response = await client.get(url, headers=_build_auth_header(path_with_query, auth_secret))
+    response.raise_for_status()
+    return response
 
 
 async def _get_current_range() -> dict[str, Any]:

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -103,7 +103,7 @@ AZBA_API_BASE_URL = os.getenv(
     "BACKEND_AZBA_API_BASE_URL",
     "https://bo-prod-sofia-vac.sia-france.fr/api/",
 )
-AZBA_API_VERSION = os.getenv("BACKEND_AZBA_API_VERSION", "v2/")
+AZBA_API_VERSION = os.getenv("BACKEND_AZBA_API_VERSION", "v3/")
 AZBA_API_AUTH_SECRET = os.getenv("BACKEND_AZBA_API_AUTH_SECRET")
 AZBA_CACHE_TTL_SECONDS = int(os.getenv("BACKEND_AZBA_CACHE_TTL_SECONDS", "900"))
 AZBA_SITE_RADIUS_KM = float(os.getenv("BACKEND_AZBA_SITE_RADIUS_KM", "10"))

--- a/apps/backend/tests/unit/test_azba_airspace.py
+++ b/apps/backend/tests/unit/test_azba_airspace.py
@@ -1,6 +1,8 @@
 import asyncio
 from datetime import datetime, timezone
 
+import httpx
+
 import azba_airspace
 
 
@@ -150,3 +152,81 @@ def test_extract_coordinates_supports_sia_dms_coordinates():
     assert azba_airspace._extract_coordinates(
         {"coordinates": [{"latitude": "470438.00N", "longitude": "0034000.00E"}]}
     ) == [(47.077222222222225, 3.6666666666666665)]
+
+
+def test_extract_azba_public_app_script_url():
+    assert (
+        azba_airspace._extract_azba_public_app_script_url(
+            '<script src="runtime.123.js" type="module"></script>'
+            '<script src="main.35bcb85181c01b05.js" type="module"></script>'
+        )
+        == "https://www.sia.aviation-civile.gouv.fr/azbaEx/main.35bcb85181c01b05.js"
+    )
+
+
+def test_extract_azba_public_auth_secret():
+    assert (
+        azba_airspace._extract_azba_public_auth_secret(
+            'baseUrl:"https://bo-prod-sofia-vac.sia-france.fr/api/",share_secret:"public-signature"'
+        )
+        == "public-signature"
+    )
+
+
+def test_get_json_retries_once_after_cached_public_auth_failure(monkeypatch):
+    request = httpx.Request(
+        "GET", "https://bo-prod-sofia-vac.sia-france.fr/api/v3/custom/currentDate"
+    )
+    api_call_count = {"value": 0}
+
+    class FakeResponse:
+        def __init__(self, status_code, *, text="", payload=None):
+            self.status_code = status_code
+            self.text = text
+            self._payload = payload
+            self.request = request
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise httpx.HTTPStatusError("error", request=self.request, response=self)
+
+        def json(self):
+            return self._payload
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def get(self, url, headers=None):
+            if url == azba_airspace.AZBA_PUBLIC_APP_URL:
+                return FakeResponse(
+                    200,
+                    text='<script src="main.35bcb85181c01b05.js" type="module"></script>',
+                )
+            if url.endswith("/azbaEx/main.35bcb85181c01b05.js"):
+                return FakeResponse(200, text='share_secret:"fresh-public-signature"')
+
+            api_call_count["value"] += 1
+            if api_call_count["value"] == 1:
+                return FakeResponse(401)
+            expected_auth = azba_airspace._build_auth_header(
+                "v3/custom/currentDate", "fresh-public-signature"
+            )["AUTH"]
+            assert headers and headers["AUTH"] == expected_auth
+            return FakeResponse(200, payload={"rtba": "2026-06-16"})
+
+    monkeypatch.setattr(azba_airspace.config, "AZBA_API_AUTH_SECRET", None)
+    monkeypatch.setattr(azba_airspace.httpx, "AsyncClient", FakeClient)
+    monkeypatch.setattr(azba_airspace, "_AZBA_API_AUTH_SECRET_CACHE", "stale-public-signature")
+
+    result = asyncio.run(azba_airspace._get_json("v3/custom/currentDate"))
+
+    assert result == {"rtba": "2026-06-16"}
+    assert api_call_count["value"] == 2
+    assert azba_airspace._AZBA_API_AUTH_SECRET_CACHE == "fresh-public-signature"

--- a/apps/backend/tests/unit/test_azba_airspace.py
+++ b/apps/backend/tests/unit/test_azba_airspace.py
@@ -16,14 +16,20 @@ def test_evaluate_site_azba_constraints_blocks_near_active_zone(monkeypatch):
                 {
                     "id": "rtba-near",
                     "name": "RTBA TEST",
-                    "startTime": "2026-06-16T08:00:00Z",
-                    "endTime": "2026-06-16T10:00:00Z",
-                    "floor": "SFC",
-                    "ceiling": "4500FT",
+                    "valDistVerLower": 0,
+                    "uomDistVerLower": "FT",
+                    "valDistVerUpper": 4500,
+                    "uomDistVerUpper": "FT",
+                    "timeSlots": [
+                        {
+                            "startTime": "2026-06-16T08:00:00Z",
+                            "endTime": "2026-06-16T10:00:00Z",
+                        }
+                    ],
                     "coordinates": [
-                        {"latitude": 47.2, "longitude": 6.0},
-                        {"latitude": 47.21, "longitude": 6.0},
-                        {"latitude": 47.21, "longitude": 6.01},
+                        {"latitude": "471200N", "longitude": "0060000E"},
+                        {"latitude": "471236N", "longitude": "0060000E"},
+                        {"latitude": "471236N", "longitude": "0060036E"},
                     ],
                 },
                 {
@@ -114,3 +120,33 @@ def test_evaluate_site_azba_constraints_returns_unknown_on_source_error(monkeypa
     assert result["status"] == "unknown"
     assert result["message"]
     assert azba_airspace._CACHE == {}
+
+
+def test_get_active_zones_uses_sia_v3_interval_params(monkeypatch):
+    captured = {}
+
+    async def fake_get_json(path_with_query):
+        captured["path_with_query"] = path_with_query
+        return {"items": []}
+
+    monkeypatch.setattr(azba_airspace, "_get_json", fake_get_json)
+
+    asyncio.run(
+        azba_airspace._get_active_zones(
+            datetime(2026, 6, 16, 8, tzinfo=timezone.utc),
+            datetime(2026, 6, 16, 12, tzinfo=timezone.utc),
+            "2026-06-16",
+        )
+    )
+
+    assert captured["path_with_query"].startswith("v3/r_t_b_as?")
+    assert "itemsPerPage=600" in captured["path_with_query"]
+    assert "debutIntervalTemps=2026-06-16T08%3A00%3A00.000Z" in captured["path_with_query"]
+    assert "finIntervalTemps=2026-06-16T12%3A00%3A00.000Z" in captured["path_with_query"]
+    assert "timeSlots" not in captured["path_with_query"]
+
+
+def test_extract_coordinates_supports_sia_dms_coordinates():
+    assert azba_airspace._extract_coordinates(
+        {"coordinates": [{"latitude": "470438.00N", "longitude": "0034000.00E"}]}
+    ) == [(47.077222222222225, 3.6666666666666665)]


### PR DESCRIPTION
## Summary
- auto-discover the public SIA AZBA auth signature when no override is configured
- retry once with a fresh signature when SIA returns 401/403
- keep BACKEND_AZBA_API_AUTH_SECRET optional in .env.example

## Validation
- TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_LOG_FILE=logs/test.log BACKEND_STRAVA_VERIFY_TOKEN=PARAPENTE_2025 ../../.venv/bin/pytest tests/unit/test_azba_airspace.py tests/api/test_routes_azba_airspace.py -q --tb=short
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend
- BACKEND_AZBA_API_AUTH_SECRET= ... python -c 'import asyncio, azba_airspace; print(asyncio.run(azba_airspace._get_current_range()))'

## Notes
- CodeRabbit was rerun after validation but the CLI review limit was reached; the previous CodeRabbit run on the same fix reported no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * SIA AZBA integration now dynamically resolves authentication credentials with automatic retry on authentication failures for improved reliability.

* **Tests**
  * Added test coverage for authentication credential resolution and API error handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->