### PR TITLE
perf(video-export): stream manual_fast frames to ffmpeg

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import time
+from collections import deque
 from datetime import datetime
 from urllib.error import URLError
 
@@ -199,6 +200,133 @@ def test_parse_ffmpeg_out_time_seconds_parses_progress_lines():
 def test_ffmpeg_encoding_settings_use_fast_preset_for_manual_fast():
     assert video_export_manual._ffmpeg_encoding_settings(True) == ("veryfast", "23")
     assert video_export_manual._ffmpeg_encoding_settings(False) == ("medium", "18")
+
+
+def test_ffmpeg_command_streams_png_frames_for_manual_fast(tmp_path):
+    output_file = tmp_path / "export.mp4"
+
+    command = video_export_manual._ffmpeg_command(
+        fps=15,
+        output_file=output_file,
+        is_fast_mode=True,
+    )
+
+    assert command[:9] == [
+        "ffmpeg",
+        "-f",
+        "image2pipe",
+        "-framerate",
+        "15",
+        "-vcodec",
+        "png",
+        "-i",
+        "pipe:0",
+    ]
+    assert command[-1] == str(output_file)
+    assert command[command.index("-preset") + 1] == "veryfast"
+    assert command[command.index("-crf") + 1] == "23"
+
+
+def test_ffmpeg_command_reads_saved_frames_for_classic_mode(tmp_path):
+    frames_dir = tmp_path / "frames"
+    output_file = tmp_path / "export.mp4"
+
+    command = video_export_manual._ffmpeg_command(
+        fps=30,
+        output_file=output_file,
+        is_fast_mode=False,
+        frames_dir=frames_dir,
+    )
+
+    assert command[:5] == [
+        "ffmpeg",
+        "-framerate",
+        "30",
+        "-i",
+        str(frames_dir / "frame%05d.png"),
+    ]
+    assert "image2pipe" not in command
+    assert command[command.index("-preset") + 1] == "medium"
+    assert command[command.index("-crf") + 1] == "18"
+
+
+@pytest.mark.asyncio
+async def test_drain_ffmpeg_stderr_tracks_latest_progress(monkeypatch):
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"out_time_us=1500000\nprogress=continue\ninvalid PNG frame\n")
+    reader.feed_eof()
+    lines: deque[str] = deque(maxlen=2)
+    state: dict[str, float] = {}
+    logged_messages: list[str] = []
+    monkeypatch.setattr(
+        video_export_manual,
+        "_log_job",
+        lambda _job_id, message: logged_messages.append(message),
+    )
+
+    await video_export_manual._drain_ffmpeg_stderr("job-1", reader, lines, state)
+
+    assert list(lines) == ["invalid PNG frame"]
+    assert state["encoded_seconds"] == 1.5
+    assert state["last_output_at"] > 0
+    assert logged_messages == ["ffmpeg: invalid PNG frame"]
+
+
+class _FakeFfmpegStdin:
+    def __init__(self):
+        self.frames: list[bytes] = []
+
+    def write(self, frame: bytes) -> None:
+        self.frames.append(frame)
+
+    async def drain(self) -> None:
+        return None
+
+
+class _FakeFfmpegProcess:
+    def __init__(self):
+        self.stdin = _FakeFfmpegStdin()
+        self.returncode = None
+
+
+@pytest.mark.asyncio
+async def test_write_ffmpeg_frame_writes_complete_png(monkeypatch):
+    process = _FakeFfmpegProcess()
+    stderr_task = asyncio.create_task(asyncio.sleep(0))
+    monkeypatch.setattr(video_export_manual, "_is_cancelled", lambda _job_id: False)
+
+    written = await video_export_manual._write_ffmpeg_frame(
+        job_id="job-1",
+        process=process,
+        stderr_task=stderr_task,
+        stderr_lines=deque(),
+        state={"started_at": time.monotonic()},
+        frame_png=b"png-frame",
+    )
+
+    await stderr_task
+    assert written is True
+    assert process.stdin.frames == [b"png-frame"]
+
+
+@pytest.mark.asyncio
+async def test_write_ffmpeg_frame_stops_before_write_when_cancelled(monkeypatch):
+    process = _FakeFfmpegProcess()
+    stderr_task = asyncio.create_task(asyncio.sleep(0))
+    monkeypatch.setattr(video_export_manual, "_is_cancelled", lambda _job_id: True)
+
+    written = await video_export_manual._write_ffmpeg_frame(
+        job_id="job-1",
+        process=process,
+        stderr_task=stderr_task,
+        stderr_lines=deque(),
+        state={"started_at": time.monotonic()},
+        frame_png=b"png-frame",
+    )
+
+    await stderr_task
+    assert written is False
+    assert process.stdin.frames == []
 
 
 def test_ffmpeg_timeout_is_not_limited_to_thirty_minutes():
@@ -518,6 +646,24 @@ def test_first_missing_frame_index_returns_resume_point(tmp_path):
     (frames_dir / "frame00003.png").write_bytes(b"frame")
 
     assert video_export_manual._first_missing_frame_index(frames_dir, 5) == 2
+
+
+def test_first_missing_frame_index_ignores_partial_frame(tmp_path):
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    (frames_dir / "frame00000.png").write_bytes(b"complete")
+    (frames_dir / "frame00001.png.part").write_bytes(b"partial")
+
+    assert video_export_manual._first_missing_frame_index(frames_dir, 3) == 1
+
+
+def test_write_frame_file_atomic_publishes_complete_frame(tmp_path):
+    frame_path = tmp_path / "frame00000.png"
+
+    video_export_manual._write_frame_file_atomic(frame_path, b"png-frame")
+
+    assert frame_path.read_bytes() == b"png-frame"
+    assert not (tmp_path / "frame00000.png.part").exists()
 
 
 def test_job_resume_info_requires_terminal_status_and_frames(tmp_path, monkeypatch):

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -13,6 +13,7 @@ import threading
 import uuid
 import traceback
 import time
