### PR TITLE
perf(video-export): use local temp storage and GPU worker

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -462,16 +462,49 @@ jobs:
             }
 
             configure_compose_cmd() {
+              compose_files="-f docker-compose.yml"
+              if [ -f docker-compose.gpu.yml ]; then
+                compose_files="$compose_files -f docker-compose.gpu.yml"
+                echo "Using GPU compose override"
+              fi
+
               if [ -f stack.env ]; then
-                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" --env-file stack.env "$@"; }
+                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files --env-file stack.env "$@"; }
                 echo "Using stack.env for docker compose"
               elif [ -f .env ]; then
-                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" --env-file .env "$@"; }
+                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files --env-file .env "$@"; }
                 echo "Using .env for docker compose"
               else
-                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" "$@"; }
+                compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files "$@"; }
                 echo "No env file found (stack.env/.env), using shell environment"
               fi
+            }
+
+            download_gpu_compose_override() {
+              gpu_url="https://raw.githubusercontent.com/$REPO_SLUG/$TARGET_SHA/docker-compose.gpu.yml"
+              if ! gpu_status=$(curl --silent --show-error --location \
+                --output docker-compose.gpu.yml.tmp \
+                --write-out '%{http_code}' \
+                "$gpu_url"); then
+                rm -f docker-compose.gpu.yml.tmp
+                echo "Failed to download GPU compose override"
+                return 1
+              fi
+
+              case "$gpu_status" in
+                200)
+                  mv docker-compose.gpu.yml.tmp docker-compose.gpu.yml
+                  ;;
+                404)
+                  rm -f docker-compose.gpu.yml.tmp docker-compose.gpu.yml
+                  echo "GPU compose override not present at target commit; using CPU compose"
+                  ;;
+                *)
+                  rm -f docker-compose.gpu.yml.tmp
+                  echo "GPU compose override download returned HTTP $gpu_status"
+                  return 1
+                  ;;
+              esac
             }
 
             deploy_from_compose_path() {
@@ -492,6 +525,7 @@ jobs:
               echo "Updating production compose file from $REPO_SLUG@$TARGET_SHA"
               curl -fsSL "https://raw.githubusercontent.com/$REPO_SLUG/$TARGET_SHA/docker-compose.yml" -o docker-compose.yml.tmp
               mv docker-compose.yml.tmp docker-compose.yml
+              download_gpu_compose_override
 
               configure_compose_cmd
 
@@ -525,12 +559,39 @@ jobs:
                   curl -fsSL "https://raw.githubusercontent.com/$REPO_SLUG/$TARGET_SHA/docker-compose.yml" -o docker-compose.yml.tmp
                   mv docker-compose.yml.tmp docker-compose.yml
 
+                  gpu_url="https://raw.githubusercontent.com/$REPO_SLUG/$TARGET_SHA/docker-compose.gpu.yml"
+                  if ! gpu_status=$(curl --silent --show-error --location \
+                    --output docker-compose.gpu.yml.tmp \
+                    --write-out "%{http_code}" \
+                    "$gpu_url"); then
+                    rm -f docker-compose.gpu.yml.tmp
+                    echo "Failed to download GPU compose override"
+                    exit 1
+                  fi
+                  case "$gpu_status" in
+                    200) mv docker-compose.gpu.yml.tmp docker-compose.gpu.yml ;;
+                    404)
+                      rm -f docker-compose.gpu.yml.tmp docker-compose.gpu.yml
+                      echo "GPU compose override not present at target commit; using CPU compose"
+                      ;;
+                    *)
+                      rm -f docker-compose.gpu.yml.tmp
+                      echo "GPU compose override download returned HTTP $gpu_status"
+                      exit 1
+                      ;;
+                  esac
+
+                  compose_files="-f docker-compose.yml"
+                  if [ -f docker-compose.gpu.yml ]; then
+                    compose_files="$compose_files -f docker-compose.gpu.yml"
+                  fi
+
                   if [ -f stack.env ]; then
-                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" --env-file stack.env "$@"; }
+                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files --env-file stack.env "$@"; }
                   elif [ -f .env ]; then
