### PR TITLE
fix(frontend): poll media job statuses without tokens

### DIFF
--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.test.tsx
@@ -1,7 +1,14 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { formatEta, toStatusPayload } from './useVideoExportStatus';
 import { useVideoExportStatus } from './useVideoExportStatus';
+
+const apiGet = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/api', () => ({
+  api: { get: apiGet },
+}));
 
 const eventSourceMock = vi.hoisted(() => {
   const instances: {
@@ -33,11 +40,34 @@ function TestHarness({
   jobId?: string | null;
   jobToken?: string | null;
 }) {
-  useVideoExportStatus(jobId, true, jobToken);
-  return null;
+  const { status } = useVideoExportStatus(jobId, true, jobToken);
+  return <div>{status?.log_tail?.join('\n')}</div>;
+}
+
+function renderHarness(props: {
+  jobId?: string | null;
+  jobToken?: string | null;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TestHarness {...props} />
+    </QueryClientProvider>
+  );
 }
 
 beforeEach(() => {
+  apiGet.mockReset();
+  apiGet.mockReturnValue({
+    json: vi.fn().mockResolvedValue({
+      job_id: 'job-123',
+      status: 'completed',
+      internal_status: 'completed',
+      log_tail: ['Persisted export log'],
+    }),
+  });
   eventSourceMock.instances.length = 0;
   globalThis.EventSource =
     eventSourceMock.MockEventSource as unknown as typeof EventSource;
@@ -99,21 +129,19 @@ describe('formatEta', () => {
 });
 
 describe('useVideoExportStatus', () => {
-  it('uses the public stream without an auth token when no job token is available', async () => {
-    render(<TestHarness jobId="job-123" />);
+  it('polls the authenticated status endpoint when no job token is available', async () => {
+    renderHarness({ jobId: 'job-123' });
 
     await waitFor(() => {
-      expect(eventSourceMock.instances).toHaveLength(1);
+      expect(apiGet).toHaveBeenCalledWith('exports/job-123/status');
     });
 
-    expect(eventSourceMock.instances[0]?.url).toContain(
-      '/api/exports/job-123/stream'
-    );
-    expect(eventSourceMock.instances[0]?.url).not.toContain('access_token=');
+    expect(eventSourceMock.instances).toHaveLength(0);
+    expect(await screen.findByText('Persisted export log')).toBeInTheDocument();
   });
 
   it('uses the scoped job-access stream when a job token is available', async () => {
-    render(<TestHarness jobId="job-123" jobToken="job-token-abc" />);
+    renderHarness({ jobId: 'job-123', jobToken: 'job-token-abc' });
 
     await waitFor(() => {
       expect(eventSourceMock.instances).toHaveLength(1);
@@ -125,5 +153,6 @@ describe('useVideoExportStatus', () => {
     expect(eventSourceMock.instances[0]?.url).toContain(
       'access_token=job-token-abc'
     );
+    expect(apiGet).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../../lib/api';
 
 export type VideoExportPhase =
   | 'queued'
@@ -34,6 +36,9 @@ const initialState: HookState = {
   status: null,
   isConnected: false,
 };
+
+const TERMINAL_STATUSES = new Set(['cancelled', 'completed', 'failed']);
+const STATUS_POLL_INTERVAL_MS = 2000;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object');
@@ -115,6 +120,23 @@ export function useVideoExportStatus(
   jobToken?: string | null
 ) {
   const [state, setState] = useState<HookState>(initialState);
+  const polledStatus = useQuery({
+    queryKey: ['video-export-status', jobId],
+    queryFn: async () => {
+      const payload = await api.get(`exports/${jobId}/status`).json<unknown>();
+      const status = toStatusPayload(payload);
+      if (!status) throw new Error('Invalid video export status response');
+      return status;
+    },
+    enabled: enabled && Boolean(jobId) && !jobToken,
+    refetchInterval: (query) => {
+      const status = query.state.data;
+      const currentStatus = status?.internal_status ?? status?.status;
+      return currentStatus && TERMINAL_STATUSES.has(currentStatus)
+        ? false
+        : STATUS_POLL_INTERVAL_MS;
+    },
+  });
 
   useEffect(() => {
     setState(initialState);
@@ -123,13 +145,11 @@ export function useVideoExportStatus(
       return;
     }
 
-    const path = jobToken
-      ? `/api/job-access/exports/${jobId}/stream`
-      : `/api/exports/${jobId}/stream`;
+    if (!jobToken) return;
+
+    const path = `/api/job-access/exports/${jobId}/stream`;
     const streamUrl = new URL(path, window.location.origin);
-    if (jobToken) {
-      streamUrl.searchParams.set('access_token', jobToken);
-    }
+    streamUrl.searchParams.set('access_token', jobToken);
 
     const eventSource = new EventSource(streamUrl.toString());
 
@@ -170,6 +190,13 @@ export function useVideoExportStatus(
       eventSource.close();
     };
   }, [enabled, jobId, jobToken]);
+
+  if (!jobToken) {
+    return {
+      status: polledStatus.data ?? null,
+      isConnected: polledStatus.isSuccess,
+    };
+  }
 
   return state;
 }

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.test.tsx
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGoproOverlayJobStream } from './useGoproOverlay';
+
+const apiGet = vi.hoisted(() => vi.fn());
+
+vi.mock('../../lib/api', () => ({
+  api: { get: apiGet },
+}));
+
+const eventSourceMock = vi.hoisted(() => {
+  const instances: { url: string }[] = [];
+
+  class MockEventSource {
+    url: string;
+    addEventListener = vi.fn();
+    removeEventListener = vi.fn();
+    close = vi.fn();
+    onerror: (() => void) | null = null;
+
+    constructor(url: string) {
+      this.url = url;
+      instances.push(this);
+    }
+  }
+
+  return { MockEventSource, instances };
+});
+
+function TestHarness({ jobToken }: { jobToken?: string | null }) {
+  const { job } = useGoproOverlayJobStream('overlay-job', jobToken, true);
+  return <div>{job?.log_tail?.join('\n')}</div>;
+}
+
+function renderHarness(jobToken?: string | null) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TestHarness jobToken={jobToken} />
+    </QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiGet.mockReturnValue({
+    json: vi.fn().mockResolvedValue({
+      job_id: 'overlay-job',
+      status: 'completed',
+      progress: 100,
+      message: 'Overlay ready',
+      layout_id: 'parapente-1080',
+      layout_label: 'Parapente',
+      output_filename: 'final.mp4',
+      created_at: '2026-07-31T10:00:00Z',
+      updated_at: '2026-07-31T10:10:00Z',
+      log_tail: ['Persisted overlay log'],
+    }),
+  });
+  eventSourceMock.instances.length = 0;
+  globalThis.EventSource =
+    eventSourceMock.MockEventSource as unknown as typeof EventSource;
+});
+
+describe('useGoproOverlayJobStream', () => {
+  it('polls the authenticated status endpoint when no job token is available', async () => {
+    renderHarness();
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        'gopro-overlays/jobs/overlay-job/status'
+      );
+    });
+
+    expect(eventSourceMock.instances).toHaveLength(0);
+    expect(
+      await screen.findByText('Persisted overlay log')
+    ).toBeInTheDocument();
+  });
+
+  it('uses the scoped job-access stream when a job token is available', async () => {
+    renderHarness('overlay-token');
+
+    await waitFor(() => {
+      expect(eventSourceMock.instances).toHaveLength(1);
+    });
+
+    expect(eventSourceMock.instances[0]?.url).toContain(
+      '/api/job-access/gopro-overlays/jobs/overlay-job/stream'
+    );
+    expect(eventSourceMock.instances[0]?.url).toContain(
+      'access_token=overlay-token'
+    );
+    expect(apiGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
+++ b/apps/frontend/src/hooks/gopro/useGoproOverlay.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '../../lib/api';
 
 export type GoproOverlayJob = {
@@ -45,12 +45,27 @@ const initialState = {
   isConnected: false,
 };
 
+const TERMINAL_STATUSES = new Set(['cancelled', 'completed', 'failed']);
+const STATUS_POLL_INTERVAL_MS = 2000;
+
 export function useGoproOverlayJobStream(
   jobId?: string | null,
   jobToken?: string | null,
   enabled = true
 ) {
   const [state, setState] = useState(initialState);
+  const polledJob = useQuery({
+    queryKey: ['gopro-overlay-job', jobId],
+    queryFn: () =>
+      api.get(`gopro-overlays/jobs/${jobId}/status`).json<GoproOverlayJob>(),
+    enabled: enabled && Boolean(jobId) && !jobToken,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && TERMINAL_STATUSES.has(status)
+        ? false
+        : STATUS_POLL_INTERVAL_MS;
+    },
+  });
 
   useEffect(() => {
     setState(initialState);
@@ -58,13 +73,11 @@ export function useGoproOverlayJobStream(
       return;
     }
 
-    const path = jobToken
-      ? `/api/job-access/gopro-overlays/jobs/${jobId}/stream`
-      : `/api/gopro-overlays/jobs/${jobId}/stream`;
+    if (!jobToken) return;
+
+    const path = `/api/job-access/gopro-overlays/jobs/${jobId}/stream`;
     const url = new URL(path, window.location.origin);
-    if (jobToken) {
-      url.searchParams.set('access_token', jobToken);
-    }
+    url.searchParams.set('access_token', jobToken);
     const eventSource = new EventSource(url.toString(), {
       withCredentials: true,
     });
@@ -91,6 +104,13 @@ export function useGoproOverlayJobStream(
       eventSource.close();
     };
   }, [enabled, jobId, jobToken]);
+
+  if (!jobToken) {
+    return {
+      job: polledJob.data ?? null,
+      isConnected: polledJob.isSuccess,
+    };
+  }
 
   return state;
 }


### PR DESCRIPTION
## Summary
- Poll media job statuses through React Query when no scoped job token is available
- Keep SSE for tokenized job-access streams
- Cover both video export and GoPro overlay hooks with tests

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --uncommitted --exclude=e2e ✅
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --uncommitted --parallel=5 --exclude=e2e ⚠️ repo test run hit Vitest browser/storybook teardown issues after passing 181/181 tests
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend ✅
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm vitest run src/hooks/flights/useVideoExportStatus.test.tsx src/hooks/gopro/useGoproOverlay.test.tsx ✅

## Notes
- CodeRabbit review already ran on this branch and reported no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated status polling for video export and GoPro overlay jobs when no job token is available.
  * Polling automatically stops when jobs reach a terminal status.
  * Token-based jobs continue receiving real-time updates through secure streaming.
  * Persisted job logs and completion status are now surfaced consistently across both update methods.

* **Bug Fixes**
  * Improved job status handling and reliability across polling and streaming workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->