+from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -104,6 +105,9 @@ _JOB_RUNTIME: dict[str, dict[str, Any]] = {}
 _JOB_CANCEL_REQUESTS: set[str] = set()
 
 _CANCEL_CHECK_INTERVAL = 10
+_MAX_PENDING_FRAME_WRITES = 4
+_MAX_FFMPEG_STDERR_LINES = 200
+_FFMPEG_PIPE_POLL_SECONDS = 1.0
 _EXPORT_VIEWER_READY_TIMEOUT_SECONDS = 180
 _FFMPEG_STALL_TIMEOUT_SECONDS = 10 * 60
 _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS = 30
@@ -708,6 +712,12 @@ def _first_missing_frame_index(frames_dir: Path, total_frames: int) -> int:
     return max(total_frames, 0)
 
 
+def _write_frame_file_atomic(frame_path: Path, frame_png: bytes) -> None:
+    partial_path = frame_path.with_name(f"{frame_path.name}.part")
+    partial_path.write_bytes(frame_png)
+    partial_path.replace(frame_path)
+
+
 def _job_resume_info(job: VideoExportJob) -> dict[str, Any]:
     frames_dir = _job_frames_dir(_video_temp_images_dir(), job.id)
     existing_indexes = _existing_frame_indexes(frames_dir)
@@ -1005,6 +1015,233 @@ def _ffmpeg_encoding_settings(is_fast_mode: bool) -> tuple[str, str]:
     return "medium", "18"
 
 
+def _ffmpeg_command(
+    *,
+    fps: int,
+    output_file: Path,
+    is_fast_mode: bool,
+    frames_dir: Path | None = None,
+) -> list[str]:
+    ffmpeg_preset, ffmpeg_crf = _ffmpeg_encoding_settings(is_fast_mode)
+    if frames_dir is None:
+        input_args = [
+            "-f",
+            "image2pipe",
+            "-framerate",
+            str(fps),
+            "-vcodec",
+            "png",
+            "-i",
+            "pipe:0",
+        ]
+    else:
+        input_args = [
+            "-framerate",
+            str(fps),
+            "-i",
+            str(frames_dir / "frame%05d.png"),
+        ]
+
+    return [
+        "ffmpeg",
+        *input_args,
+        "-c:v",
+        "libx264",
+        "-preset",
+        ffmpeg_preset,
+        "-crf",
+        ffmpeg_crf,
+        "-pix_fmt",
+        "yuv420p",
+        "-nostats",
+        "-progress",
+        "pipe:2",
+        "-y",
+        str(output_file),
+    ]
+
+
+async def _drain_ffmpeg_stderr(
+    job_id: str,
+    stderr: asyncio.StreamReader,
+    lines: deque[str],
+    state: dict[str, float],
+) -> None:
+    while line_bytes := await stderr.readline():
+        line = line_bytes.decode("utf-8", errors="replace").strip()
+        state["last_output_at"] = time.monotonic()
+        encoded_seconds = _parse_ffmpeg_out_time_seconds(line)
+        if encoded_seconds is not None:
+            state["encoded_seconds"] = encoded_seconds
+            continue
+        key, separator, _value = line.partition("=")
+        if not line or (separator and key.replace("_", "").isalnum()):
+            continue
+        lines.append(line)
+        _log_job(job_id, f"ffmpeg: {line}")
+
+
+async def _write_ffmpeg_frame(
+    *,
+    job_id: str,
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    stderr_lines: deque[str],
+    state: dict[str, float],
+    frame_png: bytes,
+) -> bool:
+    if _is_cancelled(job_id):
+        return False
+    if process.returncode is not None:
+        await stderr_task
+        stderr_output = "\n".join(stderr_lines).strip()
+        raise RuntimeError(f"FFmpeg exited while receiving frames: {stderr_output}")
+
+    assert process.stdin is not None
+    process.stdin.write(frame_png)
+    while True:
+        try:
+            await asyncio.wait_for(
+                process.stdin.drain(),
+                timeout=_FFMPEG_PIPE_POLL_SECONDS,
+            )
+            return True
+        except TimeoutError:
+            if _is_cancelled(job_id):
+                return False
+            if process.returncode is not None:
+                await stderr_task
+                stderr_output = "\n".join(stderr_lines).strip()
+                raise RuntimeError(
+                    f"FFmpeg exited while receiving frames: {stderr_output}"
+                ) from None
+            if stderr_task.done():
+                stderr_exception = stderr_task.exception()
+                if stderr_exception is not None:
+                    raise RuntimeError("Failed to read FFmpeg output") from stderr_exception
+
+            now = time.monotonic()
+            started_at = state.get("started_at", now)
+            last_output_at = state.get("last_output_at", started_at)
+            if now - last_output_at > _FFMPEG_STALL_TIMEOUT_SECONDS:
+                raise RuntimeError(
+                    f"FFmpeg stalled for {_FFMPEG_STALL_TIMEOUT_SECONDS}s while receiving frames"
+                ) from None
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            await process.wait()
+            await stderr_task
+            stderr_output = "\n".join(stderr_lines).strip()
+            raise RuntimeError(f"FFmpeg stopped receiving frames: {stderr_output}") from exc
+
+
+async def _wait_for_ffmpeg_process(
+    *,
+    job_id: str,
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    stderr_lines: deque[str],
+    state: dict[str, float],
+    output_file: Path,
+    video_duration: float,
+    ffmpeg_cmd: list[str],
+) -> bool:
+    encoding_started_at = state.get("started_at", time.monotonic())
+    last_ffmpeg_output_at = state.get("last_output_at", encoding_started_at)
+    total_duration_seconds = max(video_duration, 1e-6)
+    ffmpeg_timeout_seconds = _ffmpeg_timeout_seconds(total_duration_seconds)
+    last_output_file_size = -1
+    last_output_file_mtime_ns = -1
+    last_reported_seconds = -1.0
+
+    try:
+        while True:
+            if _is_cancelled(job_id):
+                if process.returncode is None:
+                    process.kill()
+                    await process.wait()
+                await stderr_task
+                _update_job(
+                    job_id,
+                    status=_STATUS_CANCELLED,
+                    message="Export cancelled during encoding",
+                )
+                return False
+
+            now = time.monotonic()
+            has_output_file_activity, last_output_file_size, last_output_file_mtime_ns = (
+                _ffmpeg_output_file_activity(
+                    output_file,
+                    last_output_file_size,
+                    last_output_file_mtime_ns,
+                )
+            )
+            if has_output_file_activity:
+                last_ffmpeg_output_at = now
+            last_ffmpeg_output_at = max(
+                last_ffmpeg_output_at,
+                state.get("last_output_at", last_ffmpeg_output_at),
+            )
+
+            if process.returncode is not None:
+                break
+
+            if now - last_ffmpeg_output_at > _FFMPEG_STALL_TIMEOUT_SECONDS:
+                process.kill()
+                await process.wait()
+                raise RuntimeError(
+                    "FFmpeg stalled for "
+                    f"{_FFMPEG_STALL_TIMEOUT_SECONDS}s: {' '.join(ffmpeg_cmd)}"
+                )
+
+            if now - encoding_started_at > ffmpeg_timeout_seconds:
+                process.kill()
+                await process.wait()
+                raise RuntimeError(
+                    f"FFmpeg timeout after {ffmpeg_timeout_seconds}s: {' '.join(ffmpeg_cmd)}"
+                )
+
+            encoded_seconds = state.get("encoded_seconds")
+            if encoded_seconds is not None and encoded_seconds != last_reported_seconds:
+                last_reported_seconds = encoded_seconds
+                progress = _encoding_progress_percent(encoded_seconds, total_duration_seconds)
+                elapsed_encoding = max(now - encoding_started_at, 1e-6)
+                encoding_speed = encoded_seconds / elapsed_encoding
+                remaining = max(total_duration_seconds - encoded_seconds, 0.0)
+                eta_seconds = (
+                    max(0, int(remaining / encoding_speed)) if encoding_speed > 0 else None
+                )
+                _set_job_runtime(
+                    job_id,
+                    phase=_STATUS_ENCODING,
+                    eta_seconds=eta_seconds,
+                    encoded_seconds=round(encoded_seconds, 2),
+                )
+                _update_job(
+                    job_id,
+                    status=_STATUS_ENCODING,
+                    progress=progress,
+                    message=(
+                        "Encoding "
+                        f"{int(min(max((encoded_seconds / total_duration_seconds) * 100, 0), 100))}%"
+                    ),
+                )
+
+            await asyncio.sleep(0.25)
+
+        return_code = await process.wait()
+        await stderr_task
+        if return_code != 0:
+            stderr_output = "\n".join(stderr_lines).strip()
+            raise RuntimeError(f"FFmpeg encoding failed: {stderr_output}")
+        return True
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+        if not stderr_task.done():
+            await stderr_task
+
+
 def _ffmpeg_timeout_seconds(video_duration_seconds: float) -> int:
     dynamic_timeout = int(max(video_duration_seconds, 1.0) * 20)
     return max(6 * 60 * 60, dynamic_timeout)