-                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" --env-file .env "$@"; }
+                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files --env-file .env "$@"; }
                   else
-                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" "$@"; }
+                    compose_cmd() { docker compose -p "$COMPOSE_PROJECT_NAME" $compose_files "$@"; }
                   fi
 
                   printf "%s" "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcups2 \
     libdbus-1-3 \
     libdrm2 \
+    libegl1 \
+    libegl-mesa0 \
     libgbm1 \
+    libgl1-mesa-dri \
     libgtk-3-0 \
     libnspr4 \
     libnss3 \
@@ -67,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 \
     libxkbcommon0 \
     libxrandr2 \
+    mesa-vulkan-drivers \
     xdg-utils \
     curl \
     ffmpeg \

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -29,6 +29,24 @@ def _resolve_project_root(backend_root: Path) -> Path:
     return backend_root
 
 
+def _configured_storage_dir(
+    env_name: str,
+    default: str,
+    *,
+    forbidden_roots: tuple[Path, ...] = (),
+) -> str:
+    raw_value = os.getenv(env_name)
+    value = raw_value.strip() if raw_value and raw_value.strip() else default
+    path = Path(value)
+    if not path.is_absolute():
+        raise ValueError(f"{env_name} must be an absolute path")
+
+    resolved_path = path.resolve(strict=False)
+    if resolved_path in {root.resolve(strict=False) for root in forbidden_roots}:
+        raise ValueError(f"{env_name} points to an unsafe shared root: {resolved_path}")
+    return str(path)
+
+
 PROJECT_ROOT = _resolve_project_root(BACKEND_ROOT)
 
 # Charger les variables d'environnement selon le contexte
@@ -228,7 +246,23 @@ PARAGLIDING_DATA_ROOT = (
     "/tmp/dashboard-parapente-test/parapente" if IS_TEST_ENV else "/app/parapente"
 )
 VIDEO_EXPORT_DIR = PARAGLIDING_DATA_ROOT
-VIDEO_TEMP_IMAGES_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "video-frames")
+VIDEO_LEGACY_TEMP_IMAGES_DIR = str(Path(PARAGLIDING_DATA_ROOT) / ".tmp" / "video-frames")
+VIDEO_TEMP_IMAGES_DIR = _configured_storage_dir(
+    "BACKEND_VIDEO_TEMP_IMAGES_DIR",
+    VIDEO_LEGACY_TEMP_IMAGES_DIR,
+    forbidden_roots=(
+        Path("/"),
+        Path("/tmp"),
+        Path("/var/tmp"),
+        Path("/app"),
+        Path("/app/db"),
+        Path("/app/video-exports"),
+        Path("/app/emagram-cache"),
+        Path("/app/gopro-overlay"),
+        Path("/app/codex-home"),
+        Path(PARAGLIDING_DATA_ROOT),
+    ),
+)
 
 # ============================================================================
 # GOPRO OVERLAY EXPORT

--- a/apps/backend/job_worker.py
+++ b/apps/backend/job_worker.py
@@ -21,7 +21,7 @@ def main() -> None:
     if not is_rq_enabled():
         raise RuntimeError("RQ worker requires BACKEND_JOB_QUEUE_BACKEND=rq")
 
-    queued_count = enqueue_pending_video_export_jobs()
+    queued_count = enqueue_pending_video_export_jobs(recover_active=True)
     if queued_count:
         logger.info("Enqueued %s pending video export job(s)", queued_count)
 

--- a/apps/backend/tests/unit/test_required_env.py
+++ b/apps/backend/tests/unit/test_required_env.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -37,11 +38,40 @@ def test_required_env_accepts_non_empty_variable(monkeypatch):
     assert config.required_env("BACKEND_VALID_PATH") == "/valid/path"
 
 
-def test_video_export_paths_are_fixed():
+def test_video_export_paths_use_legacy_defaults():
     data_root = Path(config.PARAGLIDING_DATA_ROOT)
 
     assert Path(config.VIDEO_EXPORT_DIR) == data_root
