### PR TITLE
fix(backend): prioritize wind category in best spot scoring

### DIFF
--- a/apps/backend/best_spot.py
+++ b/apps/backend/best_spot.py
@@ -110,10 +110,16 @@ def get_wind_favorability(
         return "bad"
 
 
-def get_wind_score_multiplier(favorability: str) -> float:
-    """Get score multiplier based on wind favorability"""
-    multipliers = {"good": 1.0, "moderate": 0.7, "bad": 0.3}
-    return multipliers.get(favorability, 0.7)
+def calculate_wind_adjusted_score(para_index: float, favorability: str) -> int:
+    """Return a 0-100 score whose bands preserve wind-category priority."""
+    score_bands = {
+        "good": (68, 100),
+        "moderate": (34, 66),
+        "bad": (0, 32),
+    }
+    lower_bound, upper_bound = score_bands.get(favorability, score_bands["moderate"])
+    clamped_para_index = min(max(para_index, 0), 100)
+    return round(lower_bound + (upper_bound - lower_bound) * clamped_para_index / 100)
 
 
 def _filter_flyable_hours(
@@ -235,8 +241,7 @@ async def calculate_best_spot_from_cache(db: Session, day_index: int = 0) -> dic
                 )
 
                 # Calculate final score
-                wind_multiplier = get_wind_score_multiplier(wind_favorability)
-                final_score = para_index * wind_multiplier
+                final_score = calculate_wind_adjusted_score(para_index, wind_favorability)
 
                 # Calculate best flyable slot
                 slots = analyze_hourly_slots(flyable_hours)
@@ -470,8 +475,7 @@ async def calculate_best_spot_from_db(db: Session, day_index: int = 0) -> dict[s
             wind_favorability = get_wind_favorability(wind_direction, site.orientation, wind_speed)
 
             # Calculate final score
-            wind_multiplier = get_wind_score_multiplier(wind_favorability)
-            final_score = para_index * wind_multiplier
+            final_score = calculate_wind_adjusted_score(para_index, wind_favorability)
 
             # Generate reason text
             if para_index >= 70:
@@ -585,7 +589,7 @@ async def calculate_hourly_best_spots_from_cache(
                     wind_favorability = get_wind_favorability(
                         wind_dir_str, site.orientation, wind_speed
                     )
-                    final_score = para_index * get_wind_score_multiplier(wind_favorability)
+                    final_score = calculate_wind_adjusted_score(para_index, wind_favorability)
 
                     parts = [f"Para-Index {para_index}"]
                     if wind_dir_str and wind_speed is not None:

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -2876,7 +2876,7 @@ async def get_weather(
     para_result = calculate_para_index(flyable_consensus)
 
     # Calculate wind-adjusted score (same logic as best_spot)
-    from best_spot import degrees_to_cardinal, get_wind_favorability, get_wind_score_multiplier
+    from best_spot import calculate_wind_adjusted_score, degrees_to_cardinal, get_wind_favorability
 
     midday_hours = [h for h in flyable_consensus if 10 <= h.get("hour", 0) <= 14]
     if midday_hours:
@@ -2889,8 +2889,7 @@ async def get_weather(
 
     wind_dir_str = degrees_to_cardinal(mid_wind_dir) if mid_wind_dir is not None else None
     wind_favorability = get_wind_favorability(wind_dir_str, site.orientation, mid_wind_speed)
-    wind_multiplier = get_wind_score_multiplier(wind_favorability)
-    score = round(para_result["para_index"] * wind_multiplier)
+    score = calculate_wind_adjusted_score(para_result["para_index"], wind_favorability)
 
     # Analyze hourly slots (also only flyable hours)
     slots = analyze_hourly_slots(flyable_consensus)
@@ -3263,9 +3262,9 @@ async def get_daily_summary(
             if day_result:
                 # Calculate wind-adjusted score
                 from best_spot import (
+                    calculate_wind_adjusted_score,
                     degrees_to_cardinal,
                     get_wind_favorability,
-                    get_wind_score_multiplier,
                 )
 
                 wind_dir_str = (
@@ -3276,8 +3275,7 @@ async def get_daily_summary(
                 wind_fav = get_wind_favorability(
                     wind_dir_str, site.orientation, day_result["wind_avg"]
                 )
-                wind_mult = get_wind_score_multiplier(wind_fav)
-                day_score = round(day_result["para_index"] * wind_mult)
+                day_score = calculate_wind_adjusted_score(day_result["para_index"], wind_fav)
 
                 summary_days.append(
                     {

--- a/apps/backend/tests/unit/test_best_spot.py
+++ b/apps/backend/tests/unit/test_best_spot.py
@@ -18,6 +18,7 @@ Strategy:
 """
 
 from datetime import date, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,9 +30,9 @@ from best_spot import (
     calculate_best_spot_from_cache,
     calculate_best_spot_from_db,
     calculate_hourly_best_spots_from_cache,
+    calculate_wind_adjusted_score,
     degrees_to_cardinal,
     get_wind_favorability,
-    get_wind_score_multiplier,
     parse_wind_direction,
     refresh_best_spot_cache,
 )
@@ -170,14 +171,10 @@ def test_get_wind_favorability_missing_data():
     assert get_wind_favorability("SW", "SW", None) == "moderate"
 
 
-def test_get_wind_score_multiplier():
-    """Test wind score multiplier"""
-    assert get_wind_score_multiplier("good") == 1.0
-    assert get_wind_score_multiplier("moderate") == 0.7
-    assert get_wind_score_multiplier("bad") == 0.3
-
-    # Unknown favorability defaults to moderate
-    assert get_wind_score_multiplier("unknown") == 0.7
+def test_wind_category_score_bands_are_strictly_ordered() -> None:
+    """A less favorable wind category can never receive a higher score."""
+    assert calculate_wind_adjusted_score(0, "good") > calculate_wind_adjusted_score(100, "moderate")
+    assert calculate_wind_adjusted_score(0, "moderate") > calculate_wind_adjusted_score(100, "bad")
 
 
 # ============================================================================
@@ -242,6 +239,51 @@ async def test_calculate_best_spot_from_cache_success(db_session, arguel_site, c
     assert result["paraIndex"] == 75
     assert result["windFavorability"] == "good"
     assert result["score"] > 0
+
+
+@pytest.mark.asyncio
+async def test_daily_best_spot_prioritizes_wind_category_over_para_index(
+    db_session, arguel_site, chalais_site
+) -> None:
+    """A good wind category wins even when another site has a higher Para-Index."""
+    forecasts = {
+        "Arguel": {
+            "success": True,
+            "sunrise": "07:00",
+            "sunset": "19:00",
+            "consensus": [{"hour": 12, "wind_speed": 15, "wind_direction": 225}],
+        },
+        "Chalais": {
+            "success": True,
+            "sunrise": "07:00",
+            "sunset": "19:00",
+            "consensus": [{"hour": 12, "wind_speed": 15, "wind_direction": 90}],
+        },
+    }
+
+    async def mock_get_forecast(
+        lat: float,
+        lon: float,
+        day_index: int,
+        site_name: str | None = None,
+        elevation_m: float | None = None,
+        db: object | None = None,
+    ) -> dict[str, Any]:
+        return forecasts[site_name]
+
+    def mock_calculate_para_index(consensus_hours: list[dict[str, Any]]) -> dict[str, int]:
+        return {"para_index": 1 if consensus_hours == forecasts["Arguel"]["consensus"] else 100}
+
+    with (
+        patch("weather_pipeline.get_normalized_forecast", new=mock_get_forecast),
+        patch("para_index.calculate_para_index", side_effect=mock_calculate_para_index),
+    ):
+        result = await calculate_best_spot_from_cache(db_session)
+
+    assert result is not None
+    assert result["site"]["name"] == "Arguel"
+    assert result["windFavorability"] == "good"
+    assert result["score"] > calculate_wind_adjusted_score(100, "bad")
 
 
 @pytest.mark.asyncio
@@ -343,6 +385,52 @@ async def test_calculate_hourly_best_spots_from_cache_can_change_by_hour(
     assert result["hours"][1]["site"]["name"] == "Chalais"
     assert result["hours"][0]["windFavorability"] == "good"
     assert result["hours"][1]["windFavorability"] == "good"
+
+
+@pytest.mark.asyncio
+async def test_hourly_best_spot_prioritizes_wind_category_over_para_index(
+    db_session, arguel_site, chalais_site
+) -> None:
+    """Hourly winners cannot be overtaken by a less favorable wind category."""
+    forecasts = {
+        "Arguel": {
+            "success": True,
+            "sunrise": "07:00",
+            "sunset": "19:00",
+            "consensus": [{"hour": 12, "wind_speed": 15, "wind_direction": 225}],
+        },
+        "Chalais": {
+            "success": True,
+            "sunrise": "07:00",
+            "sunset": "19:00",
+            "consensus": [{"hour": 12, "wind_speed": 15, "wind_direction": 90}],
+        },
+    }
+
+    async def mock_get_forecast(
+        lat: float,
+        lon: float,
+        day_index: int,
+        site_name: str | None = None,
+        elevation_m: float | None = None,
+        db: object | None = None,
+    ) -> dict[str, Any]:
+        return forecasts[site_name]
+
+    def mock_hourly_para_index(hour_data: dict[str, Any]) -> int:
+        return 1 if hour_data["wind_direction"] == 225 else 100
+
+    with (
+        patch("weather_pipeline.get_normalized_forecast", new=mock_get_forecast),
+        patch("para_index.calculate_hourly_para_index", side_effect=mock_hourly_para_index),
+    ):
+        result = await calculate_hourly_best_spots_from_cache(db_session, day_index=1, hours=1)
+
+    assert result is not None
+    winner = result["hours"][0]
+    assert winner["site"]["name"] == "Arguel"
+    assert winner["windFavorability"] == "good"
+    assert winner["score"] > calculate_wind_adjusted_score(100, "bad")
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/unit/test_best_spot_algorithm.py
+++ b/apps/backend/tests/unit/test_best_spot_algorithm.py
@@ -12,9 +12,9 @@ import pytest
 
 from best_spot import (
     calculate_angle_difference,
+    calculate_wind_adjusted_score,
     degrees_to_cardinal,
     get_wind_favorability,
-    get_wind_score_multiplier,
     parse_wind_direction,
 )
 
@@ -172,29 +172,6 @@ class TestGetWindFavorability:
 
 
 @pytest.mark.unit
-class TestGetWindScoreMultiplier:
-    """Test score multiplier calculation"""
-
-    def test_good_multiplier(self):
-        """Good favorability → 1.0"""
-        assert get_wind_score_multiplier("good") == 1.0
-
-    def test_moderate_multiplier(self):
-        """Moderate favorability → 0.7"""
-        assert get_wind_score_multiplier("moderate") == 0.7
-
-    def test_bad_multiplier(self):
-        """Bad favorability → 0.3"""
-        assert get_wind_score_multiplier("bad") == 0.3
-
-    def test_invalid_favorability_default(self):
-        """Invalid → default 0.7"""
-        assert get_wind_score_multiplier("unknown") == 0.7
-        assert get_wind_score_multiplier("") == 0.7
-        assert get_wind_score_multiplier(None) == 0.7
-
-
-@pytest.mark.unit
 class TestDegreesToCardinal:
     """Test degrees to cardinal direction conversion"""
 
@@ -248,67 +225,26 @@ class TestBestSpotAlgorithm:
     """Test the overall best spot algorithm logic"""
 
     def test_para_index_with_good_wind(self):
-        """High Para-Index × good wind → high score"""
-        # Simulate: Para-Index 80, wind aligned → score = 80 × 1.0 = 80
-        para_index = 80
-        favorability = get_wind_favorability("SW", "SW", 12.0)
-        multiplier = get_wind_score_multiplier(favorability)
-
-        final_score = para_index * multiplier
-
-        assert favorability == "good"
-        assert multiplier == 1.0
-        assert final_score == 80
+        """Good wind scores in the top band."""
+        assert calculate_wind_adjusted_score(80, "good") == 94
 
     def test_para_index_with_moderate_wind(self):
-        """High Para-Index × moderate wind → reduced score"""
-        # Simulate: Para-Index 80, wind cross → score = 80 × 0.7 = 56
-        para_index = 80
-        favorability = get_wind_favorability("W", "SW", 12.0)  # Cross wind
-        multiplier = get_wind_score_multiplier(favorability)
-
-        final_score = para_index * multiplier
-
-        assert favorability in ["moderate", "good"]
-        if favorability == "moderate":
-            assert multiplier == 0.7
-            assert final_score == 56.0
+        """Moderate wind scores in the middle band."""
+        assert calculate_wind_adjusted_score(80, "moderate") == 60
 
     def test_para_index_with_bad_wind(self):
-        """High Para-Index × bad wind → very low score"""
-        # Simulate: Para-Index 80, wind opposed → score = 80 × 0.3 = 24
-        para_index = 80
-        favorability = get_wind_favorability("NE", "SW", 12.0)  # Opposite
-        multiplier = get_wind_score_multiplier(favorability)
-
-        final_score = para_index * multiplier
-
-        assert favorability == "bad"
-        assert multiplier == 0.3
-        assert final_score == 24.0
+        """Bad wind scores in the bottom band."""
+        assert calculate_wind_adjusted_score(80, "bad") == 26
 
     def test_low_para_index_good_wind(self):
-        """Low Para-Index even with good wind → low score"""
-        # Simulate: Para-Index 30, wind aligned → score = 30 × 1.0 = 30
-        para_index = 30
-        favorability = get_wind_favorability("SW", "SW", 12.0)
-        multiplier = get_wind_score_multiplier(favorability)
-
-        final_score = para_index * multiplier
-
-        assert favorability == "good"
-        assert final_score == 30.0
+        """Even a low Para-Index stays above lower wind categories."""
+        assert calculate_wind_adjusted_score(0, "good") > calculate_wind_adjusted_score(
+            100, "moderate"
+        )
 
     def test_wind_orientation_matters(self):
-        """Site with lower Para-Index but better wind can win"""
-        # Site A: Para-Index 70, wind aligned → 70 × 1.0 = 70
-        site_a_score = 70 * get_wind_score_multiplier(get_wind_favorability("SW", "SW", 12.0))
-
-        # Site B: Para-Index 80, wind opposed → 80 × 0.3 = 24
-        site_b_score = 80 * get_wind_score_multiplier(get_wind_favorability("NE", "SW", 12.0))
-
-        # Site A should win despite lower Para-Index
-        assert site_a_score > site_b_score
+        """A better wind category always wins across sites."""
+        assert calculate_wind_adjusted_score(1, "good") > calculate_wind_adjusted_score(100, "bad")
 
 
 @pytest.mark.unit
@@ -339,11 +275,11 @@ class TestEdgeCases:
         result = get_wind_favorability("SW", "SW", 30.0)
         assert result in ["bad", "moderate", "good"]
 
-    def test_multiplier_range(self):
-        """Multipliers always in valid range"""
-        for favorability in ["good", "moderate", "bad", "unknown", None]:
-            multiplier = get_wind_score_multiplier(favorability)
-            assert 0.0 <= multiplier <= 1.0
+    def test_score_is_clamped_to_the_valid_range(self):
+        """Scores remain within the public 0-100 range."""
+        for favorability in ["good", "moderate", "bad", "unknown"]:
+            assert 0 <= calculate_wind_adjusted_score(-1, favorability) <= 100
+            assert 0 <= calculate_wind_adjusted_score(101, favorability) <= 100
 
     def test_circular_symmetry(self):
         """Angle difference is symmetric"""


### PR DESCRIPTION
## Summary\n- Replace wind multiplier scoring with disjoint category bands so good > moderate > bad.\n- Apply the same scoring to best spot, weather routes, and regression tests.\n\n## Validation\n-  + : 75 passed\n- E902 No such file or directory (os error 2)
--> ...:1:1

Found 1 error.: passed\n- : passed\n- : passed, except 1 pre-existing failing backend test unrelated to this change ()\n- : failed due existing repo-level frontend/playwright issues outside this backend diff\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated wind-adjusted spot scoring to use favorability-based score bands.
  - Scores are now consistently rounded and constrained to a 0–100 range.
  - Improved best-spot selection so wind favorability is prioritized more reliably across hourly, daily, cached, and weather views.

- **Tests**
  - Expanded coverage for wind-category prioritization, score ordering, and out-of-range inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->