### PR TITLE
fix(frontend): trigger emagram on hour click

### DIFF
--- a/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.stories.tsx
@@ -148,6 +148,9 @@ export const Default = meta.story({
 });
 
 Default.test('displays emagram score and metrics', async ({ canvas }) => {
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /Analyse 14h/ })
+  );
   await canvas.findByText(/75/);
   await expect(canvas.getByText(/Arguel/)).toBeInTheDocument();
   const explanationButton = canvas.getByLabelText(/Comment l'IA a analysé/);
@@ -174,7 +177,14 @@ export const AnalysisInProgress = meta.story({
           HttpResponse.json({
             site_id: 'site-arguel',
             forecast_date: '2026-03-24',
-            hours: [],
+            hours: [
+              {
+                hour: 12,
+                score: null,
+                status: 'pending',
+                id: 'pending-12',
+              },
+            ],
           })
         ),
         http.get('*/api/emagram/latest', () => HttpResponse.json(null)),
@@ -187,6 +197,9 @@ export const AnalysisInProgress = meta.story({
 });
 
 AnalysisInProgress.test('shows analysis in progress', async ({ canvas }) => {
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /Analyse 12h en attente/ })
+  );
   await canvas.findByText(/Analyse en cours/);
 });
 
@@ -200,7 +213,14 @@ export const Error = meta.story({
           HttpResponse.json({
             site_id: 'site-arguel',
             forecast_date: '2026-03-24',
-            hours: [],
+            hours: [
+              {
+                hour: 12,
+                score: null,
+                status: 'pending',
+                id: 'pending-12',
+              },
+            ],
           })
         ),
         http.get('*/api/emagram/latest', () => {
@@ -215,6 +235,9 @@ export const Error = meta.story({
 });
 
 Error.test('displays error message', async ({ canvas }) => {
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /Analyse 12h en attente/ })
+  );
   await canvas.findByText(/Erreur/);
 });
 
@@ -256,7 +279,14 @@ export const Loading = meta.story({
           HttpResponse.json({
             site_id: 'site-arguel',
             forecast_date: '2026-03-24',
-            hours: [],
+            hours: [
+              {
+                hour: 12,
+                score: null,
+                status: 'pending',
+                id: 'pending-12',
+              },
+            ],
           })
         ),
         http.get('*/api/emagram/latest', async () => {
@@ -265,6 +295,13 @@ export const Loading = meta.story({
       ],
     },
   },
+});
+
+Loading.test('shows loading after choosing an hour', async ({ canvas }) => {
+  await userEvent.click(
+    await canvas.findByRole('button', { name: /Analyse 12h en attente/ })
+  );
+  await canvas.findByText(/Analyse en cours/);
 });
 
 export const HoursWithoutAnalysis = meta.story({
@@ -281,11 +318,17 @@ export const HoursWithoutAnalysis = meta.story({
 });
 
 HoursWithoutAnalysis.test(
-  'shows hour chooser before analysis exists',
+  'starts analysis only after choosing an hour',
   async ({ canvas }) => {
     await canvas.findByText(/9h/);
     await expect(canvas.getByText(/12h/)).toBeInTheDocument();
     await expect(canvas.getByText(/15h/)).toBeInTheDocument();
+    await expect(canvas.getByText(/Choisissez une heure/)).toBeInTheDocument();
+    await expect(
+      canvas.queryByText(/Analyse en cours/)
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: /Analyse 12h/ }));
     await canvas.findByText(/Analyse en cours/);
   }
 );

--- a/apps/frontend/src/components/dashboard/EmagramWidget.test.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import EmagramWidget from './EmagramWidget';
+
+const { useLatestEmagram, useEmagramHours, useTriggerEmagram } = vi.hoisted(
+  () => ({
+    useLatestEmagram: vi.fn(),
+    useEmagramHours: vi.fn(),
+    useTriggerEmagram: vi.fn(),
+  })
+);
+
+vi.mock('../../hooks/weather/useEmagramAnalysis', () => ({
+  useLatestEmagram,
+  useEmagramHours,
+  useTriggerEmagram,
+}));
+
+describe('EmagramWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEmagramHours.mockReturnValue({
+      data: {
+        hours: [
+          {
+            hour: 12,
+            score: null,
+            status: 'pending',
+            id: 'pending-12',
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    useLatestEmagram.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useTriggerEmagram.mockReturnValue({
+      mutateAsync: vi.fn(),
+      error: null,
+    });
+  });
+
+  it('enables analysis only after an hour is selected', async () => {
+    const { rerender } = render(<EmagramWidget siteId="site-arguel" />);
+
+    expect(useLatestEmagram).toHaveBeenLastCalledWith('site-arguel', 0, null, {
+      enabled: false,
+    });
+    expect(
+      screen.getByText('Choisissez une heure pour lancer l’analyse.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Analyse 12h en attente' })
+    );
+
+    await waitFor(() => {
+      expect(useLatestEmagram).toHaveBeenLastCalledWith('site-arguel', 0, 12, {
+        enabled: true,
+      });
+    });
+
+    rerender(<EmagramWidget siteId="site-mont-poupet" />);
+
+    expect(
+      useLatestEmagram.mock.calls.some(
+        ([siteId, dayIndex, hour, options]) =>
+          siteId === 'site-mont-poupet' &&
+          dayIndex === 0 &&
+          hour === 12 &&
+          options.enabled
+      )
+    ).toBe(false);
+    expect(useLatestEmagram).toHaveBeenLastCalledWith(
+      'site-mont-poupet',
+      0,
+      null,
+      { enabled: false }
+    );
+  });
+});

