### PR TITLE
feat(frontend): add flight file import entrypoint

### DIFF
--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.stories.tsx
@@ -106,6 +106,33 @@ export const FlightModal = meta.story({
   },
 });
 
+export const FileImport = meta.story({
+  name: 'File Import',
+  args: {
+    isOpen: true,
+    sites: mockSites,
+    initialMode: 'file',
+    onClose: fn(),
+    onCreateComplete: fn(),
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post('*/api/flights/create-from-gpx', () => {
+          return HttpResponse.json(mockFlightResult);
+        }),
+      ],
+    },
+  },
+});
+
+FileImport.test('It opens directly on file import', async () => {
+  await expect(
+    screen.getByRole('tab', { name: /Importer un fichier/u })
+  ).toHaveAttribute('aria-selected', 'true');
+  await expect(screen.getByLabelText('Fichier GPX ou IGC')).toBeInTheDocument();
+});
+
 FlightModal.test(
   'It can create a flight from basic information',
   async ({ args }) => {

--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.test.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.test.tsx
@@ -1,0 +1,33 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CreateFlightModal } from './CreateFlightModal';
+
+describe('CreateFlightModal', () => {
+  it('uses the requested creation mode when reopened', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const renderModal = (isOpen: boolean, initialMode: 'manual' | 'file') => (
+      <QueryClientProvider client={queryClient}>
+        <CreateFlightModal
+          isOpen={isOpen}
+          sites={[]}
+          initialMode={initialMode}
+          onClose={vi.fn()}
+          onCreateComplete={vi.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    const view = render(renderModal(false, 'manual'));
+    view.rerender(renderModal(false, 'file'));
+    view.rerender(renderModal(true, 'file'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('tab', { name: 'flights.importFile' })
+      ).toHaveAttribute('aria-selected', 'true')
+    );
+  });
+});

--- a/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
+++ b/apps/frontend/src/components/flights/create-flight/CreateFlightModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Form,
@@ -38,6 +38,7 @@ import { formatFlightSiteLabel } from '../siteDisplay';
 interface CreateFlightModalProps {
   isOpen: boolean;
   sites: Site[];
+  initialMode?: CreationMode;
   onClose: () => void;
   onCreateComplete: () => void;
 }
@@ -69,13 +70,14 @@ const initialManualValues = (): FlightFormData => ({
 export function CreateFlightModal({
   isOpen,
   sites,
+  initialMode = 'manual',
   onClose,
   onCreateComplete,
 }: CreateFlightModalProps) {
   const { t } = useTranslation();
   const toast = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [mode, setMode] = useState<CreationMode>('manual');
+  const [mode, setMode] = useState<CreationMode>(initialMode);
   const [manualValues, setManualValues] = useState(initialManualValues);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [createdFlight, setCreatedFlight] = useState<Flight | null>(null);
@@ -83,6 +85,10 @@ export function CreateFlightModal({
   const manualMutation = useCreateFlight();
   const fileMutation = useCreateFlightFromGPX();
   const isPending = manualMutation.isPending || fileMutation.isPending;
+
+  useEffect(() => {
+    if (isOpen) setMode(initialMode);
+  }, [initialMode, isOpen]);
 
   const siteOptions = sites.map((site) => ({
     id: site.id,
@@ -101,7 +107,7 @@ export function CreateFlightModal({
     : '';
 
   const reset = () => {
-    setMode('manual');
+    setMode(initialMode);
     setManualValues(initialManualValues());
     setSelectedFile(null);
     setCreatedFlight(null);

--- a/apps/frontend/src/pages/FlightHistory.tsx
+++ b/apps/frontend/src/pages/FlightHistory.tsx
@@ -9,6 +9,7 @@ import { Input, TextField } from 'react-aria-components';
 import {
   CheckSquare,
   FilePlus2,
+  Upload,
   Search,
   Trash2,
   X,
@@ -60,6 +61,9 @@ export default function FlightHistory() {
   const [showMultiDeleteConfirm, setShowMultiDeleteConfirm] = useState(false);
   const [showStravaSyncModal, setShowStravaSyncModal] = useState(false);
   const [showCreateFlightModal, setShowCreateFlightModal] = useState(false);
+  const [createFlightMode, setCreateFlightMode] = useState<'manual' | 'file'>(
+    'file'
+  );
   const [showCreateSiteModal, setShowCreateSiteModal] = useState(false);
   const [showMobileDetail, setShowMobileDetail] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -354,11 +358,28 @@ export default function FlightHistory() {
           <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
             {!selectionMode && (
               <Button
-                onClick={() => setShowCreateFlightModal(true)}
+                onClick={() => {
+                  setCreateFlightMode('file');
+                  setShowCreateFlightModal(true);
+                }}
                 className="px-4 py-2 bg-sky-600 text-white rounded-lg hover:bg-sky-700 transition-colors flex items-center gap-2"
               >
+                <Upload className="h-4 w-4" aria-hidden="true" />
+                {t('flights.importFile')}
+              </Button>
+            )}
+
+            {!selectionMode && (
+              <Button
+                onClick={() => {
+                  setCreateFlightMode('manual');
+                  setShowCreateFlightModal(true);
+                }}
+                variant="secondary"
+                className="px-4 py-2 rounded-lg transition-colors flex items-center gap-2"
+              >
                 <FilePlus2 className="h-4 w-4" aria-hidden="true" />
-                {t('flights.createFlight')}
+                {t('flights.manualEntry')}
               </Button>
             )}
 
@@ -528,6 +549,7 @@ export default function FlightHistory() {
       <CreateFlightModal
         isOpen={showCreateFlightModal}
         sites={sites}
+        initialMode={createFlightMode}
         onClose={() => setShowCreateFlightModal(false)}
         onCreateComplete={() => {
           void queryClient.invalidateQueries({ queryKey: ['flights'] });


### PR DESCRIPTION
Adds a direct file-import entrypoint for flights, plus modal mode handling, story, and test coverage.\n\nValidation:\n- 
> nx run frontend:build:production  [existing outputs match the cache, left as is]

[1m[33mThe `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.[39m[22m
[36mvite v8.1.5 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...[32m✓[0m 4916 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/apps/frontend/[0m[32mindex.html                                    [0m[1;2m  1.25 kB[0m[2m │ gzip:   0.47 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[35mindex-CvRJncuF.css                     [0m[1;2m137.52 kB[0m[2m │ gzip:  19.70 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights.lazy-aN-62n7i.js               [0m[1;2m  0.14 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights._flightId.lazy-D6zfcmEK.js     [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure.lazy-BX3TRCzL.js        [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure._tab.lazy-BMiRVDrK.js   [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msearch-6LTHujm6.js                     [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflightMediaState-Bb1JtFLR.js           [0m[1;2m  0.26 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mtrash-2-BBgGEcK-.js                    [0m[1;2m  0.41 kB[0m[2m │ gzip:   0.25 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museToast-DK0ed9ui.js                   [0m[1;2m  0.47 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museAppSettings-CQuN1Jqj.js             [0m[1;2m  0.62 kB[0m[2m │ gzip:   0.31 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mrolldown-runtime-QTnfLwEv.js           [0m[1;2m  0.69 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museIsMobile-DN6SBz6n.js                [0m[1;2m  0.92 kB[0m[2m │ gzip:   0.50 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museFlight-CghIPCNd.js                  [0m[1;2m  1.19 kB[0m[2m │ gzip:   0.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mTabs-CymXPHKm.js                       [0m[1;2m  1.23 kB[0m[2m │ gzip:   0.52 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mModal-CN6JwU4P.js                      [0m[1;2m  1.54 kB[0m[2m │ gzip:   0.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mappSettingsStore-COBGr0k4.js           [0m[1;2m  1.60 kB[0m[2m │ gzip:   0.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mexport-viewer.lazy-CCheOEdG.js         [0m[1;2m  1.62 kB[0m[2m │ gzip:   0.79 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mmap-pin-VMH1purF.js                    [0m[1;2m  1.63 kB[0m[2m │ gzip:   0.94 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mviewer._flightId.lazy-6UamGrZk.js      [0m[1;2m  1.72 kB[0m[2m │ gzip:   0.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museCityWeather-PMdZfSFC.js             [0m[1;2m  2.46 kB[0m[2m │ gzip:   0.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mDataTable-D6mLbCVS.js                  [0m[1;2m  2.71 kB[0m[2m │ gzip:   1.19 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mJobLiveLogsPanel-BU9NcSC_.js           [0m[1;2m  5.16 kB[0m[2m │ gzip:   2.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mSelect-7uoF58_-.js                     [0m[1;2m  6.40 kB[0m[2m │ gzip:   1.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msrc-DsO_Z-DD.js                        [0m[1;2m  9.62 kB[0m[2m │ gzip:   2.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mthermal.lazy-4KaQJoMV.js               [0m[1;2m 10.43 kB[0m[2m │ gzip:   3.26 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mEmagramExplanationTooltip-Bx97o0If.js  [0m[1;2m 25.32 kB[0m[2m │ gzip:   7.59 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightViewer3D-cAJ0Wecp.js             [0m[1;2m 32.92 kB[0m[2m │ gzip:   9.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msites.lazy-Cesq1Pc2.js                 [0m[1;2m 36.34 kB[0m[2m │ gzip:   9.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mInfrastructurePage-BTwx7ILO.js         [0m[1;2m 43.03 kB[0m[2m │ gzip:  10.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msettings.lazy-LoXd6GBA.js              [0m[1;2m 49.59 kB[0m[2m │ gzip:   9.61 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-i18n-DtA15pmn.js                [0m[1;2m 78.38 kB[0m[2m │ gzip:  24.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightHistory-COonAtnB.js              [0m[1;2m 99.54 kB[0m[2m │ gzip:  23.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mweather.lazy-Z1lQ4rID.js               [0m[1;2m104.95 kB[0m[2m │ gzip:  23.49 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mschemas-CNHpn5vC.js                    [0m[1;2m128.09 kB[0m[2m │ gzip:  37.77 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-DPknFk9V.js               [0m[1;2m182.16 kB[0m[2m │ gzip:  57.35 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mindex-Bxszy9EW.js                      [0m[1;2m199.72 kB[0m[2m │ gzip:  60.55 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-tanstack-CeORqlar.js            [0m[1;2m232.55 kB[0m[2m │ gzip:  64.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-aria-Dh7gU_mP.js          [0m[1;2m403.71 kB[0m[2m │ gzip: 124.62 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36manalytics.lazy-DJOtO52i.js             [0m[1;2m453.93 kB[0m[2m │ gzip: 125.77 kB[0m

[32m✓ built in 2.27s[39m



 NX   Successfully ran target build for project frontend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

  Run duration:      74ms
  Cache:             1/1 hit (100%)
  Critical path:     21ms (1 task)
  Recoverable time:  <1ms ✅\n- 
 NX   Running target type-check for project frontend and 1 task it depends on:



> nx run frontend:build:production  [existing outputs match the cache, left as is]

[1m[33mThe `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.[39m[22m
[36mvite v8.1.5 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...[32m✓[0m 4916 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/apps/frontend/[0m[32mindex.html                                    [0m[1;2m  1.25 kB[0m[2m │ gzip:   0.47 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[35mindex-CvRJncuF.css                     [0m[1;2m137.52 kB[0m[2m │ gzip:  19.70 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights.lazy-aN-62n7i.js               [0m[1;2m  0.14 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights._flightId.lazy-D6zfcmEK.js     [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure.lazy-BX3TRCzL.js        [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure._tab.lazy-BMiRVDrK.js   [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msearch-6LTHujm6.js                     [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflightMediaState-Bb1JtFLR.js           [0m[1;2m  0.26 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mtrash-2-BBgGEcK-.js                    [0m[1;2m  0.41 kB[0m[2m │ gzip:   0.25 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museToast-DK0ed9ui.js                   [0m[1;2m  0.47 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museAppSettings-CQuN1Jqj.js             [0m[1;2m  0.62 kB[0m[2m │ gzip:   0.31 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mrolldown-runtime-QTnfLwEv.js           [0m[1;2m  0.69 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museIsMobile-DN6SBz6n.js                [0m[1;2m  0.92 kB[0m[2m │ gzip:   0.50 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museFlight-CghIPCNd.js                  [0m[1;2m  1.19 kB[0m[2m │ gzip:   0.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mTabs-CymXPHKm.js                       [0m[1;2m  1.23 kB[0m[2m │ gzip:   0.52 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mModal-CN6JwU4P.js                      [0m[1;2m  1.54 kB[0m[2m │ gzip:   0.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mappSettingsStore-COBGr0k4.js           [0m[1;2m  1.60 kB[0m[2m │ gzip:   0.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mexport-viewer.lazy-CCheOEdG.js         [0m[1;2m  1.62 kB[0m[2m │ gzip:   0.79 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mmap-pin-VMH1purF.js                    [0m[1;2m  1.63 kB[0m[2m │ gzip:   0.94 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mviewer._flightId.lazy-6UamGrZk.js      [0m[1;2m  1.72 kB[0m[2m │ gzip:   0.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museCityWeather-PMdZfSFC.js             [0m[1;2m  2.46 kB[0m[2m │ gzip:   0.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mDataTable-D6mLbCVS.js                  [0m[1;2m  2.71 kB[0m[2m │ gzip:   1.19 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mJobLiveLogsPanel-BU9NcSC_.js           [0m[1;2m  5.16 kB[0m[2m │ gzip:   2.08 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mSelect-7uoF58_-.js                     [0m[1;2m  6.40 kB[0m[2m │ gzip:   1.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msrc-DsO_Z-DD.js                        [0m[1;2m  9.62 kB[0m[2m │ gzip:   2.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mthermal.lazy-4KaQJoMV.js               [0m[1;2m 10.43 kB[0m[2m │ gzip:   3.26 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mEmagramExplanationTooltip-Bx97o0If.js  [0m[1;2m 25.32 kB[0m[2m │ gzip:   7.59 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightViewer3D-cAJ0Wecp.js             [0m[1;2m 32.92 kB[0m[2m │ gzip:   9.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msites.lazy-Cesq1Pc2.js                 [0m[1;2m 36.34 kB[0m[2m │ gzip:   9.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mInfrastructurePage-BTwx7ILO.js         [0m[1;2m 43.03 kB[0m[2m │ gzip:  10.32 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msettings.lazy-LoXd6GBA.js              [0m[1;2m 49.59 kB[0m[2m │ gzip:   9.61 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-i18n-DtA15pmn.js                [0m[1;2m 78.38 kB[0m[2m │ gzip:  24.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightHistory-COonAtnB.js              [0m[1;2m 99.54 kB[0m[2m │ gzip:  23.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mweather.lazy-Z1lQ4rID.js               [0m[1;2m104.95 kB[0m[2m │ gzip:  23.49 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mschemas-CNHpn5vC.js                    [0m[1;2m128.09 kB[0m[2m │ gzip:  37.77 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-DPknFk9V.js               [0m[1;2m182.16 kB[0m[2m │ gzip:  57.35 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mindex-Bxszy9EW.js                      [0m[1;2m199.72 kB[0m[2m │ gzip:  60.55 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-tanstack-CeORqlar.js            [0m[1;2m232.55 kB[0m[2m │ gzip:  64.87 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-aria-Dh7gU_mP.js          [0m[1;2m403.71 kB[0m[2m │ gzip: 124.62 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36manalytics.lazy-DJOtO52i.js             [0m[1;2m453.93 kB[0m[2m │ gzip: 125.77 kB[0m

[32m✓ built in 2.27s[39m

> nx run frontend:type-check  [existing outputs match the cache, left as is]

> tsc --noEmit




 NX   Successfully ran target type-check for project frontend and 1 task it depends on

Nx read the output from the cache instead of running the command for 2 out of 2 tasks.

  Run duration:      66ms
  Cache:             2/2 hit (100%)
  Critical path:     13ms (2 tasks)
  Recoverable time:  <1ms ✅\n- targeted Vitest unit test ✅\n- repo-wide affected lint/test still show pre-existing unrelated failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate options to create a flight manually or import a GPX/IGC file from Flight History.
  * The creation modal now opens directly in the selected mode and preserves that mode when reopened.

* **Tests**
  * Added coverage for file-import mode selection and mode persistence.
  * Added a Storybook example for importing flight files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->