-    assert Path(config.VIDEO_TEMP_IMAGES_DIR) == data_root / ".tmp" / "video-frames"
+    assert Path(config.VIDEO_LEGACY_TEMP_IMAGES_DIR) == data_root / ".tmp" / "video-frames"
+    assert Path(config.VIDEO_TEMP_IMAGES_DIR) == Path(
+        os.getenv("BACKEND_VIDEO_TEMP_IMAGES_DIR", config.VIDEO_LEGACY_TEMP_IMAGES_DIR)
+    )
+
+
+def test_configured_storage_dir_treats_blank_as_default(monkeypatch):
+    monkeypatch.setenv("BACKEND_TEST_STORAGE", "  ")
+
+    assert config._configured_storage_dir("BACKEND_TEST_STORAGE", "/safe/default") == (
+        "/safe/default"
+    )
+
+
+def test_configured_storage_dir_rejects_relative_path(monkeypatch):
+    monkeypatch.setenv("BACKEND_TEST_STORAGE", "relative/path")
+
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        config._configured_storage_dir("BACKEND_TEST_STORAGE", "/safe/default")
+
+
+def test_configured_storage_dir_rejects_shared_root(monkeypatch):
+    monkeypatch.setenv("BACKEND_TEST_STORAGE", "/app")
+
+    with pytest.raises(ValueError, match="unsafe shared root"):
+        config._configured_storage_dir(
+            "BACKEND_TEST_STORAGE",
+            "/safe/default",
+            forbidden_roots=(Path("/app"),),
+        )
 
 
 def test_gopro_overlay_paths_are_derived_from_paragliding_root():

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -223,6 +223,42 @@ def test_parse_ffmpeg_out_time_seconds_parses_progress_lines():
     assert video_export_manual._parse_ffmpeg_out_time_seconds("progress=continue") is None
 
 
+@pytest.mark.parametrize(
+    "renderer",
+    [
+        "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device))",
+        "llvmpipe (LLVM 19.1.7, 256 bits)",
+        "Mesa softpipe",
+        "Software Rasterizer",
+    ],
+)
+def test_software_webgl_renderer_is_detected(renderer):
+    assert video_export_manual._is_software_webgl_renderer(renderer) is True
+
+
+def test_hardware_webgl_renderer_is_not_marked_as_software():
+    assert video_export_manual._is_software_webgl_renderer("NV168 (nouveau)") is False
+
+
+def test_chromium_launch_args_use_hardware_egl_when_render_device_exists(tmp_path):
+    render_device = tmp_path / "renderD128"
+    render_device.touch()
+
+    args = video_export_manual._chromium_launch_args(render_device)
+
+    assert "--use-angle=gl-egl" in args
+    assert "--enable-gpu-rasterization" in args
+    assert "--use-angle=swiftshader-webgl" not in args
+
+
+def test_chromium_launch_args_fall_back_to_swiftshader_without_render_device(tmp_path):
+    args = video_export_manual._chromium_launch_args(tmp_path / "missing-render-device")
+
+    assert "--use-angle=swiftshader-webgl" in args
+    assert "--enable-unsafe-swiftshader" in args
+    assert "--use-angle=gl-egl" not in args
+
+
 def test_ffmpeg_encoding_settings_use_fast_preset_for_manual_fast():
     assert video_export_manual._ffmpeg_encoding_settings(True) == ("veryfast", "23")
     assert video_export_manual._ffmpeg_encoding_settings(False) == ("medium", "18")
