### PR TITLE
fix(backend): harden weather source fallbacks

### DIFF
--- a/apps/backend/scrapers/meteoblue.py
+++ b/apps/backend/scrapers/meteoblue.py
@@ -85,8 +85,11 @@ class MeteoblueScraper(PlaywrightScraper):
             timeout=timeout,
         )
 
-    def _get_city_code(self, city_name: str) -> str | None:
+    def _get_city_code(self, city_name: str | None) -> str | None:
         """Get Meteoblue city code"""
+        if not city_name:
+            return None
+
         city_key = city_name.lower()
 
         if city_key in self.CITY_CODE_OVERRIDE:
@@ -110,7 +113,7 @@ class MeteoblueScraper(PlaywrightScraper):
         Returns:
             List of hourly forecast dictionaries
         """
-        city_name = kwargs.get("city_name", "location")
+        city_name = kwargs.get("city_name") or "location"
 
         # Get city code
         city_code = self._get_city_code(city_name)

--- a/apps/backend/scrapers/meteociel.py
+++ b/apps/backend/scrapers/meteociel.py
@@ -143,20 +143,15 @@ class MeteocielScraper(BaseScraper):
         """
         site_name = kwargs.get("site_name")
 
-        if not site_name:
-            return self._build_response(
-                success=False, error="site_name is required for meteociel scraper"
-            )
-
         try:
-            # Step 1: Get INSEE code
-            insee_code = await self._get_insee_code(site_name)
+            # Step 1: Get INSEE code from site name, or from nearest commune when absent.
+            insee_code = await self._get_insee_code(site_name) if site_name else None
             city_name_for_url = site_name
 
             if not insee_code:
                 # Graceful degradation: Try to find nearest French city using coordinates
                 logger.info(
-                    f"No INSEE code found for {site_name}, trying reverse geocoding with coordinates"
+                    f"No INSEE code found for {site_name or 'coordinates'}, trying reverse geocoding with coordinates"
                 )
                 nearest_commune = await self._get_nearest_commune(lat, lon)
 

--- a/apps/backend/tests/scrapers/test_meteoblue.py
+++ b/apps/backend/tests/scrapers/test_meteoblue.py
@@ -5,7 +5,7 @@ Live tests for Meteoblue scraper
 import pytest
 
 from config import METEOBLUE_API_KEY
-from scrapers.meteoblue import fetch_meteoblue
+from scrapers.meteoblue import MeteoblueScraper, fetch_meteoblue
 
 ARGUEL_LAT = 47.2
 ARGUEL_LON = 6.0
@@ -33,3 +33,9 @@ async def test_fetch_meteoblue_timeout():
     duration = time.time() - start
     assert duration < 20.0
     assert "success" in result
+
+
+def test_meteoblue_city_code_handles_missing_city_name() -> None:
+    scraper = MeteoblueScraper()
+
+    assert scraper._get_city_code(None) is None

--- a/apps/backend/tests/scrapers/test_meteociel.py
+++ b/apps/backend/tests/scrapers/test_meteociel.py
@@ -32,35 +32,39 @@ async def test_fetch_meteociel_timeout():
 
 
 @pytest.mark.asyncio
-async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(monkeypatch):
-    requested_urls = []
+async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
 
-    async def fake_get_insee_code(self, city_name):
+    async def fake_get_insee_code(self: MeteocielScraper, city_name: str | None) -> None:
         return None
 
-    async def fake_get_nearest_commune(self, lat, lon):
+    async def fake_get_nearest_commune(
+        self: MeteocielScraper, lat: float, lon: float
+    ) -> tuple[str, str]:
         return "25056", "Besançon"
 
-    def fake_parse_forecast_tables(self, soup):
+    def fake_parse_forecast_tables(self: MeteocielScraper, soup: object) -> list[dict[str, float]]:
         return [{"hour": 12, "temperature": 20.0}]
 
     class FakeResponse:
         text = "<html></html>"
 
-        def raise_for_status(self):
+        def raise_for_status(self) -> None:
             return None
 
     class FakeAsyncClient:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
-        async def __aenter__(self):
+        async def __aenter__(self) -> "FakeAsyncClient":
             return self
 