@@ -1262,6 +1499,9 @@ async def _export_video_manual_render(job_id: str):
     temp_root = _video_temp_images_dir()
     temp_dir: Path | None = None
     frames_dir: Path | None = None
+    ffmpeg_process: asyncio.subprocess.Process | None = None
+    ffmpeg_stderr_task: asyncio.Task[None] | None = None
+    pending_frame_writes: set[asyncio.Task[None]] = set()
     auth_token = job.auth_token
     url = f"{frontend_url}/export-viewer?flightId={flight_id}&jobId={job_id}"
     preflight_url = url
@@ -1527,6 +1767,55 @@ async def _export_video_manual_render(job_id: str):
                 )
                 _log_job(job_id, f"Resuming capture from frame {resume_from_frame}/{total_frames}")
 
+            encoding_output_file = temp_dir / "encoding.mp4"
+            ffmpeg_cmd = _ffmpeg_command(
+                fps=fps,
+                output_file=encoding_output_file,
+                is_fast_mode=is_fast_mode,
+                frames_dir=None if is_fast_mode else frames_dir,
+            )
+            ffmpeg_stderr: deque[str] = deque(maxlen=_MAX_FFMPEG_STDERR_LINES)
+            ffmpeg_state: dict[str, float] = {}
+
+            if is_fast_mode:
+                _log_job(job_id, f"Starting concurrent FFmpeg encoding: {' '.join(ffmpeg_cmd)}")
+                ffmpeg_process = await asyncio.create_subprocess_exec(
+                    *ffmpeg_cmd,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                assert ffmpeg_process.stdin is not None
+                assert ffmpeg_process.stderr is not None
+                ffmpeg_state["started_at"] = time.monotonic()
+                ffmpeg_stderr_task = asyncio.create_task(
+                    _drain_ffmpeg_stderr(
+                        job_id,
+                        ffmpeg_process.stderr,
+                        ffmpeg_stderr,
+                        ffmpeg_state,
+                    )
+                )
+
+                for existing_frame_index in range(resume_from_frame):
+                    existing_frame = frames_dir / f"frame{existing_frame_index:05d}.png"
+                    frame_written = await _write_ffmpeg_frame(
+                        job_id=job_id,
+                        process=ffmpeg_process,
+                        stderr_task=ffmpeg_stderr_task,
+                        stderr_lines=ffmpeg_stderr,
+                        state=ffmpeg_state,
+                        frame_png=await asyncio.to_thread(existing_frame.read_bytes),
+                    )
+                    if not frame_written:
+                        await browser.close()
+                        _update_job(
+                            job_id,
+                            status=_STATUS_CANCELLED,
+                            message="Export cancelled by user",
+                        )
+                        return
+
             terrain_wait_enabled = True
             for i in range(resume_from_frame, total_frames):
                 if i % _CANCEL_CHECK_INTERVAL == 0 and _is_cancelled(job_id):
@@ -1560,7 +1849,40 @@ async def _export_video_manual_render(job_id: str):
                         _log_job(job_id, "Disabling per-frame terrain waits after timeout")
 
                 frame_path = frames_dir / f"frame{i:05d}.png"
-                await page.screenshot(path=str(frame_path), timeout=60000)
+                if is_fast_mode:
+                    assert ffmpeg_process is not None
+                    assert ffmpeg_process.stdin is not None
+                    frame_png = await page.screenshot(type="png", timeout=60000)
+                    frame_written = await _write_ffmpeg_frame(
+                        job_id=job_id,
+                        process=ffmpeg_process,
+                        stderr_task=ffmpeg_stderr_task,
+                        stderr_lines=ffmpeg_stderr,
+                        state=ffmpeg_state,
+                        frame_png=frame_png,
+                    )
+                    if not frame_written:
+                        await browser.close()
+                        _update_job(
+                            job_id,
+                            status=_STATUS_CANCELLED,
+                            message="Export cancelled by user",
+                        )
+                        return
+
+                    pending_frame_writes.add(
+                        asyncio.create_task(
+                            asyncio.to_thread(_write_frame_file_atomic, frame_path, frame_png)
+                        )
+                    )
+                    if len(pending_frame_writes) >= _MAX_PENDING_FRAME_WRITES:
+                        completed_writes, pending_frame_writes = await asyncio.wait(
+                            pending_frame_writes,
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        await asyncio.gather(*completed_writes)
+                else:
+                    await page.screenshot(path=str(frame_path), timeout=60000)
 
                 frame_count += 1
                 if frame_count % 10 == 0:
@@ -1593,6 +1915,21 @@ async def _export_video_manual_render(job_id: str):
                 if not is_fast_mode:
                     await asyncio.sleep(ms_per_frame / 1000)
 
+            if pending_frame_writes:
+                await asyncio.gather(*pending_frame_writes)
+                pending_frame_writes.clear()
+
+            if is_fast_mode:
+                assert ffmpeg_process is not None
+                assert ffmpeg_process.stdin is not None
+                ffmpeg_process.stdin.close()
+                try:
+                    await ffmpeg_process.stdin.wait_closed()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                ffmpeg_state["started_at"] = time.monotonic()
+                ffmpeg_state["last_output_at"] = time.monotonic()
+
             total_capture_time = time.time() - start_time
             _log_job(
                 job_id,
@@ -1619,142 +1956,42 @@ async def _export_video_manual_render(job_id: str):
             )
             _set_job_runtime(job_id, phase=_STATUS_ENCODING, eta_seconds=None)
 
+            if not is_fast_mode:
+                _log_job(job_id, f"FFmpeg command: {' '.join(ffmpeg_cmd)}")
+                ffmpeg_process = await asyncio.create_subprocess_exec(
+                    *ffmpeg_cmd,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                assert ffmpeg_process.stderr is not None
+                ffmpeg_state["started_at"] = time.monotonic()
+                ffmpeg_stderr_task = asyncio.create_task(
+                    _drain_ffmpeg_stderr(
+                        job_id,
+                        ffmpeg_process.stderr,
+                        ffmpeg_stderr,
+                        ffmpeg_state,
+                    )
+                )
+
+            assert ffmpeg_process is not None
+            assert ffmpeg_stderr_task is not None
+            encoding_completed = await _wait_for_ffmpeg_process(
+                job_id=job_id,
+                process=ffmpeg_process,
+                stderr_task=ffmpeg_stderr_task,
+                stderr_lines=ffmpeg_stderr,
+                state=ffmpeg_state,
+                output_file=encoding_output_file,
+                video_duration=video_duration,
+                ffmpeg_cmd=ffmpeg_cmd,
+            )
+            if not encoding_completed:
+                return
+
             timestamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
             output_file = _video_output_path(flight_id, timestamp)
-            ffmpeg_preset, ffmpeg_crf = _ffmpeg_encoding_settings(is_fast_mode)
-
-            ffmpeg_cmd = [
-                "ffmpeg",
-                "-framerate",
-                str(fps),
-                "-i",
-                str(frames_dir / "frame%05d.png"),
-                "-c:v",
-                "libx264",
-                "-preset",
-                ffmpeg_preset,
-                "-crf",
-                ffmpeg_crf,
-                "-pix_fmt",
-                "yuv420p",
-                "-nostats",
-                "-progress",
-                "pipe:2",
-                "-y",
-                str(output_file),
-            ]
-
-            _log_job(job_id, f"FFmpeg command: {' '.join(ffmpeg_cmd)}")
-            process = await asyncio.create_subprocess_exec(
-                *ffmpeg_cmd,
-                stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.PIPE,
-            )
-
-            encoding_started_at = time.monotonic()
-            last_ffmpeg_output_at = encoding_started_at
-            ffmpeg_stderr: list[str] = []
-            total_duration_seconds = max(video_duration, 1e-6)
-            ffmpeg_timeout_seconds = _ffmpeg_timeout_seconds(total_duration_seconds)
-            last_output_file_size = -1
-            last_output_file_mtime_ns = -1
-
-            try:
-                assert process.stderr is not None
-                while True:
-                    if _is_cancelled(job_id):
-                        process.kill()
-                        await process.wait()
-                        _update_job(
-                            job_id,
-                            status=_STATUS_CANCELLED,
-                            message="Export cancelled during encoding",
-                        )
-                        return
-
-                    now = time.monotonic()
-                    (
-                        has_output_file_activity,
-                        last_output_file_size,
-                        last_output_file_mtime_ns,
-                    ) = _ffmpeg_output_file_activity(
-                        output_file,
-                        last_output_file_size,
-                        last_output_file_mtime_ns,
-                    )
-                    if has_output_file_activity:
-                        last_ffmpeg_output_at = now
-
-                    if now - last_ffmpeg_output_at > _FFMPEG_STALL_TIMEOUT_SECONDS:
-                        process.kill()
-                        await process.wait()
-                        raise Exception(
-                            "FFmpeg stalled for "
-                            f"{_FFMPEG_STALL_TIMEOUT_SECONDS}s: {' '.join(ffmpeg_cmd)}"
-                        )
-
-                    if now - encoding_started_at > ffmpeg_timeout_seconds:
-                        process.kill()
-                        await process.wait()
-                        raise Exception(
-                            f"FFmpeg timeout after {ffmpeg_timeout_seconds}s: {' '.join(ffmpeg_cmd)}"
-                        )
-
-                    try:
-                        line_bytes = await asyncio.wait_for(process.stderr.readline(), timeout=1.0)
-                    except TimeoutError:
-                        if process.returncode is not None:
-                            break
-                        continue
-
-                    if not line_bytes:
-                        if process.returncode is not None:
-                            break
-                        continue
-
-                    line = line_bytes.decode("utf-8", errors="replace").strip()
-                    last_ffmpeg_output_at = time.monotonic()
-                    ffmpeg_stderr.append(line)
-                    if line:
-                        _log_job(job_id, f"ffmpeg: {line}")
-                    encoded_seconds = _parse_ffmpeg_out_time_seconds(line)
-
-                    if encoded_seconds is not None:
-                        progress = _encoding_progress_percent(
-                            encoded_seconds,
-                            total_duration_seconds,
-                        )
-                        elapsed_encoding = max(time.monotonic() - encoding_started_at, 1e-6)
-                        encoding_speed = encoded_seconds / elapsed_encoding
-                        remaining = max(total_duration_seconds - encoded_seconds, 0.0)
-                        eta_seconds = (
-                            max(0, int(remaining / encoding_speed)) if encoding_speed > 0 else None
-                        )
-
-                        _set_job_runtime(
-                            job_id,
-                            phase=_STATUS_ENCODING,
-                            eta_seconds=eta_seconds,
-                            encoded_seconds=round(encoded_seconds, 2),
-                        )
-                        _update_job(
-                            job_id,
-                            status=_STATUS_ENCODING,
-                            progress=progress,
-                            message=(
-                                f"Encoding {int(min(max((encoded_seconds / total_duration_seconds) * 100, 0), 100))}%"
-                            ),
-                        )
-
-                return_code = await process.wait()
-                if return_code != 0:
-                    stderr_output = "\n".join(ffmpeg_stderr).strip()
-                    raise Exception(f"FFmpeg encoding failed: {stderr_output}")
-            finally:
-                if process.returncode is None:
-                    process.kill()
-                    await process.wait()
-
+            await asyncio.to_thread(shutil.move, str(encoding_output_file), str(output_file))
             _log_job(job_id, f"Video encoded: {output_file}")
 
             _cleanup_temp_dir(temp_dir)
@@ -1783,6 +2020,15 @@ async def _export_video_manual_render(job_id: str):
             message=f"Error: {e}",
         )
     finally:
+        if pending_frame_writes:
+            await asyncio.gather(*pending_frame_writes, return_exceptions=True)
+        if ffmpeg_process is not None and ffmpeg_process.returncode is None:
+            if ffmpeg_process.stdin is not None:
+                ffmpeg_process.stdin.close()
+            ffmpeg_process.kill()
+            await ffmpeg_process.wait()
+        if ffmpeg_stderr_task is not None:
+            await asyncio.gather(ffmpeg_stderr_task, return_exceptions=True)
         _clear_job_cancel_requested(job_id)
         _clear_job_auth_token(job_id)
 


### PR DESCRIPTION
## Summary\n- Stream manual_fast frames directly to FFmpeg with resumable atomic PNG checkpoints\n- Keep encoding quality unchanged while removing the serial PNG-only encode bottleneck\n- Add focused backend tests for FFmpeg command generation, stderr parsing, atomic frame writes, and resume behavior\n\n## Validation\n- 
> nx run backend:lint  [existing outputs match the cache, left as is]

> command -v ../../../.venv/bin/ruff >/dev/null 2>&1 && RUFF=../../../.venv/bin/ruff || RUFF=ruff; $RUFF check . --output-format=github

> command -v ../../../.venv/bin/black >/dev/null 2>&1 && BLACK=../../../.venv/bin/black || BLACK=black; $BLACK --check --diff .

All done! ✨ 🍰 ✨
194 files would be left unchanged.



 NX   Successfully ran target lint for project backend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

  Run duration:      19ms
  Cache:             1/1 hit (100%)
  Critical path:     3ms (1 task)
  Recoverable time:  <1ms ✅\n- 
> nx run backend:test  [local cache]

> command -v ../../../.venv/bin/pytest >/dev/null 2>&1 && PYTEST=../../../.venv/bin/pytest || PYTEST=pytest; $PYTEST tests/ -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml

[1m============================= test session starts ==============================[0m
collected 849 items / 3 deselected / 846 selected

tests/api/test_admin_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                       [  2%][0m
tests/api/test_deployment_drain.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [  3%][0m
tests/api/test_gopro_overlay_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [  6%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 11%][0m
tests/api/test_intervals_sync.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 12%][0m
tests/api/test_metrics.py [32m.[0m[32m.[0m[33m                                             [ 12%][0m
tests/api/test_routes_azba_airspace.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                              [ 13%][0m
tests/api/test_routes_flight_decision.py [32m.[0m[32m.[0m[32m.[0m[33m                             [ 13%][0m
tests/api/test_routes_flight_summaries.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                      [ 14%][0m
tests/api/test_routes_flights.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 19%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                          [ 21%][0m
tests/api/test_routes_landings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                        [ 22%][0m
tests/api/test_routes_live_wind.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                 [ 23%][0m
tests/api/test_routes_settings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                 [ 26%][0m
tests/api/test_routes_spots.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 30%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                  [ 31%][0m
tests/api/test_routes_version.py [32m.[0m[32m.[0m[33m                                      [ 32%][0m
tests/api/test_routes_weather_simple.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                [ 34%][0m
tests/api/test_video_export_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 37%]
[0m[32m.[0m[32m.[0m[33m                                                                       [ 37%][0m
tests/scrapers/test_met_no.py [32m.[0m[33m                                          [ 38%][0m
tests/scrapers/test_meteo_parapente.py [33mx[0m[33m                                 [ 38%][0m
tests/scrapers/test_meteoblue.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 39%][0m
tests/scrapers/test_meteociel.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                   [ 39%][0m
tests/scrapers/test_open_meteo.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[33m                                   [ 40%][0m
tests/scrapers/test_openweathermap.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 40%][0m
tests/scrapers/test_weatherapi.py [33mX[0m[32m.[0m[33m                                     [ 40%][0m
tests/test_admin.py [32m.[0m[32m.[0m[32m.[0m[33m                                                  [ 41%][0m
tests/test_emagram.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                           [ 44%][0m
tests/test_emagram_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m              [ 47%][0m
tests/test_models.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                             [ 50%][0m
tests/test_routes.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                     [ 51%][0m
tests/test_scrapers.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                           [ 52%][0m
tests/unit/test_app_settings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                         [ 54%][0m
tests/unit/test_azba_airspace.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 55%][0m
tests/unit/test_best_spot.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m    [ 60%][0m
tests/unit/test_best_spot_algorithm.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 64%]
[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                      [ 64%][0m
tests/unit/test_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                       [ 65%][0m
tests/unit/test_codex_analyzer.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                              [ 66%][0m
tests/unit/test_e2e_db_utils.py [32m.[0m[33m                                        [ 66%][0m
tests/unit/test_emagram_cache.py [32m.[0m[32m.[0m[32m.[0m[33m                                     [ 67%][0m
tests/unit/test_emagram_generation_failures.py [32m.[0m[32m.[0m[33m                        [ 67%][0m
tests/unit/test_emagram_llm_fallback.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                  [ 69%][0m
tests/unit/test_emagram_thermal_validation.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                       [ 69%][0m
tests/unit/test_external_flight_import.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                           [ 69%][0m
tests/unit/test_external_identity_migration.py [32m.[0m[32m.[0m[33m                        [ 70%][0m
tests/unit/test_flight_decision.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                             [ 71%][0m
tests/unit/test_flight_storage.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 72%][0m
tests/unit/test_flight_summary_migration.py [32m.[0m[33m                            [ 72%][0m
tests/unit/test_flight_tracks.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                            [ 73%][0m
tests/unit/test_intervals_config.py [32m.[0m[32m.[0m[32m.[0m[33m                                  [ 74%][0m
tests/unit/test_intervals_icu.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                  [ 74%][0m
tests/unit/test_intervals_sync.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                 [ 75%][0m
tests/unit/test_job_queue.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                        [ 76%][0m
tests/unit/test_main.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                           [ 76%][0m
tests/unit/test_max_speed_backfill.py [32m.[0m[33m                                  [ 76%][0m
tests/unit/test_meteociel_emagram_screenshot.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                     [ 77%][0m
tests/unit/test_metrics_helpers.py [32m.[0m[33m                                     [ 77%][0m
tests/unit/test_open_meteo_emagram_sources.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                       [ 77%][0m
tests/unit/test_para_index.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m     [ 82%][0m
tests/unit/test_required_env.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 83%][0m
tests/unit/test_scheduler.py [32m.[0m[32m.[0m[33ms[0m[33ms[0m[33ms[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33ms[0m[33ms[0m[33m                       [ 86%][0m
tests/unit/test_screenshot_inputs.py [32m.[0m[33m                                   [ 86%][0m
tests/unit/test_seed_weather_sources.py [32m.[0m[32m.[0m[33m                               [ 86%][0m
tests/unit/test_spotair_live_wind.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                          [ 87%][0m
tests/unit/test_spots_distance.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m               [ 90%][0m
tests/unit/test_versioning.py [32m.[0m[32m.[0m[32m.[0m[33m                                        [ 90%][0m
tests/unit/test_video_export_manual.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 94%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                 [ 97%][0m
tests/unit/test_video_export_stream_admission.py [32m.[0m[32m.[0m[33m                      [ 97%][0m
tests/unit/test_weather_pipeline_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                        [ 98%][0m
tests/unit/test_weather_pipeline_sources.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                         [ 99%][0m
tests/unit/test_weather_sources_registry.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                     [100%][0m

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.13.5-final-0 ________________

Name                                  Stmts   Miss   Cover   Missing
--------------------------------------------------------------------
__init__.py                               2      0 100.00%
api/__init__.py                           0      0 100.00%
api/routes/__init__.py                    0      0 100.00%
app_settings.py                          59      0 100.00%
auth.py                                 102     51  50.00%   32-34, 38-40, 44-46, 52, 56, 75, 114-126, 131-134, 139-173
azba_airspace.py                        240     31  87.08%   49-53, 63, 70, 78, 87, 93-95, 103, 115, 121, 150, 157, 164, 180, 182, 187, 205, 208, 259, 273, 277-278, 280, 294-295, 336
benchmark_flight_summaries.py            52     52   0.00%   3-97
best_spot.py                            344     73  78.78%   34-36, 126, 160-161, 222, 227, 249-250, 256, 291, 297-303, 307, 311, 313, 345-347, 389-403, 407-409, 417-419, 505-508, 512-515, 548, 554-556, 571-572, 589-590, 594, 621, 649-651, 655-656, 664-666, 698-699, 712-715, 727-730, 748-752, 788-789
cache.py                                143     39  72.73%   72-79, 117-131, 197-198, 221-224, 228-229, 259-260, 277-299
config.py                               128     15  88.28%   48-50, 54, 264-277
database.py                              27      8  70.37%   16-24, 42-46
deployment_drain.py                     179     58  67.60%   148, 156-159, 165, 193-200, 222-234, 241, 248-261, 268, 274-278, 284-289, 306-351
e2e_db_utils.py                           7      0 100.00%
emagram_aggregator.py                    33     33   0.00%   6-181
emagram_freshness.py                     11      2  81.82%   23-24
emagram_multi_source.py                 374    109  70.86%   56-57, 67, 73, 87, 280, 285-286, 306, 351, 364-365, 456, 479, 512, 566-567, 570-571, 602-605, 640-656, 672-729, 746-760, 780-783, 939-944, 953-965, 1022-1081
env_utils.py                              9      0 100.00%
external_flight_import.py               153     24  84.31%   31, 64, 67-68, 78, 82, 85-86, 126, 166-167, 217-223, 225-230
flight_backfill.py                       27     27   0.00%   1-53
flight_decision.py                      265     36  86.42%   235, 239-240, 310, 322, 324, 362, 379, 385, 398, 416, 426, 458, 472, 549, 551, 572-598, 629, 643, 685, 715, 743, 745-751, 753, 755
flight_storage.py                        44      7  84.09%   17, 31, 52-54, 63-64
flight_summaries.py                     122     16  86.89%   77, 80, 82-85, 110, 145-149, 163, 179, 222, 297
flight_tracks.py                        221     17  92.31%   40, 43, 55, 62, 67, 115, 158, 160, 176, 189, 191, 207, 211, 237, 245, 247, 314
gopro_overlay_export.py                1154    367  68.20%   123-127, 147-155, 160, 178, 182, 187, 218-222, 225-228, 230-232, 247, 283, 289, 375-378, 388-389, 435, 448, 450-452, 456, 462, 465, 467, 475, 480, 482, 493-499, 507, 520-522, 535-537, 540-542, 549, 568-569, 586-601, 608-616, 624-625, 635-661, 685-689, 694, 697-698, 700, 705-719, 723-744, 753-785, 794-795, 802, 810, 822, 865, 881, 946-950, 953-957, 959-961, 963, 975-976, 985, 989, 995, 1034-1036, 1061, 1074, 1079, 1106, 1162, 1165, 1191, 1196-1207, 1215-1221, 1232, 1242, 1274-1301, 1344-1348, 1351, 1357-1358, 1410-1412, 1437, 1479-1481, 1484, 1550, 1576, 1585-1588, 1593, 1602-1612, 1628-1629, 1639-1648, 1658, 1679-1688, 1692-1700, 1708-1716, 1728-1730, 1764-1780, 1785, 1788-1791, 1798-1799, 1803-1804, 1813, 1819, 1825, 1836, 1847-1849, 1853-1866, 1891, 1907, 1910, 1913, 1919, 1939-1945, 1956-1963, 1975-1983, 1989, 1995, 1997, 2012-2018, 2025-2028, 2046-2048, 2060, 2062, 2065, 2083-2099, 2106-2107, 2111-2124, 2128-2134
gopro_overlay_worker.py                  18     18   0.00%   3-31
init_e2e_db.py                           10     10   0.00%   4-20
intervals_icu.py                        108     24  77.78%   54, 57-58, 109, 121, 138, 140-141, 143, 165-178, 180
intervals_sync.py                        50      9  82.00%   51-53, 61-62, 85-88
job_queue.py                             44     12  72.73%   19, 28, 36, 49, 53-60
job_worker.py                            18     18   0.00%   3-31
main.py                                 265    156  41.13%   42-265, 315-341, 350-420, 426-427, 445-447, 469-471, 482-483, 499, 503-504, 614-633
meteorology/__init__.py                   0      0 100.00%
meteorology/classic_analysis.py         211     66  68.72%   56, 85, 100, 103-105, 111, 114-116, 126-128, 144-146, 152-154, 161-163, 170, 176-179, 185-192, 197, 200-205, 231-232, 255-264, 274, 297, 315, 320, 322, 326, 335-336, 365-366, 369-370, 379-380, 395-396, 425, 427, 436, 452, 458
metrics.py                              119      3  97.48%   84, 118, 212
models.py                               314      7  97.77%   336, 343, 358, 361-365, 522
para_index.py                           254     26  89.76%   56-57, 71, 144, 150, 170-171, 254-255, 259-260, 267-268, 343, 391-401, 434, 440, 458
pipeline/__init__.py                      0      0 100.00%
routes.py                              2925   1057  63.86%   186, 256, 269, 283, 295, 328, 335-336, 368, 372, 382, 391-393, 425, 469, 473, 502-504, 506-507, 509, 542, 562, 621, 781, 796, 811, 835-851, 857, 889-902, 909, 943-966, 980-982, 1006, 1010, 1038-1039, 1092, 1103, 1113, 1169, 1171, 1175, 1185, 1189, 1195, 1203, 1218-1244, 1275, 1311-1380, 1452-1454, 1471-1472, 1496-1499, 1544-1569, 1601, 1606, 1612, 1650-1653, 1680-1682, 1697-1700, 1743-1746, 1799, 1836-1838, 1877, 1917-2008, 2070, 2074-2076, 2093-2110, 2236-2240, 2261-2264, 2283-2297, 2313-2337, 2345-2379, 2394-2396, 2400, 2412, 2423-2424, 2451-2452, 2506, 2518-2540, 2572, 2577, 2584, 2597, 2652, 2663-2665, 2722-2724, 2740-2743, 2751, 2757-2759, 2769-2823, 2849, 2895, 2926-2927, 3023-3029, 3041-3109, 3203, 3219, 3323-3348, 3447-3471, 3491-3497, 3506-3508, 3564-3565, 3569-3573, 3633-3635, 3931, 3934-3937, 4023, 4107-4109, 4142-4144, 4163-4166, 4177, 4182-4209, 4218-4240, 4248, 4253-4260, 4268, 4274, 4284, 4288, 4306, 4337-4340, 4388, 4423-4424, 4433-4436, 4457-4595, 4617-4620, 4631-4634, 4648-4677, 4698, 4718-4730, 4764-4855, 4863-4912, 4923-4938, 4951-4980, 4987-5068, 5086-5099, 5108-5117, 5124-5127, 5133, 5187-5188, 5251, 5270-5279, 5310, 5315, 5319, 5336, 5373, 5391-5421, 5451, 5457, 5459, 5462-5478, 5486, 5493, 5497, 5499, 5505, 5543, 5548-5566, 5624, 5627, 5630, 5646-5647, 5653-5654, 5663, 5670-5674, 5683-5691, 5700, 5727, 5734, 5751, 5779, 5783, 5801, 5809, 5852-5862, 5898-5899, 5910, 5920-5922, 5935-5937, 5945, 5951, 5959, 5963, 5965, 5991-5992, 5998-5999, 6011-6012, 6036, 6101, 6120-6139, 6160-6188, 6207-6232, 6257-6330, 6367, 6398-6432, 6469, 6506, 6535, 6553, 6562, 6566, 6572-6574, 6658, 6690-6692, 6744-6746, 6767-6869, 6907-6931, 6947-6976, 6980-7001, 7022-7036, 7039, 7042-7044, 7084-7107, 7133, 7137-7146, 7177-7210, 7235, 7238, 7243-7244, 7250-7251, 7284, 7286, 7307-7322, 7325, 7329, 7342-7343, 7400-7402, 7412-7413, 7431-7448, 7547-7548, 7648-7649, 7654, 7673-7678
scheduler.py                            157     60  61.78%   61-158, 182-183, 228, 279, 285-286, 317-323, 332-333
schemas.py                              745     44  94.09%   146-148, 152-154, 158-160, 164-166, 170-172, 176-178, 289, 295, 319-321, 327, 333-335, 382-390, 792, 796, 1008, 1013, 1018-1023
scrapers/__init__.py                      6      0 100.00%
scrapers/base.py                         95     49  48.42%   103-130, 163, 172-179, 204-223, 241-243, 247-266
scrapers/config.py                       13     13   0.00%   3-122
scrapers/exceptions.py                   12     12   0.00%   4-37
scrapers/met_no.py                       42     16  61.90%   16-43, 56, 60, 71, 75
scrapers/meteo_parapente.py             174    123  29.31%   21-23, 37, 53-56, 102-125, 144-145, 155-156, 167-171, 186-193, 234-312, 359-393, 413-480
scrapers/meteo_parapente_emagram.py      72     72   0.00%   6-224
scrapers/meteoblue.py                   246    103  58.13%   94-102, 139-141, 156-236, 265-266, 277-278, 305, 318, 330, 354-361, 373, 385, 400-402, 415, 425-436, 452, 464, 468, 474-477, 492-514, 533-534
scrapers/meteociel.py                   235     77  67.23%   22-24, 63-96, 126-131, 160-161, 164-166, 197, 205, 228-235, 261, 266, 280, 312, 377-379, 407-410, 419, 438-463, 501-502
scrapers/open_meteo.py                   61     35  42.62%   37-39, 56-58, 73-74, 115-146, 166-226
scrapers/openweathermap.py               50      7  86.00%   24, 63-64, 77, 81, 101, 105
scrapers/sources/__init__.py              0      0 100.00%
scrapers/utils.py                        68     68   0.00%   3-205
scrapers/weatherapi.py                   34     21  38.24%   36-38, 51-52, 72-108
spotair_live_wind.py                    101     19  81.19%   65, 72, 97-117, 120-121, 131, 136-137, 145-146
spots/__init__.py                         5      0 100.00%
spots/data_fetcher.py                   161     73  54.66%   58-116, 147-148, 156-157, 164, 206-208, 213-218, 244-301, 347-348, 367-372, 382-384, 400-403
spots/distance.py                        31      9  70.97%   100-113
spots/geocoding.py                       93     60  35.48%   66-75, 80-82, 104-105, 118-123, 132-197, 206-208, 218
spots/search.py                          82     30  63.41%   107-165, 207-208, 252, 316
spots/site_updater.py                    70     54  22.86%   45-120, 127-131, 144-160
versioning.py                            69      8  88.41%   31-32, 44-46, 52-53, 119
weather_pipeline.py                     335    157  53.13%   51, 55, 91-139, 184-186, 196-233, 245-250, 265-289, 293-295, 332, 359-364, 381-422, 460, 490-491, 509-510, 656, 668-669, 747-748, 801-866, 899-928
weather_sources.py                       83      6  92.77%   63, 90, 119, 134, 277, 297
--------------------------------------------------------------------
TOTAL                                 11072   3487  68.51%
Coverage XML written to file ../../coverage/apps/backend/coverage.xml
[33m= [32m836 passed[0m, [33m[1m5 skipped[0m, [33m[1m3 deselected[0m, [33m[1m1 xfailed[0m, [33m[1m4 xpassed[0m, [33m[1m1279 warnings[0m[33m in 88.52s (0:01:28)[0m[33m =[0m



 NX   Successfully ran target test for project backend

Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

  Run duration:      28ms
  Cache:             1/1 hit (100%)
  Critical path:     8ms (1 task)
  Recoverable time:  <1ms ✅\n-  image2pipe smoke test ✅\n- CodeRabbit review ✅\n\n## Notes\n- Nx affected frontend/design-system tests produced pre-existing Vitest browser connection errors unrelated to this backend change; backend validation passed cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video export reliability during fast and standard export modes.
  * Prevented incomplete frame files from being used when resuming exports.
  * Added safer handling for cancellation, stalled encoding, timeouts, and cleanup.
  * Ensured exported videos are finalized atomically, reducing the risk of incomplete output files.
* **Performance**
  * Improved FFmpeg progress monitoring and buffering for smoother exports.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->