@@ -625,6 +661,45 @@ def test_start_video_export_worker_enqueues_pending_jobs_with_rq(test_db, monkey
     assert enqueued_job_ids == ["job-pending-rq"]
 
 
+def test_worker_restart_immediately_recovers_active_job(test_db, monkeypatch):
+    enqueued_job_ids: list[str] = []
+    monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
+    monkeypatch.setattr(video_export_manual.config, "JOB_QUEUE_BACKEND", "rq")
+    monkeypatch.setattr(
+        video_export_manual,
+        "_enqueue_video_export_job_in_rq",
+        lambda job_id: enqueued_job_ids.append(job_id),
+    )
+
+    with test_db() as db_session:
+        db_session.add(
+            VideoExportJob(
+                id="job-active-rq",
+                flight_id="flight-test-001",
+                status="capturing",
+                mode="manual_fast",
+                quality="1080p",
+                fps=15,
+                speed=1,
+                progress=50,
+                message="capturing",
+                frontend_url="http://localhost:5173",
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            )
+        )
+        db_session.commit()
+
+    assert video_export_manual.enqueue_pending_video_export_jobs(recover_active=True) == 1
+
+    with test_db() as db_session:
+        job = db_session.get(VideoExportJob, "job-active-rq")
+        assert job is not None
+        assert job.status == "queued"
+        assert job.message == "Recovered after worker restart"
+    assert enqueued_job_ids == ["job-active-rq"]
+
+
 def test_process_video_export_job_runs_only_requested_queued_job(test_db, monkeypatch):
     processed_job_ids: list[str] = []
     monkeypatch.setattr(video_export_manual, "SessionLocal", test_db)
@@ -681,6 +756,59 @@ def test_first_missing_frame_index_ignores_partial_frame(tmp_path):
     (frames_dir / "frame00001.png.part").write_bytes(b"partial")
 
     assert video_export_manual._first_missing_frame_index(frames_dir, 3) == 1
+
+
+def test_job_temp_dir_for_export_uses_local_storage_for_new_job(tmp_path, monkeypatch):
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: local_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: legacy_root)
+
+    assert video_export_manual._job_temp_dir_for_export("job-new") == local_root / "job-new"
+
+
+def test_job_temp_dir_for_export_resumes_legacy_frames(tmp_path, monkeypatch):
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    legacy_frames = legacy_root / "job-resume" / "frames"
+    legacy_frames.mkdir(parents=True)
+    (legacy_frames / "frame00000.png").write_bytes(b"frame")
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: local_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: legacy_root)
+
+    assert video_export_manual._job_temp_dir_for_export("job-resume") == legacy_root / "job-resume"
+
+
+def test_job_temp_dir_for_export_prefers_local_frames(tmp_path, monkeypatch):
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    local_frames = local_root / "job-resume" / "frames"
+    legacy_frames = legacy_root / "job-resume" / "frames"
+    local_frames.mkdir(parents=True)
+    legacy_frames.mkdir(parents=True)
+    (local_frames / "frame00000.png").write_bytes(b"local")
+    (legacy_frames / "frame00000.png").write_bytes(b"legacy")
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: local_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: legacy_root)
+
+    assert video_export_manual._job_temp_dir_for_export("job-resume") == local_root / "job-resume"
+
+
+def test_job_temp_dir_for_export_uses_longest_contiguous_capture(tmp_path, monkeypatch):
+    local_root = tmp_path / "local"
+    legacy_root = tmp_path / "legacy"
+    local_frames = local_root / "job-resume" / "frames"
+    legacy_frames = legacy_root / "job-resume" / "frames"
+    local_frames.mkdir(parents=True)
+    legacy_frames.mkdir(parents=True)
+    (local_frames / "frame00000.png").write_bytes(b"local")
+    (local_frames / "frame00010.png").write_bytes(b"local-gap")
+    (legacy_frames / "frame00000.png").write_bytes(b"legacy-0")
+    (legacy_frames / "frame00001.png").write_bytes(b"legacy-1")
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: local_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: legacy_root)
+
+    assert video_export_manual._job_temp_dir_for_export("job-resume") == legacy_root / "job-resume"
 
 
 def test_write_frame_file_atomic_publishes_complete_frame(tmp_path):
@@ -1208,6 +1336,7 @@ def test_cleanup_video_export_temp_files_uses_configured_temp_dir(tmp_path, monk
     temp_root = tmp_path / "configured-temp-images"
     export_root = tmp_path / "configured-video-exports"
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: temp_root)
     monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
 
     inactive_temp_dir = temp_root / "job-failed"
