### PR TITLE
fix(sync): filter intervals activity types case-insensitively

### DIFF
--- a/apps/backend/intervals_icu.py
+++ b/apps/backend/intervals_icu.py
@@ -142,13 +142,13 @@ class IntervalsClient:
         if not isinstance(payload, list):
             raise IntervalsResponseError("Intervals.icu returned an unexpected activities payload.")
 
-        allowed = set(allowed_types)
+        allowed = {activity_type.casefold() for activity_type in allowed_types}
         activities = [
             _activity_from_json(item)
             for item in payload
             if isinstance(item, dict)
             and item.get("source") == "ZEPP"
-            and (not allowed or item.get("type") in allowed)
+            and (not allowed or str(item.get("type") or "").casefold() in allowed)
         ]
         return sorted(activities, key=lambda activity: (activity.start_date, activity.id))
 

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -3777,7 +3777,11 @@ async def preview_intervals_activities(
     request = IntervalsSyncRequest(date_from=date_from, date_to=date_to)
     client = _intervals_client()
     try:
-        activities = await client.list_activities(request.date_from, request.date_to, [])
+        activities = await client.list_activities(
+            request.date_from,
+            request.date_to,
+            config.INTERVALS_ICU_ACTIVITY_TYPES,
+        )
     except Exception as exc:
         _raise_intervals_http_error(exc)
     return IntervalsPreviewResponse(

--- a/apps/backend/tests/api/test_intervals_sync.py
+++ b/apps/backend/tests/api/test_intervals_sync.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from unittest.mock import AsyncMock, patch
 
 import config
@@ -17,9 +17,10 @@ def activity() -> ExternalActivity:
     )
 
 
-def test_preview_returns_typed_candidate_metadata(client):
+def test_preview_returns_candidates_filtered_by_configured_activity_types(client, monkeypatch):
     provider = AsyncMock()
     provider.list_activities.return_value = [activity()]
+    monkeypatch.setattr(config, "INTERVALS_ICU_ACTIVITY_TYPES", ["walk"])
     with patch("routes._intervals_client", return_value=provider):
         response = client.get(
             "/api/flights/sync-intervals/preview?date_from=2026-07-01&date_to=2026-07-02"
@@ -29,7 +30,7 @@ def test_preview_returns_typed_candidate_metadata(client):
     assert response.json()["activities"][0]["id"] == "i123"
     assert response.json()["activities"][0]["type"] == "HangGliding"
     assert response.json()["activity_types"] == ["HangGliding"]
-    provider.list_activities.assert_awaited_once()
+    provider.list_activities.assert_awaited_once_with(date(2026, 7, 1), date(2026, 7, 2), ["walk"])
 
 
 def test_preview_rejects_reversed_dates(client):

--- a/apps/backend/tests/unit/test_intervals_icu.py
+++ b/apps/backend/tests/unit/test_intervals_icu.py
@@ -12,7 +12,7 @@ from intervals_icu import (
 
 
 @pytest.mark.asyncio
-async def test_lists_only_zepp_exact_allowed_types_in_ascending_order():
+async def test_lists_only_zepp_allowed_types_case_insensitively_in_ascending_order():
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.params["oldest"] == "2026-07-01"
         assert request.url.params["newest"] == "2026-07-03"
@@ -24,7 +24,7 @@ async def test_lists_only_zepp_exact_allowed_types_in_ascending_order():
                     "id": "2",
                     "name": "Second",
                     "start_date_local": "2026-07-02T12:00:00",
-                    "type": "HangGliding",
+                    "type": "Walk",
                     "source": "ZEPP",
                     "icu_original_file_type": "FIT",
                 },
@@ -32,7 +32,7 @@ async def test_lists_only_zepp_exact_allowed_types_in_ascending_order():
                     "id": "1",
                     "name": "First",
                     "start_date_local": "2026-07-01T12:00:00",
-                    "type": "HangGliding",
+                    "type": "Walk",
                     "source": "ZEPP",
                     "file_type": "GPX",
                 },
@@ -53,9 +53,7 @@ async def test_lists_only_zepp_exact_allowed_types_in_ascending_order():
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
         client = IntervalsClient("secret", "https://example.test/api/v1", client=http_client)
-        activities = await client.list_activities(
-            date(2026, 7, 1), date(2026, 7, 3), ["HangGliding"]
-        )
+        activities = await client.list_activities(date(2026, 7, 1), date(2026, 7, 3), ["walk"])
 
     assert [activity.id for activity in activities] == ["1", "2"]
     assert activities[1].file_type == "FIT"


### PR DESCRIPTION
## Summary
- Filter Intervals.icu activities using the configured activity types on preview and import
- Match activity types case-insensitively so walk matches Walk
- Add regression tests for preview wiring and type normalization

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend
- /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest apps/backend/tests/unit/test_intervals_icu.py apps/backend/tests/api/test_intervals_sync.py -q --tb=short --no-cov

## Review
- CodeRabbit review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intervals.icu activity previews now honor the configured activity types.
  * Activity type filtering is case-insensitive, improving matching for differently capitalized values.

* **Bug Fixes**
  * Preview results now exclude activities that do not match the configured types.
  * Improved consistency when retrieving and displaying external activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->