--- a/apps/frontend/src/components/dashboard/EmagramWidget.tsx
+++ b/apps/frontend/src/components/dashboard/EmagramWidget.tsx
@@ -16,7 +16,7 @@ import {
   getScoreColor,
   getScoreCategory,
 } from '../../types/emagram';
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { parseApiUtcDate } from '../../lib/date';
 import { getApiUrlWithSearchParams } from '../../lib/api';
 import { useAuthStore } from '../../stores/authStore';
@@ -270,9 +270,11 @@ export default function EmagramWidget({
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [selectedHour, setSelectedHour] = useState<number | null>(null);
+  const selectionContextRef = useRef({ siteId, dayIndex });
   const authToken = useAuthStore((s) => s.token);
 
   useEffect(() => {
+    selectionContextRef.current = { siteId, dayIndex };
     setSelectedHour(null);
   }, [dayIndex, siteId]);
 
@@ -289,27 +291,11 @@ export default function EmagramWidget({
     [hoursData?.hours]
   );
 
-  // Determine which hour to display: selected, or current hour if in range, or null
-  const activeHour = useMemo(() => {
-    if (
-      selectedHour !== null &&
-      availableHours.some((h) => h.hour === selectedHour)
-    ) {
-      return selectedHour;
-    }
-    if (!availableHours.length || dayIndex > 0) return selectedHour;
-    const targetHour = new Date().getHours();
-    const hours = availableHours.map((h) => h.hour);
-
-    if (hours.includes(targetHour)) return targetHour;
-    // Default to closest available hour
-    return hours.reduce((prev, curr) =>
-      Math.abs(curr - targetHour) < Math.abs(prev - targetHour) ? curr : prev
-    );
-  }, [selectedHour, availableHours, dayIndex]);
-
-  const shouldFetchEmagram =
-    !!siteId && (dayIndex === 0 || activeHour !== null);
+  const selectionContextChanged =
+    selectionContextRef.current.siteId !== siteId ||
+    selectionContextRef.current.dayIndex !== dayIndex;
+  const activeHour = selectionContextChanged ? null : selectedHour;
+  const shouldFetchEmagram = !!siteId && activeHour !== null;
 
   const {
     data: emagram,
@@ -343,16 +329,6 @@ export default function EmagramWidget({
       },
     ].sort((a, b) => a.hour - b.hour);
   }, [availableHours, emagram]);
-
-  useEffect(() => {
-    if (
-      selectedHour == null &&
-      !availableHours.length &&
-      emagram?.forecast_hour != null
-    ) {
-      setSelectedHour(emagram.forecast_hour);
-    }
-  }, [availableHours.length, emagram?.forecast_hour, selectedHour]);
 
   const hasHourlyData = displayHours.length > 0;
   const hourSlider = hasHourlyData ? (


### PR DESCRIPTION
## Summary\n- stop auto-triggering emagram analysis on page load\n- trigger analysis only after selecting an hour\n- add regression coverage for hour selection and context changes\n\n## Validation\n- NX_NO_CLOUD=true pnpm nx affected -t build,lint,type-check --parallel=3 --exclude=e2e\n- NX_NO_CLOUD=true pnpm exec vitest run --config vitest.config.ts --project unit src/components/dashboard/EmagramWidget.test.tsx\n- CodeRabbit review: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users must now explicitly select an hour before an emagram analysis can start.
  * Hour selections reset when switching sites, preventing results from being requested for the wrong context.
  * Analysis no longer starts automatically based on the current or nearest available hour.
  * Improved handling of loading, pending, error, and unavailable-analysis states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->