### PR TITLE
fix(frontend): add wind arrow to dashboard cards

### DIFF
--- a/apps/frontend/src/components/dashboard/AllSitesConditions.stories.tsx
+++ b/apps/frontend/src/components/dashboard/AllSitesConditions.stories.tsx
@@ -25,6 +25,7 @@ const makeWeather = (
   temp: number,
   windSpeed: number,
   windDir: string,
+  windDegrees: number,
   conditions: string
 ): WeatherData => ({
   spot_name: name,
@@ -34,6 +35,7 @@ const makeWeather = (
   temperature: temp,
   wind_speed: windSpeed,
   wind_direction: windDir,
+  wind_direction_deg: windDegrees,
   conditions,
   forecast_time: '2025-06-15T10:00:00Z',
   cached_at: '2025-06-15T10:00:00Z',
@@ -42,7 +44,7 @@ const makeWeather = (
 const threeEntries: SiteWeatherEntry[] = [
   {
     site: makeSite('site-1', 'Arguel', 'NW'),
-    weather: makeWeather('Arguel', 82, 'bon', 22, 12, 'NW', 'Ensoleillé'),
+    weather: makeWeather('Arguel', 82, 'bon', 22, 12, 'NW', 315, 'Ensoleillé'),
     isLoading: false,
     isError: false,
   },
@@ -55,6 +57,7 @@ const threeEntries: SiteWeatherEntry[] = [
       18,
       22,
       'S',
+      180,
       '45% nuages, Sec'
     ),
     isLoading: false,
@@ -69,6 +72,7 @@ const threeEntries: SiteWeatherEntry[] = [
       12,
       35,
       'E',
+      90,
       '85% nuages, 3mm pluie'
     ),
     isLoading: false,
@@ -103,6 +107,7 @@ Default.test('displays all site cards', async ({ canvas }) => {
   await canvas.findByText('Arguel');
   await expect(canvas.getByText('Mont Poupet Sud')).toBeInTheDocument();
   await expect(canvas.getByText('La Côte')).toBeInTheDocument();
+  await expect(canvas.getByLabelText('Vent 315°')).toBeInTheDocument();
 });
 
 // Loading state

--- a/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
+++ b/apps/frontend/src/components/dashboard/AllSitesConditions.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { Cloud, Thermometer, Wind } from 'lucide-react';
 import { WindIndicator } from '../common/WindIndicator';
 import CacheTimestamp from '../common/CacheTimestamp';
+import WindArrow from '../weather/WindArrow';
 import type { WeatherData } from '../../types';
 import type { Site } from '@dashboard-parapente/shared-types';
 import { getSiteDisplayName } from '../../lib/siteDisplay';
@@ -121,6 +122,13 @@ function SiteConditionCard({
                 <span className="font-bold text-slate-950 dark:text-white">
                   {weather.wind_speed} km/h
                 </span>
+                {weather.wind_direction_deg != null && (
+                  <WindArrow
+                    degrees={weather.wind_direction_deg}
+                    size={16}
+                    className="text-slate-700 dark:text-slate-200"
+                  />
+                )}
                 {site.orientation && (
                   <WindIndicator
                     windDirection={weather.wind_direction}

--- a/apps/frontend/src/hooks/weather/useWeather.ts
+++ b/apps/frontend/src/hooks/weather/useWeather.ts
@@ -159,6 +159,7 @@ export const transformWeatherResponse = (
     temperature: currentHour.temperature ?? metrics.avg_temp_c ?? 0,
     wind_speed: currentHour.wind_speed ?? metrics.avg_wind_kmh ?? 0,
     wind_direction: formatWindDirection(currentHour.wind_direction),
+    wind_direction_deg: currentHour.wind_direction ?? null,
     wind_gusts: currentHour.wind_gust ?? metrics.max_gust_kmh ?? 0,
     conditions: buildCurrentConditions(),
     forecast_time: data.cached_at || new Date().toISOString(),

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -27,6 +27,7 @@ export interface WeatherData {
   temperature: number;
   wind_speed: number;
   wind_direction: string;
+  wind_direction_deg?: number | null;
   wind_gusts?: number;
   conditions: string;
   forecast_time: string;


### PR DESCRIPTION
## Summary\n- show a wind-direction arrow on dashboard current-conditions cards\n- expose wind direction degrees in weather data mapping\n- update the dashboard story to cover the arrow\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend\n- /home/capic/.local/share/pnpm/pnpm exec oxlint -c .oxlintrc.json apps/frontend/src/components/dashboard/AllSitesConditions.tsx apps/frontend/src/components/dashboard/AllSitesConditions.stories.tsx apps/frontend/src/hooks/weather/useWeather.ts apps/frontend/src/types/index.ts\n- git diff --check\n\n## Notes\n- CodeRabbit review was not run for this shipment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wind direction arrows to site condition cards.
  * Wind direction is now displayed in degrees alongside wind speed when available.
* **Bug Fixes**
  * Improved weather data handling to preserve wind direction values from forecasts.
  * Added coverage to verify ventilation labels reflect the displayed wind direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->