### PR TITLE
fix(strava): surface auth failures in sync flow

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4101,6 +4101,7 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
         }
     """
     from strava import (
+        StravaAPIError,
         download_gpx,
         get_activities_by_period,
         match_site_by_coordinates,
@@ -4141,76 +4142,80 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
                 continue
 
             try:
-                # 4. Télécharger GPX
-                gpx_content = await download_gpx(strava_id)
+                with db.begin_nested():
+                    # 4. Télécharger GPX
+                    gpx_content = await download_gpx(strava_id)
 
-                if not gpx_content:
-                    logger.warning(f"No GPX available for activity {strava_id}")
+                    if not gpx_content:
+                        logger.warning(f"No GPX available for activity {strava_id}")
 
-                # 6. Détecter le site depuis les coordonnées GPX
-                site_id = None
-                if gpx_content:
-                    try:
-                        coordinates = parse_gpx_file_from_string(gpx_content)
-                        if coordinates:
-                            first_coord = coordinates[0]
-                            site_id = match_site_by_coordinates(
-                                first_coord["lat"], first_coord["lon"], sites_data
+                    # 6. Détecter le site depuis les coordonnées GPX
+                    site_id = None
+                    if gpx_content:
+                        try:
+                            coordinates = parse_gpx_file_from_string(gpx_content)
+                            if coordinates:
+                                first_coord = coordinates[0]
+                                site_id = match_site_by_coordinates(
+                                    first_coord["lat"], first_coord["lon"], sites_data
+                                )
+                        except Exception as e:
+                            logger.warning(f"Failed to detect site from GPX: {e}")
+
+                    # 7. Extraire données de l'activité Strava
+                    start_date_local = activity.get("start_date_local", "")
+
+                    # Date du vol (YYYY-MM-DD)
+                    activity_date = datetime.strptime(
+                        start_date_local.split("T")[0], "%Y-%m-%d"
+                    ).date()
+
+                    # Heure de départ (datetime complet)
+                    departure_time = None
+                    if start_date_local:
+                        try:
+                            departure_time = datetime.fromisoformat(
+                                start_date_local.replace("Z", "+00:00")
                             )
-                    except Exception as e:
-                        logger.warning(f"Failed to detect site from GPX: {e}")
+                        except Exception as e:
+                            logger.warning(f"Failed to parse departure_time for {strava_id}: {e}")
 
-                # 7. Extraire données de l'activité Strava
-                start_date_local = activity.get("start_date_local", "")
+                    # 7. Créer Flight
+                    flight_name = (
+                        f"Vol du {activity_date.strftime('%d/%m/%Y')} à "
+                        f"{departure_time.strftime('%H:%M')}"
+                        if departure_time
+                        else f"Vol du {activity_date.strftime('%d/%m/%Y')}"
+                    )
 
-                # Date du vol (YYYY-MM-DD)
-                activity_date = datetime.strptime(start_date_local.split("T")[0], "%Y-%m-%d").date()
+                    flight = Flight(
+                        id=str(uuid.uuid4()),
+                        strava_id=strava_id,
+                        title=flight_name,
+                        name=flight_name,
+                        site_id=site_id,
+                        flight_date=activity_date,
+                        departure_time=departure_time,
+                        duration_minutes=int(activity.get("moving_time", 0) / 60),
+                        max_altitude_m=(
+                            int(activity.get("elev_high", 0)) if activity.get("elev_high") else None
+                        ),
+                        distance_km=round(activity.get("distance", 0) / 1000, 2),
+                        elevation_gain_m=(
+                            int(activity.get("total_elevation_gain", 0))
+                            if activity.get("total_elevation_gain")
+                            else None
+                        ),
+                        external_url=f"https://www.strava.com/activities/{strava_id}",
+                        created_at=datetime.utcnow(),
+                        updated_at=datetime.utcnow(),
+                    )
 
-                # Heure de départ (datetime complet)
-                departure_time = None
-                if start_date_local:
-                    try:
-                        departure_time = datetime.fromisoformat(
-                            start_date_local.replace("Z", "+00:00")
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to parse departure_time for {strava_id}: {e}")
-
-                # 7. Créer Flight
-                flight_name = (
-                    f"Vol du {activity_date.strftime('%d/%m/%Y')} à {departure_time.strftime('%H:%M')}"
-                    if departure_time
-                    else f"Vol du {activity_date.strftime('%d/%m/%Y')}"
-                )
-
-                flight = Flight(
-                    id=str(uuid.uuid4()),
-                    strava_id=strava_id,
-                    title=flight_name,
-                    name=flight_name,
-                    site_id=site_id,
-                    flight_date=activity_date,
-                    departure_time=departure_time,
-                    duration_minutes=int(activity.get("moving_time", 0) / 60),
-                    max_altitude_m=(
-                        int(activity.get("elev_high", 0)) if activity.get("elev_high") else None
-                    ),
-                    distance_km=round(activity.get("distance", 0) / 1000, 2),
-                    elevation_gain_m=(
-                        int(activity.get("total_elevation_gain", 0))
-                        if activity.get("total_elevation_gain")
-                        else None
-                    ),
-                    external_url=f"https://www.strava.com/activities/{strava_id}",
-                    created_at=datetime.utcnow(),
-                    updated_at=datetime.utcnow(),
-                )
-
-                db.add(flight)
-                db.flush()
-                if gpx_content:
-                    gpx_path = write_flight_text_file(db, flight, "strava.gpx", gpx_content)
-                    flight.gpx_file_path = str(gpx_path)
+                    db.add(flight)
+                    db.flush()
+                    if gpx_content:
+                        gpx_path = write_flight_text_file(db, flight, "strava.gpx", gpx_content)
+                        flight.gpx_file_path = str(gpx_path)
 
                 imported_flights.append(
                     {
@@ -4223,6 +4228,8 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
 
                 logger.info(f" Imported: {flight.title} (Strava ID: {strava_id})")
 
+            except StravaAPIError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to import activity {strava_id}: {e}")
                 failed_count += 1
@@ -4238,6 +4245,10 @@ async def sync_strava_activities(request: dict, db: Session = Depends(get_db)):
             "flights": imported_flights,
         }
 
+    except StravaAPIError as e:
+        logger.warning("Strava sync unavailable: %s", e)
+        db.rollback()
+        raise HTTPException(status_code=502, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Sync failed: {e}", exc_info=True)
         db.rollback()

--- a/apps/backend/strava.py
+++ b/apps/backend/strava.py
@@ -37,6 +37,15 @@ _REFRESH_MAX_ATTEMPTS = 5
 _REFRESH_INITIAL_BACKOFF_SECONDS = 1.0
 
 
+class StravaAPIError(Exception):
+    """Actionable failure returned by the Strava API."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+
+
 def _get_persisted_refresh_token() -> str | None:
     """Read the refresh token from DB (app_settings), fallback to env."""
     try:
@@ -510,13 +519,15 @@ async def get_activities_by_period(
         Liste d'activités Strava filtrées par type
 
     Raises:
-        Exception si échec API
+        StravaAPIError: if authentication or the Strava API request fails
     """
     token = await get_access_token()
 
     if not token:
         logger.error("Cannot get activities: no access token")
-        raise Exception("No Strava access token available")
+        raise StravaAPIError(
+            "Strava authentication is unavailable. Reauthorize the Strava connection."
+        )
 
     try:
         # Convertir dates en timestamps Unix
@@ -586,9 +597,31 @@ async def get_activities_by_period(
 
         return all_activities
 
-    except Exception as e:
-        logger.error(f"Failed to get activities by period: {e}")
-        raise
+    except httpx.HTTPStatusError as e:
+        status_code = e.response.status_code
+        logger.error(
+            "Strava activities request failed with HTTP %s: %s",
+            status_code,
+            e.response.text[:500],
+        )
+        if status_code in {401, 403}:
+            raise StravaAPIError(
+                "Strava denied access to activities. Reauthorize the connection "
+                "with the activity:read_all scope.",
+                status_code=status_code,
+            ) from e
+        if status_code == 429:
+            raise StravaAPIError(
+                "Strava rate limit reached. Try the import again later.",
+                status_code=status_code,
+            ) from e
+        raise StravaAPIError(
+            f"Strava API request failed with HTTP {status_code}.",
+            status_code=status_code,
+        ) from e
+    except httpx.RequestError as e:
+        logger.error("Strava activities request failed: %s", e)
+        raise StravaAPIError("Strava API is currently unreachable.") from e
 
 
 def save_gpx_file(gpx_content: str, activity_id: str) -> str | None:

--- a/apps/backend/tests/api/test_sync_strava.py
+++ b/apps/backend/tests/api/test_sync_strava.py
@@ -9,6 +9,7 @@ from datetime import date
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from models import Flight
+from strava import StravaAPIError
 
 API_PREFIX = "/api"
 
@@ -131,3 +132,22 @@ class TestSyncStravaEndpoint:
         assert flight is not None
         assert flight.site_id is None
         assert flight.name == "Vol du 15/03/2026 à 15:00"
+
+    def test_sync_strava_reports_missing_activity_scope(self, client):
+        with patch(
+            "strava.get_activities_by_period",
+            new=AsyncMock(
+                side_effect=StravaAPIError(
+                    "Strava denied access to activities. Reauthorize the connection "
+                    "with the activity:read_all scope.",
+                    status_code=403,
+                )
+            ),
+        ):
+            response = client.post(
+                f"{API_PREFIX}/flights/sync-strava",
+                json={"date_from": "2026-07-24", "date_to": "2026-07-25"},
+            )
+
+        assert response.status_code == 502
+        assert "activity:read_all" in response.json()["detail"]

--- a/apps/backend/tests/unit/test_strava.py
+++ b/apps/backend/tests/unit/test_strava.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 
 from strava import (
+    StravaAPIError,
     download_gpx,
     get_access_token,
     get_activities_by_period,
@@ -879,3 +880,20 @@ async def test_get_activities_by_period_end_date_is_inclusive():
 
     assert captured_params["after"] == expected_after
     assert captured_params["before"] == expected_before
+
+
+@pytest.mark.asyncio
+async def test_get_activities_by_period_reports_missing_activity_scope() -> None:
+    request = httpx.Request("GET", "https://www.strava.com/api/v3/athlete/activities")
+    response = httpx.Response(403, request=request, json={"message": "Forbidden"})
+
+    with (
+        patch("strava.get_access_token", new=AsyncMock(return_value="test_token")),
+        patch("strava.httpx.AsyncClient") as mock_client,
+    ):
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(return_value=response)
+
+        with pytest.raises(StravaAPIError, match="activity:read_all") as exc_info:
+            await get_activities_by_period("2026-07-24", "2026-07-25")
+
+    assert exc_info.value.status_code == 403

--- a/apps/frontend/src/hooks/flights/useFlights.ts
+++ b/apps/frontend/src/hooks/flights/useFlights.ts
@@ -198,18 +198,27 @@ export function useStravaSyncMutation() {
       date_from: string;
       date_to: string;
     }) => {
-      const data = await api
-        .post('flights/sync-strava', {
-          json: { date_from, date_to },
-        })
-        .json<{
-          success: boolean;
-          imported: number;
-          skipped: number;
-          failed: number;
-          flights: unknown[];
-        }>();
-      return data;
+      try {
+        return await api
+          .post('flights/sync-strava', {
+            json: { date_from, date_to },
+          })
+          .json<{
+            success: boolean;
+            imported: number;
+            skipped: number;
+            failed: number;
+            flights: unknown[];
+          }>();
+      } catch (error) {
+        if (error instanceof Error) {
+          error.message = await getApiErrorMessage(
+            error,
+            i18n.t('strava.syncError')
+          );
+        }
+        throw error;
+      }
     },
     onSuccess: () => {
       // Invalider le cache des vols pour forcer le refresh


### PR DESCRIPTION
## Summary\n- Return a clear 502 when Strava rejects activity imports due to missing scope or auth failures.\n- Preserve partial imports with nested DB transactions for per-activity failures.\n- Surface the API error message in the frontend sync toast.\n\n## Validation\n- .venv/bin/python -m pytest apps/backend/tests/unit/test_strava.py apps/backend/tests/api/test_sync_strava.py -q --tb=short --no-header --no-cov\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx build frontend\n- NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx type-check frontend\n- CodeRabbit review completed with no findings\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Strava sync error handling with clearer messages for authorization, rate-limit, network, and service failures.
  * Strava API failures now return an appropriate gateway error instead of a generic server error.
  * Individual activity processing failures no longer stop the remaining activities from syncing.
  * Frontend sync errors now display a localized message.

* **Tests**
  * Added coverage for missing Strava activity permissions and related error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->