### PR TITLE
feat(flights): move generation logs to tab

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
@@ -90,6 +90,12 @@ const minimalFlight: Flight = {
   notes: null,
 };
 
+const flightWithGenerationLogs: Flight = {
+  ...fullFlight,
+  video_export_status: 'running',
+  video_export_progress: 78,
+};
+
 const mockGPXData = {
   coordinates: Array.from({ length: 100 }, (_, i) => ({
     lat: 47.2 + i * 0.001,
@@ -263,6 +269,38 @@ Mobile.test('shows compact mobile infos tab by default', async ({ canvas }) => {
     canvas.queryByText(i18n.t('flights.loading3dViewer'))
   ).not.toBeInTheDocument();
 });
+
+export const WithGenerationLogs = meta.story({
+  name: 'With Generation Logs',
+  args: { flight: flightWithGenerationLogs },
+});
+
+WithGenerationLogs.test(
+  'keeps logs out of the main view until their tab is selected',
+  async ({ canvas, userEvent }) => {
+    await expect(
+      canvas.queryByText(i18n.t('flights.generationLogs.title'))
+    ).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', {
+        name: flightWithGenerationLogs.title ?? '',
+      })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('tab', { name: i18n.t('flights.logsTab') })
+    );
+
+    await expect(
+      await canvas.findByText(i18n.t('flights.generationLogs.title'))
+    ).toBeVisible();
+    await expect(
+      canvas.queryByRole('heading', {
+        name: flightWithGenerationLogs.title ?? '',
+      })
+    ).not.toBeInTheDocument();
+  }
+);
 
 export const MobileWithoutGpx = meta.story({
   name: 'Mobile Without GPX',

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -39,29 +39,73 @@ const {
   } as Flight,
 }));
 
-vi.mock('@dashboard-parapente/design-system', () => ({
-  Button: ({
-    children,
-    isDisabled,
-    onPress,
-    ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
-    isDisabled?: boolean;
-    onPress?: () => void;
-  }) => (
-    <button type="button" disabled={isDisabled} onClick={onPress} {...props}>
-      {children}
-    </button>
-  ),
-  Tab: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TabList: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  TabPanel: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+vi.mock('@dashboard-parapente/design-system', async () => {
+  const React = await import('react');
+  const MockTabsContext = React.createContext<{
+    selectedKey: string;
+    onSelectionChange: (key: string) => void;
+  }>({
+    selectedKey: 'infos',
+    onSelectionChange: () => undefined,
+  });
+
+  return {
+    Button: ({
+      children,
+      isDisabled,
+      onPress,
+      ...props
+    }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      isDisabled?: boolean;
+      onPress?: () => void;
+    }) => (
+      <button type="button" disabled={isDisabled} onClick={onPress} {...props}>
+        {children}
+      </button>
+    ),
+    Tab: ({ children, id }: { children: React.ReactNode; id: string }) => {
+      const tabs = React.useContext(MockTabsContext);
+      return (
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tabs.selectedKey === id}
+          onClick={() => tabs.onSelectionChange(id)}
+        >
+          {children}
+        </button>
+      );
+    },
+    TabList: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    TabPanel: ({ children, id }: { children: React.ReactNode; id: string }) => {
+      const tabs = React.useContext(MockTabsContext);
+      return tabs.selectedKey === id ? (
+        <div role="tabpanel">{children}</div>
+      ) : null;
+    },
+    Tabs: ({
+      children,
+      selectedKey,
+      onSelectionChange,
+    }: {
+      children: React.ReactNode;
+      selectedKey: string;
+      onSelectionChange: (key: string) => void;
+    }) => {
+      const contextValue = React.useMemo(
+        () => ({ selectedKey, onSelectionChange }),
+        [selectedKey, onSelectionChange]
+      );
+      return (
+        <MockTabsContext.Provider value={contextValue}>
+          <div>{children}</div>
+        </MockTabsContext.Provider>
+      );
+    },
+  };
+});
 
 vi.mock('react-aria-components', () => ({
   TextArea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
@@ -104,6 +148,9 @@ vi.mock('react-i18next', () => ({
         'flights.generationLogs.status.running': 'Running',
         'flights.generationLogs.status.encoding': 'Encoding',
         'flights.generationLogs.status.failed': 'Failed',
+        'flights.infoTab': 'Info',
+        'flights.replayTab': 'Replay',
+        'flights.logsTab': 'Logs',
       })[key] ?? key,
   }),
 }));
@@ -245,7 +292,7 @@ describe('FlightDetails GoPro overlay action', () => {
     expect(formData.get('gpx_offset')).toBe('2.5');
   });
 
