### PR TITLE
fix(backend): harden emagram production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,8 @@ COPY --from=frontend-builder /workspace/dist/apps/frontend ./static
 
 # Créer répertoires pour la base de données et les exports vidéo
 RUN mkdir -p /app/db && chmod 755 /app/db && \
-    mkdir -p /app/exports/videos && chmod 755 /app/exports/videos
+    mkdir -p /app/exports/videos && chmod 755 /app/exports/videos && \
+    mkdir -p /app/emagram-cache && chmod 755 /app/emagram-cache
 
 # Rendre le script d'entrypoint exécutable
 RUN chmod +x entrypoint.sh

--- a/apps/backend/emagram_multi_source.py
+++ b/apps/backend/emagram_multi_source.py
@@ -44,6 +44,7 @@ PROVIDER_ENV_VARS = {
 }
 
 _LLM_QUOTA_COOLDOWNS: dict[str, float] = {}
+MIN_COMPLETED_EMAGRAM_SOURCES = 2
 
 
 def _to_float(value: Any) -> float | None:
@@ -464,6 +465,10 @@ def _is_usable_llm_analysis(analysis: dict[str, Any]) -> bool:
     return not any(phrase in details or phrase in advice for phrase in failure_phrases)
 
 
+def _analysis_status_for_sources(successful_source_count: int) -> str:
+    return "completed" if successful_source_count >= MIN_COMPLETED_EMAGRAM_SOURCES else "partial"
+
+
 async def generate_multi_source_emagram_for_spot(
     site_id: str,
     db: Session,
@@ -528,7 +533,7 @@ async def generate_multi_source_emagram_for_spot(
                 EmagramAnalysis.station_code == site_id,
                 EmagramAnalysis.analysis_method == "llm_vision",
                 EmagramAnalysis.analysis_datetime >= cutoff_time,
-                EmagramAnalysis.analysis_status == "completed",
+                EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
                 EmagramAnalysis.forecast_date == forecast_date,
             ]
             if hour is not None:
@@ -598,7 +603,11 @@ async def generate_multi_source_emagram_for_spot(
                 failure_result["analysis_id"] = failed_analysis.id
             return failure_result
 
-        logger.info(f"📸 {len(successful_screenshots)}/3 screenshots successful")
+        logger.info(
+            "📸 %s/%s emagram sources successful",
+            len(successful_screenshots),
+            screenshot_result.get("sources_total", 0),
+        )
 
         # Step 4: Analyze with AI using the configured fallback chain.
         image_sources = [
@@ -750,6 +759,14 @@ def save_emagram_analysis(
             source_name = screenshot.get("source", "unknown")
             sources_errors[source_name] = screenshot.get("error", "Unknown error")
 
+    source_count = screenshot_result.get("sources_successful", 0)
+    analysis_status = _analysis_status_for_sources(source_count)
+    if analysis_status == "partial":
+        sources_errors["analysis_quality"] = (
+            f"Only {source_count}/{screenshot_result.get('sources_total', 0)} emagram sources "
+            "were available; analysis saved as partial."
+        )
+
     # Create EmagramAnalysis object
     emagram = EmagramAnalysis(
         id=analysis_id,
@@ -794,19 +811,19 @@ def save_emagram_analysis(
         # Raw data storage (new fields for multi-source)
         external_source_urls=json.dumps(external_urls, ensure_ascii=False),
         screenshot_paths=json.dumps(screenshot_paths, ensure_ascii=False),
-        sources_count=screenshot_result.get("sources_successful", 0),
+        sources_count=source_count,
         sources_agreement=analysis_result.get("sources_agreement"),
         sources_errors=json.dumps(sources_errors, ensure_ascii=False) if sources_errors else None,
         ai_raw_response=json.dumps(analysis_result, ensure_ascii=False),
         # Status
-        analysis_status="completed",
+        analysis_status=analysis_status,
     )
 
     db.add(emagram)
     db.commit()
     db.refresh(emagram)
 
-    logger.info(f"💾 Saved emagram analysis {analysis_id} to database")
+    logger.info("💾 Saved %s emagram analysis %s to database", analysis_status, analysis_id)
 
     return emagram
 
@@ -894,8 +911,9 @@ def emagram_analysis_to_dict(emagram: EmagramAnalysis, db: Session | None = None
         alertes = []
 
     return {
-        "success": emagram.analysis_status == "completed",
+        "success": emagram.analysis_status in {"completed", "partial"},
         "analysis_id": emagram.id,
+        "analysis_status": emagram.analysis_status,
         "spot_name": emagram.station_name,
         "spot_id": emagram.station_code,
         "last_update": emagram.analysis_datetime.isoformat(),

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -6281,7 +6281,7 @@ async def get_latest_emagram(
 
         analysis_filters = [
             EmagramAnalysis.forecast_date == target_date,
-            EmagramAnalysis.analysis_status == "completed",
+            EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
             EmagramAnalysis.analysis_datetime >= cutoff_time,
         ]
         if hour is not None:
@@ -6322,7 +6322,7 @@ async def get_latest_emagram(
                     min_distance = dist
                     result = analysis
 
-        # If no completed analysis, check for recent failed ones to show the error
+        # If no usable analysis, check for recent failed ones to show the error
         if result is None and site_id:
             failed_filters = [
                 EmagramAnalysis.forecast_date == target_date,
@@ -6735,7 +6735,7 @@ async def trigger_emagram_analysis(
                     EmagramAnalysis.station_code == closest_site.id,
                     EmagramAnalysis.analysis_method == "llm_vision",
                     EmagramAnalysis.analysis_datetime >= cutoff_time,
-                    EmagramAnalysis.analysis_status == "completed",
+                    EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
                     EmagramAnalysis.forecast_date == forecast_date,
                 )
                 .count()
@@ -6748,7 +6748,7 @@ async def trigger_emagram_analysis(
                         EmagramAnalysis.station_code == closest_site.id,
                         EmagramAnalysis.analysis_method == "llm_vision",
                         EmagramAnalysis.analysis_datetime >= cutoff_time,
-                        EmagramAnalysis.analysis_status == "completed",
+                        EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
                         EmagramAnalysis.forecast_date == forecast_date,
                     )
                     .order_by(EmagramAnalysis.analysis_datetime.desc())
@@ -6766,7 +6766,7 @@ async def trigger_emagram_analysis(
                 EmagramAnalysis.station_code == closest_site.id,
                 EmagramAnalysis.analysis_method == "llm_vision",
                 EmagramAnalysis.analysis_datetime >= cutoff_time,
-                EmagramAnalysis.analysis_status == "completed",
+                EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
                 EmagramAnalysis.forecast_date == forecast_date,
                 EmagramAnalysis.forecast_hour == request.hour,
             ]

--- a/apps/backend/scrapers/emagram_screenshots.py
+++ b/apps/backend/scrapers/emagram_screenshots.py
@@ -6,6 +6,7 @@ Captures emagram images from Meteo-Parapente, TopMeteo, and Windy
 import asyncio
 import base64
 import logging
+import os
 from contextlib import suppress
 from datetime import datetime
 from datetime import timedelta
@@ -20,7 +21,7 @@ from playwright.async_api import async_playwright
 logger = logging.getLogger(__name__)
 
 # Cache directory for temporary screenshots
-EMAGRAM_CACHE_DIR = Path("/tmp/emagram_cache")
+EMAGRAM_CACHE_DIR = Path(os.getenv("BACKEND_EMAGRAM_CACHE_DIR", "/tmp/emagram_cache"))
 EMAGRAM_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 METEO_PARAPENTE_SCREENSHOT_TIMEOUT_SECONDS = 35
 METEOCIEL_SCREENSHOT_TIMEOUT_SECONDS = 30
@@ -78,6 +79,19 @@ async def _capture_page_png(
     else:
         screenshot_kwargs["full_page"] = False
     await page.screenshot(**screenshot_kwargs)
+
+
+def _write_image_atomically(image_path: Path, content: bytes) -> None:
+    if not content:
+        raise RuntimeError("Downloaded image is empty")
+
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = image_path.with_suffix(f"{image_path.suffix}.tmp")
+    tmp_path.write_bytes(content)
+    if tmp_path.stat().st_size == 0:
+        tmp_path.unlink(missing_ok=True)
+        raise RuntimeError("Downloaded image was written as an empty file")
+    tmp_path.replace(image_path)
 
 
 async def screenshot_meteo_parapente(
@@ -218,6 +232,7 @@ async def screenshot_meteo_parapente(
                         )
 
             # Navigate to the correct hour if specified
+            hour_navigated = hour is None
             if hour is not None:
                 logger.info(f"Navigating to hour {hour}h on Meteo-Parapente...")
                 hour_navigated = False
@@ -257,12 +272,11 @@ async def screenshot_meteo_parapente(
                                 continue
 
                     if not hour_navigated:
-                        logger.warning(
-                            f"Could not navigate to hour {hour} on Meteo-Parapente, "
-                            "capturing default hour"
+                        raise RuntimeError(
+                            f"Could not navigate Meteo-Parapente to requested hour {hour}"
                         )
                 except Exception as e:
-                    logger.warning(f"Hour navigation failed: {e}")
+                    raise RuntimeError(f"Hour navigation failed: {e}") from e
 
             # Wait for emagram to render
             await page.wait_for_timeout(5000)
@@ -283,6 +297,8 @@ async def screenshot_meteo_parapente(
             "source": "meteo-parapente",
             "image_path": str(image_path),
             "external_url": url,
+            "requested_hour": hour,
+            "hour_confirmed": hour is None or hour_navigated,
             "timestamp": datetime.now().isoformat(),
         }
 
@@ -386,7 +402,13 @@ async def screenshot_meteociel_emagram(
 
             image_response = await client.get(image_src)
             image_response.raise_for_status()
-            image_path.write_bytes(image_response.content)
+            content_type = image_response.headers.get("content-type", "")
+            if content_type and not content_type.startswith("image/"):
+                logger.warning(
+                    "Meteociel emagram image response has unexpected content-type: %s",
+                    content_type,
+                )
+            _write_image_atomically(image_path, image_response.content)
 
         if not image_path.exists() or image_path.stat().st_size == 0:
             raise RuntimeError("Meteociel emagram image was not written")
@@ -631,7 +653,7 @@ def cleanup_old_screenshots(max_age_hours: int = 1, cache_dir: Path | None = Non
             fresh_analyses = (
                 db.query(EmagramAnalysis)
                 .filter(
-                    EmagramAnalysis.analysis_status == "completed",
+                    EmagramAnalysis.analysis_status.in_(["completed", "partial"]),
                     EmagramAnalysis.analysis_datetime >= get_emagram_cutoff_utc(db=db),
                     EmagramAnalysis.screenshot_paths.isnot(None),
                 )

--- a/apps/backend/scrapers/open_meteo_sounding.py
+++ b/apps/backend/scrapers/open_meteo_sounding.py
@@ -6,6 +6,7 @@ Skew-T generator used by the LLM vision pipeline.
 """
 
 from datetime import datetime
+from time import monotonic
 from typing import Any
 
 import httpx
@@ -30,6 +31,8 @@ OPEN_METEO_MODEL_CONFIGS = {
         "model": "auto",
     },
 }
+OPEN_METEO_RATE_LIMIT_COOLDOWN_SECONDS = 15 * 60
+_OPEN_METEO_RATE_LIMIT_COOLDOWNS: dict[str, float] = {}
 
 COMMON_PRESSURE_LEVELS = [
     1000,
@@ -125,6 +128,30 @@ def _target_hour_index(day_index: int, hour: int | None, forecast_hour: int) -> 
     return forecast_hour
 
 
+def _open_meteo_cooldown_key(model_key: str, latitude: float, longitude: float) -> str:
+    return f"{model_key}:{latitude:.3f}:{longitude:.3f}"
+
+
+def _get_open_meteo_cooldown_error(cooldown_key: str, source: str) -> dict[str, Any] | None:
+    expires_at = _OPEN_METEO_RATE_LIMIT_COOLDOWNS.get(cooldown_key)
+    if not expires_at:
+        return None
+
+    now = monotonic()
+    if expires_at <= now:
+        _OPEN_METEO_RATE_LIMIT_COOLDOWNS.pop(cooldown_key, None)
+        return None
+
+    remaining_seconds = int(expires_at - now)
+    return {
+        "success": False,
+        "source": source,
+        "error": f"Open-Meteo rate limited; cooling down for {remaining_seconds}s",
+        "rate_limited": True,
+        "retry_after_seconds": remaining_seconds,
+    }
+
+
 def _hourly_value(hourly: dict[str, list[Any]], key: str, index: int) -> Any:
     values = hourly.get(key) or []
     if index < 0 or index >= len(values):
@@ -167,6 +194,10 @@ async def fetch_open_meteo_sounding(
         return {"success": False, "source": "open-meteo", "error": f"Unknown model {model_key}"}
 
     config = OPEN_METEO_MODEL_CONFIGS[model_key]
+    cooldown_key = _open_meteo_cooldown_key(model_key, latitude, longitude)
+    if cooldown_error := _get_open_meteo_cooldown_error(cooldown_key, config["source"]):
+        return cooldown_error
+
     pressure_levels = _pressure_levels_for_model(model_key)
     if (
         day_index < 0
@@ -279,6 +310,23 @@ async def fetch_open_meteo_sounding(
         }
 
     except httpx.HTTPStatusError as e:
+        retry_after = e.response.headers.get("retry-after")
+        retry_after_seconds = None
+        if retry_after:
+            try:
+                retry_after_seconds = max(1, int(retry_after))
+            except ValueError:
+                retry_after_seconds = None
+        if e.response.status_code == 429:
+            cooldown_seconds = retry_after_seconds or OPEN_METEO_RATE_LIMIT_COOLDOWN_SECONDS
+            _OPEN_METEO_RATE_LIMIT_COOLDOWNS[cooldown_key] = monotonic() + cooldown_seconds
+            return {
+                "success": False,
+                "source": config["source"],
+                "error": f"Open-Meteo rate limited (HTTP 429); cooling down for {cooldown_seconds}s",
+                "rate_limited": True,
+                "retry_after_seconds": cooldown_seconds,
+            }
         return {
             "success": False,
             "source": config["source"],

--- a/apps/backend/tests/test_emagram.py
+++ b/apps/backend/tests/test_emagram.py
@@ -430,5 +430,122 @@ class TestCleanupOldScreenshots:
         assert recent.exists()
 
 
+class TestEmagramProductionHardening:
+    """Regression tests for production emagram failure modes."""
+
+    def test_write_image_atomically_rejects_empty_content(self, tmp_path):
+        from scrapers.emagram_screenshots import _write_image_atomically
+
+        image_path = tmp_path / "empty.png"
+
+        with pytest.raises(RuntimeError, match="empty"):
+            _write_image_atomically(image_path, b"")
+
+        assert not image_path.exists()
+
+    def test_write_image_atomically_writes_non_empty_content(self, tmp_path):
+        from scrapers.emagram_screenshots import _write_image_atomically
+
+        image_path = tmp_path / "emagram.png"
+
+        _write_image_atomically(image_path, b"png-bytes")
+
+        assert image_path.read_bytes() == b"png-bytes"
+
+    def test_single_source_analysis_is_saved_as_partial(self, db_session):
+        import json
+
+        from emagram_multi_source import save_emagram_analysis
+        from models import Site
+
+        site = Site(
+            id="site-single-source",
+            code="SSS",
+            name="Single Source",
+            latitude=47.0,
+            longitude=6.0,
+            elevation_m=500,
+        )
+        db_session.add(site)
+        db_session.commit()
+
+        emagram = save_emagram_analysis(
+            db=db_session,
+            site=site,
+            screenshot_result={
+                "sources_successful": 1,
+                "sources_total": 4,
+                "screenshots": [
+                    {
+                        "success": True,
+                        "source": "meteo-parapente",
+                        "image_path": "/tmp/emagram.png",
+                        "external_url": "https://example.test/emagram",
+                    },
+                    {
+                        "success": False,
+                        "source": "open-meteo-arome",
+                        "error": "Open-Meteo rate limited",
+                    },
+                ],
+            },
+            analysis_result={
+                "llm_provider": "groq",
+                "llm_model": "test-model",
+                "plafond_thermique_m": 1800,
+                "force_thermique_ms": 1.5,
+                "score_volabilite": 55,
+                "conseils_vol": "Analyse de confiance reduite.",
+                "alertes_securite": [],
+            },
+        )
+
+        assert emagram.analysis_status == "partial"
+        assert emagram.sources_count == 1
+        assert emagram.sources_errors is not None
+        errors = json.loads(emagram.sources_errors)
+        assert "analysis_quality" in errors
+        assert "open-meteo-arome" in errors
+
+    @pytest.mark.asyncio
+    async def test_open_meteo_429_sets_cooldown(self, monkeypatch):
+        import httpx
+        import scrapers.open_meteo_sounding as sounding
+
+        sounding._OPEN_METEO_RATE_LIMIT_COOLDOWNS.clear()
+
+        class RateLimitedClient:
+            calls = 0
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+            async def get(self, url, params=None):
+                RateLimitedClient.calls += 1
+                request = httpx.Request("GET", url, params=params)
+                response = httpx.Response(429, request=request, headers={"retry-after": "42"})
+                raise httpx.HTTPStatusError("rate limited", request=request, response=response)
+
+        monkeypatch.setattr(sounding.httpx, "AsyncClient", RateLimitedClient)
+
+        first = await sounding.fetch_open_meteo_sounding(47.0, 6.0, model="icon")
+        second = await sounding.fetch_open_meteo_sounding(47.0, 6.0, model="icon")
+
+        assert first["success"] is False
+        assert first["rate_limited"] is True
+        assert first["retry_after_seconds"] == 42
+        assert second["success"] is False
+        assert second["rate_limited"] is True
+        assert RateLimitedClient.calls == 1
+
+        sounding._OPEN_METEO_RATE_LIMIT_COOLDOWNS.clear()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/apps/backend/tests/test_emagram_endpoints.py
+++ b/apps/backend/tests/test_emagram_endpoints.py
@@ -114,6 +114,47 @@ class TestEmagramEndpoints:
         assert data["station_code"] == "site-arguel"
         assert data["score_volabilite"] == 72
 
+    def test_get_latest_returns_recent_partial_analysis(self, client, db_session):
+        """Partial analyses are exposed instead of causing immediate regeneration loops."""
+        site = Site(
+            id="site-partial",
+            code="PAR",
+            name="Partial Site",
+            latitude=47.2,
+            longitude=6.0,
+            elevation_m=427,
+        )
+        db_session.add(site)
+
+        analysis = EmagramAnalysis(
+            id="partial-site-analysis",
+            station_code="site-partial",
+            station_name="Partial Site",
+            station_latitude=47.2,
+            station_longitude=6.0,
+            analysis_date=datetime.utcnow().date(),
+            analysis_time=datetime.utcnow().time(),
+            analysis_datetime=datetime.utcnow(),
+            forecast_date=datetime.utcnow().date(),
+            distance_km=0.0,
+            data_source="test",
+            sounding_time="12Z",
+            analysis_method="llm_vision",
+            score_volabilite=55,
+            analysis_status="partial",
+            sources_count=1,
+        )
+        db_session.add(analysis)
+        db_session.commit()
+
+        response = client.get("/api/emagram/latest?site_id=site-partial&auto_analyze=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "partial-site-analysis"
+        assert data["analysis_status"] == "partial"
+        assert data["sources_count"] == 1
+
     def test_get_emagram_screenshot_regenerates_missing_file(self, client, db_session, tmp_path):
         """Missing screenshot files are regenerated instead of returning 404"""
         from models import EmagramAnalysis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       # Backend - Video export storage
       - BACKEND_VIDEO_EXPORT_DIR=${BACKEND_VIDEO_EXPORT_DIR:-/app/video-exports}
       - BACKEND_VIDEO_TEMP_IMAGES_DIR=${BACKEND_VIDEO_TEMP_IMAGES_DIR:-/app/video-temp-images}
+      - BACKEND_EMAGRAM_CACHE_DIR=${BACKEND_EMAGRAM_CACHE_DIR:-/app/emagram-cache}
 
       # Backend - GoPro overlay toolchain
       - BACKEND_GOPRO_OVERLAY_ROOT=/app/gopro-overlay
@@ -133,6 +134,7 @@ services:
       - /home/capic/docker-data/dashboard-parapente/db:/app/db
       - ${VIDEO_EXPORT_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/videos}:${BACKEND_VIDEO_EXPORT_DIR:-/app/video-exports}
       - ${VIDEO_TEMP_IMAGES_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/video-temp-images}:${BACKEND_VIDEO_TEMP_IMAGES_DIR:-/app/video-temp-images}
+      - ${EMAGRAM_CACHE_HOST_DIR:-/home/capic/docker-data/dashboard-parapente/emagram-cache}:${BACKEND_EMAGRAM_CACHE_DIR:-/app/emagram-cache}
       - ${GOPRO_OVERLAY_DATA_HOST_DIR:?GOPRO_OVERLAY_DATA_HOST_DIR is required}:/app/parapente
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:8001/health']


### PR DESCRIPTION
## Summary\n- mark emagram analyses as partial when only one source is usable\n- make Meteo-Parapente hour selection strict instead of silently falling back\n- make Meteociel image writes atomic and reject empty payloads\n- add Open-Meteo 429 cooldown handling\n- persist emagram cache screenshots via configurable volume\n\n## Validation\n- TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../.venv/bin/pytest tests/test_emagram.py tests/test_emagram_endpoints.py -q --tb=short --no-header\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n\n## Notes\n- CodeRabbit review not run in this session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retaining and reusing partially successful emagram analyses.
  * Added a configurable cache directory for emagram images in containerized deployments.
  * Improved handling of upstream rate limits by temporarily cooling down repeated sounding requests.

* **Bug Fixes**
  * Made image writes safer and more reliable.
  * Prevented in-use emagram screenshots from being cleaned up too early.
  * Improved emagram result reporting with clearer status and source-count details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->