### PR TITLE
fix(backend): add Open-Meteo emagram sources

### DIFF
--- a/apps/backend/scrapers/emagram_generator.py
+++ b/apps/backend/scrapers/emagram_generator.py
@@ -270,3 +270,39 @@ def generate_emagram_from_wyoming(
     )
 
     return result
+
+
+def generate_emagram_from_openmeteo(
+    sounding_data: dict[str, Any], output_dir: str = "/tmp/emagram_images"
+) -> dict[str, Any]:
+    """Generate a Skew-T image from a normalized Open-Meteo sounding."""
+    if not sounding_data.get("success"):
+        upstream_error = sounding_data.get("error") or "Open-Meteo data fetch was not successful"
+        return {"success": False, "error": str(upstream_error)}
+
+    generator_data = sounding_data.get("generator_data")
+    if not generator_data:
+        return {"success": False, "error": "No generator_data in Open-Meteo result"}
+
+    source = str(sounding_data.get("source") or "open-meteo")
+    station_name = str(sounding_data.get("station_name") or "Open-Meteo model sounding")
+    sounding_time = str(sounding_data.get("sounding_time") or "model")
+    sounding_date = str(sounding_data.get("sounding_date") or "unknown")
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    filename = f"skewt_{source}_{sounding_date}_{sounding_time}_{timestamp}.png"
+    output_path = os.path.join(output_dir, filename)
+
+    result = generate_skewt_image(
+        sounding_data=generator_data,
+        station_name=station_name,
+        sounding_time=sounding_time,
+        output_path=output_path,
+        show_parcel=True,
+        compress_webp=False,
+    )
+    if result.get("success"):
+        result["source"] = source
+        result["external_url"] = sounding_data.get("external_url")
+        result["model"] = sounding_data.get("model")
+
+    return result

--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -24,6 +24,7 @@ EMAGRAM_CACHE_DIR = Path("/tmp/emagram_cache")
 EMAGRAM_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS = 35
 METEOCIEL_SCREENSHOT_TIMEOUT_SECONDS = 30
+OPEN_METEO_EMAGRAM_TIMEOUT_SECONDS = 35
 
 
 def _meteo_parapente_day_labels(day_index: int) -> list[str]:
@@ -411,6 +412,58 @@ async def screenshot_meteociel_emagram(
         }
 
 
