### PR TITLE
fix(weather): stabilize scrapers and stale fallback

### DIFF
--- a/apps/backend/scrapers/meteoblue.py
+++ b/apps/backend/scrapers/meteoblue.py
@@ -13,6 +13,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any
 
+import httpx
 from bs4 import BeautifulSoup
 
 from .base import PlaywrightScraper
@@ -99,6 +100,45 @@ class MeteoblueScraper(PlaywrightScraper):
             return self.CITY_CODE_CACHE[city_key]
 
         return None
+
+    def _build_forecast_url(self, lat: float, lon: float, day_index: int = 0) -> str:
+        lat_str = f"{abs(lat):.2f}{'N' if lat >= 0 else 'S'}"
+        lon_str = f"{abs(lon):.2f}{'E' if lon >= 0 else 'W'}"
+        url = f"{self.base_url}/fr/meteo/semaine/{lat_str}{lon_str}"
+        return f"{url}?day={day_index + 1}" if day_index > 0 else url
+
+    async def fetch(self, lat: float, lon: float, **kwargs) -> dict[str, Any]:
+        """Fetch Meteoblue's server-rendered three-hour forecast table."""
+        day_index = max(0, int(kwargs.get("day_index", 0)))
+        url = self._build_forecast_url(lat, lon, day_index)
+        self.logger.info(f"Fetching Meteoblue forecast: {url}")
+
+        try:
+            headers = {
+                "User-Agent": (
+                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+                )
+            }
+            async with httpx.AsyncClient(
+                timeout=self.timeout,
+                follow_redirects=True,
+                headers=headers,
+            ) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+
+            hourly_data = self._parse_html(response.text)
+            if not hourly_data:
+                return self._build_response(
+                    success=False, error="No forecast table data found in Meteoblue response"
+                )
+            return self._build_response(success=True, data=hourly_data)
+        except httpx.HTTPStatusError as e:
+            return self._build_response(success=False, error=f"HTTP {e.response.status_code}: {e}")
+        except Exception as e:
+            self.logger.error(f"Meteoblue fetch error: {e}", exc_info=True)
+            return self._build_response(success=False, error=str(e))
 
     async def _scrape_page(self, page, lat: float, lon: float, **kwargs) -> list[dict[str, Any]]:
         """
@@ -208,8 +248,9 @@ class MeteoblueScraper(PlaywrightScraper):
         try:
             soup = BeautifulSoup(html, "html.parser")
 
-            # Find the hourly view table
-            hourly_table = soup.find("table", class_="picto hourly-view")
+            # The 1h table is loaded dynamically and is no longer reliable. The
+            # server-rendered 3h table contains the same core forecast fields.
+            hourly_table = soup.select_one("table.picto.hourly-view, table.picto.three-hourly-view")
 
             if not hourly_table:
                 self.logger.warning("No hourly forecast table found")
@@ -288,10 +329,12 @@ class MeteoblueScraper(PlaywrightScraper):
                     if i >= len(hourly_data):
                         break
                     wind_text = cell.get_text(strip=True)
-                    wind_match = re.search(r"(\d+)", wind_text)
-                    if wind_match:
-                        wind_kmh = int(wind_match.group(1))
+                    wind_values = [int(value) for value in re.findall(r"\d+", wind_text)]
+                    if wind_values:
+                        wind_kmh = wind_values[0]
                         hourly_data[i]["wind_speed"] = wind_kmh  # Already km/h
+                        if len(wind_values) > 1:
+                            hourly_data[i]["wind_gust"] = wind_values[1]
 
                     # Try to extract wind direction from div class (format: "glyph winddir SE")
                     wind_dir_div = cell.find("div", class_="winddir")
@@ -474,10 +517,15 @@ class MeteoblueScraper(PlaywrightScraper):
 # Standalone functions for compatibility
 
 
-async def fetch_meteoblue(lat: float, lon: float, city_name: str = "location") -> dict[str, Any]:
+async def fetch_meteoblue(
+    lat: float,
+    lon: float,
+    city_name: str = "location",
+    day_index: int = 0,
+) -> dict[str, Any]:
     """Fetch Meteoblue forecast (standalone function)"""
     scraper = MeteoblueScraper()
-    return await scraper.fetch(lat, lon, city_name=city_name)
+    return await scraper.fetch(lat, lon, city_name=city_name, day_index=day_index)
 
 
 def extract_meteoblue_hourly(data: dict[str, Any], day_index: int = 0) -> list[dict[str, Any]]:

--- a/apps/backend/scrapers/meteociel.py
+++ b/apps/backend/scrapers/meteociel.py
@@ -6,6 +6,7 @@ Strategy: Get INSEE code from city name, then parse forecast HTML
 
 import logging
 import re
+import unicodedata
 from typing import Any
 
 import httpx
@@ -129,6 +130,41 @@ class MeteocielScraper(BaseScraper):
             logger.error(f"Error in reverse geocoding for {lat},{lon}: {e}")
             return None
 
+    async def _get_forecast_path(self, city_name: str) -> str | None:
+        """Resolve Meteociel's internal city identifier through its city search."""
+        search_name = "".join(
+            char
+            for char in unicodedata.normalize("NFD", city_name)
+            if unicodedata.category(char) != "Mn"
+        )
+        expected_slug = re.sub(r"[^a-z0-9]+", "_", search_name.lower()).strip("_")
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.get(
+                    "https://www.meteociel.fr/prevville.php",
+                    params={"action": "getville", "ville": search_name},
+                )
+                response.raise_for_status()
+
+            # The search page contains malformed legacy HTML that BeautifulSoup
+            # can discard; extract the stable forecast href directly.
+            forecast_path = None
+            for link_match in re.finditer(r"/previsions/\d+/([^\"' >]+)\.htm", response.text):
+                candidate_slug = re.sub(r"[^a-z0-9]+", "_", link_match.group(1).lower()).strip("_")
+                if candidate_slug == expected_slug:
+                    forecast_path = link_match.group(0)
+                    break
+
+            if not forecast_path:
+                logger.warning(f"No Meteociel forecast page found for city: {city_name}")
+                return None
+
+            return forecast_path.replace("/previsions/", "/previsions-arome-1h/", 1)
+        except Exception as e:
+            logger.error(f"Error resolving Meteociel city '{city_name}': {e}")
+            return None
+
     async def fetch(self, lat: float, lon: float, **kwargs) -> dict[str, Any]:
         """
         Fetch forecast from meteociel
@@ -144,36 +180,34 @@ class MeteocielScraper(BaseScraper):
         site_name = kwargs.get("site_name")
 
         try:
-            # Step 1: Get INSEE code from site name, or from nearest commune when absent.
-            insee_code = await self._get_insee_code(site_name) if site_name else None
-            city_name_for_url = site_name
+            # Meteociel search is fuzzy. Only search a site name when Geo API
+            # confirms that it is a commune; otherwise use reverse geocoding.
+            is_commune = bool(await self._get_insee_code(site_name)) if site_name else False
+            forecast_path = (
+                await self._get_forecast_path(site_name) if site_name and is_commune else None
+            )
 
-            if not insee_code:
-                # Graceful degradation: Try to find nearest French city using coordinates
+            if not forecast_path:
                 logger.info(
-                    f"No INSEE code found for {site_name or 'coordinates'}, trying reverse geocoding with coordinates"
+                    f"No Meteociel page found for {site_name or 'coordinates'}, trying the nearest commune"
                 )
                 nearest_commune = await self._get_nearest_commune(lat, lon)
 
                 if not nearest_commune:
                     return self._build_response(
                         success=False,
-                        error=f"Meteociel only supports French cities. Could not find INSEE code for {site_name} or nearby location.",
+                        error=f"Meteociel only supports French cities. Could not resolve {site_name or 'coordinates'} or a nearby location.",
                     )
 
-                insee_code, city_name_for_url = nearest_commune
+                _, nearest_city_name = nearest_commune
+                forecast_path = await self._get_forecast_path(nearest_city_name)
+                if not forecast_path:
+                    return self._build_response(
+                        success=False,
+                        error=f"No Meteociel forecast page found for nearest city {nearest_city_name}.",
+                    )
 
-            # Step 2: Build URL - Using AROME hourly forecasts (1h resolution)
-            # Normalize city name: lowercase, remove accents, replace spaces
-            import unicodedata
-
-            city_normalized = "".join(
-                c
-                for c in unicodedata.normalize("NFD", city_name_for_url)
-                if unicodedata.category(c) != "Mn"
-            )
-            city_slug = city_normalized.lower().replace(" ", "-").replace("_", "-")
-            url = f"https://www.meteociel.fr/previsions-arome-1h/{insee_code}/{city_slug}.htm"
+            url = f"https://www.meteociel.fr{forecast_path}"
 
             logger.info(f"Fetching meteociel forecast: {url}")
 

--- a/apps/backend/scrapers/open_meteo.py
+++ b/apps/backend/scrapers/open_meteo.py
@@ -66,6 +66,7 @@ async def fetch_open_meteo(lat: float, lon: float, days: int = 2) -> dict[str, A
         return {
             "success": False,
             "source": "open-meteo",
+            "status_code": e.response.status_code,
             "error": f"HTTP {e.response.status_code}: {str(e)}",
             "timestamp": datetime.now().isoformat(),
         }
@@ -137,6 +138,7 @@ async def _fetch_open_meteo_model(
         return {
             "success": False,
             "source": source,
+            "status_code": e.response.status_code,
             "error": f"HTTP {e.response.status_code}: {str(e)}",
             "timestamp": datetime.now().isoformat(),
         }

--- a/apps/backend/scrapers/openweathermap.py
+++ b/apps/backend/scrapers/openweathermap.py
@@ -11,10 +11,16 @@ from config import OPENWEATHERMAP_API_KEY
 PARIS_TZ = ZoneInfo("Europe/Paris")
 
 
-async def fetch_openweathermap(lat: float, lon: float, days: int = 5) -> dict[str, Any]:
+async def fetch_openweathermap(
+    lat: float,
+    lon: float,
+    days: int = 5,
+    api_key: str | None = None,
+) -> dict[str, Any]:
     """Fetch 5-day/3-hour forecast from OpenWeatherMap."""
 
-    if not OPENWEATHERMAP_API_KEY:
+    resolved_api_key = api_key or OPENWEATHERMAP_API_KEY
+    if not resolved_api_key:
         return {
             "success": False,
             "source": "openweathermap",
@@ -27,7 +33,7 @@ async def fetch_openweathermap(lat: float, lon: float, days: int = 5) -> dict[st
         params = {
             "lat": lat,
             "lon": lon,
-            "appid": OPENWEATHERMAP_API_KEY,
+            "appid": resolved_api_key,
             "units": "metric",
             "cnt": min(forecast_days * 8, 40),
         }
@@ -50,7 +56,8 @@ async def fetch_openweathermap(lat: float, lon: float, days: int = 5) -> dict[st
         return {
             "success": False,
             "source": "openweathermap",
-            "error": f"HTTP {e.response.status_code}: {str(e)}",
+            "status_code": e.response.status_code,
+            "error": f"HTTP {e.response.status_code}: OpenWeatherMap request failed",
             "timestamp": datetime.now().isoformat(),
         }
     except Exception as e:

--- a/apps/backend/tests/scrapers/test_meteoblue.py
+++ b/apps/backend/tests/scrapers/test_meteoblue.py
@@ -3,8 +3,10 @@ Live tests for Meteoblue scraper
 """
 
 import pytest