@@ -1233,9 +1362,10 @@ def test_cleanup_video_export_temp_files_removes_configured_orphan_temp_dirs(tmp
     temp_root = tmp_path / "configured-temp-images"
     export_root = tmp_path / "configured-video-exports"
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: temp_root)
     monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
 
-    orphan_temp_dir = temp_root / "orphan-job"
+    orphan_temp_dir = temp_root / "8cd6dce7-885e-4385-bf7f-a10d1731dfeb"
     orphan_temp_dir.mkdir(parents=True)
     (orphan_temp_dir / "frame00001.png").write_bytes(b"frame")
     old_timestamp = time.time() - video_export_manual._ORPHAN_TEMP_CLEANUP_GRACE_SECONDS - 1
@@ -1247,13 +1377,33 @@ def test_cleanup_video_export_temp_files_removes_configured_orphan_temp_dirs(tmp
     assert not orphan_temp_dir.exists()
 
 
+def test_cleanup_video_export_temp_files_ignores_non_job_directories(tmp_path, monkeypatch):
+    temp_root = tmp_path / "configured-temp-images"
+    export_root = tmp_path / "configured-video-exports"
+    monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
+
+    unrelated_dir = temp_root / "unrelated-data"
+    unrelated_dir.mkdir(parents=True)
+    (unrelated_dir / "important.txt").write_text("keep")
+    old_timestamp = time.time() - video_export_manual._ORPHAN_TEMP_CLEANUP_GRACE_SECONDS - 1
+    os.utime(unrelated_dir, (old_timestamp, old_timestamp))
+
+    result = video_export_manual.cleanup_video_export_temp_files([])
+
+    assert result["files_deleted"] == 0
+    assert unrelated_dir.exists()
+
+
 def test_cleanup_video_export_temp_files_keeps_fresh_orphan_temp_dirs(tmp_path, monkeypatch):
     temp_root = tmp_path / "configured-temp-images"
     export_root = tmp_path / "configured-video-exports"
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: temp_root)
     monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
 
-    fresh_temp_dir = temp_root / "fresh-job"
+    fresh_temp_dir = temp_root / "2604316d-86bf-4882-bb3b-bfdb6e8e6cd7"
     fresh_temp_dir.mkdir(parents=True)
     (fresh_temp_dir / "frame00001.png").write_bytes(b"frame")
 
@@ -1269,6 +1419,7 @@ def test_cleanup_video_export_temp_files_removes_legacy_frames_for_inactive_job(
     temp_root = tmp_path / "configured-temp-images"
     export_root = tmp_path / "configured-video-exports"
     monkeypatch.setattr(video_export_manual, "_video_temp_images_dir", lambda: temp_root)
+    monkeypatch.setattr(video_export_manual, "_video_legacy_temp_images_dir", lambda: temp_root)
     monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: export_root)
 
     legacy_frames_dir = export_root / "frames_job-cancelled"

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -42,6 +42,10 @@ def _video_temp_images_dir() -> Path:
     return Path(config.VIDEO_TEMP_IMAGES_DIR)
 
 
+def _video_legacy_temp_images_dir() -> Path:
+    return Path(config.VIDEO_LEGACY_TEMP_IMAGES_DIR)
+
+
 _LOG_TAIL_LINE_COUNT = 100
 
 
@@ -148,6 +152,31 @@ _EXPORT_VIEWER_READY_SCRIPT = f"""
     }}
 """
 
+_WEBGL_RENDERER_SCRIPT = """
+    () => {
+        const canvas = document.querySelector('.cesium-viewer canvas, canvas');
+        if (!canvas) {
+            return { available: false, vendor: '', renderer: '' };
+        }
+
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) {
+            return { available: false, vendor: '', renderer: '' };
+        }
+
+        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        return {
+            available: true,
+            vendor: debugInfo
+                ? String(gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) || '')
+                : String(gl.getParameter(gl.VENDOR) || ''),
+            renderer: debugInfo
+                ? String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) || '')
+                : String(gl.getParameter(gl.RENDERER) || ''),
+        };
+    }
+"""
+
 
 def check_dependencies():
     """Check if required system dependencies are installed."""