-        async def __aexit__(self, exc_type, exc, tb):
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
             return None
 
-        async def get(self, url):
+        async def get(self, url: str) -> FakeResponse:
             requested_urls.append(url)
             return FakeResponse()
 
@@ -70,6 +74,50 @@ async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(mo
     monkeypatch.setattr(meteociel.httpx, "AsyncClient", FakeAsyncClient)
 
     result = await fetch_meteociel(47.24, 6.02, site_name="Test Site")
+
+    assert result["success"] is True
+    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/25056/besancon.htm"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_meteociel_uses_nearest_city_when_site_name_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_urls: list[str] = []
+
+    async def fake_get_nearest_commune(
+        self: MeteocielScraper, lat: float, lon: float
+    ) -> tuple[str, str]:
+        return "25056", "Besançon"
+
+    def fake_parse_forecast_tables(self: MeteocielScraper, soup: object) -> list[dict[str, float]]:
+        return [{"hour": 12, "temperature": 20.0}]
+
+    class FakeResponse:
+        text = "<html></html>"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str) -> FakeResponse:
+            requested_urls.append(url)
+            return FakeResponse()
+
+    monkeypatch.setattr(MeteocielScraper, "_get_nearest_commune", fake_get_nearest_commune)
+    monkeypatch.setattr(MeteocielScraper, "_parse_forecast_tables", fake_parse_forecast_tables)
+    monkeypatch.setattr(meteociel.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await fetch_meteociel(47.24, 6.02, site_name=None)
 
     assert result["success"] is True
     assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/25056/besancon.htm"]

--- a/apps/backend/tests/unit/test_weather_sources_registry.py
+++ b/apps/backend/tests/unit/test_weather_sources_registry.py
@@ -1,4 +1,6 @@
 import config
+import pytest
+import weather_sources
 from weather_sources import SYSTEM_WEATHER_SOURCE_NAMES, WEATHER_SOURCE_REGISTRY
 
 
@@ -15,3 +17,76 @@ def test_openweathermap_enablement_follows_api_key_configuration():
 
     assert source.requires_api_key is True
     assert source.is_enabled is bool(config.OPENWEATHERMAP_API_KEY)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("wrapper_name", "fetch_name"),
+    [
+        ("fetch_open_meteo_default", "fetch_open_meteo"),
+        ("fetch_open_meteo_icon_default", "fetch_open_meteo_icon"),
+        ("fetch_open_meteo_gfs_default", "fetch_open_meteo_gfs"),
+    ],
+)
+async def test_open_meteo_wrapper_requests_only_days_needed_for_day(
+    monkeypatch: pytest.MonkeyPatch, wrapper_name: str, fetch_name: str
+) -> None:
+    calls: list[tuple[float, float, int]] = []
+
+    async def fake_fetch_open_meteo(lat: float, lon: float, days: int) -> dict[str, bool]:
+        calls.append((lat, lon, days))
+        return {"success": True}
+
+    monkeypatch.setattr(weather_sources, fetch_name, fake_fetch_open_meteo)
+
+    await getattr(weather_sources, wrapper_name)(47.2, 6.0, day_index=2)
+
+    assert calls == [(47.2, 6.0, 3)]
+
+
+@pytest.mark.asyncio
+async def test_meteo_parapente_wrapper_requests_target_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FixedDateTime:
+        @classmethod
+        def now(cls) -> object:
+            from datetime import datetime
+
+            return datetime(2026, 7, 4, 12, 0, 0)
+
+    async def fake_fetch_meteo_parapente(*args: object, **kwargs: object) -> dict[str, bool]:
+        calls.append(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(weather_sources, "datetime", FixedDateTime)
+    monkeypatch.setattr(weather_sources, "fetch_meteo_parapente", fake_fetch_meteo_parapente)
+
+    await weather_sources.fetch_meteo_parapente_default(
+        47.2,
+        6.0,
+        day_index=2,
+        site_name="Arguel",
+        elevation_m=500,
+    )
+
+    assert calls[0]["date"] == "20260706"
+
+
+@pytest.mark.asyncio
+async def test_meteoblue_wrapper_uses_location_fallback_without_site_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[float, float, str]] = []
+
+    async def fake_fetch_meteoblue(lat: float, lon: float, city_name: str) -> dict[str, bool]:
+        calls.append((lat, lon, city_name))
+        return {"success": True}
+
+    monkeypatch.setattr(weather_sources, "fetch_meteoblue", fake_fetch_meteoblue)
+
+    await weather_sources.fetch_meteoblue_default(47.2, 6.0, site_name=None)
+
+    assert calls == [(47.2, 6.0, "location")]