+import httpx
 
 from config import METEOBLUE_API_KEY
+from scrapers import meteoblue
 from scrapers.meteoblue import MeteoblueScraper, fetch_meteoblue
 
 ARGUEL_LAT = 47.2
@@ -39,3 +41,140 @@ def test_meteoblue_city_code_handles_missing_city_name() -> None:
     scraper = MeteoblueScraper()
 
     assert scraper._get_city_code(None) is None
+
+
+def test_meteoblue_parses_server_rendered_three_hour_table() -> None:
+    html = """
+    <table class="picto three-hourly-view">
+      <tr class="times"><th></th><td><time datetime="2026-07-14T12:00:00+02:00">12</time></td></tr>
+      <tr class="icons"><th></th><td><img src="/assets/images/picto/02_day.svg"></td></tr>
+      <tr class="temperatures"><th></th><td>24°</td></tr>
+      <tr class="windspeeds"><th></th><td><div class="glyph winddir WSW">OSO</div>13-29</td></tr>
+      <tr class="precips"><th></th><td><div class="precip">0.4</div></td></tr>
+    </table>
+    """
+
+    result = MeteoblueScraper()._parse_html(html)
+
+    assert result == [
+        {
+            "datetime": "2026-07-14T12:00:00+02:00",
+            "temperature": 24,
+            "wind_speed": 13,
+            "wind_gust": 29,
+            "wind_direction": 247,
+            "precipitation": 0.4,
+            "clouds": 25,
+            "humidity": None,
+            "picto": "/assets/images/picto/02_day.svg",
+        }
+    ]
+
+
+def test_meteoblue_builds_selected_day_url() -> None:
+    scraper = MeteoblueScraper()
+
+    assert (
+        scraper._build_forecast_url(46.9693, 5.8747, day_index=2)
+        == "https://www.meteoblue.com/fr/meteo/semaine/46.97N5.87E?day=3"
+    )
+
+
+@pytest.mark.asyncio
+async def test_meteoblue_fetch_uses_browser_user_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_headers: dict[str, str] = {}
+
+    class FakeResponse:
+        text = "<html>forecast</html>"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            captured_headers.update(kwargs["headers"])
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(meteoblue.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(
+        MeteoblueScraper,
+        "_parse_html",
+        lambda self, html: [{"datetime": "2026-07-14T12:00:00+02:00"}],
+    )
+
+    result = await MeteoblueScraper().fetch(46.9693, 5.8747)
+
+    assert result["success"] is True
+    assert captured_headers["User-Agent"].startswith("Mozilla/5.0")
+
+
+@pytest.mark.asyncio
+async def test_meteoblue_fetch_fails_when_response_has_no_forecast_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        text = "<html></html>"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(meteoblue.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await MeteoblueScraper().fetch(46.9693, 5.8747)
+
+    assert result["success"] is False
+    assert result["error"] == "No forecast table data found in Meteoblue response"
+
+
+@pytest.mark.asyncio
+async def test_meteoblue_fetch_returns_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            request = httpx.Request("GET", "https://www.meteoblue.com/blocked")
+            response = httpx.Response(403, request=request)
+            raise httpx.HTTPStatusError("blocked", request=request, response=response)
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(meteoblue.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await MeteoblueScraper().fetch(46.9693, 5.8747)
+
+    assert result["success"] is False
+    assert result["error"].startswith("HTTP 403:")

--- a/apps/backend/tests/scrapers/test_meteociel.py
+++ b/apps/backend/tests/scrapers/test_meteociel.py
@@ -37,7 +37,15 @@ async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(
 ) -> None:
     requested_urls: list[str] = []
 
-    async def fake_get_insee_code(self: MeteocielScraper, city_name: str | None) -> None:
+    resolved_cities: list[str] = []
+
+    async def fake_get_insee_code(self: MeteocielScraper, city_name: str) -> None:
+        return None
+
+    async def fake_get_forecast_path(self: MeteocielScraper, city_name: str) -> str | None:
+        resolved_cities.append(city_name)
+        if city_name == "Besançon":
+            return "/previsions-arome-1h/7497/besancon.htm"
         return None
 
     async def fake_get_nearest_commune(
@@ -68,6 +76,7 @@ async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(
             requested_urls.append(url)
             return FakeResponse()
 
+    monkeypatch.setattr(MeteocielScraper, "_get_forecast_path", fake_get_forecast_path)
     monkeypatch.setattr(MeteocielScraper, "_get_insee_code", fake_get_insee_code)
     monkeypatch.setattr(MeteocielScraper, "_get_nearest_commune", fake_get_nearest_commune)
     monkeypatch.setattr(MeteocielScraper, "_parse_forecast_tables", fake_parse_forecast_tables)
@@ -76,7 +85,8 @@ async def test_fetch_meteociel_uses_nearest_city_slug_after_reverse_geocoding(
     result = await fetch_meteociel(47.24, 6.02, site_name="Test Site")
 
     assert result["success"] is True
-    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/25056/besancon.htm"]
+    assert resolved_cities == ["Besançon"]
+    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/7497/besancon.htm"]
 
 
 @pytest.mark.asyncio
@@ -89,6 +99,10 @@ async def test_fetch_meteociel_uses_nearest_city_when_site_name_missing(
         self: MeteocielScraper, lat: float, lon: float
     ) -> tuple[str, str]:
         return "25056", "Besançon"
+
+    async def fake_get_forecast_path(self: MeteocielScraper, city_name: str) -> str:
+        assert city_name == "Besançon"
+        return "/previsions-arome-1h/7497/besancon.htm"
 
     def fake_parse_forecast_tables(self: MeteocielScraper, soup: object) -> list[dict[str, float]]:
         return [{"hour": 12, "temperature": 20.0}]
@@ -114,10 +128,45 @@ async def test_fetch_meteociel_uses_nearest_city_when_site_name_missing(
             return FakeResponse()
 
     monkeypatch.setattr(MeteocielScraper, "_get_nearest_commune", fake_get_nearest_commune)
+    monkeypatch.setattr(MeteocielScraper, "_get_forecast_path", fake_get_forecast_path)
     monkeypatch.setattr(MeteocielScraper, "_parse_forecast_tables", fake_parse_forecast_tables)
     monkeypatch.setattr(meteociel.httpx, "AsyncClient", FakeAsyncClient)
 
     result = await fetch_meteociel(47.24, 6.02, site_name=None)
 
     assert result["success"] is True
-    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/25056/besancon.htm"]
+    assert requested_urls == ["https://www.meteociel.fr/previsions-arome-1h/7497/besancon.htm"]
+
+
+@pytest.mark.asyncio
+async def test_get_forecast_path_uses_meteociel_internal_city_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        text = """
+        <a href="/previsions/31407/saint_michel_mont_mercure.htm">Other result</a>
+        <a href="/previsions/14177/saint_thiebaud.htm">Saint-Thiébaud</a>
+        """
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def get(self, url: str, params: dict[str, str]) -> FakeResponse:
+            assert params["ville"] == "Saint-Thiebaud"
+            return FakeResponse()
+
+    monkeypatch.setattr(meteociel.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await MeteocielScraper()._get_forecast_path("Saint-Thiébaud")
+
+    assert result == "/previsions-arome-1h/14177/saint_thiebaud.htm"

--- a/apps/backend/tests/scrapers/test_openweathermap.py
+++ b/apps/backend/tests/scrapers/test_openweathermap.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from scrapers import openweathermap
@@ -68,10 +69,47 @@ async def test_fetch_openweathermap_clamps_days_to_minimum_of_one(monkeypatch):
             captured["params"] = params
             return _FakeResponse()
 
-    monkeypatch.setattr(openweathermap, "OPENWEATHERMAP_API_KEY", "test-key")
+    monkeypatch.setattr(openweathermap, "OPENWEATHERMAP_API_KEY", None)
     monkeypatch.setattr(openweathermap.httpx, "AsyncClient", lambda **kwargs: _FakeClient())
 
-    result = await openweathermap.fetch_openweathermap(47.2, 6.0, days=0)
+    result = await openweathermap.fetch_openweathermap(47.2, 6.0, days=0, api_key="database-key")
 
     assert result["success"] is True
     assert captured["params"]["cnt"] == 8
+    assert captured["params"]["appid"] == "database-key"
+
+
+@pytest.mark.asyncio
+async def test_fetch_openweathermap_does_not_expose_api_key_in_http_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_key = "secret-database-key"
+
+    class _FakeResponse:
+        status_code = 401
+
+        def raise_for_status(self) -> None:
+            request = httpx.Request(
+                "GET",
+                f"https://api.openweathermap.org/data/2.5/forecast?appid={secret_key}",
+            )
+            response = httpx.Response(401, request=request)
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response)
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, params):
+            return _FakeResponse()
+
+    monkeypatch.setattr(openweathermap.httpx, "AsyncClient", lambda **kwargs: _FakeClient())
+
+    result = await openweathermap.fetch_openweathermap(47.2, 6.0, api_key=secret_key)
+
+    assert result["success"] is False
+    assert result["status_code"] == 401
+    assert secret_key not in result["error"]

--- a/apps/backend/tests/unit/test_weather_pipeline_sources.py
+++ b/apps/backend/tests/unit/test_weather_pipeline_sources.py
@@ -1,4 +1,8 @@
-from weather_pipeline import calculate_consensus
+from unittest.mock import AsyncMock
+
+import pytest
+
+from weather_pipeline import _apply_open_meteo_stale_fallback, calculate_consensus
 
 
 def test_calculate_consensus_preserves_registered_source_details():
@@ -17,6 +21,13 @@ def test_calculate_consensus_preserves_registered_source_details():
                     "cloud_cover": [30.0, 40.0],
                     "cape": [None, None],
                     "lifted_index": [None, None],
+                    "source_freshness": {
+                        "open-meteo": {
+                            "is_stale": True,
+                            "stale_reason": "rate_limited",
+                            "cached_at": "2026-07-14T10:00:00+00:00",
+                        }
+                    },
                 }
             ],
         }
@@ -27,3 +38,68 @@ def test_calculate_consensus_preserves_registered_source_details():
     assert result["consensus"][0]["sources"]["met-no"]["wind_speed"] == 16.0
     assert result["consensus"][0]["sources"]["open-meteo"]["wind_speed"] == 12.0
     assert result["consensus"][0]["sources"]["open-meteo-icon"]["wind_speed"] is None
+    assert result["consensus"][0]["source_freshness"]["open-meteo"]["is_stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_open_meteo_429_reuses_last_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    cached_result = {
+        "success": True,
+        "source": "open-meteo",
+        "hourly": [{"hour": 12, "temperature": 20.0}],
+        "cached_at": "2026-07-14T10:00:00+00:00",
+    }
+    get_cached = AsyncMock(return_value=cached_result)
+    set_cached = AsyncMock()
+    monkeypatch.setattr("cache.get_cached", get_cached)
+    monkeypatch.setattr("cache.set_cached", set_cached)
+
+    result = await _apply_open_meteo_stale_fallback(
+        "open-meteo",
+        {
+            "success": False,
+            "status_code": 429,
+            "error": "Rate limit response with arbitrary wording",
+        },
+        lat=46.9693,
+        lon=5.8747,
+        day_index=0,
+    )
+
+    assert result["success"] is True
+    assert result["is_stale"] is True
+    assert result["stale_reason"] == "rate_limited"
+    assert result["stale_cached_at"] == "2026-07-14T10:00:00+00:00"
+    set_cached.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_open_meteo_result_updates_last_success_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_cached = AsyncMock()
+    set_cached = AsyncMock()
+    monkeypatch.setattr("cache.get_cached", get_cached)
+    monkeypatch.setattr("cache.set_cached", set_cached)
+    fresh_result = {
+        "success": True,
+        "source": "open-meteo",
+        "hourly": [{"hour": 12, "temperature": 20.0}],
+    }
+
+    result = await _apply_open_meteo_stale_fallback(
+        "open-meteo", fresh_result, lat=46.9693, lon=5.8747, day_index=0
+    )
+
+    assert result["is_stale"] is False
+    set_cached.assert_awaited_once()
+    get_cached.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_open_meteo_stale_fallback_accepts_missing_result() -> None:
+    result = await _apply_open_meteo_stale_fallback(
+        "open-meteo", None, lat=46.9693, lon=5.8747, day_index=0
+    )
+
+    assert result is None

--- a/apps/backend/tests/unit/test_weather_sources_registry.py
+++ b/apps/backend/tests/unit/test_weather_sources_registry.py
@@ -79,14 +79,35 @@ async def test_meteo_parapente_wrapper_requests_target_day(
 async def test_meteoblue_wrapper_uses_location_fallback_without_site_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[tuple[float, float, str]] = []
+    calls: list[tuple[float, float, str, int]] = []
 
-    async def fake_fetch_meteoblue(lat: float, lon: float, city_name: str) -> dict[str, bool]:
-        calls.append((lat, lon, city_name))
+    async def fake_fetch_meteoblue(
+        lat: float, lon: float, city_name: str, day_index: int
+    ) -> dict[str, bool]:
+        calls.append((lat, lon, city_name, day_index))
         return {"success": True}
 
     monkeypatch.setattr(weather_sources, "fetch_meteoblue", fake_fetch_meteoblue)
 
     await weather_sources.fetch_meteoblue_default(47.2, 6.0, site_name=None)
 
-    assert calls == [(47.2, 6.0, "location")]
+    assert calls == [(47.2, 6.0, "location", 0)]
+
+
+@pytest.mark.asyncio
+async def test_openweathermap_wrapper_forwards_database_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[float, float, int, str | None]] = []
+
+    async def fake_fetch_openweathermap(
+        lat: float, lon: float, days: int, api_key: str | None
+    ) -> dict[str, bool]:
+        calls.append((lat, lon, days, api_key))
+        return {"success": True}
+
+    monkeypatch.setattr(weather_sources, "fetch_openweathermap", fake_fetch_openweathermap)
+
+    await weather_sources.fetch_openweathermap_default(47.2, 6.0, api_key="database-key")
+
+    assert calls == [(47.2, 6.0, 5, "database-key")]

--- a/apps/backend/weather_pipeline.py
+++ b/apps/backend/weather_pipeline.py
@@ -16,6 +16,55 @@ from para_index import analyze_hourly_slots, calculate_para_index
 from weather_sources import WEATHER_SOURCE_REGISTRY
 
 logger = logging.getLogger(__name__)
+
+OPEN_METEO_STALE_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+async def _apply_open_meteo_stale_fallback(
+    source_name: str,
+    result: dict[str, Any] | None,
+    *,
+    lat: float,
+    lon: float,
+    day_index: int,
+) -> dict[str, Any] | None:
+    """Cache successful Open-Meteo data and reuse it when the API rate-limits."""
+    if not source_name.startswith("open-meteo") or result is None:
+        return result
+
+    from cache import generate_cache_key, get_cached, set_cached
+
+    cache_key = generate_cache_key(
+        "source-last-success",
+        source=source_name,
+        lat=round(lat, 4),
+        lon=round(lon, 4),
+        day_index=day_index,
+    )
+
+    if result.get("success") and result.get("hourly"):
+        result["is_stale"] = False
+        await set_cached(cache_key, result, OPEN_METEO_STALE_CACHE_TTL_SECONDS)
+        return result
+
+    if result.get("status_code") != 429:
+        return result
+
+    cached_result = await get_cached(cache_key)
+    if not isinstance(cached_result, dict) or not cached_result.get("hourly"):
+        return result
+
+    cached_result["success"] = True
+    cached_result["is_stale"] = True
+    cached_result["stale_reason"] = "rate_limited"
+    cached_result["stale_cached_at"] = cached_result.get("cached_at") or cached_result.get(
+        "timestamp"
+    )
+    cached_result["freshness_error"] = result.get("error")
+    logger.warning("Using stale cached data for rate-limited source %s", source_name)
+    return cached_result
+
+
 FULL_CONFIDENCE_SOURCE_BASELINE = 5
 
 
@@ -142,7 +191,7 @@ async def fetch_from_enabled_sources(
         )
 
         # Create instrumented tasks
-        async def instrumented_fetch(src_name: str) -> dict[str, Any]:
+        async def instrumented_fetch(src_name: str, api_key: str | None = None) -> dict[str, Any]:
             """Wrapper to instrument each fetch call"""
             try:
                 source_definition = WEATHER_SOURCE_REGISTRY[src_name]
@@ -152,6 +201,7 @@ async def fetch_from_enabled_sources(
                     day_index=day_index,
                     site_name=site_name,
                     elevation_m=elevation_m,
+                    api_key=api_key,
                 )
 
                 # CRITICAL FIX: Transform raw data to hourly format
@@ -159,6 +209,22 @@ async def fetch_from_enabled_sources(
                 # but normalize_data() expects {'success': True, 'hourly': [...]}
                 if result and result.get("success") and "data" in result:
                     result["hourly"] = source_definition.extract(result, day_index)
+
+                result = await _apply_open_meteo_stale_fallback(
+                    src_name,
+                    result,
+                    lat=lat,
+                    lon=lon,
+                    day_index=day_index,
+                )
+
+                if result is None:
+                    return {
+                        "success": False,
+                        "source": src_name,
+                        "error": "Weather source returned no result",
+                        "timestamp": datetime.now().isoformat(),
+                    }
 
                 return result
 
@@ -180,7 +246,7 @@ async def fetch_from_enabled_sources(
                 logger.warning(f"No fetch function for source '{source.source_name}', skipping")
                 continue
 
-            tasks.append(instrumented_fetch(source.source_name))
+            tasks.append(instrumented_fetch(source.source_name, source.api_key))
             source_names.append(source.source_name)
 
         # Execute all fetches in parallel
@@ -210,13 +276,15 @@ async def fetch_from_enabled_sources(
             )
 
             if source:
-                if result.get("success"):
+                if result.get("success") and not result.get("is_stale"):
                     source.success_count += 1
                     source.last_success_at = datetime.utcnow()
                 else:
                     source.error_count += 1
                     source.last_error_at = datetime.utcnow()
-                    source.last_error_message = result.get("error", "Unknown error")[:500]
+                    source.last_error_message = str(
+                        result.get("freshness_error") or result.get("error") or "Unknown error"
+                    )[:500]
 
                 source.updated_at = datetime.utcnow()
 
@@ -293,7 +361,18 @@ def normalize_data(aggregated: dict[str, Any]) -> dict[str, Any]:
 
         hourly = source_data.get("hourly", [])
         if hourly:
-            all_hourly.append({"source": source_name, "data": hourly})
+            all_hourly.append(
+                {
+                    "source": source_name,
+                    "data": hourly,
+                    "freshness": {
+                        "is_stale": bool(source_data.get("is_stale")),
+                        "stale_reason": source_data.get("stale_reason"),
+                        "cached_at": source_data.get("stale_cached_at")
+                        or source_data.get("cached_at"),
+                    },
+                }
+            )
 
     if not all_hourly:
         return {"success": False, "error": "No successful data from any source"}
@@ -322,10 +401,12 @@ def normalize_data(aggregated: dict[str, Any]) -> dict[str, Any]:
                     "cloud_cover": [],
                     "cape": [],
                     "lifted_index": [],
+                    "source_freshness": {},
                 }
 
             # Add source data
             normalized_hours[hour]["sources"].append(source)
+            normalized_hours[hour]["source_freshness"][source] = source_info["freshness"]
 
             # Collect values - ALWAYS append (even None) to maintain alignment with sources list
             # This is critical for the mapping in calculate_consensus()
@@ -437,6 +518,7 @@ def calculate_consensus(normalized: dict[str, Any]) -> dict[str, Any]:
         # Note: this requires we have the original aggregated data
         # For now, we'll preserve the per-source indices during normalization
         sources_data = {}
+        source_freshness = hour_data.get("source_freshness", {})
 
         # Build initial per-source structure for all known sources
         for source in WEATHER_SOURCE_REGISTRY:
@@ -522,6 +604,7 @@ def calculate_consensus(normalized: dict[str, Any]) -> dict[str, Any]:
                 "lifted_index": round(li_avg, 1) if li_avg is not None else None,
                 "li_confidence": round(li_conf, 2),
                 "sources": sources_data,
+                "source_freshness": source_freshness,
             }
         )
 

--- a/apps/backend/weather_sources.py
+++ b/apps/backend/weather_sources.py
@@ -123,18 +123,21 @@ async def fetch_meteoblue_default(
     lat: float,
     lon: float,
     *,
+    day_index: int = 0,
     site_name: str | None = None,
     **_: Any,
 ) -> dict[str, Any]:
-    return await fetch_meteoblue(lat, lon, city_name=site_name or "location")
+    return await fetch_meteoblue(lat, lon, city_name=site_name or "location", day_index=day_index)
 
 
 async def fetch_met_no_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
     return await fetch_met_no(lat, lon, days=7)
 
 
-async def fetch_openweathermap_default(lat: float, lon: float, **_: Any) -> dict[str, Any]:
-    return await fetch_openweathermap(lat, lon, days=5)
+async def fetch_openweathermap_default(
+    lat: float, lon: float, *, api_key: str | None = None, **_: Any
+) -> dict[str, Any]:
+    return await fetch_openweathermap(lat, lon, days=5, api_key=api_key)
 
 
 WEATHER_SOURCE_DEFINITIONS: tuple[WeatherSourceDefinition, ...] = (

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -56,6 +56,7 @@ interface BaseTooltipProps {
 
 interface SourceDataTooltipProps extends BaseTooltipProps {
   sources: Record<string, Record<string, number | null>>;
+  sourceFreshness?: HourlyForecastItem['source_freshness'];
   consensus: number | string | null;
   unit: string;
   fieldName: string;
@@ -531,6 +532,7 @@ const VerdictTooltip = ({
 const SourceDataTooltip = ({
   hour,
   sources,
+  sourceFreshness,
   consensus,
   unit,
   fieldName,
@@ -557,6 +559,9 @@ const SourceDataTooltip = ({
         {sourceKeys.map((sourceKey) => {
           const sourceData = sources[sourceKey];
           const sourceName = SOURCE_NAMES[sourceKey] || sourceKey;
+          const staleLabel = sourceFreshness?.[sourceKey]?.is_stale
+            ? ` (${t('weather.staleSourceData')})`
+            : '';
 
           if (!sourceData) {
             return (
@@ -564,8 +569,8 @@ const SourceDataTooltip = ({
                 key={sourceKey}
                 className="text-xs text-gray-400 dark:text-gray-400"
               >
-                <span className="font-semibold">{sourceName}:</span> (
-                {t('weather.notAvailable')})
+                <span className="font-semibold">{sourceName}:</span>
+                {staleLabel} ({t('weather.notAvailable')})
               </div>
             );
           }
@@ -592,8 +597,8 @@ const SourceDataTooltip = ({
                 className="text-xs text-gray-700 dark:text-gray-300 flex items-center justify-between gap-2"
               >
                 <span>
-                  <span className="font-semibold">{sourceName}:</span>{' '}
-                  {displayValue}
+                  <span className="font-semibold">{sourceName}:</span>
+                  {staleLabel} {displayValue}
                   {gustValue}
                 </span>
                 {sourceUrl && (
@@ -624,8 +629,8 @@ const SourceDataTooltip = ({
                 className="text-xs text-gray-700 dark:text-gray-300 flex items-center justify-between gap-2"
               >
                 <span>
-                  <span className="font-semibold">{sourceName}:</span>{' '}
-                  {displayValue}
+                  <span className="font-semibold">{sourceName}:</span>
+                  {staleLabel} {displayValue}
                 </span>
                 {sourceUrl && (
                   <a
@@ -649,8 +654,8 @@ const SourceDataTooltip = ({
                 key={sourceKey}
                 className="text-xs text-gray-400 dark:text-gray-400"
               >
-                <span className="font-semibold">{sourceName}:</span> (
-                {t('weather.notAvailable')})
+                <span className="font-semibold">{sourceName}:</span>
+                {staleLabel} ({t('weather.notAvailable')})
               </div>
             );
           }
@@ -664,8 +669,8 @@ const SourceDataTooltip = ({
               className="text-xs text-gray-700 dark:text-gray-300 flex items-center justify-between gap-2"
             >
               <span>
-                <span className="font-semibold">{sourceName}:</span>{' '}
-                {displayValue} {unit}
+                <span className="font-semibold">{sourceName}:</span>
+                {staleLabel} {displayValue} {unit}
               </span>
               {sourceUrl && (
                 <a
@@ -850,6 +855,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={data.temperature}
             unit="°C"
             fieldName="temperature"
@@ -863,6 +869,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={data.wind_speed}
             unit="km/h"
             fieldName="wind_speed"
@@ -876,6 +883,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={data.wind_gust ?? null}
             unit="km/h"
             fieldName="wind_gust"
@@ -889,6 +897,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={formatWindDirectionWithDegrees(
               data.sources?.['open-meteo']?.wind_direction ||
                 data.sources?.['weatherapi']?.wind_direction ||
@@ -906,6 +915,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={data.precipitation}
             unit="mm"
             fieldName="precipitation"
@@ -919,6 +929,7 @@ export default function HourlyForecast({
           <SourceDataTooltip
             hour={data.hour}
             sources={data.sources || {}}
+            sourceFreshness={data.source_freshness}
             consensus={
               data.sources?.['open-meteo']?.cloud_cover ||
               data.sources?.['weatherapi']?.cloud_cover ||

--- a/apps/frontend/src/hooks/weather/useWeather.ts
+++ b/apps/frontend/src/hooks/weather/useWeather.ts
@@ -113,6 +113,7 @@ export const transformWeatherResponse = (
         'faible',
       cloud_cover: hour.cloud_cover ?? null,
       sources: hour.sources || {},
+      source_freshness: hour.source_freshness || {},
     };
   });
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -201,6 +201,7 @@
     "liveWindOpenSpotair": "Open SpotAiR",
     "reasonsTextualFlyability": "Textual flyability reasons",
     "notAvailable": "not available",
+    "staleSourceData": "outdated data, API rate limit reached",
     "windOrientation": "Wind / Orientation",
     "favorabilityGood": "Favorable",
     "favorabilityModerate": "Moderate",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -201,6 +201,7 @@
     "liveWindOpenSpotair": "Ouvrir SpotAiR",
     "reasonsTextualFlyability": "Raisons textuelles volabilité",
     "notAvailable": "non disponible",
+    "staleSourceData": "données non actualisées, limite API atteinte",
     "windOrientation": "Vent / Orientation",
     "favorabilityGood": "Favorable",
     "favorabilityModerate": "Modéré",

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -52,6 +52,14 @@ export interface HourlyForecastItem {
   para_index: number;
   verdict: string;
   sources?: Record<string, Record<string, number | null>>;
+  source_freshness?: Record<
+    string,
+    {
+      is_stale: boolean;
+      stale_reason?: string | null;
+      cached_at?: string | null;
+    }
+  >;
   thermal_strength?: string;
   cape?: number | null;
   lifted_index?: number | null;

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -197,6 +197,16 @@ export const ConsensusHourSchema = z.object({
   verdict: z.string().optional(), // Verdict per hour
   thermal_strength: z.string().optional(), // Thermal strength
   sources: z.record(z.string(), z.any()).optional(), // Per-source data for tooltip
+  source_freshness: z
+    .record(
+      z.string(),
+      z.object({
+        is_stale: z.boolean(),
+        stale_reason: z.string().nullish(),
+        cached_at: z.string().nullish(),
+      })
+    )
+    .optional(),
 });
 
 export const SlotSchema = z.object({


### PR DESCRIPTION
## Summary\n- Repair Meteociel and Meteoblue scraping paths\n- Add Open-Meteo stale fallback on 429\n- Forward OpenWeatherMap API key from DB and surface source freshness in the UI\n\n## Validation\n- PASS: backend targeted pytest suite (weather scrapers + pipeline/source registry)\n- PASS: 
> nx run backend:lint  [existing outputs match the cache, left as is]

> command -v ../../.venv/bin/ruff >/dev/null 2>&1 && RUFF=../../.venv/bin/ruff || RUFF=ruff; $RUFF check . --output-format=github

> command -v ../../.venv/bin/black >/dev/null 2>&1 && BLACK=../../.venv/bin/black || BLACK=black; $BLACK --check --diff .

All done! ✨ 🍰 ✨
180 files would be left unchanged.



 NX   Successfully ran target lint for project backend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.\n- PASS: 
> nx run frontend:build:production  [local cache]

[1m[33mThe `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.[39m[22m
[36mvite v8.1.4 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...[32m✓[0m 4891 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/apps/frontend/[0m[32mindex.html                                    [0m[1;2m  1.25 kB[0m[2m │ gzip:   0.47 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[35mindex-CLR5hWDe.css                     [0m[1;2m137.07 kB[0m[2m │ gzip:  19.61 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights.lazy-CMAPBMmN.js               [0m[1;2m  0.14 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights._flightId.lazy-W32H6c8t.js     [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure.lazy-Bo0xIrcA.js        [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure._tab.lazy-tGrWLfM7.js   [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msearch-Dv1OugJ6.js                     [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflightMediaState-Bb1JtFLR.js           [0m[1;2m  0.26 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mtrash-2-DJE5TNpP.js                    [0m[1;2m  0.31 kB[0m[2m │ gzip:   0.20 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museToast-Nxo-zjjq.js                   [0m[1;2m  0.47 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museAppSettings-CaeRCrp1.js             [0m[1;2m  0.62 kB[0m[2m │ gzip:   0.31 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mrolldown-runtime-QTnfLwEv.js           [0m[1;2m  0.69 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museIsMobile-D4_n0WZW.js                [0m[1;2m  0.92 kB[0m[2m │ gzip:   0.50 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museFlight-CWCCFffY.js                  [0m[1;2m  1.19 kB[0m[2m │ gzip:   0.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mTabs-DDFq-Igo.js                       [0m[1;2m  1.23 kB[0m[2m │ gzip:   0.51 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mModal-BK-0YdcU.js                      [0m[1;2m  1.54 kB[0m[2m │ gzip:   0.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mappSettingsStore-CHJyyziy.js           [0m[1;2m  1.60 kB[0m[2m │ gzip:   0.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mexport-viewer.lazy-CuVX5bTg.js         [0m[1;2m  1.62 kB[0m[2m │ gzip:   0.79 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mmap-pin-CgLZG7sg.js                    [0m[1;2m  1.63 kB[0m[2m │ gzip:   0.94 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mviewer._flightId.lazy-BguU4KbA.js      [0m[1;2m  1.72 kB[0m[2m │ gzip:   0.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museCityWeather-D7ZXmXxX.js             [0m[1;2m  2.46 kB[0m[2m │ gzip:   0.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mDataTable-DXZuoCNK.js                  [0m[1;2m  2.71 kB[0m[2m │ gzip:   1.19 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mJobLiveLogsPanel-BFwtPhCt.js           [0m[1;2m  5.16 kB[0m[2m │ gzip:   2.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mSelect-DqP3eJBZ.js                     [0m[1;2m  6.40 kB[0m[2m │ gzip:   1.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msrc-Cpm3hboC.js                        [0m[1;2m  9.62 kB[0m[2m │ gzip:   2.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mthermal.lazy-CbSPNWYt.js               [0m[1;2m 10.43 kB[0m[2m │ gzip:   3.26 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mEmagramExplanationTooltip-D-3m_H9a.js  [0m[1;2m 25.32 kB[0m[2m │ gzip:   7.59 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightViewer3D-C-RyJXzZ.js             [0m[1;2m 32.92 kB[0m[2m │ gzip:   9.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msites.lazy-BroGlltz.js                 [0m[1;2m 36.41 kB[0m[2m │ gzip:   9.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mInfrastructurePage-CFZYKb_z.js         [0m[1;2m 43.03 kB[0m[2m │ gzip:  10.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msettings.lazy-J5WCJaLw.js              [0m[1;2m 49.59 kB[0m[2m │ gzip:   9.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-i18n-zqN_fCwb.js                [0m[1;2m 76.15 kB[0m[2m │ gzip:  24.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightHistory-BfnCQUA4.js              [0m[1;2m 94.64 kB[0m[2m │ gzip:  22.45 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mweather.lazy-D0-iGqaD.js               [0m[1;2m104.76 kB[0m[2m │ gzip:  23.40 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mschemas-DebG2fnq.js                    [0m[1;2m128.09 kB[0m[2m │ gzip:  37.77 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-Dmc2spWo.js               [0m[1;2m182.16 kB[0m[2m │ gzip:  57.35 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mindex-BxhtSXmU.js                      [0m[1;2m198.29 kB[0m[2m │ gzip:  60.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-tanstack-DSDMfdVD.js            [0m[1;2m232.57 kB[0m[2m │ gzip:  64.78 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-aria-D1k20z5Y.js          [0m[1;2m403.71 kB[0m[2m │ gzip: 124.62 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36manalytics.lazy-Bt3J8QOR.js             [0m[1;2m447.61 kB[0m[2m │ gzip: 123.76 kB[0m

[32m✓ built in 2.45s[39m



 NX   Successfully ran target build for project frontend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.\n- FAIL (pre-existing repo issues): 
 NX   Affected criteria defaulted to --base=main --head=HEAD


 NX   Running targets build, lint, type-check, test for 4 projects:

- backend
- frontend
- design-system
- shared-types



> nx run frontend:build:production  [existing outputs match the cache, left as is]

[1m[33mThe `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.[39m[22m
[36mvite v8.1.4 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...[32m✓[0m 4891 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/apps/frontend/[0m[32mindex.html                                    [0m[1;2m  1.25 kB[0m[2m │ gzip:   0.47 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[35mindex-CLR5hWDe.css                     [0m[1;2m137.07 kB[0m[2m │ gzip:  19.61 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights.lazy-CMAPBMmN.js               [0m[1;2m  0.14 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights._flightId.lazy-W32H6c8t.js     [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure.lazy-Bo0xIrcA.js        [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure._tab.lazy-tGrWLfM7.js   [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msearch-Dv1OugJ6.js                     [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflightMediaState-Bb1JtFLR.js           [0m[1;2m  0.26 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mtrash-2-DJE5TNpP.js                    [0m[1;2m  0.31 kB[0m[2m │ gzip:   0.20 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museToast-Nxo-zjjq.js                   [0m[1;2m  0.47 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museAppSettings-CaeRCrp1.js             [0m[1;2m  0.62 kB[0m[2m │ gzip:   0.31 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mrolldown-runtime-QTnfLwEv.js           [0m[1;2m  0.69 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museIsMobile-D4_n0WZW.js                [0m[1;2m  0.92 kB[0m[2m │ gzip:   0.50 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museFlight-CWCCFffY.js                  [0m[1;2m  1.19 kB[0m[2m │ gzip:   0.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mTabs-DDFq-Igo.js                       [0m[1;2m  1.23 kB[0m[2m │ gzip:   0.51 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mModal-BK-0YdcU.js                      [0m[1;2m  1.54 kB[0m[2m │ gzip:   0.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mappSettingsStore-CHJyyziy.js           [0m[1;2m  1.60 kB[0m[2m │ gzip:   0.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mexport-viewer.lazy-CuVX5bTg.js         [0m[1;2m  1.62 kB[0m[2m │ gzip:   0.79 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mmap-pin-CgLZG7sg.js                    [0m[1;2m  1.63 kB[0m[2m │ gzip:   0.94 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mviewer._flightId.lazy-BguU4KbA.js      [0m[1;2m  1.72 kB[0m[2m │ gzip:   0.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museCityWeather-D7ZXmXxX.js             [0m[1;2m  2.46 kB[0m[2m │ gzip:   0.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mDataTable-DXZuoCNK.js                  [0m[1;2m  2.71 kB[0m[2m │ gzip:   1.19 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mJobLiveLogsPanel-BFwtPhCt.js           [0m[1;2m  5.16 kB[0m[2m │ gzip:   2.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mSelect-DqP3eJBZ.js                     [0m[1;2m  6.40 kB[0m[2m │ gzip:   1.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msrc-Cpm3hboC.js                        [0m[1;2m  9.62 kB[0m[2m │ gzip:   2.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mthermal.lazy-CbSPNWYt.js               [0m[1;2m 10.43 kB[0m[2m │ gzip:   3.26 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mEmagramExplanationTooltip-D-3m_H9a.js  [0m[1;2m 25.32 kB[0m[2m │ gzip:   7.59 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightViewer3D-C-RyJXzZ.js             [0m[1;2m 32.92 kB[0m[2m │ gzip:   9.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msites.lazy-BroGlltz.js                 [0m[1;2m 36.41 kB[0m[2m │ gzip:   9.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mInfrastructurePage-CFZYKb_z.js         [0m[1;2m 43.03 kB[0m[2m │ gzip:  10.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msettings.lazy-J5WCJaLw.js              [0m[1;2m 49.59 kB[0m[2m │ gzip:   9.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-i18n-zqN_fCwb.js                [0m[1;2m 76.15 kB[0m[2m │ gzip:  24.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightHistory-BfnCQUA4.js              [0m[1;2m 94.64 kB[0m[2m │ gzip:  22.45 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mweather.lazy-D0-iGqaD.js               [0m[1;2m104.76 kB[0m[2m │ gzip:  23.40 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mschemas-DebG2fnq.js                    [0m[1;2m128.09 kB[0m[2m │ gzip:  37.77 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-Dmc2spWo.js               [0m[1;2m182.16 kB[0m[2m │ gzip:  57.35 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mindex-BxhtSXmU.js                      [0m[1;2m198.29 kB[0m[2m │ gzip:  60.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-tanstack-DSDMfdVD.js            [0m[1;2m232.57 kB[0m[2m │ gzip:  64.78 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-aria-D1k20z5Y.js          [0m[1;2m403.71 kB[0m[2m │ gzip: 124.62 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36manalytics.lazy-Bt3J8QOR.js             [0m[1;2m447.61 kB[0m[2m │ gzip: 123.76 kB[0m

[32m✓ built in 2.45s[39m

> nx run design-system:type-check  [existing outputs match the cache, left as is]

> tsc --noEmit -p libs/design-system/tsconfig.json && tsc --noEmit -p libs/design-system/tsconfig.node.json


> nx run shared-types:type-check  [existing outputs match the cache, left as is]

> tsc --noEmit -p libs/shared-types/tsconfig.json


> nx run design-system:lint  [existing outputs match the cache, left as is]

> oxlint -c .oxlintrc.json libs/design-system/src

libs/design-system/src/components/DatePicker/DatePicker.stories.tsx:73:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/components/DatePicker/DatePicker.stories.tsx:77:60: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/ToastContainer.stories.tsx:70:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/ToastContainer.stories.tsx:111:22: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/ToastContainer.stories.tsx:113:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/ToastContainer.stories.tsx:114:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Lightbox.stories.tsx:66:58: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Lightbox.stories.tsx:84:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Lightbox.stories.tsx:86:59: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Lightbox.stories.tsx:107:36: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Lightbox.stories.tsx:126:59: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/components/ErrorBoundary/ErrorBoundary.stories.tsx:102:24: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/components/ErrorBoundary/ErrorBoundary.stories.tsx:107:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/components/ErrorBoundary/ErrorBoundary.stories.tsx:112:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
libs/design-system/src/Toast.stories.tsx:59:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.

> nx run shared-types:lint  [existing outputs match the cache, left as is]

> oxlint -c .oxlintrc.json libs/shared-types/src


> nx run backend:lint  [existing outputs match the cache, left as is]

> command -v ../../.venv/bin/ruff >/dev/null 2>&1 && RUFF=../../.venv/bin/ruff || RUFF=ruff; $RUFF check . --output-format=github

> command -v ../../.venv/bin/black >/dev/null 2>&1 && BLACK=../../.venv/bin/black || BLACK=black; $BLACK --check --diff .

All done! ✨ 🍰 ✨
180 files would be left unchanged.

> nx run frontend:type-check  [existing outputs match the cache, left as is]

> tsc --noEmit


> nx run backend:test

> command -v ../../.venv/bin/pytest >/dev/null 2>&1 && PYTEST=../../.venv/bin/pytest || PYTEST=pytest; $PYTEST tests/ -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml

/bin/sh: 1: pytest: not found
Warning: command "command -v ../../.venv/bin/pytest >/dev/null 2>&1 && PYTEST=../../.venv/bin/pytest || PYTEST=pytest; $PYTEST tests/ -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml" exited with non-zero status code
> nx run frontend:lint

> oxlint -c .oxlintrc.json apps/frontend/src

apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:83:40: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:90:47: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:96:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:100:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:102:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/create-site/CreateSiteModal.stories.tsx:142:45: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/LandingAssociationsManager.stories.tsx:185:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/LandingAssociationsManager.stories.tsx:187:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/LandingAssociationsManager.stories.tsx:270:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/LandingAssociationsManager.stories.tsx:271:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/AllSitesConditions.stories.tsx:138:27: warning oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
apps/frontend/src/components/common/AppUpdateBanner.stories.tsx:31:24: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/common/AppUpdateBanner.stories.tsx:34:40: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/common/AppUpdateBanner.stories.tsx:44:62: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/common/AppUpdateBanner.stories.tsx:67:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/LiveWindCard.stories.tsx:80:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/LiveWindCard.stories.tsx:82:22: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/MultiOrientationSelector.stories.tsx:317:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/MultiOrientationSelector.stories.tsx:396:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/hooks/flights/useFlights.ts:134:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/dashboard/SiteSelector.tsx:82:9: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/StatsPanel.stories.tsx:53:42: warning eslint(no-promise-executor-return): Return statement should not be used in Promise executor. help: Use `resolve()` or `reject()` instead of returning a value.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:214:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:229:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:266:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:281:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:307:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:322:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:503:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/Forecast7Day.stories.tsx:525:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/analytics/FilterBar.stories.tsx:133:42: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramExplanationTooltip.tsx:82:16: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/SiteSelector.stories.tsx:129:39: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/dashboard/SiteSelector.stories.tsx:141:39: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/dashboard/SiteSelector.stories.tsx:152:39: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/dashboard/SiteSelector.stories.tsx:160:39: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:256:11: warning eslint(radix): Missing radix parameter. help: Add radix parameter `10` for parsing decimal numbers, or specify the appropriate radix for other number formats.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:261:7: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:291:11: warning eslint(radix): Missing radix parameter. help: Add radix parameter `10` for parsing decimal numbers, or specify the appropriate radix for other number formats.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:296:7: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:369:52: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:386:36: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:432:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:433:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/HourlyForecast.stories.tsx:434:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/EditSiteModal.stories.tsx:171:38: warning eslint(no-promise-executor-return): Return statement should not be used in Promise executor. help: Use `resolve()` or `reject()` instead of returning a value.
apps/frontend/src/components/sites/EditSiteModal.stories.tsx:179:57: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/EditSiteModal.stories.tsx:381:38: warning eslint(no-promise-executor-return): Return statement should not be used in Promise executor. help: Use `resolve()` or `reject()` instead of returning a value.
apps/frontend/src/components/sites/EditSiteModal.stories.tsx:414:38: warning eslint(no-promise-executor-return): Return statement should not be used in Promise executor. help: Use `resolve()` or `reject()` instead of returning a value.
apps/frontend/src/lib/api.ts:11:58: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/lib/api.ts:60:11: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/lib/api.ts:65:7: warning eslint(require-await): Async function has no `await` expression. help: Consider removing the `async` keyword.
apps/frontend/src/lib/api.ts:77:11: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/dashboard/MultiOrientationSelector.tsx:34:17: warning react(no-object-type-as-default-prop): Do not use a `new` expression as default prop value. Use a stable reference instead. help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:151:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:152:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:153:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:159:44: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:190:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:218:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:230:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:231:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:232:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:234:44: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:246:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:286:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:287:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:288:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:289:29: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:340:11: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx:346:5: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/hooks/weather/useWeather.ts:77:9: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/hooks/weather/useWeather.ts:79:13: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/hooks/weather/useWeather.ts:103:9: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/hooks/weather/useWeather.ts:211:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/sites/LandingAssociationsManager.tsx:118:22: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/sites/LandingAssociationsManager.tsx:139:8: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/flights/create-site/CreateSiteModal.tsx:79:30: warning eslint(radix): Missing radix parameter. help: Add radix parameter `10` for parsing decimal numbers, or specify the appropriate radix for other number formats.
apps/frontend/src/components/analytics/TimeOfDayChart.tsx:65:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/lib/siteDisplay.ts:9:14: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/lib/siteDisplay.ts:11:14: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/lib/siteDisplay.ts:13:14: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/hooks/sites/useSites.ts:49:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:271:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:309:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:351:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:379:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:419:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/settings/WeatherSourceCard.stories.tsx:541:27: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/weather/LiveWindCard.tsx:86:10: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/weather/LiveWindCard.tsx:175:8: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/analytics/WeekdayChart.tsx:50:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/hooks/flights/useFlightGPX.ts:50:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/hooks/flights/useFlightGPX.ts:51:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/lib/emagramAnnotations.ts:271:18: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/utils/cameraOrientation.ts:51:10: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/lib/date.ts:1:26: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/hooks/weather/useEmagramAnalysis.ts:33:14: warning eslint(require-await): Async function has no `await` expression. help: Consider removing the `async` keyword.
apps/frontend/src/hooks/weather/useEmagramAnalysis.ts:79:14: warning eslint(require-await): Async function has no `await` expression. help: Consider removing the `async` keyword.
apps/frontend/src/hooks/weather/useEmagramAnalysis.ts:108:14: warning eslint(require-await): Async function has no `await` expression. help: Consider removing the `async` keyword.
apps/frontend/src/hooks/weather/useEmagramAnalysis.ts:135:17: warning eslint(require-await): Async function has no `await` expression. help: Consider removing the `async` keyword.
apps/frontend/src/components/weather/BestSpotSuggestion.tsx:193:21: warning react(no-object-type-as-default-prop): Do not use an array literal as default prop value. Use a stable reference instead. help: Default values are re-created on every render and break referential equality, causing unnecessary re-renders. Move the value out of the component or memoize it.
apps/frontend/src/components/weather/BestSpotSuggestion.tsx:558:25: error jsx-a11y(control-has-associated-label): A control must be associated with a text label. help: Add a text label to the control element. This can be done by adding text content, an `aria-label` attribute, or an `aria-labelledby` attribute.
apps/frontend/src/components/analytics/AltitudeChart.stories.tsx:70:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:196:35: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:197:15: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:202:15: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:208:25: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:395:12: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:395:12: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:397:15: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:466:10: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/dashboard/EmagramWidget.tsx:615:17: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:218:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:220:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:221:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:222:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:252:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:254:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:255:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:256:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:284:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:286:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:287:33: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CurrentConditions.stories.tsx:289:22: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:257:46: warning oxc(no-map-spread): Spreading to modify object properties in `map` calls is inefficient help: If in-place mutation is acceptable, use `Object.assign` or direct property assignment instead of spreading
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:373:7: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:437:28: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:487:7: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:511:28: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts:515:35: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/SiteCard.stories.tsx:79:44: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/sites/SiteCard.stories.tsx:83:62: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/hooks/common/useAppVersion.ts:69:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/hooks/common/useAppVersion.ts:72:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/lib/version.ts:9:10: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/ViewerExport.tsx:34:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/pages/ViewerExport.tsx:35:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/pages/Settings.stories.tsx:130:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Settings.stories.tsx:147:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/weather/CityWeatherSearch.tsx:424:18: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/weather/CityWeatherSearch.tsx:512:14: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/weather/CityWeatherSearch.tsx:588:14: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/pages/ThermalAnalysis.tsx:55:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `ThermalHistoryTable` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/ThermalAnalysis.tsx:103:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `ThermalHistoryTable` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/Sites.stories.tsx:118:52: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:131:52: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:149:56: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:154:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:159:50: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:160:50: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:161:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:162:50: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:163:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:164:50: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:170:46: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:188:56: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:200:51: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:202:31: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:207:46: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/Sites.stories.tsx:227:56: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:676:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:867:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:910:9: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1077:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1126:26: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1162:7: warning eslint(no-lonely-if): Unexpected `if` as the only statement in an `else` block help: Consider using `else if` instead.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1157:9: warning eslint(no-negated-condition): Unexpected negated condition. help: Remove the negation operator and switch the consequent and alternate branches.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1623:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1637:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1677:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:1681:7: warning eslint(no-console): Unexpected console statement. help: Delete this console statement.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:2062:28: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:2064:31: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx:2066:33: warning eslint(no-nested-ternary): Do not nest ternary expressions. help: Refactor nested ternary expressions into if-else statements for better readability.
apps/frontend/src/pages/InfrastructurePage.tsx:66:5: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/InfrastructurePage.tsx:66:23: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/InfrastructurePage.tsx:955:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `GroupSection` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/InfrastructurePage.tsx:963:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `GroupSection` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/InfrastructurePage.tsx:972:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `GroupSection` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/InfrastructurePage.tsx:981:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `GroupSection` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/InfrastructurePage.tsx:990:15: error react(no-unstable-nested-components): Do not define components during render. help: Move this component definition out of the parent component `GroupSection` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.
apps/frontend/src/pages/WeatherPage.stories.tsx:634:28: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/WeatherPage.stories.tsx:820:54: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/WeatherPage.stories.tsx:822:66: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/WeatherPage.stories.tsx:825:13: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/WeatherPage.stories.tsx:827:47: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
apps/frontend/src/pages/WeatherPage.stories.tsx:865:27: warning eslint(require-unicode-regexp): Use the 'u' flag. help: Add the 'u' flag.
Warning: command "oxlint -c .oxlintrc.json apps/frontend/src" exited with non-zero status code
> nx run design-system:test

> vitest run --config vitest.config.ts


 RUN  v4.1.9 /media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/libs/design-system

16:39:37 [vite] [90m[2m(client)[22m[39m [optimizer] scanning dependencies...
16:39:39 [vite] [90m[2m(client)[22m[39m [optimizer] bundling dependencies...
⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: browserType.launch: Executable doesn't exist at /home/capic/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pnpm exec playwright install                           ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
 ❯ ../../node_modules/.pnpm/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@25.9.2_typescript@6.0.3__playwr_1854d2a6e91560d5393a3b540a189fa3/node_modules/@vitest/browser-playwright/dist/index.js:929:55

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { log: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  1 passed (15)
      Tests  1 passed (1)
     Errors  1 error
   Start at  16:39:34
   Duration  6.77s (transform 576ms, setup 0ms, import 4.40s, tests 17ms, environment 1.09s)

error during close browserType.launch: Executable doesn't exist at /home/capic/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pnpm exec playwright install                           ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
    at /media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/node_modules/[4m.pnpm[24m/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@25.9.2_typescript@6.0.3__playwr_1854d2a6e91560d5393a3b540a189fa3/node_modules/[4m@vitest/browser-playwright[24m/dist/index.js:929:55 {
  log: [],
  name: [32m'Error'[39m,
  type: [32m'Unhandled Error'[39m,
  stacks: [
    {
      method: [32m''[39m,
      file: [32m'/media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/node_modules/.pnpm/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@25.9.2_typescript@6.0.3__playwr_1854d2a6e91560d5393a3b540a189fa3/node_modules/@vitest/browser-playwright/dist/index.js'[39m,
      line: [33m929[39m,
      column: [33m55[39m
    }
  ]
}
Warning: command "vitest run --config vitest.config.ts" exited with non-zero status code
> nx run frontend:test

> vitest run --config vitest.config.ts


 RUN  v4.1.9 /media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/apps/frontend

Port 63315 is in use, trying another one...
 ❯ |unit| src/components/flights/details/FlightDetails.test.tsx (6 tests | 1 failed) 6401ms
     × regenerates overlay after cancellation 5299ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  |unit| src/components/flights/details/FlightDetails.test.tsx > FlightDetails GoPro overlay action > regenerates overlay after cancellation
Error: Test timed out in 5000ms.
If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
 ❯ src/components/flights/details/FlightDetails.test.tsx:301:3
    299|   });
    300|
    301|   it('regenerates overlay after cancellation', async () => {
       |   ^
    302|     mockFlight.gopro_overlay_job_id = 'job-overlay';
    303|     mockFlight.gopro_overlay_status = 'cancelled';

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
Error: browserType.launch: Executable doesn't exist at /home/capic/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pnpm exec playwright install                           ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
 ❯ ../../node_modules/.pnpm/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@24.13.3_typescript@6.0.3__playw_4bf22c47db33ba588b8a7a77056152a0/node_modules/@vitest/browser-playwright/dist/index.js:929:55

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { log: [] }
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  1 failed | 32 passed (125)
      Tests  1 failed | 152 passed (153)
     Errors  1 error
   Start at  16:39:37
   Duration  28.35s (transform 21.12s, setup 89.19s, import 67.12s, tests 19.79s, environment 74.99s)

error during close browserType.launch: Executable doesn't exist at /home/capic/.cache/ms-playwright/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell
╔════════════════════════════════════════════════════════════╗
║ Looks like Playwright was just installed or updated.       ║
║ Please run the following command to download new browsers: ║
║                                                            ║
║     pnpm exec playwright install                           ║
║                                                            ║
║ <3 Playwright Team                                         ║
╚════════════════════════════════════════════════════════════╝
    at /media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/node_modules/[4m.pnpm[24m/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@24.13.3_typescript@6.0.3__playw_4bf22c47db33ba588b8a7a77056152a0/node_modules/[4m@vitest/browser-playwright[24m/dist/index.js:929:55 {
  log: [],
  name: [32m'Error'[39m,
  type: [32m'Unhandled Error'[39m,
  stacks: [
    {
      method: [32m''[39m,
      file: [32m'/media/usb/data-m2/developement/dashboard-parapente/.codenomad/worktree/wt-weather-scrapers-fix/node_modules/.pnpm/@vitest+browser-playwright@4.1.9_msw@2.14.6_@types+node@24.13.3_typescript@6.0.3__playw_4bf22c47db33ba588b8a7a77056152a0/node_modules/@vitest/browser-playwright/dist/index.js'[39m,
      line: [33m929[39m,
      column: [33m55[39m
    }
  ]
}
Warning: command "vitest run --config vitest.config.ts" exited with non-zero status code\n\n## Notes\n- CodeRabbit review already completed on the final diff with 0 findings.