-  it('shows a dedicated generation logs panel for video and GoPro jobs', () => {
+  it('shows video and GoPro job details in the logs tab', () => {
     mockFlight.video_export_job_id = 'video-job';
     mockFlight.video_export_status = 'running';
     overlayJobStreamMock.current = {
@@ -278,6 +325,10 @@ describe('FlightDetails GoPro overlay action', () => {
       />
     );
 
+    expect(screen.queryByText('Generation logs')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
+
     expect(screen.getByText('Generation logs')).toBeInTheDocument();
     expect(screen.getByText('Flight video')).toBeInTheDocument();
     expect(screen.getByText('GoPro overlay')).toBeInTheDocument();
@@ -296,9 +347,28 @@ describe('FlightDetails GoPro overlay action', () => {
     );
 
     expect(screen.queryByText('Generation logs')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Logs' })).not.toBeInTheDocument();
   });
 
-  it('regenerates overlay after cancellation', async () => {
+  it('keeps the logs tab available while a job status is loading', () => {
+    mockFlight.video_export_job_id = 'video-job';
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
+
+    expect(screen.getByText('Generation logs')).toBeInTheDocument();
+    expect(screen.getByText('Flight video')).toBeInTheDocument();
+    expect(screen.getByText('No logs yet.')).toBeInTheDocument();
+  });
+
+  it('regenerates overlay after cancellation', () => {
     mockFlight.gopro_overlay_job_id = 'job-overlay';
     mockFlight.gopro_overlay_status = 'cancelled';
 

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -47,7 +47,7 @@ interface FlightDetailsProps {
   onCloseMobile?: () => void;
 }
 
-type FlightDetailsTab = 'infos' | 'replay';
+type FlightDetailsTab = 'infos' | 'replay' | 'logs';
 
 export function FlightDetails({
   flight,
@@ -410,6 +410,22 @@ export function FlightDetails({
   const canUseGoproOverlayAction =
     (isGoproOverlayRunning && Boolean(effectiveGoproOverlayJobId)) ||
     (hasGoproCameraVideo && hasVideo && !isGoproOverlayRunning);
+  const hasGenerationLogs = Boolean(
+    flight.video_export_job_id ||
+    videoExportStatus?.internal_status ||
+    videoExportStatus?.status ||
+    videoExportStatus?.job_id ||
+    flight.video_export_status ||
+    goproOverlayJob?.status ||
+    goproOverlayJob?.job_id ||
+    effectiveGoproOverlayJobId ||
+    flight.gopro_overlay_status
+  );
+  const visibleActiveTab: FlightDetailsTab =
+    (mobileMode && !hasGenerationLogs && activeTab === 'logs') ||
+    (!mobileMode && activeTab === 'replay')
+      ? 'infos'
+      : activeTab;
 
   const infoCard = (
     <div className="rounded-xl bg-white p-4 shadow-md dark:bg-gray-800">
@@ -528,14 +544,6 @@ export function FlightDetails({
               onDownload={handleDownloadGoproOverlay}
             />
           )}
-          <FlightGenerationLogsPanel
-            videoStatus={videoExportStatus}
-            videoFallbackStatus={flight.video_export_status}
-            videoFallbackProgress={flight.video_export_progress}
-            goproOverlayJob={goproOverlayJob}
-            goproOverlayFallbackStatus={flight.gopro_overlay_status}
-            goproOverlayFallbackProgress={flight.gopro_overlay_progress}
-          />
           <FlightStatsGrid flight={flight} sites={sites} />
           <FlightNotesSection
             notes={flight.notes}
@@ -564,6 +572,19 @@ export function FlightDetails({
     />
   );
 
+  const logsPanel = (
+    <FlightGenerationLogsPanel
+      videoJobId={flight.video_export_job_id}
+      videoStatus={videoExportStatus}
+      videoFallbackStatus={flight.video_export_status}
+      videoFallbackProgress={flight.video_export_progress}
+      goproOverlayJob={goproOverlayJob}
+      goproOverlayJobId={effectiveGoproOverlayJobId}
+      goproOverlayFallbackStatus={flight.gopro_overlay_status}
+      goproOverlayFallbackProgress={flight.gopro_overlay_progress}
+    />
+  );
+
   if (mobileMode) {
     return (
       <div className="space-y-4">
@@ -584,7 +605,7 @@ export function FlightDetails({
         </div>
 
         <Tabs
-          selectedKey={activeTab}
+          selectedKey={visibleActiveTab}
           onSelectionChange={(key) => {
             const tab = key as FlightDetailsTab;
             setActiveTab(tab);
@@ -594,13 +615,20 @@ export function FlightDetails({
           }}
           className="space-y-4"
         >
-          <TabList className="mb-4 grid-cols-2">
+          <TabList
+            className={`mb-4 ${hasGenerationLogs ? 'grid-cols-3' : 'grid-cols-2'}`}
+          >
             <Tab id="infos" className="rounded-md px-3 py-2 text-sm">
               {t('flights.infoTab')}
             </Tab>
             <Tab id="replay" className="rounded-md px-3 py-2 text-sm">
               {t('flights.replayTab')}
             </Tab>
+            {hasGenerationLogs && (
+              <Tab id="logs" className="rounded-md px-3 py-2 text-sm">
+                {t('flights.logsTab')}
+              </Tab>
+            )}
           </TabList>
 
           <TabPanel id="infos" className="outline-none">
@@ -609,6 +637,11 @@ export function FlightDetails({
           <TabPanel id="replay" className="outline-none">
             {hasOpenedReplay ? replayCard : null}
           </TabPanel>
+          {hasGenerationLogs && (
+            <TabPanel id="logs" className="outline-none">
+              {logsPanel}
+            </TabPanel>
+          )}
         </Tabs>
       </div>
     );
@@ -616,7 +649,22 @@ export function FlightDetails({
 
   return (
     <>
-      {infoCard}
+      {hasGenerationLogs ? (
+        <Tabs
+          selectedKey={visibleActiveTab}
+          onSelectionChange={(key) => setActiveTab(key as FlightDetailsTab)}
+          className="space-y-4"
+        >
+          <TabList className="mb-4 grid-cols-2">
+            <Tab id="infos">{t('flights.infoTab')}</Tab>
+            <Tab id="logs">{t('flights.logsTab')}</Tab>
+          </TabList>
+          <TabPanel id="infos">{infoCard}</TabPanel>
+          <TabPanel id="logs">{logsPanel}</TabPanel>
+        </Tabs>
+      ) : (
+        infoCard
+      )}
       {hasGpx ? replayCard : null}
     </>
   );

--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -4,10 +4,12 @@ import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
 import { JobLogViewer } from '../job-logs/JobLogViewer';
 
 type FlightGenerationLogsPanelProps = {
+  videoJobId?: string | null;
   videoStatus: VideoExportStatusPayload | null;
   videoFallbackStatus?: string | null;
   videoFallbackProgress?: number | null;
   goproOverlayJob: GoproOverlayJob | null;
+  goproOverlayJobId?: string | null;
   goproOverlayFallbackStatus?: string | null;
   goproOverlayFallbackProgress?: number | null;
 };
@@ -131,10 +133,12 @@ function LogSourceCard({
 }
 
 export function FlightGenerationLogsPanel({
+  videoJobId,
   videoStatus,
   videoFallbackStatus,
   videoFallbackProgress,
   goproOverlayJob,
+  goproOverlayJobId,
   goproOverlayFallbackStatus,
   goproOverlayFallbackProgress,
 }: FlightGenerationLogsPanelProps) {
@@ -146,9 +150,11 @@ export function FlightGenerationLogsPanel({
     null;
   const goproOverlayStatusValue =
     goproOverlayJob?.status ?? goproOverlayFallbackStatus ?? null;
-  const hasVideoLogSource = Boolean(videoStatusValue || videoStatus?.job_id);
+  const hasVideoLogSource = Boolean(
+    videoStatusValue || videoStatus?.job_id || videoJobId
+  );
   const hasGoproOverlayLogSource = Boolean(
-    goproOverlayStatusValue || goproOverlayJob?.job_id
+    goproOverlayStatusValue || goproOverlayJob?.job_id || goproOverlayJobId
   );
 
   if (!hasVideoLogSource && !hasGoproOverlayLogSource) {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1057,6 +1057,7 @@
     "gpxFileInput": "GPX file",
     "infoTab": "Info",
     "replayTab": "Replay",
+    "logsTab": "Logs",
     "backToList": "← Back",
     "replayUnavailable": "No GPX available for this flight",
     "viewerExportMissingFlightId": "No flight ID provided. Use ?flightId=xxx",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1061,6 +1061,7 @@
     "gpxFileInput": "Fichier GPX",
     "infoTab": "Infos",
     "replayTab": "Replay",
+    "logsTab": "Logs",
     "backToList": "← Retour",
     "replayUnavailable": "Aucun GPX disponible pour ce vol",
     "viewerExportMissingFlightId": "Aucun identifiant de vol fourni. Utilisez ?flightId=xxx",


### PR DESCRIPTION
## Summary
- move flight generation logs out of the main information view
- add responsive Logs tabs while keeping the desktop replay visible
- keep log access available while media job status is loading
- add translations, unit coverage, and a Storybook interaction story

## Validation
- NODE_OPTIONS=--preserve-symlinks TESTING=true NX_DAEMON=false NX_NO_CLOUD=true pnpm nx lint frontend
- NODE_OPTIONS=--preserve-symlinks TESTING=true NX_DAEMON=false NX_NO_CLOUD=true pnpm nx test frontend
- NODE_OPTIONS=--preserve-symlinks TESTING=true NX_DAEMON=false NX_NO_CLOUD=true pnpm nx build frontend
- CodeRabbit CLI review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Logs tab to flight details when video or overlay generation activity is available.
  - Generation logs can now be viewed on desktop and mobile.
  - Log cards remain available while generation status is loading or incomplete.
  - Added English and French translations for the Logs tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->