### PR TITLE
feat(flights): improve media job logs

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -48,6 +48,14 @@ _PROGRESS_PERCENT_RE = re.compile(r"(?P<percent>\d{1,3})\s*%")
 _LOG_TAIL_LINE_COUNT = 100
 
 
+def _gopro_overlay_log_dir() -> Path:
+    return Path(config.GOPRO_OVERLAY_PARAGLIDING_ROOT) / ".logs" / "gopro-overlays"
+
+
+def _gopro_overlay_log_path(job_id: str) -> Path:
+    return _gopro_overlay_log_dir() / f"{job_id}.log"
+
+
 @dataclass(frozen=True)
 class GoproOverlayLayout:
     id: str
@@ -1439,7 +1447,7 @@ def _create_gopro_overlay_job_from_paths(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_output_path = _temp_output_path(output_path, job_id)
-    log_path = work_dir / "overlay.log"
+    log_path = _gopro_overlay_log_path(job_id)
     preparation_metadata = _job_preparation_metadata(
         pin_inputs=pin_inputs,
         requested_layout_id=layout_id,
@@ -2031,6 +2039,20 @@ def delete_gopro_overlay_job(job_id: str) -> dict[str, Any] | None:
         result["dirs_deleted"] = dirs_count
         result["bytes_deleted"] = bytes_count
         result["paths_deleted"] = [str(work_dir)]
+
+    log_path_value = job.get("log_path")
+    if log_path_value:
+        log_path = Path(str(log_path_value))
+        if log_path.exists() and _is_path_inside(log_path, _gopro_overlay_log_dir()):
+            try:
+                log_size = log_path.stat().st_size
+                log_path.unlink()
+            except OSError as exc:
+                result["errors"].append({"path": str(log_path), "error": str(exc)})
+                return result
+            result["files_deleted"] += 1
+            result["bytes_deleted"] += log_size
+            result["paths_deleted"].append(str(log_path))
 
     with _LOCK:
         _JOBS.pop(job_id, None)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1192,6 +1192,10 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
     work_dir.mkdir(parents=True)
     layout_path = work_dir / "layout.xml"
     layout_path.write_text("<layout />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+    log_path = gopro_overlay_export._gopro_overlay_log_path(job_id)
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("Overlay rendering failed\n")
 
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     session = test_db()
@@ -1213,6 +1217,7 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
                 output_path=str(tmp_path / "final.mp4"),
                 temp_output_path=str(tmp_path / "final.part.mp4"),
                 output_filename="final.mp4",
+                log_path=str(log_path),
             )
         )
         session.add(
@@ -1232,8 +1237,9 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
 
     assert result is not None
     assert result["deleted"] is True
-    assert result["files_deleted"] == 1
+    assert result["files_deleted"] == 2
     assert not work_dir.exists()
+    assert not log_path.exists()
     assert gopro_overlay_export.get_gopro_overlay_job(job_id) is None
     session = test_db()
     try:
@@ -1243,6 +1249,28 @@ def test_delete_gopro_overlay_job_removes_terminal_row_and_work_dir(
         assert flight.gopro_overlay_status is None
     finally:
         session.close()
+
+
+def test_overlay_log_survives_work_directory_cleanup(tmp_path, monkeypatch):
+    job_id = "job-overlay-persistent-log"
+    work_dir = tmp_path / ".gopro-overlay-work" / job_id
+    work_dir.mkdir(parents=True)
+    layout_path = work_dir / "layout.xml"
+    layout_path.write_text("<layout />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+    log_path = gopro_overlay_export._gopro_overlay_log_path(job_id)
+    gopro_overlay_export._append_job_log(log_path, "Overlay ready")
+
+    gopro_overlay_export._cleanup_gopro_overlay_temp_files(
+        {
+            "layout_path": str(layout_path),
+            "log_path": str(log_path),
+            "temp_output_path": str(work_dir / "final.part.mp4"),
+        }
+    )
+
+    assert not work_dir.exists()
+    assert "Overlay ready" in log_path.read_text()
 
 
 def test_reconcile_gopro_overlay_flight_refs_clears_missing_active_job(test_db, monkeypatch):

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -17,6 +17,32 @@ import video_export
 import video_export_manual
 
 
+def test_video_export_log_survives_temp_cleanup_until_job_deletion(tmp_path, monkeypatch):
+    export_root = tmp_path / "exports"
+    temp_root = tmp_path / "temp"
+    job_id = "job-persistent-log"
+    job_temp_dir = temp_root / job_id
+    job_temp_dir.mkdir(parents=True)
+    (job_temp_dir / "frame.png").write_bytes(b"frame")
+
+    monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+
+    video_export_manual._log_job(job_id, "Captured 10/100 frames")
+    log_path = video_export_manual._job_log_path(job_id)
+
+    video_export_manual.cleanup_video_export_temp_files(
+        [{"job_id": job_id, "status": "completed", "internal_status": "completed"}]
+    )
+
+    assert not job_temp_dir.exists()
+    assert "Captured 10/100 frames" in log_path.read_text()
+
+    video_export_manual.cleanup_video_export_job_temp_files(job_id)
+
+    assert not log_path.exists()
+
+
 def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
     """Production should avoid localhost:5173 when static frontend is bundled."""
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -46,7 +46,7 @@ _LOG_TAIL_LINE_COUNT = 100
 
 
 def _job_log_path(job_id: str) -> Path:
-    return _job_temp_dir(_video_temp_images_dir(), job_id) / "export.log"
+    return _video_export_dir() / ".logs" / "video-exports" / f"{job_id}.log"
 
 
 def _tail_log_lines(path: Path, limit: int = _LOG_TAIL_LINE_COUNT) -> list[str]:
@@ -888,12 +888,13 @@ def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, 
 
 
 def cleanup_video_export_job_temp_files(job_id: str) -> dict[str, Any]:
-    """Delete temporary files for a single inactive video export job."""
+    """Delete temporary and log files for an explicitly deleted export job."""
     candidates = [
         (_job_temp_dir(_video_temp_images_dir(), job_id), _video_temp_images_dir()),
         (_video_export_dir() / f"frames_{job_id}", _video_export_dir()),
         (Path("/tmp") / f"playwright-debug-{job_id}.png", Path("/tmp")),
         (Path("/tmp") / f"playwright-error-{job_id}.png", Path("/tmp")),
+        (_job_log_path(job_id), _video_export_dir()),
     ]
 
     deleted_paths: list[str] = []

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -283,7 +283,7 @@ describe('FlightDetails GoPro overlay action', () => {
     expect(screen.getByText('GoPro overlay')).toBeInTheDocument();
     expect(screen.getByText('Encoding with FFmpeg')).toBeInTheDocument();
     expect(screen.getByText('Overlay failed on frame 42')).toBeInTheDocument();
-    expect(screen.getByText(/Frame 42 failed/u)).toBeInTheDocument();
+    expect(screen.getAllByText(/Frame 42 failed/u).length).toBeGreaterThan(0);
   });
 
   it('does not render an empty generation logs panel', () => {

--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { VideoExportStatusPayload } from '../../../hooks/flights/useVideoExportStatus';
 import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
+import { JobLogViewer } from '../job-logs/JobLogViewer';
 
 type FlightGenerationLogsPanelProps = {
   videoStatus: VideoExportStatusPayload | null;
@@ -45,22 +46,6 @@ function getStatusTone(status: string | null) {
   return 'border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-100';
 }
 
-function getLogContent(
-  lines: string[],
-  hasDetails: boolean,
-  t: ReturnType<typeof useTranslation>['t']
-) {
-  if (lines.length > 0) {
-    return lines.join('\n');
-  }
-
-  if (hasDetails) {
-    return t('flights.generationLogs.noRawLogs');
-  }
-
-  return t('flights.generationLogs.noLogs');
-}
-
 function LogSourceCard({
   title,
   status,
@@ -75,6 +60,12 @@ function LogSourceCard({
   const normalizedProgress = clampProgress(progress);
   const hasDetails = Boolean(message || error || lines.length > 0);
   const statusTone = getStatusTone(status);
+  const showCurrentMessage = Boolean(
+    message && !lines.some((line) => line.includes(message))
+  );
+  const isLive = Boolean(
+    status && !['cancelled', 'completed', 'failed'].includes(status)
+  );
 
   return (
     <section className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900/70">
@@ -83,7 +74,7 @@ function LogSourceCard({
           <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
             {title}
           </h4>
-          {message && (
+          {showCurrentMessage && (
             <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">
               {message}
             </p>
@@ -124,13 +115,16 @@ function LogSourceCard({
         </div>
       )}
 
-      <div className="mt-3 rounded-lg border border-slate-200 bg-slate-950 p-2 dark:border-slate-700">
-        <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-300">
-          {t('flights.generationLogs.rawLogs')}
-        </div>
-        <pre className="max-h-48 overflow-auto whitespace-pre-wrap font-mono text-xs leading-relaxed text-slate-100">
-          {getLogContent(lines, hasDetails, t)}
-        </pre>
+      <div className="mt-3">
+        <JobLogViewer
+          logs={lines}
+          isLive={isLive}
+          emptyLabel={
+            hasDetails
+              ? t('flights.generationLogs.noRawLogs')
+              : t('flights.generationLogs.noLogs')
+          }
+        />
       </div>
     </section>
   );
@@ -171,7 +165,7 @@ export function FlightGenerationLogsPanel({
           {t('flights.generationLogs.description')}
         </p>
       </div>
-      <div className="grid gap-3 lg:grid-cols-2">
+      <div className="space-y-3">
         {hasVideoLogSource && (
           <LogSourceCard
             title={t('flights.generationLogs.videoTitle')}

--- a/apps/frontend/src/components/flights/job-logs/JobLogViewer.test.tsx
+++ b/apps/frontend/src/components/flights/job-logs/JobLogViewer.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { JobLogViewer } from './JobLogViewer';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'fr' },
+    t: (key: string, values?: { count?: number }) =>
+      ({
+        'flights.generationLogs.activity': 'Journal d’activité',
+        'flights.generationLogs.technicalDetails': 'Détails techniques',
+        'flights.generationLogs.level.info': 'Information',
+        'flights.generationLogs.level.success': 'Succès',
+        'flights.generationLogs.level.warning': 'Attention',
+        'flights.generationLogs.level.error': 'Erreur',
+        'flights.generationLogs.lineCount': `${values?.count ?? 0} lignes`,
+      })[key] ?? key,
+  }),
+}));
+
+describe('JobLogViewer', () => {
+  it('renders timestamped events as a readable activity journal', () => {
+    render(
+      <JobLogViewer
+        logs={[
+          '[2026-07-31T10:15:20+00:00] Video encoded successfully',
+          '[2026-07-31T10:16:20+00:00] FFmpeg timeout while encoding',
+        ]}
+        emptyLabel="Aucun événement"
+      />
+    );
+
+    expect(screen.getByLabelText('Journal d’activité')).toBeInTheDocument();
+    expect(screen.getByText('Video encoded successfully')).toBeInTheDocument();
+    expect(
+      screen.getByText('FFmpeg timeout while encoding')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Succès:')).toBeInTheDocument();
+    expect(screen.getByText('Erreur:')).toBeInTheDocument();
+  });
+
+  it('keeps raw technical lines in a collapsed section', () => {
+    render(
+      <JobLogViewer
+        logs={['[2026-07-31T10:15:20+00:00] Captured 10/100 frames']}
+        emptyLabel="Aucun événement"
+      />
+    );
+
+    const summary = screen.getByText('Détails techniques');
+    const details = summary.closest('details');
+    expect(details).not.toHaveAttribute('open');
+
+    fireEvent.click(summary);
+
+    expect(details).toHaveAttribute('open');
+    expect(
+      screen.getByText('[2026-07-31T10:15:20+00:00] Captured 10/100 frames')
+    ).toBeInTheDocument();
+  });
+
+  it('shows an explicit empty state', () => {
+    render(<JobLogViewer logs={[]} emptyLabel="Aucun événement reçu" />);
+
+    expect(screen.getByText('Aucun événement reçu')).toBeInTheDocument();
+    expect(screen.queryByText('Détails techniques')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/flights/job-logs/JobLogViewer.tsx
+++ b/apps/frontend/src/components/flights/job-logs/JobLogViewer.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Info,
+  Terminal,
+  TriangleAlert,
+} from 'lucide-react';
+
+type LogTone = 'error' | 'info' | 'success' | 'warning';
+
+type JobLogViewerProps = {
+  logs?: string[] | null;
+  emptyLabel: string;
+  isLive?: boolean;
+};
+
+const LOG_LINE_PATTERN = /^\[([^\u005d]+)\]\s*(.*)$/u;
+
+const toneStyles: Record<LogTone, string> = {
+  error:
+    'border-red-200 bg-red-50 text-red-900 dark:border-red-900/80 dark:bg-red-950/30 dark:text-red-100',
+  warning:
+    'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900/80 dark:bg-amber-950/30 dark:text-amber-100',
+  success:
+    'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-900/80 dark:bg-emerald-950/30 dark:text-emerald-100',
+  info: 'border-slate-200 bg-white text-slate-800 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
+};
+
+const toneFallbacks: Record<LogTone, string> = {
+  error: 'Error',
+  info: 'Information',
+  success: 'Success',
+  warning: 'Warning',
+};
+
+function getLogTone(message: string): LogTone {
+  if (/\b(error|failed|failure|fatal|timeout|timed out)\b/iu.test(message)) {
+    return 'error';
+  }
+  if (
+    /\b(warn|warning|cancelled|retry|missing|still loading)\b/iu.test(message)
+  ) {
+    return 'warning';
+  }
+  if (
+    /\b(completed|ready|encoded|created|configured|prepared|found)\b/iu.test(
+      message
+    )
+  ) {
+    return 'success';
+  }
+  return 'info';
+}
+
+function getLogIcon(tone: LogTone) {
+  const className = 'mt-0.5 h-4 w-4 shrink-0';
+  if (tone === 'error')
+    return <AlertCircle className={className} aria-hidden="true" />;
+  if (tone === 'warning')
+    return <TriangleAlert className={className} aria-hidden="true" />;
+  if (tone === 'success')
+    return <CheckCircle2 className={className} aria-hidden="true" />;
+  return <Info className={className} aria-hidden="true" />;
+}
+
+function parseLogLine(line: string) {
+  const match = LOG_LINE_PATTERN.exec(line);
+  if (!match) {
+    return { message: line, timestamp: null };
+  }
+  return { message: match[2] || line, timestamp: match[1] || null };
+}
+
+function formatLogTime(timestamp: string | null, locale?: string) {
+  if (!timestamp) return null;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(date);
+}
+
+export function JobLogViewer({
+  logs,
+  emptyLabel,
+  isLive = false,
+}: JobLogViewerProps) {
+  const { t, i18n } = useTranslation();
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const lines = logs?.filter(Boolean) ?? [];
+
+  useEffect(() => {
+    if (!isLive || !scrollContainerRef.current) return;
+    scrollContainerRef.current.scrollTop =
+      scrollContainerRef.current.scrollHeight;
+  }, [isLive, lines.length]);
+
+  if (lines.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-300">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div
+        ref={scrollContainerRef}
+        className="max-h-72 overflow-y-auto rounded-lg border border-slate-200 bg-slate-100/70 p-2 dark:border-slate-700 dark:bg-slate-950/50"
+        aria-label={t('flights.generationLogs.activity', 'Activity log')}
+        aria-live={isLive ? 'polite' : 'off'}
+      >
+        <ol className="space-y-1.5">
+          {lines.map((line, index) => {
+            const entry = parseLogLine(line);
+            const tone = getLogTone(entry.message);
+            const time = formatLogTime(entry.timestamp, i18n?.language);
+            return (
+              <li
+                key={`${index}-${line}`}
+                className={`flex gap-2 rounded-md border px-2.5 py-2 text-xs leading-relaxed ${toneStyles[tone]}`}
+              >
+                {getLogIcon(tone)}
+                <span className="sr-only">
+                  {t(
+                    `flights.generationLogs.level.${tone}`,
+                    toneFallbacks[tone]
+                  )}
+                  :
+                </span>
+                {time && (
+                  <time
+                    dateTime={entry.timestamp ?? undefined}
+                    className="shrink-0 font-mono text-[11px] opacity-70"
+                  >
+                    {time}
+                  </time>
+                )}
+                <span className="min-w-0 break-words">{entry.message}</span>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <details className="group rounded-lg border border-slate-200 bg-slate-950 dark:border-slate-700">
+        <summary className="flex cursor-pointer list-none items-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold text-slate-200 transition-colors hover:bg-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500">
+          <Terminal className="h-4 w-4" aria-hidden="true" />
+          {t('flights.generationLogs.technicalDetails', 'Technical details')}
+          <span className="ml-auto font-normal text-slate-400">
+            {t('flights.generationLogs.lineCount', '{{count}} lines', {
+              count: lines.length,
+            })}
+          </span>
+        </summary>
+        <pre className="max-h-64 overflow-auto whitespace-pre-wrap border-t border-slate-800 p-3 font-mono text-xs leading-relaxed text-slate-100">
+          {lines.join('\n')}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -193,7 +193,9 @@ describe('FlightVideoExportControls', () => {
 
     expect(screen.getByText('Live logs')).toBeInTheDocument();
     expect(screen.getByText('Hide')).toBeInTheDocument();
-    expect(screen.getByText(/Encoding with FFmpeg/u)).toBeInTheDocument();
+    expect(screen.getAllByText(/Encoding with FFmpeg/u).length).toBeGreaterThan(
+      0
+    );
   });
 
   it('restores live logs from session storage on remount', () => {
@@ -221,7 +223,9 @@ describe('FlightVideoExportControls', () => {
 
     expect(screen.getByText('Live logs')).toBeInTheDocument();
     expect(screen.getByText('Hide')).toBeInTheDocument();
-    expect(screen.getByText(/Encoding with FFmpeg/u)).toBeInTheDocument();
+    expect(screen.getAllByText(/Encoding with FFmpeg/u).length).toBeGreaterThan(
+      0
+    );
   });
 
   it('does not show the download button for completed videos', () => {

--- a/apps/frontend/src/components/flights/video-export/JobLiveLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/JobLiveLogsPanel.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@dashboard-parapente/design-system';
+import { JobLogViewer } from '../job-logs/JobLogViewer';
 
 type JobLiveLogsPanelProps = {
   title: string;
@@ -40,9 +41,9 @@ export function JobLiveLogsPanel({
         </span>
       </Button>
       {isOpen && (
-        <pre className="max-h-64 overflow-auto border-t border-slate-200 p-3 text-xs leading-relaxed text-slate-800 dark:border-slate-700 dark:text-slate-100">
-          {lines.length > 0 ? lines.join('\n') : emptyLabel}
-        </pre>
+        <div className="border-t border-slate-200 p-3 dark:border-slate-700">
+          <JobLogViewer logs={lines} emptyLabel={emptyLabel} isLive />
+        </div>
       )}
     </div>
   );

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1013,9 +1013,18 @@
       "goproOverlayTitle": "GoPro overlay",
       "progress": "Progress",
       "error": "Error",
-      "rawLogs": "Raw logs",
+      "activity": "Activity log",
+      "technicalDetails": "Technical details",
+      "lineCount_one": "{{count}} line",
+      "lineCount_other": "{{count}} lines",
       "noLogs": "No log available yet.",
-      "noRawLogs": "No raw log available; only the current message is exposed.",
+      "noRawLogs": "No detailed event has been received yet; status and errors remain visible above.",
+      "level": {
+        "info": "Information",
+        "success": "Success",
+        "warning": "Warning",
+        "error": "Error"
+      },
       "status": {
         "queued": "Queued",
         "processing": "Running",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1017,9 +1017,18 @@
       "goproOverlayTitle": "Overlay GoPro",
       "progress": "Progression",
       "error": "Erreur",
-      "rawLogs": "Logs bruts",
+      "activity": "Journal d’activité",
+      "technicalDetails": "Détails techniques",
+      "lineCount_one": "{{count}} ligne",
+      "lineCount_other": "{{count}} lignes",
       "noLogs": "Aucun log disponible pour le moment.",
-      "noRawLogs": "Aucun log brut disponible ; seul le message courant est exposé.",
+      "noRawLogs": "Aucun événement détaillé n’a encore été reçu ; le statut et les erreurs restent affichés ci-dessus.",
+      "level": {
+        "info": "Information",
+        "success": "Succès",
+        "warning": "Attention",
+        "error": "Erreur"
+      },
       "status": {
         "queued": "En attente",
         "processing": "En cours",


### PR DESCRIPTION
## Summary\n- Persist video and GoPro overlay logs outside temporary work directories\n- Render a readable activity journal with collapsible technical details\n- Add regression coverage for log persistence and UI rendering\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e\n- /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer job log viewer with timestamps, severity indicators, localized labels, expandable technical details, and live auto-scrolling.
  * Improved flight-generation and video-export log displays with readable activity and empty-state messages.
  * Log sources now appear in a vertically stacked layout for easier reading.
* **Bug Fixes**
  * Export logs now remain available after temporary processing files are cleaned up and are removed during complete job cleanup.
  * Improved cleanup reporting for removed log files.
* **Documentation**
  * Updated English and French translations for log statuses, details, and line counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->