### PR TITLE
fix(flights): harden Cesium altitude anchoring

### DIFF
--- a/apps/backend/flight_tracks.py
+++ b/apps/backend/flight_tracks.py
@@ -79,6 +79,62 @@ def _child_text(element: ET.Element, name: str) -> str | None:
     return None
 
 
+def _fill_segment_elevations(points: list[TrackPoint], start: int, end: int) -> None:
+    known = [index for index in range(start, end) if "elevation" in points[index]]
+    if not known:
+        for point in points[start:end]:
+            point["elevation"] = 0.0
+        return
+
+    first_known = known[0]
+    for index in range(start, first_known):
+        points[index]["elevation"] = points[first_known]["elevation"]
+
+    for previous_index, next_index in zip(known, known[1:], strict=False):
+        if next_index == previous_index + 1:
+            continue
+        previous_elevation = points[previous_index]["elevation"]
+        next_elevation = points[next_index]["elevation"]
+        previous_timestamp = points[previous_index].get("timestamp", 0)
+        next_timestamp = points[next_index].get("timestamp", 0)
+        timestamps = [
+            points[index].get("timestamp", 0) for index in range(previous_index, next_index + 1)
+        ]
+        use_timestamps = (
+            next_timestamp > previous_timestamp
+            and all(timestamp > 0 for timestamp in timestamps)
+            and all(
+                earlier <= later for earlier, later in zip(timestamps, timestamps[1:], strict=False)
+            )
+        )
+        for index in range(previous_index + 1, next_index):
+            if use_timestamps:
+                timestamp = points[index].get("timestamp", 0)
+                ratio = (timestamp - previous_timestamp) / (next_timestamp - previous_timestamp)
+                if not 0 <= ratio <= 1:
+                    ratio = (index - previous_index) / (next_index - previous_index)
+            else:
+                ratio = (index - previous_index) / (next_index - previous_index)
+            points[index]["elevation"] = (
+                previous_elevation + (next_elevation - previous_elevation) * ratio
+            )
+
+    last_known = known[-1]
+    for index in range(last_known + 1, end):
+        points[index]["elevation"] = points[last_known]["elevation"]
+
+
+def _fill_missing_elevations(points: list[TrackPoint]) -> None:
+    start = 0
+    while start < len(points):
+        segment = points[start].get("segment", 0)
+        end = start + 1
+        while end < len(points) and points[end].get("segment", 0) == segment:
+            end += 1
+        _fill_segment_elevations(points, start, end)
+        start = end
+
+
 def _parse_gpx(content: bytes) -> list[TrackPoint]:
     root = ET.fromstring(content)
     points: list[TrackPoint] = []
@@ -90,10 +146,12 @@ def _parse_gpx(content: bytes) -> list[TrackPoint]:
             point: TrackPoint = {
                 "lat": float(element.attrib["lat"]),
                 "lon": float(element.attrib["lon"]),
-                "elevation": float(_child_text(element, "ele") or 0),
                 "timestamp": _timestamp_millis(_child_text(element, "time")),
                 "segment": segment_index,
             }
+            elevation = _child_text(element, "ele")
+            if elevation is not None:
+                point["elevation"] = float(elevation)
             heart_rate = _child_text(element, "hr")
             power = _child_text(element, "power")
             if heart_rate:
@@ -119,10 +177,12 @@ def _parse_tcx(content: bytes) -> list[TrackPoint]:
             point: TrackPoint = {
                 "lat": float(latitude),
                 "lon": float(longitude),
-                "elevation": float(_child_text(element, "AltitudeMeters") or 0),
                 "timestamp": _timestamp_millis(_child_text(element, "Time")),
                 "segment": segment_index,
             }
+            elevation = _child_text(element, "AltitudeMeters")
+            if elevation is not None:
+                point["elevation"] = float(elevation)
             heart_rate = _child_text(element, "Value")
             power = _child_text(element, "Watts")
             if heart_rate:
@@ -151,14 +211,15 @@ def _parse_fit(content: bytes) -> list[TrackPoint]:
                 continue
             elevation = frame.get_value("enhanced_altitude", fallback=None)
             if elevation is None:
