### PR TITLE
fix(frontend): allow long emagram analysis requests

### DIFF
--- a/apps/frontend/src/hooks/weather/useEmagramAnalysis.test.tsx
+++ b/apps/frontend/src/hooks/weather/useEmagramAnalysis.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTriggerEmagram } from './useEmagramAnalysis';
+
+const { apiPost, responseJson } = vi.hoisted(() => ({
+  apiPost: vi.fn(),
+  responseJson: vi.fn(),
+}));
+
+vi.mock('../../lib/api', () => ({
+  api: { post: apiPost },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ i18n: { language: 'fr' } }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useTriggerEmagram', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    responseJson.mockResolvedValue({ id: 'analysis-id' });
+    apiPost.mockReturnValue({ json: responseJson });
+  });
+
+  it('does not apply the global request timeout to long analyses', async () => {
+    const { result } = renderHook(() => useTriggerEmagram(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        site_id: 'site-la-cote',
+        force_refresh: true,
+        hour: 15,
+      });
+    });
+
+    expect(apiPost).toHaveBeenCalledWith('emagram/analyze', {
+      json: {
+        locale: 'fr',
+        site_id: 'site-la-cote',
+        force_refresh: true,
+        hour: 15,
+      },
+      timeout: false,
+    });
+  });
+});

--- a/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
+++ b/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
@@ -144,6 +144,7 @@ export function useTriggerEmagram() {
       return api
         .post('emagram/analyze', {
           json: { locale: i18n.language, ...request },
+          timeout: false,
         })
         .json<EmagramAnalysis>();
     },


### PR DESCRIPTION
## Summary
- disable the global 30-second HTTP timeout for manual emagram analyses
- let successful long-running analyses invalidate and refresh cached emagram data
- add a regression test for the request configuration

## Validation
- targeted frontend test: passed
- frontend lint, type-check, and production build: passed
- CodeRabbit CLI: 0 findings
- full affected run: backend 869 passed; frontend unit tests 183 passed before unrelated Playwright browser closures in existing Storybook suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for manual Emagram analyses by preventing long-running requests from being interrupted by the standard timeout.
  * Ensured analysis requests continue to use localized parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->