@@ -166,6 +195,49 @@ def check_dependencies():
 
 
 _dependencies_ok = check_dependencies()
+
+
+def _is_software_webgl_renderer(renderer: str) -> bool:
+    normalized = renderer.lower()
+    return any(
+        marker in normalized
+        for marker in ("swiftshader", "llvmpipe", "softpipe", "software rasterizer", "swrast")
+    )
+
+
+def _chromium_launch_args(
+    render_device: Path = Path("/dev/dri/renderD128"),
+) -> list[str]:
+    args = [
+        "--enable-gpu",
+        "--enable-webgl",
+        "--enable-webgl2",
+        "--ignore-gpu-blocklist",
+        "--disable-gpu-vsync",
+        "--disable-dev-shm-usage",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--js-flags=--max-old-space-size=8192",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+        "--force-device-scale-factor=1",
+        "--high-dpi-support=1",
+    ]
+    if render_device.exists():
+        return [
+            *args,
+            "--use-gl=angle",
+            "--use-angle=gl-egl",
+            "--enable-gpu-rasterization",
+            "--enable-zero-copy",
+        ]
+    return [
+        *args,
+        "--use-gl=angle",
+        "--use-angle=swiftshader-webgl",
+        "--enable-unsafe-swiftshader",
+    ]
 
 
 def _to_public_status(status: str) -> str:
@@ -524,6 +596,22 @@ def _mark_stale_jobs_as_queued():
             _set_memory_snapshot(job.id, _snapshot_from_job(job))
 
 
+def _recover_active_jobs_after_worker_restart() -> None:
+    with SessionLocal() as db:
+        active_jobs = (
+            db.query(VideoExportJob).filter(VideoExportJob.status.in_(list(_ACTIVE_STATUSES))).all()
+        )
+        for job in active_jobs:
+            job.status = _STATUS_QUEUED
+            job.message = "Recovered after worker restart"
+            job.updated_at = datetime.utcnow()
+        if active_jobs:
+            db.commit()
+
+        for job in active_jobs:
+            _set_memory_snapshot(job.id, _snapshot_from_job(job))
+
+
 def _acquire_next_job() -> str | None:
     with SessionLocal() as db:
         job = (
@@ -652,7 +740,7 @@ def _is_rq_video_export_job_started(job_id: str) -> bool:
     return str(getattr(status, "value", status)).lower() == "started"
 
 
-def enqueue_pending_video_export_jobs() -> int:
+def enqueue_pending_video_export_jobs(*, recover_active: bool = False) -> int:
     """Enqueue queued DB jobs into RQ after an API or worker restart."""
     from job_queue import is_rq_enabled
 
@@ -660,7 +748,10 @@ def enqueue_pending_video_export_jobs() -> int:
     if not is_rq_enabled():
         return 0
 
-    _mark_stale_jobs_as_queued()
+    if recover_active:
+        _recover_active_jobs_after_worker_restart()
+    else:
+        _mark_stale_jobs_as_queued()
     job_ids = _queued_job_ids()
     for job_id in job_ids:
         _enqueue_video_export_job_in_rq(job_id)
@@ -712,6 +803,30 @@ def _first_missing_frame_index(frames_dir: Path, total_frames: int) -> int:
     return max(total_frames, 0)
 
 
+def _contiguous_frame_count(frames_dir: Path) -> int:
+    existing_indexes = _existing_frame_indexes(frames_dir)
+    frame_index = 0
+    while frame_index in existing_indexes:
+        frame_index += 1
+    return frame_index
+
+
+def _job_temp_dir_for_export(job_id: str) -> Path:
+    preferred_temp_dir = _job_temp_dir(_video_temp_images_dir(), job_id)
+    preferred_frames_dir = preferred_temp_dir / "frames"
+    legacy_temp_root = _video_legacy_temp_images_dir()
+    legacy_temp_dir = _job_temp_dir(legacy_temp_root, job_id)
+    if legacy_temp_dir == preferred_temp_dir:
+        return preferred_temp_dir
+
+    preferred_frame_count = _contiguous_frame_count(preferred_frames_dir)
+    legacy_frame_count = _contiguous_frame_count(legacy_temp_dir / "frames")
+    if legacy_frame_count > preferred_frame_count:
+        return legacy_temp_dir
+
+    return preferred_temp_dir
+
+
 def _write_frame_file_atomic(frame_path: Path, frame_png: bytes) -> None:
     partial_path = frame_path.with_name(f"{frame_path.name}.part")
     partial_path.write_bytes(frame_png)
@@ -719,7 +834,7 @@ def _write_frame_file_atomic(frame_path: Path, frame_png: bytes) -> None:
 
 
 def _job_resume_info(job: VideoExportJob) -> dict[str, Any]:
-    frames_dir = _job_frames_dir(_video_temp_images_dir(), job.id)
+    frames_dir = _job_temp_dir_for_export(job.id) / "frames"
     existing_indexes = _existing_frame_indexes(frames_dir)
     total_frames = job.total_frames or 0
     resume_from_frame = _first_missing_frame_index(frames_dir, total_frames)
@@ -818,6 +933,13 @@ def _is_path_older_than(path: Path, age_seconds: int) -> bool:
         return False
 
 
+def _is_job_temp_dir_name(name: str) -> bool:
+    try:
+        return str(uuid.UUID(name)) == name.lower()
+    except ValueError:
+        return False
+
+
 def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, Any]:
     """Delete non-active video export temporary files from configured storage."""
     active_job_ids = {
@@ -832,21 +954,30 @@ def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, 
     }
 
     candidates: list[tuple[Path, Path]] = []