--- a/apps/backend/weather_pipeline.py
+++ b/apps/backend/weather_pipeline.py
@@ -149,6 +149,7 @@ async def fetch_from_enabled_sources(
                 result = await source_definition.fetch(
                     lat,
                     lon,
+                    day_index=day_index,
                     site_name=site_name,
                     elevation_m=elevation_m,
                 )

--- a/apps/backend/weather_sources.py
+++ b/apps/backend/weather_sources.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 import uuid
 from typing import Any
 
@@ -57,16 +58,32 @@ class WeatherSourceDefinition:
         }
 
 
-async def fetch_open_meteo_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
-    return await fetch_open_meteo(lat, lon, days=7)
+def _bounded_day_index(day_index: int, max_days: int) -> int:
+    if max_days < 1:
+        raise ValueError("max_days must be greater than 0")
+    return max(0, min(day_index, max_days - 1))
 
 
-async def fetch_open_meteo_icon_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
-    return await fetch_open_meteo_icon(lat, lon, days=7)
+def _days_needed_for_day_index(day_index: int, max_days: int) -> int:
+    return _bounded_day_index(day_index, max_days) + 1
 
 
-async def fetch_open_meteo_gfs_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
-    return await fetch_open_meteo_gfs(lat, lon, days=7)
+async def fetch_open_meteo_default(
+    lat: float, lon: float, *, day_index: int = 0, **_: Any
+) -> dict[str, Any]:
+    return await fetch_open_meteo(lat, lon, days=_days_needed_for_day_index(day_index, 7))
+
+
+async def fetch_open_meteo_icon_default(
+    lat: float, lon: float, *, day_index: int = 0, **_: Any
+) -> dict[str, Any]:
+    return await fetch_open_meteo_icon(lat, lon, days=_days_needed_for_day_index(day_index, 7))
+
+
+async def fetch_open_meteo_gfs_default(
+    lat: float, lon: float, *, day_index: int = 0, **_: Any
+) -> dict[str, Any]:
+    return await fetch_open_meteo_gfs(lat, lon, days=_days_needed_for_day_index(day_index, 7))
 
 
 async def fetch_weatherapi_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
@@ -77,6 +94,7 @@ async def fetch_meteo_parapente_default(
     lat: float,
     lon: float,
     *,
+    day_index: int = 0,
     site_name: str | None = None,
     elevation_m: int | None = None,
     **_: Any,
@@ -87,6 +105,7 @@ async def fetch_meteo_parapente_default(
         site_name=site_name,
         elevation_m=elevation_m,
         days=1,
+        date=(datetime.now() + timedelta(days=_bounded_day_index(day_index, 7))).strftime("%Y%m%d"),
     )
 
 
@@ -107,7 +126,7 @@ async def fetch_meteoblue_default(
     site_name: str | None = None,
     **_: Any,
 ) -> dict[str, Any]:
-    return await fetch_meteoblue(lat, lon, city_name=site_name)
+    return await fetch_meteoblue(lat, lon, city_name=site_name or "location")
 
 
 async def fetch_met_no_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary\n- make Meteoblue and Meteociel resilient when site_name is missing\n- pass day_index through the weather pipeline and source wrappers\n- reduce Open-Meteo pressure by requesting only the needed forecast window\n\n## Validation\n- pytest target tests: 9 passed\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx lint backend: passed\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather lookups when location details are missing, so forecasts can still load from coordinates or a generic fallback.
  * Fixed day-based forecast requests so the app fetches the correct amount of weather data for the selected day.
  * Updated weather source handling to better support date-specific results and reduce failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->