### PR TITLE
fix(frontend): show thunderstorm flyability hourly

### DIFF
--- a/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.behavior.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import HourlyForecast from './HourlyForecast';
 
@@ -12,6 +12,8 @@ vi.mock('react-i18next', () => ({
         'weather.metricsUsed': 'Metriques utilisees',
         'weather.verdictLabel': 'Verdict',
         'weather.criteriaEvaluated': 'Criteres evalues',
+        'weather.hourly.reasons.thunderstorms': 'Orages',
+        'weather.hourly.reasons.thunderstormRisk': "Risque d'orage",
       };
       if (labels[key]) return labels[key];
       return key;
@@ -158,5 +160,79 @@ describe('HourlyForecast tooltip behavior', () => {
     render(<HourlyForecast spotId="site-1" dayIndex={0} />);
 
     expect(screen.getByText('NW (315°)')).toBeTruthy();
+  });
+
+  it('shows thunderstorms as the hourly flyability reason', () => {
+    mockedUseWeather.mockReturnValue({
+      data: {
+        cached_at: '2026-04-25T10:00:00Z',
+        hourly_forecast: [
+          {
+            hour: '10:00',
+            time: '10:00',
+            temp: 22,
+            temperature: 22,
+            wind: 10,
+            wind_speed: 10,
+            wind_gust: 15,
+            direction: 'NW',
+            wind_direction: 'NW',
+            wind_direction_deg: 315,
+            conditions: 'clear',
+            precipitation: 0,
+            cloud_cover: 10,
+            cape: 2600,
+            lifted_index: -5,
+            thermal_strength: 'fort',
+            para_index: 25,
+            verdict: 'mauvais',
+            sources: {},
+          },
+          {
+            hour: '11:00',
+            time: '11:00',
+            temp: 23,
+            temperature: 23,
+            wind: 10,
+            wind_speed: 10,
+            wind_gust: 15,
+            direction: 'NW',
+            wind_direction: 'NW',
+            wind_direction_deg: 315,
+            conditions: 'clear',
+            precipitation: 0,
+            cloud_cover: 10,
+            cape: 1600,
+            lifted_index: -2,
+            thermal_strength: 'fort',
+            para_index: 55,
+            verdict: 'moyen',
+            sources: {},
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    } as never);
+
+    render(<HourlyForecast spotId="site-1" dayIndex={0} />);
+
+    const tenRow = screen
+      .getAllByText('10:00')
+      .map((element) => element.closest('tr'))
+      .find((row) => row != null);
+    const elevenRow = screen
+      .getAllByText('11:00')
+      .map((element) => element.closest('tr'))
+      .find((row) => row != null);
+
+    expect(tenRow).not.toBeNull();
+    expect(elevenRow).not.toBeNull();
+    expect(
+      within(tenRow as HTMLElement).getByText('MAUVAIS — Orages')
+    ).toBeTruthy();
+    expect(
+      within(elevenRow as HTMLElement).getByText("MOYEN — Risque d'orage")
+    ).toBeTruthy();
   });
 });

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -101,6 +101,8 @@ type FlyabilityReasonLabels = {
   veryCloudy: string;
   moderateWind: string;
   averageConditions: string;
+  thunderstorms: string;
+  thunderstormRisk: string;
 };
 
 const DEFAULT_FLYABILITY_REASON_LABELS: FlyabilityReasonLabels = {
@@ -113,6 +115,69 @@ const DEFAULT_FLYABILITY_REASON_LABELS: FlyabilityReasonLabels = {
   veryCloudy: 'Très nuageux',
   moderateWind: 'Vent modéré',
   averageConditions: 'Conditions moyennes',
+  thunderstorms: 'Orages',
+  thunderstormRisk: "Risque d'orage",
+};
+
+type ThunderstormRisk = 'nul' | 'faible' | 'modere' | 'eleve';
+
+const THUNDERSTORM_RISK_RANKS: Record<ThunderstormRisk, number> = {
+  nul: 0,
+  faible: 1,
+  modere: 2,
+  eleve: 3,
+};
+
+const maxThunderstormRisk = (
+  left: ThunderstormRisk,
+  right: ThunderstormRisk
+): ThunderstormRisk => {
+  return THUNDERSTORM_RISK_RANKS[left] >= THUNDERSTORM_RISK_RANKS[right]
+    ? left
+    : right;
+};
+
+const getLiftedIndexRisk = (
+  liftedIndex: number | null | undefined
+): ThunderstormRisk => {
+  if (liftedIndex == null) return 'nul';
+  if (liftedIndex <= -7) return 'eleve';
+  if (liftedIndex <= -5) return 'modere';
+  if (liftedIndex <= -3) return 'faible';
+  return 'nul';
+};
+
+const getCapeRisk = (cape: number | null | undefined): ThunderstormRisk => {
+  if (cape == null) return 'nul';
+  if (cape >= 2500) return 'eleve';
+  if (cape >= 1500) return 'modere';
+  if (cape >= 300) return 'faible';
+  return 'nul';
+};
+
+const getThunderstormRisk = (
+  cape: number | null | undefined,
+  liftedIndex: number | null | undefined
+): ThunderstormRisk => {
+  const capeRisk = getCapeRisk(cape);
+  const liftedIndexRisk = getLiftedIndexRisk(liftedIndex);
+
+  if (
+    cape != null &&
+    liftedIndex != null &&
+    cape >= 1500 &&
+    liftedIndex <= -4
+  ) {
+    return 'eleve';
+  }
+  if (cape != null && liftedIndex != null && cape >= 800 && liftedIndex <= -2) {
+    return maxThunderstormRisk(
+      'modere',
+      maxThunderstormRisk(capeRisk, liftedIndexRisk)
+    );
+  }
+
+  return maxThunderstormRisk(capeRisk, liftedIndexRisk);
 };
 
 // ============================================================================
@@ -160,6 +225,26 @@ export const getFlyabilityDisplay = (
   color: string;
   Icon: ReturnType<typeof getVerdictVisual>['Icon'];
 } => {
+  const thunderstormRisk = getThunderstormRisk(hour.cape, hour.lifted_index);
+
+  if (thunderstormRisk === 'eleve') {
+    const visual = getVerdictVisual('mauvais');
+    return {
+      text: `MAUVAIS — ${reasonLabels.thunderstorms}`,
+      color: visual.textClassName,
+      Icon: visual.Icon,
+    };
+  }
+
+  if (thunderstormRisk === 'modere') {
+    const visual = getVerdictVisual('moyen');
+    return {
+      text: `MOYEN — ${reasonLabels.thunderstormRisk}`,
+      color: visual.textClassName,
+      Icon: visual.Icon,
+    };
+  }
+
   const verdict = hour.verdict?.toLowerCase();
   const verdictUpper = verdict?.toUpperCase() || 'MOYEN';
   const visual = getVerdictVisual(verdict || 'moyen');
@@ -680,6 +765,8 @@ export default function HourlyForecast({
     veryCloudy: t('weather.hourly.reasons.veryCloudy'),
     moderateWind: t('weather.hourly.reasons.moderateWind'),
     averageConditions: t('weather.hourly.reasons.averageConditions'),
+    thunderstorms: t('weather.hourly.reasons.thunderstorms'),
+    thunderstormRisk: t('weather.hourly.reasons.thunderstormRisk'),
   };
 
   if (isLoading) {

--- a/apps/frontend/src/hooks/weather/useWeather.ts
+++ b/apps/frontend/src/hooks/weather/useWeather.ts
@@ -107,6 +107,7 @@ export const transformWeatherResponse = (
       para_index: hour.para_index ?? 0,
       verdict: hour.verdict ?? hourToVerdict.get(hour.hour) ?? 'N/A',
       cape: hour.cape ?? null,
+      lifted_index: hour.lifted_index ?? null,
       thermal_strength:
         (hour.thermal_strength?.toLowerCase() as HourlyForecastItem['thermal_strength']) ||
         'faible',

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -326,7 +326,9 @@
         "acceptableWind": "Acceptable wind",
         "veryCloudy": "Very cloudy",
         "moderateWind": "Moderate wind",
-        "averageConditions": "Average conditions"
+        "averageConditions": "Average conditions",
+        "thunderstorms": "Thunderstorms",
+        "thunderstormRisk": "Thunderstorm risk"
       }
     },
     "criteria": {

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -326,7 +326,9 @@
         "acceptableWind": "Vent acceptable",
         "veryCloudy": "Très nuageux",
         "moderateWind": "Vent modéré",
-        "averageConditions": "Conditions moyennes"
+        "averageConditions": "Conditions moyennes",
+        "thunderstorms": "Orages",
+        "thunderstormRisk": "Risque d'orage"
       }
     },
     "criteria": {

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -53,6 +53,7 @@ export interface HourlyForecastItem {
   sources?: Record<string, Record<string, number | null>>;
   thermal_strength?: string;
   cape?: number | null;
+  lifted_index?: number | null;
   cloud_cover?: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Display thunderstorm-driven flyability reasons hour by hour.
- Propagate lifted_index into hourly weather data.
- Add FR/EN labels and targeted test coverage.

## Validation
- vitest run src/components/weather/HourlyForecast.behavior.test.tsx --config vitest.config.ts ✅
- oxlint on modified frontend files ✅ (warnings only in pre-existing useWeather.ts)
- nx build frontend ✅
- nx affected lint/test commands with projects flag were not usable as written in this repo; equivalent targeted validation was run instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hourly weather forecasts now show thunderstorm-related flyability reasons, with clearer labels for higher-risk conditions.
  * Forecast displays now consider an additional weather signal to better reflect storm risk in hourly guidance.

* **Bug Fixes**
  * Improved hourly flyability messaging so verdicts and reason text are more accurate in thunderstorm scenarios.

* **Tests**
  * Added coverage for hourly forecast messages to verify the new thunderstorm-related labels appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->