-    temp_root = _video_temp_images_dir()
+    temp_roots = {
+        _video_temp_images_dir().resolve(strict=False),
+        _video_legacy_temp_images_dir().resolve(strict=False),
+    }
     export_root = _video_export_dir()
 
     for job_id in known_inactive_job_ids:
-        candidates.append((_job_temp_dir(temp_root, job_id), temp_root))
+        for temp_root in temp_roots:
+            candidates.append((_job_temp_dir(temp_root, job_id), temp_root))
         candidates.append((export_root / f"frames_{job_id}", export_root))
         candidates.append((Path("/tmp") / f"playwright-debug-{job_id}.png", Path("/tmp")))
         candidates.append((Path("/tmp") / f"playwright-error-{job_id}.png", Path("/tmp")))
 
-    if temp_root.exists():
-        for child in temp_root.iterdir():
-            if child.name not in active_job_ids and _is_path_older_than(
-                child, _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS
-            ):
-                candidates.append((child, temp_root))
+    for temp_root in temp_roots:
+        if temp_root.exists():
+            for child in temp_root.iterdir():
+                if child.resolve(strict=False) in temp_roots:
+                    continue
+                if not _is_job_temp_dir_name(child.name):
+                    continue
+                if child.name not in active_job_ids and _is_path_older_than(
+                    child, _ORPHAN_TEMP_CLEANUP_GRACE_SECONDS
+                ):
+                    candidates.append((child, temp_root))
 
     if export_root.exists():
         for child in export_root.glob("frames_*"):