-                elevation = frame.get_value("altitude", fallback=0)
+                elevation = frame.get_value("altitude", fallback=None)
             point: TrackPoint = {
                 "lat": _degrees(float(latitude)),
                 "lon": _degrees(float(longitude)),
-                "elevation": float(elevation or 0),
                 "timestamp": _timestamp_millis(frame.get_value("timestamp", fallback=None)),
                 "segment": 0,
             }
+            if elevation is not None:
+                point["elevation"] = float(elevation)
             heart_rate = frame.get_value("heart_rate", fallback=None)
             power = frame.get_value("power", fallback=None)
             if heart_rate is not None:
@@ -184,6 +245,7 @@ def normalize_track(content: bytes, file_type: str) -> tuple[bytes, list[TrackPo
         raise ValueError(f"Unsupported original activity file type: {file_type or 'unknown'}")
     if not points:
         raise ValueError("Activity file contains no positioned track points")
+    _fill_missing_elevations(points)
     return track_to_gpx(points), points
 
 

--- a/apps/backend/tests/unit/test_flight_tracks.py
+++ b/apps/backend/tests/unit/test_flight_tracks.py
@@ -1,7 +1,9 @@
 import gzip
 import sys
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,6 +14,36 @@ GPX = b"""<?xml version="1.0"?>
 <trkpt lat="47.2000" lon="6.0000"><ele>400</ele><time>2026-07-01T10:00:00Z</time></trkpt>
 <trkpt lat="47.2010" lon="6.0010"><ele>450</ele><time>2026-07-01T10:01:00Z</time></trkpt>
 </trkseg></trk></gpx>"""
+
+
+class FakeFitDataMessage:
+    name = "record"
+
+    def __init__(self, values: dict[str, Any]) -> None:
+        self.values = values
+
+    def get_value(self, name: str, fallback: Any = None) -> Any:
+        return self.values.get(name, fallback)
+
+
+def install_fitdecode_mock(
+    monkeypatch: pytest.MonkeyPatch, frames: list[FakeFitDataMessage]
+) -> None:
+    class FitReader:
+        def __init__(self, _stream: object) -> None:
+            pass
+
+        def __enter__(self) -> Iterator[FakeFitDataMessage]:
+            return iter(frames)
+
+        def __exit__(self, *_args: object) -> bool:
+            return False
+
+    monkeypatch.setitem(
+        sys.modules,
+        "fitdecode",
+        SimpleNamespace(FitDataMessage=FakeFitDataMessage, FitReader=FitReader),
+    )
 
 
 def test_normalizes_gzipped_gpx_and_calculates_stats():
@@ -37,17 +69,8 @@ def test_normalizes_tcx():
 
 
 def test_normalizes_fit_records(monkeypatch):
-    class FitDataMessage:
-        name = "record"
-
-        def __init__(self, values):
-            self.values = values
-
-        def get_value(self, name, fallback=None):
-            return self.values.get(name, fallback)
-
     frames = [
-        FitDataMessage(
+        FakeFitDataMessage(
             {
                 "position_lat": 47.2,
                 "position_long": 6.0,
@@ -59,21 +82,7 @@ def test_normalizes_fit_records(monkeypatch):
         )
     ]
 
-    class FitReader:
-        def __init__(self, _stream):
-            pass
-
-        def __enter__(self):
-            return iter(frames)
-
-        def __exit__(self, *_args):
-            return False
-
-    monkeypatch.setitem(
-        sys.modules,
-        "fitdecode",
-        SimpleNamespace(FitDataMessage=FitDataMessage, FitReader=FitReader),
-    )
+    install_fitdecode_mock(monkeypatch, frames)
 
     normalized, points = normalize_track(b"fit-data", "fit")
 
@@ -81,6 +90,100 @@ def test_normalizes_fit_records(monkeypatch):
     assert points[0]["elevation"] == 410.0
     assert points[0]["heart_rate"] == 120
     assert b"TrackPointExtension" in normalized
+
+
+def test_fills_missing_initial_fit_altitude_without_false_elevation_gain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frames = [
+        FakeFitDataMessage(
+            {
+                "position_lat": 47.2,
+                "position_long": 6.0,
+                "timestamp": datetime(2026, 7, 1, 10, tzinfo=timezone.utc),
+            }
+        ),
+        FakeFitDataMessage(
+            {
+                "position_lat": 47.2001,
+                "position_long": 6.0001,
+                "enhanced_altitude": 470.2,
+                "timestamp": datetime(2026, 7, 1, 10, 0, 1, tzinfo=timezone.utc),
+            }
+        ),
+    ]
+    install_fitdecode_mock(monkeypatch, frames)
+
+    normalized, points = normalize_track(b"fit-data", "fit")
+    stats = calculate_track_stats(points)
+
+    assert [point["elevation"] for point in points] == [470.2, 470.2]
+    assert normalized.count(b">470.2</") == 2
+    assert stats["elevation_gain_m"] == 0
+
+
+def test_preserves_explicit_zero_fit_altitude(monkeypatch: pytest.MonkeyPatch) -> None:
+    frames = [
+        FakeFitDataMessage(
+            {
+                "position_lat": 47.2,
+                "position_long": 6.0,
+                "enhanced_altitude": 0.0,
+            }
+        ),
+        FakeFitDataMessage(
+            {
+                "position_lat": 47.2001,
+                "position_long": 6.0001,
+                "enhanced_altitude": 0.0,
+            }
+        ),
+    ]
+    install_fitdecode_mock(monkeypatch, frames)
+
+    _, points = normalize_track(b"fit-data", "fit")
+
+    assert [point["elevation"] for point in points] == [0.0, 0.0]
+
+
+def test_interpolates_missing_altitudes_and_fills_track_ends() -> None:
+    gpx = b"""<gpx><trk><trkseg>
+    <trkpt lat="47.2" lon="6.0"><time>2026-07-01T10:00:00Z</time></trkpt>
+    <trkpt lat="47.201" lon="6.001"><ele>400</ele><time>2026-07-01T10:00:10Z</time></trkpt>
+    <trkpt lat="47.202" lon="6.002"><time>2026-07-01T10:00:20Z</time></trkpt>
+    <trkpt lat="47.203" lon="6.003"><ele>460</ele><time>2026-07-01T10:01:10Z</time></trkpt>
+    <trkpt lat="47.204" lon="6.004"><time>2026-07-01T10:01:20Z</time></trkpt>
+    </trkseg></trk></gpx>"""
+
+    _, points = normalize_track(gpx, "gpx")
+
+    assert [point["elevation"] for point in points] == [400, 400, 410, 460, 460]
+
+
+def test_uses_zero_when_track_has_no_altitude_data() -> None:
+    gpx = b"""<gpx><trk><trkseg>
+    <trkpt lat="47.2" lon="6.0"/><trkpt lat="47.201" lon="6.001"/>
+    </trkseg></trk></gpx>"""
+
+    normalized, points = normalize_track(gpx, "gpx")
+
+    assert [point["elevation"] for point in points] == [0.0, 0.0]
+    assert normalized.count(b">0.0</") == 2
+
+
+def test_uses_index_interpolation_when_a_gap_has_missing_timestamps() -> None:
+    gpx = b"""<gpx><trk><trkseg>
+    <trkpt lat="47.2" lon="6.0"><ele>400</ele></trkpt>
+    <trkpt lat="47.201" lon="6.001"><time>2026-07-01T10:00:10Z</time></trkpt>
+    <trkpt lat="47.202" lon="6.002"><time>2026-07-01T10:00:20Z</time></trkpt>
+    <trkpt lat="47.203" lon="6.003"><ele>500</ele><time>2026-07-01T10:00:30Z</time></trkpt>
+    </trkseg></trk></gpx>"""
+
+    _, points = normalize_track(gpx, "gpx")
+
+    assert [point["elevation"] for point in points] == pytest.approx(
+        [400, 433.333, 466.667, 500], abs=0.001
+    )
 
 
 def test_statistics_do_not_bridge_separate_track_segments():

--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.tsx
@@ -56,6 +56,8 @@ import {
 import {
   getBearingRadians,
   getRenderedTrackElevation,
+  getTerrainElevationOffset,
+  repairTrackEndpointElevations,
 } from './flightViewerTrackPlacement';
 import { getReplayTrackTrailPositions } from './flightViewerTrackTrail';
 import { useAppSettingsStore } from '../../../stores/appSettingsStore';
@@ -692,22 +694,23 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
     let isEffectActive = true;
 
     try {
+      const coordinates = repairTrackEndpointElevations(gpxData.coordinates);
       // Convert GPX coordinates to Cartesian3 avec offset d'élévation
-      const positions = gpxData.coordinates.map((point, index) =>
+      const positions = coordinates.map((point, index) =>
         Cartesian3.fromDegrees(
           point.lon,
           point.lat,
           getRenderedTrackElevation(
             point,
             index,
-            gpxData.coordinates.length,
+            coordinates.length,
             elevationOffset,
             landingElevationOffset
           )
         )
       );
 
-      const timestamps = gpxData.coordinates.map((coord) => coord.timestamp);
+      const timestamps = coordinates.map((coord) => coord.timestamp);
 
       allPositionsRef.current = positions;
       timestampsRef.current = timestamps;
@@ -720,6 +723,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
       if (typeof window !== 'undefined' && window._exportMode) {
         window._gpxData = {
           ...gpxData,
+          coordinates,
           positions,
           timestamps,
         };
@@ -761,7 +765,7 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
             () =>
               computeCursorTelemetryLabel(
                 currentIndexRef.current,
-                gpxData.coordinates,
+                coordinates,
                 elevationOffset,
                 viewerUnitsRef.current
               ),
@@ -799,16 +803,16 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       // Calculate camera heading to face the takeoff point
       const calculateOptimalHeading = (): number => {
-        if (gpxData.coordinates.length < 2) return 0;
+        if (coordinates.length < 2) return 0;
 
-        const numPoints = gpxData.coordinates.length;
+        const numPoints = coordinates.length;
 
         // Takeoff is at the beginning
-        const takeoffCoord = gpxData.coordinates[0];
+        const takeoffCoord = coordinates[0];
 
         // Use middle of the flight (50%) as reference for better perspective
         const referenceIndex = Math.floor(numPoints * 0.5);
-        const referenceCoord = gpxData.coordinates[referenceIndex];
+        const referenceCoord = coordinates[referenceIndex];
 
         // Calculate heading from reference point BACK to takeoff
         // This makes the camera look toward the takeoff/launch site
@@ -1056,12 +1060,14 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
 
       if (samples && samples.length > 0 && samples[0].height !== undefined) {
         const terrainHeight = samples[0].height;
-        const gpsElevation = firstPoint.elevation;
-
         // Calculer l'offset nécessaire pour que le pilote soit au-dessus du terrain
         // Si terrain = 1000m et GPS = 800m, offset = 1000 - 800 = +200m (on monte le pilote)
         // Si terrain = 1000m et GPS = 1200m, offset = 1000 - 1200 = -200m (on descend le pilote)
-        const offset = terrainHeight - gpsElevation;
+        const offset = getTerrainElevationOffset(
+          terrainHeight,
+          gpxData.coordinates,
+          'takeoff'
+        );
 
         setAutoOffset(offset);
         setElevationOffset(offset);
@@ -1069,7 +1075,13 @@ export const FlightViewer3D: React.FC<FlightViewer3DProps> = ({
         if (landingTerrainHeight === undefined) {
           setLandingElevationOffset(null);
         } else {
-          setLandingElevationOffset(landingTerrainHeight - lastPoint.elevation);
+          setLandingElevationOffset(
+            getTerrainElevationOffset(
+              landingTerrainHeight,
+              gpxData.coordinates,
+              'landing'
+            )
+          );
         }
         // Le flyTo se fera automatiquement via le useEffect qui dépend de elevationOffset
       }

--- a/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
+++ b/apps/frontend/src/components/flights/viewer/FlightViewer3D.video-export.test.tsx
@@ -36,6 +36,14 @@ const {
   },
 }));
 
+const mockGpxData = vi.hoisted(() => ({
+  coordinates: [
+    { lat: 45, lon: 6, elevation: 1000, timestamp: 0 },
+    { lat: 45.1, lon: 6.1, elevation: 1100, timestamp: 1000 },
+  ],
+  flight_duration_seconds: 1,
+}));
+
 vi.mock('cesium', () => {
   class Cartesian3 {
     constructor(
@@ -232,13 +240,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('../../../hooks/flights/useFlightGPX', () => ({
   useFlightGPX: () => ({
-    data: {
-      coordinates: [
-        { lat: 45, lon: 6, elevation: 1000, timestamp: 0 },
-        { lat: 45.1, lon: 6.1, elevation: 1100, timestamp: 1000 },
-      ],
-      flight_duration_seconds: 1,
-    },
+    data: mockGpxData,
     isLoading: false,
     error: null,
   }),
@@ -293,6 +295,10 @@ describe('FlightViewer3D video export mode', () => {
     mockFlight.video_export_status = null;
     mockFlight.video_export_job_id = null;
     mockFlight.video_file_path = null;
+    mockGpxData.coordinates = [
+      { lat: 45, lon: 6, elevation: 1000, timestamp: 0 },
+      { lat: 45.1, lon: 6.1, elevation: 1100, timestamp: 1000 },
+    ];
     window._exportMode = undefined;
     window._setExportFrame = undefined;
     window._getExportMetadata = undefined;
@@ -414,6 +420,23 @@ describe('FlightViewer3D video export mode', () => {
     await waitFor(() => {
       expect(cartesianFromDegreesCalls[0]).toEqual([6, 45, 1000]);
       expect(cartesianFromDegreesCalls[1]).toEqual([6.1, 45.1, 1100]);
+    });
+  });
+
+  it('repairs an isolated invalid takeoff elevation before Cesium rendering', async () => {
+    mockGpxData.coordinates = [0, 470.2, 470.2, 470.2].map(
+      (elevation, index) => ({
+        lat: 47.194 + index * 0.0001,
+        lon: 5.989 + index * 0.0001,
+        elevation,
+        timestamp: index * 1000,
+      })
+    );
+
+    render(<FlightViewer3D flightId="flight-1" exportOnly />);
+
+    await waitFor(() => {
+      expect(cartesianFromDegreesCalls[0]).toEqual([5.989, 47.194, 470.2]);
     });
   });
 

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.test.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   getBearingRadians,
   getInterpolatedElevationOffset,
+  getReliableEndpointElevation,
   getRenderedTrackElevation,
+  getTerrainElevationOffset,
+  repairTrackEndpointElevations,
 } from './flightViewerTrackPlacement';
 
 describe('flightViewerTrackPlacement', () => {
@@ -21,6 +24,90 @@ describe('flightViewerTrackPlacement', () => {
 
     expect(getRenderedTrackElevation(point, 1, 3, 100, -50)).toBe(825);
     expect(point).toEqual({ lat: 45.12, lon: 6.34, elevation: 800 });
+  });
+
+  it('ignores an isolated invalid takeoff elevation', () => {
+    const points = [0, 470.2, 470.2, 470.2].map((elevation) => ({
+      lat: 47.194,
+      lon: 5.989,
+      elevation,
+    }));
+
+    expect(getReliableEndpointElevation(points, 'takeoff')).toBe(470.2);
+  });
+
+  it('ignores an isolated invalid landing elevation', () => {
+    const points = [254.8, 254.6, 254.4, 0].map((elevation) => ({
+      lat: 47.202,
+      lon: 5.988,
+      elevation,
+    }));
+
+    expect(getReliableEndpointElevation(points, 'landing')).toBe(254.6);
+  });
+
+  it('keeps valid endpoint elevations unchanged', () => {
+    const points = [470, 472, 474, 476].map((elevation) => ({
+      lat: 47.194,
+      lon: 5.989,
+      elevation,
+    }));
+
+    expect(getReliableEndpointElevation(points, 'takeoff')).toBe(470);
+  });
+
+  it('preserves a real sea-level track', () => {
+    const points = [0, 0, 0.2, 0.1].map((elevation) => ({
+      lat: 43.3,
+      lon: 5.4,
+      elevation,
+    }));
+
+    expect(getReliableEndpointElevation(points, 'takeoff')).toBe(0);
+  });
+
+  it('falls back deterministically for a single-point track', () => {
+    expect(
+      getReliableEndpointElevation(
+        [{ lat: 47.194, lon: 5.989, elevation: 462 }],
+        'landing'
+      )
+    ).toBe(462);
+  });
+
+  it('preserves both endpoints when a track is too short to detect outliers', () => {
+    const points = [1000, 1100].map((elevation) => ({
+      lat: 45,
+      lon: 6,
+      elevation,
+    }));
+
+    expect(repairTrackEndpointElevations(points)).toEqual(points);
+  });
+
+  it('calculates terrain offset from the reliable endpoint elevation', () => {
+    const points = [0, 470.2, 470.2, 470.2].map((elevation) => ({
+      lat: 47.194,
+      lon: 5.989,
+      elevation,
+    }));
+
+    expect(getTerrainElevationOffset(462, points, 'takeoff')).toBeCloseTo(-8.2);
+  });
+
+  it('repairs only invalid track endpoints without mutating source data', () => {
+    const points = [0, 470.2, 470.2, 470.2].map((elevation) => ({
+      lat: 47.194,
+      lon: 5.989,
+      elevation,
+    }));
+
+    const repaired = repairTrackEndpointElevations(points);
+
+    expect(repaired.map((point) => point.elevation)).toEqual([
+      470.2, 470.2, 470.2, 470.2,
+    ]);
+    expect(points[0].elevation).toBe(0);
   });
 
   it('computes bearings with radians, not degree deltas', () => {

--- a/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.ts
+++ b/apps/frontend/src/components/flights/viewer/flightViewerTrackPlacement.ts
@@ -4,6 +4,69 @@ export type TrackPoint = {
   elevation: number;
 };
 
+const ENDPOINT_SAMPLE_SIZE = 5;
+const ENDPOINT_OUTLIER_THRESHOLD_METERS = 30;
+
+const median = (values: number[]) => {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+export const getReliableEndpointElevation = (
+  points: TrackPoint[],
+  endpoint: 'takeoff' | 'landing'
+) => {
+  if (points.length === 0) return 0;
+
+  const endpointIndex = endpoint === 'takeoff' ? 0 : points.length - 1;
+  const endpointElevation = points[endpointIndex].elevation;
+  const nearbyPoints =
+    endpoint === 'takeoff'
+      ? points.slice(1, ENDPOINT_SAMPLE_SIZE + 1)
+      : points.slice(Math.max(0, points.length - ENDPOINT_SAMPLE_SIZE - 1), -1);
+  const nearbyElevations = nearbyPoints
+    .map((point) => point.elevation)
+    .filter(Number.isFinite);
+
+  if (nearbyElevations.length < 2) {
+    return Number.isFinite(endpointElevation) ? endpointElevation : 0;
+  }
+
+  const nearbyMedian = median(nearbyElevations);
+  return !Number.isFinite(endpointElevation) ||
+    Math.abs(endpointElevation - nearbyMedian) >
+      ENDPOINT_OUTLIER_THRESHOLD_METERS
+    ? nearbyMedian
+    : endpointElevation;
+};
+
+export const repairTrackEndpointElevations = <Point extends TrackPoint>(
+  points: Point[]
+) => {
+  if (points.length === 0) return points;
+
+  const repaired = [...points];
+  const takeoffElevation = getReliableEndpointElevation(points, 'takeoff');
+  const landingElevation = getReliableEndpointElevation(points, 'landing');
+  if (takeoffElevation !== points[0].elevation) {
+    repaired[0] = { ...points[0], elevation: takeoffElevation };
+  }
+  const lastIndex = points.length - 1;
+  if (landingElevation !== points[lastIndex].elevation) {
+    repaired[lastIndex] = { ...points[lastIndex], elevation: landingElevation };
+  }
+  return repaired;
+};
+
+export const getTerrainElevationOffset = (
+  terrainElevation: number,
+  points: TrackPoint[],
+  endpoint: 'takeoff' | 'landing'
+) => terrainElevation - getReliableEndpointElevation(points, endpoint);
+
 export const getInterpolatedElevationOffset = (
   pointIndex: number,
   totalPoints: number,


### PR DESCRIPTION
## Summary
- Repair missing FIT/GPX altitude handling before rendering
- Ignore isolated endpoint altitude outliers when anchoring Cesium to terrain
- Add backend and frontend regression tests for the affected elevation paths

## Validation
- `../../../.venv/bin/pytest tests/unit/test_flight_tracks.py -q --tb=short --no-header --no-cov`
- `../../node_modules/.bin/vitest run --config vitest.config.ts src/components/flights/viewer/flightViewerTrackPlacement.test.ts src/components/flights/viewer/FlightViewer3D.video-export.test.tsx`
- `NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e`
- `NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx run frontend:type-check`
- `NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx build frontend`
- `NX_NO_CLOUD=true NX_DAEMON=false /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5`

## Review
- CodeRabbit review: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing elevation data in GPX, TCX, and FIT flight tracks.
  * Filled gaps in elevation data using nearby values and interpolation.
  * Corrected unreliable takeoff and landing elevations in 3D flight playback and exports.
  * Improved terrain offset calculations for more accurate track placement.
  * Preserved valid zero-elevation values and handled tracks without elevation data safely.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->