+async def generate_open_meteo_emagram_image(
+    latitude: float,
+    longitude: float,
+    spot_name: str,
+    model: str,
+    day_index: int = 0,
+    hour: int | None = None,
+) -> dict[str, Any]:
+    """Generate an emagram image from Open-Meteo pressure-level model data."""
+    from scrapers.emagram_generator import generate_emagram_from_openmeteo
+    from scrapers.open_meteo_sounding import fetch_sounding_for_spot
+
+    sounding = await fetch_sounding_for_spot(
+        spot_latitude=latitude,
+        spot_longitude=longitude,
+        spot_name=spot_name,
+        model=model,
+        day_index=day_index,
+        hour=hour,
+    )
+    source = str(sounding.get("source") or f"open-meteo-{model}")
+    if not sounding.get("success"):
+        return {
+            "success": False,
+            "source": source,
+            "error": str(sounding.get("error") or "Open-Meteo sounding fetch failed"),
+            "external_url": sounding.get("external_url", "https://open-meteo.com/"),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    image_result = generate_emagram_from_openmeteo(
+        sounding_data=sounding,
+        output_dir=str(EMAGRAM_CACHE_DIR),
+    )
+    if not image_result.get("success"):
+        return {
+            "success": False,
+            "source": source,
+            "error": str(image_result.get("error") or "Open-Meteo emagram generation failed"),
+            "external_url": sounding.get("external_url", "https://open-meteo.com/"),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+    return {
+        "success": True,
+        "source": source,
+        "image_path": image_result["image_path"],
+        "external_url": sounding.get("external_url", "https://open-meteo.com/"),
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
 async def _run_screenshot_with_timeout(
     source: str, screenshot_coro: Any, timeout_seconds: float, external_url: str
 ) -> dict[str, Any]:
@@ -447,7 +500,7 @@ async def fetch_all_emagram_screenshots(
     hour: int | None = None,
 ) -> dict[str, Any]:
     """
-    Fetch emagram screenshots from all 3 sources in parallel
+    Fetch emagram images from screenshot and model-generated sources in parallel
 
     Args:
         spot_id: Site ID (e.g., "arguel")
@@ -462,11 +515,12 @@ async def fetch_all_emagram_screenshots(
             "spot_name": "Arguel",
             "screenshots": [
                 {"source": "meteo-parapente", "success": True, "image_path": "...", ...},
-                {"source": "topmeteo", "success": True, "image_path": "...", ...},
-                {"source": "windy", "success": False, "error": "...", ...}
+                {"source": "meteociel", "success": True, "image_path": "...", ...},
+                {"source": "open-meteo-arome", "success": True, "image_path": "...", ...},
+                {"source": "open-meteo-icon", "success": True, "image_path": "...", ...}
             ],
-            "sources_successful": 2,
-            "sources_total": 3,
+            "sources_successful": 4,
+            "sources_total": 4,
             "timestamp": "2024-03-07T20:00:00"
         }
     """
@@ -500,6 +554,22 @@ async def fetch_all_emagram_screenshots(
             ),
             timeout_seconds=METEOCIEL_SCREENSHOT_TIMEOUT_SECONDS,
             external_url=meteociel_url,
+        ),
+        _run_screenshot_with_timeout(
+            "open-meteo-arome",
+            generate_open_meteo_emagram_image(
+                latitude, longitude, spot_name, model="arome", day_index=day_index, hour=hour
+            ),
+            timeout_seconds=OPEN_METEO_EMAGRAM_TIMEOUT_SECONDS,
+            external_url="https://open-meteo.com/en/docs/meteofrance-api",
+        ),
+        _run_screenshot_with_timeout(
+            "open-meteo-icon",
+            generate_open_meteo_emagram_image(
+                latitude, longitude, spot_name, model="icon", day_index=day_index, hour=hour
+            ),
+            timeout_seconds=OPEN_METEO_EMAGRAM_TIMEOUT_SECONDS,
+            external_url="https://open-meteo.com/en/docs/dwd-api",
         ),
     ]
 

--- a/apps/backend/scrapers/open_meteo_sounding.py
+++ b/apps/backend/scrapers/open_meteo_sounding.py
@@ -1,7 +1,8 @@
 """
-Open-Meteo atmospheric sounding scraper
-Fetches model-based atmospheric profiles for any location
-Better alternative to Wyoming for French spots
+Open-Meteo atmospheric sounding scraper.
+
+Fetches model-based pressure-level profiles and normalizes them for the
+Skew-T generator used by the LLM vision pipeline.
 """
 
 from datetime import datetime
@@ -9,8 +10,28 @@ from typing import Any
 
 import httpx
 
-# Pressure levels available from Open-Meteo (hPa)
-PRESSURE_LEVELS = [
+OPEN_METEO_MODEL_CONFIGS = {
+    "arome": {
+        "source": "open-meteo-arome",
+        "label": "Open-Meteo Meteo-France AROME",
+        "base_url": "https://api.open-meteo.com/v1/meteofrance",
+        "model": "meteofrance_seamless",
+    },
+    "icon": {
+        "source": "open-meteo-icon",
+        "label": "Open-Meteo DWD ICON",
+        "base_url": "https://api.open-meteo.com/v1/dwd-icon",
+        "model": "icon_seamless",
+    },
+    "auto": {
+        "source": "open-meteo",
+        "label": "Open-Meteo Best Match",
+        "base_url": "https://api.open-meteo.com/v1/forecast",
+        "model": "auto",
+    },
+}
+
+COMMON_PRESSURE_LEVELS = [
     1000,
     975,
     950,
@@ -32,8 +53,36 @@ PRESSURE_LEVELS = [
     30,
 ]
 
-# Geopotential height approximation (m) for pressure levels
-# These are standard atmosphere approximations
+METEOFRANCE_PRESSURE_LEVELS = [
+    1000,
+    950,
+    925,
+    900,
+    850,
+    800,
+    750,
+    700,
+    650,
+    600,
+    550,
+    500,
+    450,
+    400,
+    350,
+    300,
+    275,
+    250,
+    225,
+    200,
+    175,
+    150,
+    125,
+    100,
+    70,
+    50,
+    30,
+]
+
 STANDARD_HEIGHTS = {
     1000: 111,
     975: 320,
@@ -42,14 +91,23 @@ STANDARD_HEIGHTS = {
     900: 988,
     850: 1457,
     800: 1949,
+    750: 2500,
     700: 3012,
+    650: 3600,
     600: 4206,
+    550: 4900,
     500: 5574,
+    450: 6300,
     400: 7185,
+    350: 8100,
     300: 9164,
+    275: 9700,
     250: 10363,
+    225: 11000,
     200: 11784,
+    175: 12600,
     150: 13608,
+    125: 14600,
     100: 16180,
     70: 18442,
     50: 20576,
@@ -57,92 +115,127 @@ STANDARD_HEIGHTS = {
 }
 
 
+def _pressure_levels_for_model(model: str) -> list[int]:
+    return METEOFRANCE_PRESSURE_LEVELS if model == "arome" else COMMON_PRESSURE_LEVELS
+
+
+def _target_hour_index(day_index: int, hour: int | None, forecast_hour: int) -> int:
+    if hour is not None:
+        return (day_index * 24) + hour
+    return forecast_hour
+
+
+def _hourly_value(hourly: dict[str, list[Any]], key: str, index: int) -> Any:
+    values = hourly.get(key) or []
+    if index < 0 or index >= len(values):
+        return None
+    return values[index]
+
+
+def _levels_to_generator_data(levels: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    return {
+        "pressure_hpa": [level.get("pressure") for level in levels],
+        "height_m": [level.get("height") for level in levels],
+        "temperature_c": [level.get("temp") for level in levels],
+        "dewpoint_c": [level.get("dewpoint") for level in levels],
+        "wind_direction_deg": [level.get("wind_dir") for level in levels],
+        "wind_speed_knots": [
+            level.get("wind_speed") / 1.852 if level.get("wind_speed") is not None else None
+            for level in levels
+        ],
+    }
+
+
 async def fetch_open_meteo_sounding(
-    latitude: float, longitude: float, forecast_hour: int = 0, use_icon: bool = False
+    latitude: float,
+    longitude: float,
+    forecast_hour: int = 0,
+    use_icon: bool = False,
+    model: str | None = None,
+    day_index: int = 0,
+    hour: int | None = None,
 ) -> dict[str, Any]:
     """
-    Fetch atmospheric sounding from Open-Meteo model data
+    Fetch atmospheric pressure-level profile from Open-Meteo.
 
-    Args:
-        latitude: Location latitude
-        longitude: Location longitude
-        forecast_hour: Hours from now (0 = current, 12 = +12h, etc.)
-        use_icon: Use ICON-D2 model (higher resolution for Europe)
-
-    Returns:
-        Dict with sounding data in Wyoming-compatible format
+    `forecast_hour` is kept for older callers and is interpreted as the
+    absolute index in Open-Meteo's hourly arrays, which start at today's 00Z.
+    New callers should pass `day_index` and `hour`.
     """
+    model_key = model or ("icon" if use_icon else "auto")
+    if model_key not in OPEN_METEO_MODEL_CONFIGS:
+        return {"success": False, "source": "open-meteo", "error": f"Unknown model {model_key}"}
 
-    # Build API parameters for all pressure levels
-    temp_params = [f"temperature_{level}hPa" for level in PRESSURE_LEVELS]
-    dewpoint_params = [f"dewpoint_{level}hPa" for level in PRESSURE_LEVELS if level >= 200]
-    wind_speed_params = [f"windspeed_{level}hPa" for level in PRESSURE_LEVELS]
-    wind_dir_params = [f"winddirection_{level}hPa" for level in PRESSURE_LEVELS]
+    config = OPEN_METEO_MODEL_CONFIGS[model_key]
+    pressure_levels = _pressure_levels_for_model(model_key)
+    if (
+        day_index < 0
+        or (hour is not None and not 0 <= hour < 24)
+        or (hour is None and forecast_hour < 0)
+    ):
+        return {
+            "success": False,
+            "source": config["source"],
+            "error": (
+                "Invalid forecast time: day_index must be >= 0, hour must be 0-23, "
+                "and forecast_hour must be >= 0"
+            ),
+        }
+    target_index = _target_hour_index(day_index, hour, forecast_hour)
 
-    all_params = temp_params + dewpoint_params + wind_speed_params + wind_dir_params
-
-    # Choose model
-    base_url = "https://api.open-meteo.com/v1/forecast"
-    if use_icon:
-        base_url = "https://api.open-meteo.com/v1/dwd-icon"  # Higher res for Germany/France
+    temp_params = [f"temperature_{level}hPa" for level in pressure_levels]
+    dewpoint_params = [f"dew_point_{level}hPa" for level in pressure_levels]
+    wind_speed_params = [f"wind_speed_{level}hPa" for level in pressure_levels]
+    wind_dir_params = [f"wind_direction_{level}hPa" for level in pressure_levels]
+    height_params = [f"geopotential_height_{level}hPa" for level in pressure_levels]
 
     params = {
         "latitude": latitude,
         "longitude": longitude,
-        "hourly": ",".join(all_params),
-        "forecast_days": 1,
+        "hourly": ",".join(
+            temp_params + dewpoint_params + wind_speed_params + wind_dir_params + height_params
+        ),
+        "forecast_days": max(1, (target_index // 24) + 1),
+        "wind_speed_unit": "kmh",
     }
+    if config["model"] != "auto":
+        params["models"] = config["model"]
 
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(base_url, params=params)
+            response = await client.get(config["base_url"], params=params)
             response.raise_for_status()
-            data = response.json()
+            payload = response.json()
 
-        # Extract data for requested forecast hour
-        hourly = data.get("hourly", {})
+        hourly = payload.get("hourly", {})
         times = hourly.get("time", [])
-
-        if forecast_hour >= len(times):
+        if target_index >= len(times):
             return {
                 "success": False,
-                "source": "open-meteo",
-                "error": f"Forecast hour {forecast_hour} not available (max: {len(times)-1})",
+                "source": config["source"],
+                "error": f"Forecast hour index {target_index} not available (max: {len(times)-1})",
             }
 
-        # Build sounding levels
         levels = []
-        for pressure in PRESSURE_LEVELS:
-            temp_key = f"temperature_{pressure}hPa"
-            dewpoint_key = f"dewpoint_{pressure}hPa"
-            wind_speed_key = f"windspeed_{pressure}hPa"
-            wind_dir_key = f"winddirection_{pressure}hPa"
+        for pressure in pressure_levels:
+            temp = _hourly_value(hourly, f"temperature_{pressure}hPa", target_index)
+            dewpoint = _hourly_value(hourly, f"dew_point_{pressure}hPa", target_index)
+            wind_speed = _hourly_value(hourly, f"wind_speed_{pressure}hPa", target_index)
+            wind_dir = _hourly_value(hourly, f"wind_direction_{pressure}hPa", target_index)
+            height = _hourly_value(hourly, f"geopotential_height_{pressure}hPa", target_index)
 
-            # Get values for this hour
-            temp = hourly.get(temp_key, [None] * len(times))[forecast_hour]
-            dewpoint = (
-                hourly.get(dewpoint_key, [None] * len(times))[forecast_hour]
-                if pressure >= 200
-                else None
-            )
-            wind_speed = hourly.get(wind_speed_key, [None] * len(times))[forecast_hour]
-            wind_dir = hourly.get(wind_dir_key, [None] * len(times))[forecast_hour]
-
-            # Skip if no temperature data
             if temp is None:
                 continue
 
-            # Use standard atmosphere height
-            height = STANDARD_HEIGHTS.get(pressure, 0)
+            if height is None:
+                height = STANDARD_HEIGHTS.get(pressure, 0)
 
-            # Calculate relative humidity if dewpoint available
             if dewpoint is not None:
-                # Magnus formula for RH
                 es = 6.112 * (10 ** ((7.5 * temp) / (237.7 + temp)))
                 e = 6.112 * (10 ** ((7.5 * dewpoint) / (237.7 + dewpoint)))
                 relh = min(100, max(0, (e / es) * 100))
             else:
-                dewpoint = temp - 10  # Rough estimate
+                dewpoint = temp - 10
                 relh = 50
 
             levels.append(
@@ -157,27 +250,30 @@ async def fetch_open_meteo_sounding(
                 }
             )
 
-        # Sort by pressure (descending = surface first)
-        levels.sort(key=lambda x: x["pressure"], reverse=True)
+        levels.sort(key=lambda level: level["pressure"], reverse=True)
+        if len(levels) < 5:
+            return {
+                "success": False,
+                "source": config["source"],
+                "error": f"Insufficient Open-Meteo pressure levels for {config['label']}",
+            }
 
-        sounding_time = times[forecast_hour]
-        dt = datetime.fromisoformat(sounding_time.replace("Z", "+00:00"))
-
+        sounding_datetime = datetime.fromisoformat(times[target_index].replace("Z", "+00:00"))
         return {
             "success": True,
-            "source": "open-meteo",
-            "model": "ICON-D2" if use_icon else "GFS",
-            "station_name": f"Model sounding ({latitude:.2f}°N, {longitude:.2f}°E)",
+            "source": config["source"],
+            "model": config["label"],
+            "external_url": str(response.url),
+            "station_name": f"{config['label']} ({latitude:.2f}N, {longitude:.2f}E)",
             "station_latitude": latitude,
             "station_longitude": longitude,
-            "station_elevation_m": data.get("elevation", 0),
-            "sounding_time": dt.strftime("%Hz"),
-            "sounding_date": dt.strftime("%Y-%m-%d"),
-            "forecast_hour": forecast_hour,
-            "data": {
-                "levels": levels,
-                "station_pressure": 1013.25,  # Standard
-            },
+            "station_elevation_m": payload.get("elevation", 0),
+            "sounding_time": sounding_datetime.strftime("%Hz"),
+            "sounding_date": sounding_datetime.strftime("%Y-%m-%d"),
+            "forecast_hour": hour if hour is not None else target_index,
+            "forecast_hour_index": target_index,
+            "data": {"levels": levels, "station_pressure": 1013.25},
+            "generator_data": _levels_to_generator_data(levels),
             "timestamp": datetime.now().isoformat(),
             "from_cache": False,
         }
@@ -185,40 +281,37 @@ async def fetch_open_meteo_sounding(
     except httpx.HTTPStatusError as e:
         return {
             "success": False,
-            "source": "open-meteo",
+            "source": config["source"],
             "error": f"HTTP {e.response.status_code}: {str(e)}",
         }
     except Exception as e:
         return {
             "success": False,
-            "source": "open-meteo",
+            "source": config["source"],
             "error": f"Error fetching Open-Meteo data: {str(e)}",
         }
 
 
 async def fetch_sounding_for_spot(
-    spot_latitude: float, spot_longitude: float, spot_name: str, forecast_hour: int = 0
+    spot_latitude: float,
+    spot_longitude: float,
+    spot_name: str,
+    forecast_hour: int = 0,
+    model: str = "icon",
+    day_index: int = 0,
+    hour: int | None = None,
 ) -> dict[str, Any]:
-    """
-    Fetch sounding specifically for a paragliding spot
-
-    Args:
-        spot_latitude: Spot latitude
-        spot_longitude: Spot longitude
-        spot_name: Spot name (for display)
-        forecast_hour: Hours ahead (0=now, 3=+3h, etc.)
-
-    Returns:
-        Sounding data ready for emagram generation
-    """
+    """Fetch sounding data for a paragliding spot."""
     result = await fetch_open_meteo_sounding(
         latitude=spot_latitude,
         longitude=spot_longitude,
         forecast_hour=forecast_hour,
-        use_icon=True,  # Use ICON for better resolution in Europe
+        model=model,
+        day_index=day_index,
+        hour=hour,
     )
 
     if result.get("success"):
-        result["station_name"] = f"{spot_name} (model forecast)"
+        result["station_name"] = f"{spot_name} ({result.get('model', 'Open-Meteo')})"
 
     return result

--- a/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
+++ b/apps/backend/tests/unit/test_meteociel_emagram_screenshot.py
@@ -233,8 +233,18 @@ async def test_fetch_all_returns_success_when_one_source_times_out(monkeypatch) 
             "timestamp": datetime.now().isoformat(),
         }
 
+    async def failed_open_meteo(*args, model: str, **kwargs) -> dict[str, str | bool]:
+        return {
+            "success": False,
+            "source": f"open-meteo-{model}",
+            "error": "not tested here",
+            "external_url": "https://open-meteo.com/",
+            "timestamp": datetime.now().isoformat(),
+        }
+
     monkeypatch.setattr(emagram_screenshots, "screenshot_meteo_parapente", slow_meteo_parapente)
     monkeypatch.setattr(emagram_screenshots, "screenshot_meteociel_emagram", successful_meteociel)
+    monkeypatch.setattr(emagram_screenshots, "generate_open_meteo_emagram_image", failed_open_meteo)
     monkeypatch.setattr(emagram_screenshots, "METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS", 0.01)
 
     result = await emagram_screenshots.fetch_all_emagram_screenshots(

--- a/apps/backend/tests/unit/test_open_meteo_emagram_sources.py
+++ b/apps/backend/tests/unit/test_open_meteo_emagram_sources.py
@@ -1,0 +1,180 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from scrapers import emagram_screenshots
+from scrapers import open_meteo_sounding
+
+
+class _FakeOpenMeteoResponse:
+    def __init__(self, url: str, payload: dict) -> None:
+        self.url = url
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeOpenMeteoClient:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.requests: list[tuple[str, dict]] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get(self, url: str, params: dict) -> _FakeOpenMeteoResponse:
+        self.requests.append((url, params))
+        return _FakeOpenMeteoResponse(f"{url}?stub=true", self.payload)
+
+
+def _open_meteo_payload() -> dict:
+    hourly = {"time": [f"2026-06-24T{hour:02d}:00" for hour in range(24)]}
+    for pressure in open_meteo_sounding.METEOFRANCE_PRESSURE_LEVELS:
+        hourly[f"temperature_{pressure}hPa"] = [20 - pressure / 100] * 24
+        hourly[f"dew_point_{pressure}hPa"] = [15 - pressure / 120] * 24
+        hourly[f"wind_speed_{pressure}hPa"] = [18.52] * 24
+        hourly[f"wind_direction_{pressure}hPa"] = [270] * 24
+        hourly[f"geopotential_height_{pressure}hPa"] = [
+            open_meteo_sounding.STANDARD_HEIGHTS[pressure]
+        ] * 24
+    return {"elevation": 250, "hourly": hourly}
+
+
+def _open_meteo_payload_hours(hours: int) -> dict:
+    base_time = datetime(2026, 6, 24)
+    hourly = {
+        "time": [
+            (base_time + timedelta(hours=hour)).isoformat(timespec="minutes")
+            for hour in range(hours)
+        ]
+    }
+    for pressure in open_meteo_sounding.COMMON_PRESSURE_LEVELS:
+        hourly[f"temperature_{pressure}hPa"] = [20 - pressure / 100] * hours
+        hourly[f"dew_point_{pressure}hPa"] = [15 - pressure / 120] * hours
+        hourly[f"wind_speed_{pressure}hPa"] = [18.52] * hours
+        hourly[f"wind_direction_{pressure}hPa"] = [270] * hours
+        hourly[f"geopotential_height_{pressure}hPa"] = [
+            open_meteo_sounding.STANDARD_HEIGHTS[pressure]
+        ] * hours
+    return {"elevation": 250, "hourly": hourly}
+
+
+@pytest.mark.asyncio
+async def test_fetch_open_meteo_sounding_normalizes_arome(monkeypatch) -> None:
+    fake_client = _FakeOpenMeteoClient(_open_meteo_payload())
+    monkeypatch.setattr(
+        open_meteo_sounding.httpx,
+        "AsyncClient",
+        lambda **kwargs: fake_client,
+    )
+
+    result = await open_meteo_sounding.fetch_open_meteo_sounding(
+        latitude=47.2,
+        longitude=6.0,
+        model="arome",
+        day_index=0,
+        hour=12,
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "open-meteo-arome"
+    assert result["forecast_hour"] == 12
+    assert result["forecast_hour_index"] == 12
+    assert result["generator_data"]["pressure_hpa"][0] == 1000
+    assert result["generator_data"]["wind_speed_knots"][0] == pytest.approx(10.0)
+
+    requested_url, params = fake_client.requests[0]
+    assert requested_url == "https://api.open-meteo.com/v1/meteofrance"
+    assert params["models"] == "meteofrance_seamless"
+    assert "dew_point_1000hPa" in params["hourly"]
+    assert "geopotential_height_1000hPa" in params["hourly"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_emagram_screenshots_includes_open_meteo_sources(monkeypatch) -> None:
+    async def fake_meteo_parapente(*args, **kwargs):
+        return {"success": True, "source": "meteo-parapente", "image_path": "/tmp/mp.png"}
+
+    async def fake_meteociel(*args, **kwargs):
+        return {"success": True, "source": "meteociel", "image_path": "/tmp/mc.png"}
+
+    async def fake_open_meteo(*args, model: str, **kwargs):
+        return {
+            "success": True,
+            "source": f"open-meteo-{model}",
+            "image_path": f"/tmp/{model}.png",
+        }
+
+    monkeypatch.setattr(emagram_screenshots, "screenshot_meteo_parapente", fake_meteo_parapente)
+    monkeypatch.setattr(emagram_screenshots, "screenshot_meteociel_emagram", fake_meteociel)
+    monkeypatch.setattr(emagram_screenshots, "generate_open_meteo_emagram_image", fake_open_meteo)
+
+    result = await emagram_screenshots.fetch_all_emagram_screenshots(
+        spot_id="arguel",
+        latitude=47.2,
+        longitude=6.0,
+        spot_name="Arguel",
+        hour=12,
+    )
+
+    sources = {screenshot["source"] for screenshot in result["screenshots"]}
+    assert result["success"] is True
+    assert result["sources_total"] == 4
+    assert result["sources_successful"] == 4
+    assert sources == {
+        "meteo-parapente",
+        "meteociel",
+        "open-meteo-arome",
+        "open-meteo-icon",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_open_meteo_sounding_rejects_negative_indices(monkeypatch) -> None:
+    fake_client = _FakeOpenMeteoClient(_open_meteo_payload())
+    monkeypatch.setattr(
+        open_meteo_sounding.httpx,
+        "AsyncClient",
+        lambda **kwargs: fake_client,
+    )
+
+    result = await open_meteo_sounding.fetch_open_meteo_sounding(
+        latitude=47.2,
+        longitude=6.0,
+        day_index=-1,
+        hour=12,
+        model="icon",
+    )
+
+    assert result["success"] is False
+    assert "Invalid forecast time" in result["error"]
+    assert fake_client.requests == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_open_meteo_sounding_requests_enough_days_for_absolute_hour(
+    monkeypatch,
+) -> None:
+    fake_client = _FakeOpenMeteoClient(_open_meteo_payload_hours(48))
+    monkeypatch.setattr(
+        open_meteo_sounding.httpx,
+        "AsyncClient",
+        lambda **kwargs: fake_client,
+    )
+
+    result = await open_meteo_sounding.fetch_open_meteo_sounding(
+        latitude=47.2,
+        longitude=6.0,
+        forecast_hour=30,
+        model="icon",
+    )
+
+    assert result["success"] is True
+    assert fake_client.requests[0][1]["forecast_days"] == 2


### PR DESCRIPTION
## Summary\n- Add Open-Meteo AROME and ICON emagram sources as generated Skew-T images\n- Normalize Open-Meteo pressure-level data for the LLM vision pipeline\n- Add targeted backend tests and update multi-source emagram coverage\n\n## Validation\n- ../../.venv/bin/pytest tests/unit/test_open_meteo_emagram_sources.py tests/unit/test_meteociel_emagram_screenshot.py -q --tb=short --no-header\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e --uncommitted\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx test backend (timed out in pre-existing suite)\n\n## Review\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating atmospheric diagram images from multiple Open-Meteo models.
  * Expanded the screenshot flow to include additional Open-Meteo sources and return more complete results.

* **Bug Fixes**
  * Improved handling of invalid or missing forecast times.
  * Added clearer error reporting when data fetching or image generation fails.

* **Tests**
  * Added coverage for Open-Meteo normalization, multi-source screenshot results, timeout/failure cases, and forecast-hour range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->