### PR TITLE
fix(backend): cap weather score by flyable slots

### DIFF
--- a/apps/backend/best_spot.py
+++ b/apps/backend/best_spot.py
@@ -110,16 +110,36 @@ def get_wind_favorability(
         return "bad"
 
 
-def calculate_wind_adjusted_score(para_index: float, favorability: str) -> int:
-    """Return a 0-100 score whose bands preserve wind-category priority."""
-    score_bands = {
-        "good": (68, 100),
-        "moderate": (34, 66),
-        "bad": (0, 32),
+def _flyability_safety_cap(slots: list[dict[str, Any]] | None) -> int:
+    """Cap daily score when the day has few genuinely green slots."""
+    if slots is None:
+        return 100
+
+    flyable_hours = sum(
+        slot["end_hour"] - slot["start_hour"] + 1 for slot in slots if slot.get("verdict") == "🟢"
+    )
+    if flyable_hours == 0:
+        return 40
+    if flyable_hours == 1:
+        return 55
+    if flyable_hours == 2:
+        return 70
+    return 100
+
+
+def calculate_wind_adjusted_score(
+    para_index: float, favorability: str, slots: list[dict[str, Any]] | None = None
+) -> int:
+    """Return Para-Index adjusted by site orientation, with optional safety cap."""
+    multipliers = {
+        "good": 1.15,
+        "moderate": 0.75,
+        "bad": 0.35,
     }
-    lower_bound, upper_bound = score_bands.get(favorability, score_bands["moderate"])
+    multiplier = multipliers.get(favorability, multipliers["moderate"])
     clamped_para_index = min(max(para_index, 0), 100)
-    return round(lower_bound + (upper_bound - lower_bound) * clamped_para_index / 100)
+    adjusted_score = min(100, round(clamped_para_index * multiplier))
+    return min(adjusted_score, _flyability_safety_cap(slots))
 
 
 def _filter_flyable_hours(
@@ -240,11 +260,11 @@ async def calculate_best_spot_from_cache(db: Session, day_index: int = 0) -> dic
                     wind_dir_str, site.orientation, avg_wind_speed
                 )
 
-                # Calculate final score
-                final_score = calculate_wind_adjusted_score(para_index, wind_favorability)
-
                 # Calculate best flyable slot
                 slots = analyze_hourly_slots(flyable_hours)
+                final_score = calculate_wind_adjusted_score(
+                    para_index, wind_favorability, slots=slots
+                )
                 best_slot = get_best_slot(slots)
                 if not best_slot:
                     flyable_slot = None

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -2889,10 +2889,9 @@ async def get_weather(
 
     wind_dir_str = degrees_to_cardinal(mid_wind_dir) if mid_wind_dir is not None else None
     wind_favorability = get_wind_favorability(wind_dir_str, site.orientation, mid_wind_speed)
-    score = calculate_wind_adjusted_score(para_result["para_index"], wind_favorability)
-
     # Analyze hourly slots (also only flyable hours)
     slots = analyze_hourly_slots(flyable_consensus)
+    score = calculate_wind_adjusted_score(para_result["para_index"], wind_favorability, slots=slots)
     slots_summary = format_slots_summary(slots)
 
     # Build sources metadata
@@ -3275,7 +3274,9 @@ async def get_daily_summary(
                 wind_fav = get_wind_favorability(
                     wind_dir_str, site.orientation, day_result["wind_avg"]
                 )
-                day_score = calculate_wind_adjusted_score(day_result["para_index"], wind_fav)
+                day_score = calculate_wind_adjusted_score(
+                    day_result["para_index"], wind_fav, slots=day_result.get("slots")
+                )
 
                 summary_days.append(
                     {

--- a/apps/backend/tests/unit/test_best_spot.py
+++ b/apps/backend/tests/unit/test_best_spot.py
@@ -171,10 +171,23 @@ def test_get_wind_favorability_missing_data():
     assert get_wind_favorability("SW", "SW", None) == "moderate"
 
 
-def test_wind_category_score_bands_are_strictly_ordered() -> None:
-    """A less favorable wind category can never receive a higher score."""
-    assert calculate_wind_adjusted_score(0, "good") > calculate_wind_adjusted_score(100, "moderate")
-    assert calculate_wind_adjusted_score(0, "moderate") > calculate_wind_adjusted_score(100, "bad")
+def test_wind_category_adjusts_score_without_creating_artificial_floor() -> None:
+    """A good orientation boosts the Para-Index without masking a poor day."""
+    assert calculate_wind_adjusted_score(33, "good") == 38
+    assert calculate_wind_adjusted_score(80, "good") > calculate_wind_adjusted_score(80, "moderate")
+    assert calculate_wind_adjusted_score(80, "moderate") > calculate_wind_adjusted_score(80, "bad")
+
+
+def test_wind_adjusted_score_applies_flyability_safety_cap() -> None:
+    """Mostly unflyable days stay limited even with favorable orientation."""
+    no_green_slots = [{"start_hour": 10, "end_hour": 14, "verdict": "🔴"}]
+    one_green_hour = [
+        {"start_hour": 10, "end_hour": 10, "verdict": "🟢"},
+        {"start_hour": 11, "end_hour": 14, "verdict": "🔴"},
+    ]
+
+    assert calculate_wind_adjusted_score(90, "good", slots=no_green_slots) == 40
+    assert calculate_wind_adjusted_score(90, "good", slots=one_green_hour) == 55
 
 
 # ============================================================================
@@ -242,10 +255,10 @@ async def test_calculate_best_spot_from_cache_success(db_session, arguel_site, c
 
 
 @pytest.mark.asyncio
-async def test_daily_best_spot_prioritizes_wind_category_over_para_index(
+async def test_daily_best_spot_uses_strong_wind_orientation_adjustment(
     db_session, arguel_site, chalais_site
 ) -> None:
-    """A good wind category wins even when another site has a higher Para-Index."""
+    """A good wind category can win against a meaningfully higher bad-orientation site."""
     forecasts = {
         "Arguel": {
             "success": True,
@@ -272,7 +285,7 @@ async def test_daily_best_spot_prioritizes_wind_category_over_para_index(
         return forecasts[site_name]
 
     def mock_calculate_para_index(consensus_hours: list[dict[str, Any]]) -> dict[str, int]:
-        return {"para_index": 1 if consensus_hours == forecasts["Arguel"]["consensus"] else 100}
+        return {"para_index": 40 if consensus_hours == forecasts["Arguel"]["consensus"] else 100}
 
     with (
         patch("weather_pipeline.get_normalized_forecast", new=mock_get_forecast),
@@ -388,10 +401,10 @@ async def test_calculate_hourly_best_spots_from_cache_can_change_by_hour(
 
 
 @pytest.mark.asyncio
-async def test_hourly_best_spot_prioritizes_wind_category_over_para_index(
+async def test_hourly_best_spot_uses_strong_wind_orientation_adjustment(
     db_session, arguel_site, chalais_site
 ) -> None:
-    """Hourly winners cannot be overtaken by a less favorable wind category."""
+    """Hourly good orientation can beat a meaningfully higher bad-orientation score."""
     forecasts = {
         "Arguel": {
             "success": True,
@@ -418,7 +431,7 @@ async def test_hourly_best_spot_prioritizes_wind_category_over_para_index(
         return forecasts[site_name]
 
     def mock_hourly_para_index(hour_data: dict[str, Any]) -> int:
-        return 1 if hour_data["wind_direction"] == 225 else 100
+        return 40 if hour_data["wind_direction"] == 225 else 100
 
     with (
         patch("weather_pipeline.get_normalized_forecast", new=mock_get_forecast),

--- a/apps/backend/tests/unit/test_best_spot_algorithm.py
+++ b/apps/backend/tests/unit/test_best_spot_algorithm.py
@@ -225,26 +225,24 @@ class TestBestSpotAlgorithm:
     """Test the overall best spot algorithm logic"""
 
     def test_para_index_with_good_wind(self):
-        """Good wind scores in the top band."""
-        assert calculate_wind_adjusted_score(80, "good") == 94
+        """Good wind boosts the Para-Index."""
+        assert calculate_wind_adjusted_score(80, "good") == 92
 
     def test_para_index_with_moderate_wind(self):
-        """Moderate wind scores in the middle band."""
+        """Moderate wind penalizes the Para-Index."""
         assert calculate_wind_adjusted_score(80, "moderate") == 60
 
     def test_para_index_with_bad_wind(self):
-        """Bad wind scores in the bottom band."""
-        assert calculate_wind_adjusted_score(80, "bad") == 26
+        """Bad wind strongly penalizes the Para-Index."""
+        assert calculate_wind_adjusted_score(80, "bad") == 28
 
     def test_low_para_index_good_wind(self):
-        """Even a low Para-Index stays above lower wind categories."""
-        assert calculate_wind_adjusted_score(0, "good") > calculate_wind_adjusted_score(
-            100, "moderate"
-        )
+        """Good wind does not create an artificial high score floor."""
+        assert calculate_wind_adjusted_score(30, "good") == 34
 
     def test_wind_orientation_matters(self):
-        """A better wind category always wins across sites."""
-        assert calculate_wind_adjusted_score(1, "good") > calculate_wind_adjusted_score(100, "bad")
+        """A better wind category matters for comparable Para-Index values."""
+        assert calculate_wind_adjusted_score(60, "good") > calculate_wind_adjusted_score(60, "bad")
 
 
 @pytest.mark.unit

--- a/apps/backend/weather_pipeline.py
+++ b/apps/backend/weather_pipeline.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any
 
-from para_index import calculate_para_index
+from para_index import analyze_hourly_slots, calculate_para_index
 from weather_sources import WEATHER_SOURCE_REGISTRY
 
 logger = logging.getLogger(__name__)
@@ -774,6 +774,7 @@ async def get_daily_aggregate(
     # Use the SAME para_index calculation as /weather endpoint for consistency
     # Calculate on flyable hours only (same filtering as /weather)
     para_result = calculate_para_index(flyable_consensus)
+    slots = analyze_hourly_slots(flyable_consensus)
 
     para_index = para_result["para_index"]
     verdict = para_result["verdict"]
@@ -788,6 +789,7 @@ async def get_daily_aggregate(
         "temp_max": temp_max,
         "wind_avg": wind_avg,
         "wind_direction_avg": wind_direction_avg,
+        "slots": slots,
         "precip_total": precip_total,
         "cached_at": forecast_result.get("cached_at"),
     }


### PR DESCRIPTION
## Summary
- keep orientation influence on weather scores without a fake 68-100 floor
- apply a safety cap when the day has too few green slots
- keep daily summary and best-spot scoring consistent with slot data

## Validation
- `../../.venv/bin/pytest tests/unit/test_best_spot.py tests/unit/test_best_spot_algorithm.py -q --tb=short --no-header --no-cov`
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend`
- `NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend` (fails on unrelated Playwright/mock issue: `test_meteociel_emagram_screenshot_downloads_emagram_image`)