### PR TITLE
feat(flights): allow manual flight creation

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -77,6 +77,7 @@ from schemas import GoproOverlayProbeResponse
 from schemas import (
     EmagramAnalysisListItem,
     EmagramTriggerRequest,
+    FlightCreate,
     FlightRecordsResponse,
     FlightUpdate,
 )
@@ -3998,22 +3999,87 @@ def download_flight_gopro_overlay(flight_id: str, db: Session = Depends(get_db))
 
 
 @router.post("/flights")
-def create_flight(flight_data: dict, db: Session = Depends(get_db)):
-    """Create a new flight (from Strava webhook)"""
+def create_flight(flight_data: FlightCreate, db: Session = Depends(get_db)):
+    """Create a flight from manually entered information."""
+    site = None
+    if flight_data.site_id:
+        site = db.query(Site).filter(Site.id == flight_data.site_id).first()
+        if not site:
+            raise HTTPException(status_code=404, detail="Site not found")
+
+    entered_name = (flight_data.name or flight_data.title or "").strip()
+    if entered_name:
+        flight_name = entered_name
+    elif site:
+        flight_name = f"{site.name} {flight_data.flight_date.strftime('%d-%m')}"
+    else:
+        flight_name = f"Vol du {flight_data.flight_date.strftime('%d/%m/%Y')}"
+
+    if flight_data.departure_time:
+        flight_name = (
+            entered_name
+            or f"{site.name if site else 'Vol'} "
+            f"{flight_data.flight_date.strftime('%d-%m')} "
+            f"{flight_data.departure_time.strftime('%Hh%M')}"
+        )
+
     flight = Flight(
         id=str(uuid.uuid4()),
-        strava_id=flight_data.get("strava_id"),
-        site_id=flight_data.get("site_id"),
-        title=flight_data.get("title"),
-        flight_date=flight_data.get("flight_date"),
-        duration_minutes=flight_data.get("duration_minutes"),
-        max_altitude_m=flight_data.get("max_altitude_m"),
-        distance_km=flight_data.get("distance_km"),
+        strava_id=flight_data.strava_id,
+        site_id=flight_data.site_id,
+        name=flight_name,
+        title=(flight_data.title or "").strip() or flight_name,
+        description=flight_data.description,
+        flight_date=flight_data.flight_date,
+        departure_time=flight_data.departure_time,
+        duration_minutes=flight_data.duration_minutes,
+        max_altitude_m=flight_data.max_altitude_m,
+        max_speed_kmh=flight_data.max_speed_kmh,
+        distance_km=flight_data.distance_km,
+        elevation_gain_m=flight_data.elevation_gain_m,
+        notes=flight_data.notes,
     )
-    db.add(flight)
-    db.commit()
-    db.refresh(flight)
-    return flight
+    try:
+        db.add(flight)
+        db.commit()
+        db.refresh(flight)
+    except Exception as exc:
+        db.rollback()
+        logger.error("Failed to create manual flight: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to create flight") from exc
+
+    return {
+        "id": flight.id,
+        "strava_id": flight.strava_id,
+        "site_id": flight.site_id,
+        "site_name": site.name if site else None,
+        "name": flight.name,
+        "title": flight.title,
+        "description": flight.description,
+        "flight_date": flight.flight_date.isoformat(),
+        "departure_time": flight.departure_time.isoformat() if flight.departure_time else None,
+        "duration_minutes": flight.duration_minutes,
+        "max_altitude_m": flight.max_altitude_m,
+        "max_speed_kmh": flight.max_speed_kmh,
+        "distance_km": flight.distance_km,
+        "elevation_gain_m": flight.elevation_gain_m,
+        "notes": flight.notes,
+        "gpx_file_path": None,
+        "external_url": None,
+        "video_export_job_id": None,
+        "video_export_status": None,
+        "video_export_progress": None,
+        "video_file_path": None,
+        "video_file_exists": False,
+        "gopro_camera_file_exists": False,
+        "gopro_overlay_job_id": None,
+        "gopro_overlay_status": None,
+        "gopro_overlay_progress": None,
+        "gopro_overlay_file_path": None,
+        "gopro_overlay_file_exists": False,
+        "created_at": flight.created_at.isoformat() if flight.created_at else None,
+        "updated_at": flight.updated_at.isoformat() if flight.updated_at else None,
+    }
 
 
 @router.post("/flights/sync-strava")

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -254,8 +254,27 @@ class FlightBase(BaseModel):
 
 
 class FlightCreate(FlightBase):