@@ -889,8 +1020,12 @@ def cleanup_video_export_temp_files(exports: list[dict[str, Any]]) -> dict[str, 
 
 def cleanup_video_export_job_temp_files(job_id: str) -> dict[str, Any]:
     """Delete temporary and log files for an explicitly deleted export job."""
+    temp_roots = {
+        _video_temp_images_dir().resolve(strict=False),
+        _video_legacy_temp_images_dir().resolve(strict=False),
+    }
     candidates = [
-        (_job_temp_dir(_video_temp_images_dir(), job_id), _video_temp_images_dir()),
+        *[(_job_temp_dir(temp_root, job_id), temp_root) for temp_root in temp_roots],
         (_video_export_dir() / f"frames_{job_id}", _video_export_dir()),
         (Path("/tmp") / f"playwright-debug-{job_id}.png", Path("/tmp")),
         (Path("/tmp") / f"playwright-error-{job_id}.png", Path("/tmp")),
@@ -1497,7 +1632,6 @@ async def _export_video_manual_render(job_id: str):
     flight_id = job.flight_id
     frontend_url = resolve_frontend_url(job.frontend_url)
     export_root = _video_export_dir()
-    temp_root = _video_temp_images_dir()
     temp_dir: Path | None = None
     frames_dir: Path | None = None
     ffmpeg_process: asyncio.subprocess.Process | None = None
@@ -1526,23 +1660,7 @@ async def _export_video_manual_render(job_id: str):
         async with async_playwright() as p:
             browser = await p.chromium.launch(
                 headless=True,
-                args=[
-                    "--enable-gpu",
-                    "--use-gl=egl",
-                    "--enable-webgl",
-                    "--enable-webgl2",
-                    "--ignore-gpu-blocklist",
-                    "--disable-gpu-vsync",
-                    "--disable-dev-shm-usage",
-                    "--no-sandbox",
-                    "--disable-setuid-sandbox",
-                    "--js-flags=--max-old-space-size=8192",
-                    "--disable-background-timer-throttling",
-                    "--disable-backgrounding-occluded-windows",
-                    "--disable-renderer-backgrounding",
-                    "--force-device-scale-factor=1",
-                    "--high-dpi-support=1",
-                ],
+                args=_chromium_launch_args(),
             )
 
             context = await browser.new_context(
@@ -1609,6 +1727,21 @@ async def _export_video_manual_render(job_id: str):
             await asyncio.sleep(3)
 
             _log_job(job_id, "Cesium viewer found")
+
+            renderer_info = await page.evaluate(_WEBGL_RENDERER_SCRIPT)
+            renderer = str(renderer_info.get("renderer") or "unknown")
+            vendor = str(renderer_info.get("vendor") or "unknown")
+            if not renderer_info.get("available"):
+                _log_job(job_id, "WebGL renderer unavailable")
+            elif _is_software_webgl_renderer(renderer):
+                _log_job(
+                    job_id,
+                    f"WebGL renderer is software: vendor={vendor}, renderer={renderer}",
+                )
+            else:
+                _log_job(
+                    job_id, f"WebGL renderer is hardware: vendor={vendor}, renderer={renderer}"
+                )
 
             _update_job(job_id, message="Configuring manual render mode")
 
@@ -1708,8 +1841,8 @@ async def _export_video_manual_render(job_id: str):
             )
             _set_job_runtime(job_id, phase=_STATUS_INITIALIZING)
 
-            temp_dir = _job_temp_dir(temp_root, job_id)
-            frames_dir = _job_frames_dir(temp_root, job_id)
+            temp_dir = _job_temp_dir_for_export(job_id)
+            frames_dir = temp_dir / "frames"
             _prepare_export_dirs(export_root, temp_dir, frames_dir)
 
             _log_job(job_id, f"Frames directory: {frames_dir}")

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,4 @@
+services:
+  backend-worker:
+    devices:
+      - ${VIDEO_WORKER_DRI_RENDER_DEVICE:-/dev/dri/renderD128}:${VIDEO_WORKER_DRI_RENDER_DEVICE:-/dev/dri/renderD128}


### PR DESCRIPTION
## Summary\n- move manual video export temp frames to local storage with legacy recovery\n- recover active jobs on worker restart\n- enable GPU-backed Chromium on worker via optional compose override\n- add diagnostics and targeted tests\n\n## Validation\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx run backend:lint\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx run backend:test --parallel=5\n- CodeRabbit review: 0 findings\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional GPU acceleration for video processing when supported, with automatic CPU fallback.
  - Improved browser rendering support across hardware and software graphics environments.
  - Added recovery for video exports interrupted by worker restarts.
  - Export resume now finds usable frames across current and legacy storage locations.

- **Bug Fixes**
  - Improved temporary-file cleanup and storage-path validation.
  - Added required graphics dependencies for reliable browser-based rendering.

- **Deployment**
  - Deployments now automatically use GPU configuration when available and report download failures appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->