+    name: str | None = None
     site_id: str | None = None
     strava_id: str | None = None
+
+    @validator("duration_minutes", "max_altitude_m", "elevation_gain_m")
+    def positive_values(cls, value):
+        if value is not None and value < 0:
+            raise ValueError("Value must be positive or zero")
+        return value
+
+    @validator("distance_km", "max_speed_kmh")
+    def positive_floats(cls, value):
+        if value is not None and value < 0:
+            raise ValueError("Value must be positive or zero")
+        return value
+
+    @validator("flight_date")
+    def date_not_future(cls, value):
+        if value > date.today():
+            raise ValueError("Flight date cannot be in the future")
+        return value
 
 
 class FlightUpdate(BaseModel):

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -1079,12 +1079,66 @@ class TestDeleteFlightEndpoint:
 class TestCreateFlightEndpoint:
     """Tests for POST /flights"""
 
-    # Note: POST /flights tests removed
-    # Endpoint is designed for Strava webhook integration
-    # Requires specific data format with flight_date (NOT NULL constraint)
-    # Testing this endpoint properly requires mocking Strava webhook payload
-    # or creating a separate endpoint for manual flight creation
-    pass
+    def test_create_manual_flight_without_gpx(self, client, db_session, arguel_site):
+        response = client.post(
+            f"{API_PREFIX}/flights",
+            json={
+                "title": "Vol du soir",
+                "site_id": "site-arguel",
+                "flight_date": date.today().isoformat(),
+                "departure_time": f"{date.today().isoformat()}T18:30:00",
+                "duration_minutes": 45,
+                "max_altitude_m": 980,
+                "max_speed_kmh": 42.5,
+                "distance_km": 8.2,
+                "elevation_gain_m": 320,
+                "notes": "Conditions calmes",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Vol du soir"
+        assert data["site_name"] == "Arguel"
+        assert data["duration_minutes"] == 45
+        assert data["max_speed_kmh"] == 42.5
+        assert data["gpx_file_path"] is None
+
+        flight = db_session.query(Flight).filter(Flight.id == data["id"]).one()
+        assert flight.gpx_file_path is None
+        assert flight.notes == "Conditions calmes"
+
+    def test_create_manual_flight_generates_name_from_date(self, client, db_session):
+        response = client.post(
+            f"{API_PREFIX}/flights",
+            json={"flight_date": date.today().isoformat()},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"].startswith("Vol du ")
+
+    def test_create_manual_flight_rejects_unknown_site(self, client, db_session):
+        response = client.post(
+            f"{API_PREFIX}/flights",
+            json={
+                "flight_date": date.today().isoformat(),
+                "site_id": "unknown-site",
+            },
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Site not found"
+
+    def test_create_manual_flight_rejects_negative_metrics(self, client, db_session):
+        response = client.post(
+            f"{API_PREFIX}/flights",
+            json={
+                "flight_date": date.today().isoformat(),
+                "duration_minutes": -1,
+            },
+        )
+
+        assert response.status_code == 422
 
 
 class TestFlightGPXEndpoints:

--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
@@ -64,6 +64,26 @@ const mockFlightResult = {
   },
 };
 
+const mockManualFlight = {
+  id: 'manual-flight-1',
+  site_id: null,
+  site_name: null,
+  strava_id: null,
+  name: 'Vol du soir',
+  title: 'Vol du soir',
+  description: null,
+  flight_date: '2024-03-15',
+  departure_time: null,
+  duration_minutes: null,
+  max_altitude_m: null,
+  max_speed_kmh: null,
+  distance_km: null,
+  elevation_gain_m: null,
+  notes: null,
+  gpx_file_path: null,
+  external_url: null,
+};
+
 export const FlightModal = meta.story({
   name: 'Flight Modal',
   args: {
@@ -75,6 +95,9 @@ export const FlightModal = meta.story({
   parameters: {
     msw: {
       handlers: [
+        http.post('*/api/flights', () => {
+          return HttpResponse.json(mockManualFlight);
+        }),
         http.post('*/api/flights/create-from-gpx', () => {
           return HttpResponse.json(mockFlightResult);
         }),
@@ -84,14 +107,36 @@ export const FlightModal = meta.story({
 });
 
 FlightModal.test(
+  'It can create a flight from basic information',
+  async ({ args }) => {
+    const titleInput = screen.getByLabelText('Titre du vol');
+    await userEvent.type(titleInput, 'Vol du soir');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Créer le vol' }));
+
+    await expect(
+      await screen.findByText('Vol créé avec succès')
+    ).toBeInTheDocument();
+    await expect(args.onCreateComplete).toHaveBeenCalled();
+  }
+);
+
+FlightModal.test(
   'The upload button is disabled when no file selected',
   async () => {
-    const uploadButton = await screen.getByText('📤 Créer le vol');
+    await userEvent.click(
+      screen.getByRole('tab', { name: /Importer un fichier/u })
+    );
+    const uploadButton = screen.getByRole('button', { name: /Créer le vol/u });
     await expect(uploadButton).toBeDisabled();
   }
 );
 
 FlightModal.test('It can upload a file', async ({ args }) => {
+  await userEvent.click(
+    screen.getByRole('tab', { name: /Importer un fichier/u })
+  );
+
   // Create a mock GPX file
   const file = new File(
     ['<?xml version="1.0"?><gpx></gpx>'],
@@ -109,29 +154,27 @@ FlightModal.test('It can upload a file', async ({ args }) => {
   await expect(await screen.findByText(/test-flight.gpx/u)).toBeInTheDocument();
 
   // Click the upload button
-  const uploadButton = await screen.findByText('📤 Créer le vol');
+  const uploadButton = screen.getByRole('button', { name: /Créer le vol/u });
   await userEvent.click(uploadButton);
 
   // Verify success message appears
   await expect(
-    await screen.findByText('✅ Vol créé avec succès')
+    await screen.findByText('Vol créé avec succès')
   ).toBeInTheDocument();
   await expect(
     await screen.findByText(/Besançon - Mont Poupet/u)
   ).toBeInTheDocument();
 
   await expect(args.onCreateComplete).toHaveBeenCalled();
-  await waitFor(
-    async () => {
-      await expect(args.onClose).toHaveBeenCalled();
-    },
-    { timeout: 3000 }
-  );
 });
 
 FlightModal.test(
   'it clears the selected file when click on cancel',
   async () => {
+    await userEvent.click(
+      screen.getByRole('tab', { name: /Importer un fichier/u })
+    );
+
     // Create a mock GPX file
     const file = new File(
       ['<?xml version="1.0"?><gpx></gpx>'],
@@ -204,6 +247,10 @@ FlightModal.test(
     },
   },
   async ({ args }) => {
+    await userEvent.click(
+      screen.getByRole('tab', { name: /Importer un fichier/u })
+    );
+
     // Create a mock GPX file
     const file = new File(
       ['<?xml version="1.0"?><gpx></gpx>'],
@@ -225,14 +272,14 @@ FlightModal.test(
     ).toBeInTheDocument();
 
     // Click the upload button
-    const uploadButton = await screen.findByText('📤 Créer le vol');
+    const uploadButton = screen.getByRole('button', { name: /Créer le vol/u });
     await userEvent.click(uploadButton);
 
     // Wait for error message to appear
     await waitFor(
       async () => {
         await expect(
-          await screen.findByText('❌ Erreur lors de la création')
+          await screen.findByText('Erreur lors de la création')
         ).toBeInTheDocument();
       },
       { timeout: 5000 }
@@ -253,7 +300,7 @@ FlightModal.test(
 
     // The success message should NOT appear
     await expect(
-      screen.queryByText('✅ Vol créé avec succès')
+      screen.queryByText('Vol créé avec succès')
     ).not.toBeInTheDocument();
   }
 );

--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
@@ -1,9 +1,38 @@
-import { useState, useRef } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
-import { Modal, Button } from '@dashboard-parapente/design-system';
-import { useCreateFlightFromGPX } from '../../../hooks/flights/useFlights';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Form,
+  Input,
+  Label,
+  NumberField,
+  TextArea,
+  TextField,
+  type Key,
+} from 'react-aria-components';
+import {
+  CheckCircle2,
+  CircleAlert,
+  FileCheck2,
+  FilePenLine,
+  Info,
+  LoaderCircle,
+  Upload,
+} from 'lucide-react';
+import {
+  Button,
+  Modal,
+  Select,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+} from '@dashboard-parapente/design-system';
+import {
+  useCreateFlight,
+  useCreateFlightFromGPX,
+} from '../../../hooks/flights/useFlights';
 import { useToast } from '../../../hooks/useToast';
-import type { Site } from '../../../types';
+import type { Flight, FlightFormData, Site } from '../../../types';
 import { formatFlightSiteLabel } from '../siteDisplay';
 
 interface CreateFlightModalProps {
@@ -13,6 +42,30 @@ interface CreateFlightModalProps {
   onCreateComplete: () => void;
 }
 
+type CreationMode = 'manual' | 'file';
+
+const inputClassName =
+  'mt-1 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 outline-none transition-shadow focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-sky-600 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100';
+
+function todayAsInputDate() {
+  const today = new Date();
+  const offset = today.getTimezoneOffset() * 60_000;
+  return new Date(today.getTime() - offset).toISOString().slice(0, 10);
+}
+
+const initialManualValues = (): FlightFormData => ({
+  title: '',
+  site_id: null,
+  flight_date: todayAsInputDate(),
+  departure_time: null,
+  duration_minutes: null,
+  max_altitude_m: null,
+  max_speed_kmh: null,
+  distance_km: null,
+  elevation_gain_m: null,
+  notes: '',
+});
+
 export function CreateFlightModal({
   isOpen,
   sites,
@@ -20,201 +73,407 @@ export function CreateFlightModal({
   onCreateComplete,
 }: CreateFlightModalProps) {
   const { t } = useTranslation();
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const { mutate: createFlight, isPending, data } = useCreateFlightFromGPX();
   const toast = useToast();
-  const createdFlightSiteLabel = data
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [mode, setMode] = useState<CreationMode>('manual');
+  const [manualValues, setManualValues] = useState(initialManualValues);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [createdFlight, setCreatedFlight] = useState<Flight | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const manualMutation = useCreateFlight();
+  const fileMutation = useCreateFlightFromGPX();
+  const isPending = manualMutation.isPending || fileMutation.isPending;
+
+  const siteOptions = sites.map((site) => ({
+    id: site.id,
+    label: formatFlightSiteLabel({
+      siteId: site.id,
+      siteName: site.name,
+      sites,
+    }),
+  }));
+  const createdFlightSiteLabel = createdFlight
     ? formatFlightSiteLabel({
-        siteId: data.flight.site_id,
-        siteName: data.flight.site_name,
+        siteId: createdFlight.site_id,
+        siteName: createdFlight.site_name,
         sites,
       })
     : '';
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      const fileName = file.name.toLowerCase();
-      if (!fileName.endsWith('.gpx') && !fileName.endsWith('.igc')) {
-        toast.error(t('flights.selectValidFile'));
-        return;
-      }
-      setSelectedFile(file);
-      setError(null); // Clear any previous errors
-    }
+  const reset = () => {
+    setMode('manual');
+    setManualValues(initialManualValues());
+    setSelectedFile(null);
+    setCreatedFlight(null);
+    setError(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
-  const handleUpload = () => {
-    if (!selectedFile) return;
+  const handleSuccess = (flight: Flight) => {
+    setCreatedFlight(flight);
+    setError(null);
+    toast.success(
+      `${t('flights.createdSuccess')} ${flight.name || t('flights.unnamed')}`
+    );
+    onCreateComplete();
+  };
 
-    setError(null); // Clear any previous errors
+  const handleError = (mutationError: Error) => {
+    const message = mutationError.message || t('flights.createGenericError');
+    setError(message);
+    toast.error(`${t('flights.createFailure')} ${message}`);
+  };
+
+  const handleManualSubmit = () => {
+    const departureTime = manualValues.departure_time
+      ? `${manualValues.flight_date}T${manualValues.departure_time}:00`
+      : null;
+    manualMutation.mutate(
+      { ...manualValues, departure_time: departureTime },
+      { onSuccess: handleSuccess, onError: handleError }
+    );
+  };
+
+  const handleFileSubmit = () => {
+    if (!selectedFile) return;
     const formData = new FormData();
     formData.append('gpx_file', selectedFile);
-
-    createFlight(formData, {
-      onSuccess: (result) => {
-        toast.success(
-          t('flights.createdSuccess') +
-            ` ${result.flight.name || t('flights.unnamed')}`
-        );
-        onCreateComplete();
-        setSelectedFile(null);
-        setError(null);
-        if (fileInputRef.current) {
-          fileInputRef.current.value = '';
-        }
-        setTimeout(() => onClose(), 2000); // Fermer après 2s
-      },
-      onError: (error: Error) => {
-        const errorMessage = error.message || t('flights.createGenericError');
-        setError(errorMessage);
-        toast.error(t('flights.createFailure') + ` ${errorMessage}`);
-      },
+    fileMutation.mutate(formData, {
+      onSuccess: (result) => handleSuccess(result.flight),
+      onError: handleError,
     });
   };
 
   const handleClose = () => {
-    if (!isPending) {
-      setSelectedFile(null);
-      setError(null);
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
-      }
-      onClose();
-    }
+    if (isPending) return;
+    reset();
+    onClose();
+  };
+
+  const setNumericValue = (
+    field: keyof Pick<
+      FlightFormData,
+      | 'duration_minutes'
+      | 'distance_km'
+      | 'max_altitude_m'
+      | 'max_speed_kmh'
+      | 'elevation_gain_m'
+    >,
+    value: number
+  ) => {
+    setManualValues((current) => ({
+      ...current,
+      [field]: Number.isNaN(value) ? null : value,
+    }));
   };
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={handleClose}
-      title={`📤 ${t('flights.createFromGpx')}`}
-      size="md"
+      title={t('flights.createFlight')}
+      size="lg"
     >
-      <div className="space-y-4">
-        <p className="text-sm text-gray-600 dark:text-gray-300">
-          {t('flights.createDescription')}
-        </p>
+      <Tabs
+        selectedKey={mode}
+        onSelectionChange={(key) => {
+          if (isPending) return;
+          setMode(String(key) as CreationMode);
+          setError(null);
+          setCreatedFlight(null);
+        }}
+      >
+        <TabList aria-label={t('flights.creationMethod')}>
+          <Tab id="manual">
+            <span className="inline-flex items-center gap-2">
+              <FilePenLine className="h-4 w-4" aria-hidden="true" />
+              {t('flights.manualEntry')}
+            </span>
+          </Tab>
+          <Tab id="file">
+            <span className="inline-flex items-center gap-2">
+              <Upload className="h-4 w-4" aria-hidden="true" />
+              {t('flights.importFile')}
+            </span>
+          </Tab>
+        </TabList>
 
-        {/* File Input */}
-        <div className="space-y-2">
-          <label
-            htmlFor="gpx-file-input"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        <TabPanel id="manual">
+          <Form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleManualSubmit();
+            }}
           >
-            {t('flights.gpxFile')}
-          </label>
-          <div className="flex items-center gap-3">
-            <input
-              id="gpx-file-input"
-              ref={fileInputRef}
-              type="file"
-              accept=".gpx,.igc"
-              aria-label={t('flights.gpxFile')}
-              onChange={handleFileChange}
-              disabled={isPending}
-              className="block w-full text-sm text-gray-500 dark:text-gray-400
-                file:mr-4 file:py-2 file:px-4
-                file:rounded-lg file:border-0
-                file:text-sm file:font-semibold
-                file:bg-orange-50 file:text-orange-700 dark:file:bg-orange-900/30 dark:file:text-orange-400
-                hover:file:bg-orange-100
-                file:cursor-pointer cursor-pointer
-                disabled:opacity-50 disabled:cursor-not-allowed"
-            />
-          </div>
-          {selectedFile && (
             <p className="text-sm text-gray-600 dark:text-gray-300">
-              📄 {selectedFile.name} ({(selectedFile.size / 1024).toFixed(1)}{' '}
-              KB)
+              {t('flights.manualCreateDescription')}
             </p>
-          )}
-        </div>
 
-        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
-            💡{' '}
-            <Trans
-              i18nKey="flights.autoDetectionMessage"
-              components={{ strong: <strong /> }}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <TextField
+                className="sm:col-span-2"
+                value={manualValues.title}
+                onChange={(title) =>
+                  setManualValues((current) => ({ ...current, title }))
+                }
+              >
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {t('flights.flightTitle')}
+                </Label>
+                <Input
+                  className={inputClassName}
+                  placeholder={t('flights.manualTitlePlaceholder')}
+                />
+              </TextField>
+
+              <TextField
+                isRequired
+                value={manualValues.flight_date}
+                onChange={(flightDate) =>
+                  setManualValues((current) => ({
+                    ...current,
+                    flight_date: flightDate,
+                  }))
+                }
+              >
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {t('flights.dateLabel')}
+                </Label>
+                <Input
+                  type="date"
+                  max={todayAsInputDate()}
+                  className={inputClassName}
+                />
+              </TextField>
+
+              <TextField
+                value={manualValues.departure_time ?? ''}
+                onChange={(departureTime) =>
+                  setManualValues((current) => ({
+                    ...current,
+                    departure_time: departureTime || null,
+                  }))
+                }
+              >
+                <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {t('flights.departureTime')}
+                </Label>
+                <Input type="time" className={inputClassName} />
+              </TextField>
+
+              <div className="sm:col-span-2">
+                <Select
+                  label={t('flights.siteLabel')}
+                  options={siteOptions}
+                  value={manualValues.site_id}
+                  onChange={(siteId: Key | null) =>
+                    setManualValues((current) => ({
+                      ...current,
+                      site_id: siteId ? String(siteId) : null,
+                    }))
+                  }
+                  placeholder={t('flights.notSpecified')}
+                />
+              </div>
+            </div>
+
+            <fieldset className="rounded-xl border border-gray-200 p-4 dark:border-gray-700">
+              <legend className="px-1 text-sm font-semibold text-gray-800 dark:text-gray-200">
+                {t('flights.optionalStats')}
+              </legend>
+              <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+                {(
+                  [
+                    ['duration_minutes', 'durationLabel', 1],
+                    ['distance_km', 'distanceLabel', 0.1],
+                    ['max_altitude_m', 'maxAltitudeLabel', 1],
+                    ['max_speed_kmh', 'maxSpeedLabel', 0.1],
+                    ['elevation_gain_m', 'elevationGainLabel', 1],
+                  ] as const
+                ).map(([field, label, step]) => (
+                  <NumberField
+                    key={field}
+                    value={manualValues[field] ?? undefined}
+                    minValue={0}
+                    step={step}
+                    onChange={(value) => setNumericValue(field, value)}
+                  >
+                    <Label className="text-xs font-medium text-gray-600 dark:text-gray-300">
+                      {t(`flights.${label}`)}
+                    </Label>
+                    <Input className={inputClassName} />
+                  </NumberField>
+                ))}
+              </div>
+            </fieldset>
+
+            <TextField
+              value={manualValues.notes ?? ''}
+              onChange={(notes) =>
+                setManualValues((current) => ({ ...current, notes }))
+              }
+            >
+              <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                {t('flights.notesLabel')}
+              </Label>
+              <TextArea
+                rows={3}
+                className={inputClassName}
+                placeholder={t('flights.notesPlaceholder')}
+              />
+            </TextField>
+
+            <ModalFeedback
+              flight={createdFlight}
+              siteLabel={createdFlightSiteLabel}
+              error={error}
             />
-          </p>
-        </div>
 
-        {/* Résultat de la création */}
-        {data && (
-          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 rounded-lg p-4">
-            <p className="font-semibold text-green-800 dark:text-green-200 mb-2">
-              ✅ {t('flights.createSuccess')}
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button
+                onClick={handleClose}
+                variant="secondary"
+                isDisabled={isPending}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                type="submit"
+                isDisabled={isPending || !manualValues.flight_date}
+              >
+                {isPending ? (
+                  <LoaderCircle
+                    className="mr-2 inline h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {isPending ? t('flights.creating') : t('flights.createButton')}
+              </Button>
+            </div>
+          </Form>
+        </TabPanel>
+
+        <TabPanel id="file">
+          <div className="space-y-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              {t('flights.createDescription')}
             </p>
-            <ul className="text-sm text-green-700 dark:text-green-300 space-y-1">
-              <li>
-                • <strong>{t('flights.name')}</strong>{' '}
-                {data.flight.name || t('flights.unnamed')}
-              </li>
-              <li>
-                • <strong>{t('flights.date')}</strong> {data.flight.flight_date}
-              </li>
-              {createdFlightSiteLabel && (
-                <li>
-                  • <strong>{t('flights.site')}</strong>{' '}
-                  {createdFlightSiteLabel}
-                </li>
-              )}
-              {data.flight.duration_minutes && (
-                <li>
-                  • <strong>{t('flights.duration')}</strong>{' '}
-                  {data.flight.duration_minutes} min
-                </li>
-              )}
-              {data.flight.distance_km && (
-                <li>
-                  • <strong>{t('flights.distance')}</strong>{' '}
-                  {data.flight.distance_km.toFixed(2)} km
-                </li>
-              )}
-            </ul>
-          </div>
-        )}
+            <div>
+              <label
+                htmlFor="gpx-file-input"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                {t('flights.gpxFile')}
+              </label>
+              <input
+                id="gpx-file-input"
+                ref={fileInputRef}
+                type="file"
+                accept=".gpx,.igc"
+                aria-label={t('flights.gpxFile')}
+                disabled={isPending}
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (!file) return;
+                  const fileName = file.name.toLowerCase();
+                  if (
+                    !fileName.endsWith('.gpx') &&
+                    !fileName.endsWith('.igc')
+                  ) {
+                    toast.error(t('flights.selectValidFile'));
+                    return;
+                  }
+                  setSelectedFile(file);
+                  setError(null);
+                }}
+                className="mt-1 block w-full cursor-pointer text-sm text-gray-500 file:mr-4 file:cursor-pointer file:rounded-lg file:border-0 file:bg-sky-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-sky-700 hover:file:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:file:bg-sky-900/30 dark:file:text-sky-300"
+              />
+            </div>
+            {selectedFile ? (
+              <p className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                <FileCheck2
+                  className="h-4 w-4 text-green-600"
+                  aria-hidden="true"
+                />
+                {selectedFile.name} ({(selectedFile.size / 1024).toFixed(1)} KB)
+              </p>
+            ) : null}
+            <div className="flex gap-2 rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-900 dark:border-sky-800 dark:bg-sky-950/40 dark:text-sky-200">
+              <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+              <p>{t('flights.autoDetectionText')}</p>
+            </div>
 
-        {/* Affichage de l'erreur */}
-        {error && (
-          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg p-4">
-            <p className="font-semibold text-red-800 dark:text-red-200 mb-2">
-              ❌ {t('flights.createError')}
-            </p>
-            <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-          </div>
-        )}
+            <ModalFeedback
+              flight={createdFlight}
+              siteLabel={createdFlightSiteLabel}
+              error={error}
+            />
 
-        {/* Boutons */}
-        <div className="flex gap-3 justify-end">
-          <Button
-            onClick={handleClose}
-            className="px-4 py-2 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-all"
-            isDisabled={isPending}
-          >
-            {t('common.cancel')}
-          </Button>
-          <Button
-            onClick={handleUpload}
-            isDisabled={isPending || !selectedFile}
-            className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
-          >
-            {isPending ? (
-              <>
-                <span className="inline-block animate-spin mr-2">⏳</span>
-                {t('flights.creating')}
-              </>
-            ) : (
-              `📤 ${t('flights.createButton')}`
-            )}
-          </Button>
+            <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <Button
+                onClick={handleClose}
+                variant="secondary"
+                isDisabled={isPending}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                onClick={handleFileSubmit}
+                isDisabled={isPending || !selectedFile}
+              >
+                {isPending ? (
+                  <LoaderCircle
+                    className="mr-2 inline h-4 w-4 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Upload className="mr-2 inline h-4 w-4" aria-hidden="true" />
+                )}
+                {isPending ? t('flights.creating') : t('flights.createButton')}
+              </Button>
+            </div>
+          </div>
+        </TabPanel>
+      </Tabs>
+    </Modal>
+  );
+}
+
+function ModalFeedback({
+  flight,
+  siteLabel,
+  error,
+}: {
+  flight: Flight | null;
+  siteLabel: string;
+  error: string | null;
+}) {
+  const { t } = useTranslation();
+
+  if (error) {
+    return (
+      <div className="flex gap-3 rounded-lg border border-red-200 bg-red-50 p-4 text-red-800 dark:border-red-800 dark:bg-red-950/30 dark:text-red-200">
+        <CircleAlert className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <div>
+          <p className="font-semibold">{t('flights.createError')}</p>
+          <p className="text-sm">{error}</p>
         </div>
       </div>
-    </Modal>
+    );
+  }
+
+  if (!flight) return null;
+  return (
+    <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 text-green-800 dark:border-green-800 dark:bg-green-950/30 dark:text-green-200">
+      <CheckCircle2 className="h-5 w-5 shrink-0" aria-hidden="true" />
+      <div>
+        <p className="font-semibold">{t('flights.createSuccess')}</p>
+        <p className="text-sm">
+          {flight.name || t('flights.unnamed')}
+          {siteLabel ? ` · ${siteLabel}` : ''}
+        </p>
+      </div>
+    </div>
   );
 }

--- a/apps/frontend/src/hooks/flights/useFlights.ts
+++ b/apps/frontend/src/hooks/flights/useFlights.ts
@@ -6,7 +6,7 @@ import {
   useQueryClient,
   type UseQueryResult,
 } from '@tanstack/react-query';
-import { api } from '../../lib/api';
+import { api, getApiErrorMessage } from '../../lib/api';
 import type {
   Flight,
   FlightFilters,
@@ -23,6 +23,7 @@ import {
   VIDEO_EXPORT_IN_PROGRESS_STATUSES,
 } from '@dashboard-parapente/shared-types';
 import { isHTTPError } from 'ky';
+import i18n from 'i18next';
 import { getStaleTime } from '../../lib/cacheConfig';
 import { isGoproOverlayInProgress } from '../../lib/flightMediaState';
 
@@ -147,6 +148,41 @@ export const useUpdateFlight = (
     },
   });
 };
+
+/** Create a flight from manually entered information. */
+export function useCreateFlight() {
+  const queryClient = useQueryClient();
+
+  return useMutation<Flight, Error, FlightFormData>({
+    mutationFn: async (flightData) => {
+      let data: unknown;
+      try {
+        data = await api.post('flights', { json: flightData }).json();
+      } catch (error) {
+        if (error instanceof Error) {
+          error.message = await getApiErrorMessage(
+            error,
+            i18n.t('flights.createGenericError')
+          );
+        }
+        throw error;
+      }
+
+      const validation = FlightSchema.safeParse(data);
+      if (!validation.success) {
+        throw new Error(
+          `Invalid flight creation response: ${validation.error.message}`
+        );
+      }
+      return validation.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['flights'] });
+      void queryClient.invalidateQueries({ queryKey: ['flights', 'stats'] });
+      void queryClient.invalidateQueries({ queryKey: ['flights', 'records'] });
+    },
+  });
+}
 
 /**
  * Synchroniser les vols Strava pour une période donnée

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -842,6 +842,12 @@
     "stackTrace": "Stack trace:"
   },
   "flights": {
+    "creationMethod": "Creation method",
+    "manualEntry": "Manual entry",
+    "importFile": "Import a file",
+    "manualCreateDescription": "The date is enough to save a flight. Add the site and any statistics you have.",
+    "manualTitlePlaceholder": "e.g. Evening flight at Arguel",
+    "optionalStats": "Optional statistics",
     "createFromGpx": "Create flight from GPX/IGC",
     "createDescription": "Upload a GPX or IGC file to automatically create a new flight. Statistics (duration, altitude, distance, speed) will be extracted from the file.",
     "gpxFile": "GPX or IGC file",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -846,6 +846,12 @@
     "stackTrace": "Stack trace:"
   },
   "flights": {
+    "creationMethod": "Méthode de création",
+    "manualEntry": "Saisie manuelle",
+    "importFile": "Importer un fichier",
+    "manualCreateDescription": "La date suffit pour enregistrer un vol. Ajoutez le site et les statistiques dont vous disposez.",
+    "manualTitlePlaceholder": "Ex : Vol du soir à Arguel",
+    "optionalStats": "Statistiques optionnelles",
     "createFromGpx": "Créer un vol depuis GPX/IGC",
     "createDescription": "Uploadez un fichier GPX ou IGC pour créer automatiquement un nouveau vol. Les statistiques (durée, altitude, distance, vitesse) seront extraites du fichier.",
     "gpxFile": "Fichier GPX ou IGC",

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -524,7 +524,7 @@ export default function FlightHistory() {
         }}
       />
 
-      {/* Modal Créer un vol depuis GPX */}
+      {/* Modal de création manuelle ou depuis un fichier de trace */}
       <CreateFlightModal
         isOpen={showCreateFlightModal}
         sites={sites}


### PR DESCRIPTION
## Summary
- add validated backend creation for flights without GPX files
- add manual-entry and GPX/IGC modes to the flight creation modal
- cover manual creation and update localized UI stories

## Validation
- backend flight API tests: 53 passed
- backend Ruff and Black on changed files: passed
- frontend build and type-check: passed
- frontend targeted Oxlint and Oxfmt: passed
- pre-commit lint-staged and Knip hooks: passed
- CodeRabbit review: passed with no findings

## Known repository issues
- full affected lint reports pre-existing errors in unrelated frontend files
- full affected tests hit an unrelated FlightDetails timeout and existing Storybook browser disconnects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added manual flight creation alongside GPX/IGC file import.
  - Added flight title, date, site, and optional statistics fields.
  - Added localized English and French guidance for creation methods.
  - Added clearer success and error feedback after submission.

- **Bug Fixes**
  - Improved validation for invalid metrics, future dates, and unknown sites.
  - Prevented file uploads when no supported file is selected.

- **Tests**
  - Expanded coverage for manual creation, validation, error handling, and file import flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->