### PR TITLE
fix(frontend): confirm media regeneration

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -124,6 +124,7 @@ vi.mock('react-i18next', () => ({
         'flights.goproOverlayCancel': 'Cancel overlay',
         'flights.goproOverlayCancelShort': 'Cancel overlay',
         'flights.goproOverlayConfirmCancel': 'Confirm cancel overlay',
+        'flights.goproOverlayConfirmRegenerate': 'Confirm regenerate overlay',
         'flights.goproOverlayRegenerate': 'Regenerate overlay',
         'flights.goproOverlayRegenerateShort': 'Regenerate overlay',
         'flights.goproOverlayGenerate': 'Generate overlay',
@@ -385,5 +386,51 @@ describe('FlightDetails GoPro overlay action', () => {
     );
 
     expect(createOverlayMock).toHaveBeenCalled();
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it('regenerates an existing overlay after confirmation', () => {
+    mockFlight.gopro_overlay_job_id = 'job-overlay';
+    mockFlight.gopro_overlay_status = 'completed';
+    mockFlight.gopro_overlay_file_path = '/exports/final.mp4';
+    mockFlight.gopro_overlay_file_exists = true;
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Regenerate overlay/u })
+    );
+
+    expect(confirmMock).toHaveBeenCalledWith('Confirm regenerate overlay');
+    expect(createOverlayMock).toHaveBeenCalled();
+  });
+
+  it('keeps an existing overlay when regeneration is not confirmed', () => {
+    mockFlight.gopro_overlay_job_id = 'job-overlay';
+    mockFlight.gopro_overlay_status = 'completed';
+    mockFlight.gopro_overlay_file_path = '/exports/final.mp4';
+    mockFlight.gopro_overlay_file_exists = true;
+    confirmMock.mockReturnValue(false);
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Regenerate overlay/u })
+    );
+
+    expect(confirmMock).toHaveBeenCalledWith('Confirm regenerate overlay');
+    expect(createOverlayMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -243,6 +243,12 @@ export function FlightDetails({
 
   const handleStartGoproOverlay = async () => {
     if (isGoproOverlayRunning) return;
+    if (
+      hasPersistedGoproOverlay &&
+      !confirm(t('flights.goproOverlayConfirmRegenerate'))
+    ) {
+      return;
+    }
     if (!hasGoproCameraVideo) {
       toast.error(t('flights.goproOverlayNeedsCameraVideo'));
       return;

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.test.tsx
@@ -54,6 +54,7 @@ vi.mock('react-i18next', () => ({
         'flights.viewer.cancelGenerationShort': 'Cancel generation',
         'flights.viewer.regenerateVideo': 'Restart generation',
         'flights.viewer.regenerateVideoShort': 'Regenerate video',
+        'flights.viewer.confirmRegenerateVideo': 'Confirm regenerate video',
         'videoJobs.liveLogs.title': 'Live logs',
         'videoJobs.liveLogs.empty': 'No logs yet.',
         'videoJobs.liveLogs.show': 'Show',
@@ -158,6 +159,7 @@ describe('FlightVideoExportControls', () => {
         searchParams: { mode: 'manual_fast' },
       });
     });
+    expect(confirmMock).not.toHaveBeenCalled();
   });
 
   it('turns the primary button into cancel while export is active', async () => {
@@ -241,7 +243,7 @@ describe('FlightVideoExportControls', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows regenerate when a video already exists', () => {
+  it('regenerates an existing video after confirmation', async () => {
     mockFlight.video_export_status = 'completed';
     mockFlight.video_export_job_id = 'job-video';
     mockFlight.video_file_path = '/exports/job-video.mp4';
@@ -252,6 +254,28 @@ describe('FlightVideoExportControls', () => {
     expect(
       screen.getByRole('button', { name: /Regenerate video/u })
     ).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Regenerate video/u }));
+
+    await waitFor(() => {
+      expect(confirmMock).toHaveBeenCalledWith('Confirm regenerate video');
+      expect(apiPost).toHaveBeenCalled();
+    });
+  });
+
+  it('keeps an existing video when regeneration is not confirmed', () => {
+    mockFlight.video_export_status = 'completed';
+    mockFlight.video_export_job_id = 'job-video';
+    mockFlight.video_file_path = '/exports/job-video.mp4';
+    mockFlight.video_file_exists = true;
+    confirmMock.mockReturnValue(false);
+
+    render(<FlightVideoExportControls flight={mockFlight} compact />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Regenerate video/u }));
+
+    expect(confirmMock).toHaveBeenCalledWith('Confirm regenerate video');
+    expect(apiPost).not.toHaveBeenCalled();
   });
 
   it('generates again when database references a missing completed video file', () => {

--- a/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
+++ b/apps/frontend/src/components/flights/video-export/FlightVideoExportControls.tsx
@@ -293,7 +293,12 @@ export function FlightVideoExportControls({
   };
 
   const handleRegenerateVideo = async () => {
-    if (!confirm(t('flights.viewer.confirmRegenerateVideo'))) return;
+    if (
+      hasGeneratedVideo &&
+      !confirm(t('flights.viewer.confirmRegenerateVideo'))
+    ) {
+      return;
+    }
 
     try {
       await startVideoExport();

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -983,6 +983,7 @@
     "goproOverlayStarted": "GoPro overlay generation started",
     "goproOverlayStartError": "Unable to start GoPro overlay",
     "goproOverlayConfirmCancel": "Are you sure you want to cancel this overlay generation?",
+    "goproOverlayConfirmRegenerate": "Are you sure you want to regenerate this overlay? The existing overlay will be replaced.",
     "goproOverlayCancelled": "GoPro overlay generation cancelled",
     "goproOverlayCancelError": "Unable to cancel GoPro overlay",
     "goproOverlayDownloadError": "Unable to download GoPro overlay",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -987,6 +987,7 @@
     "goproOverlayStarted": "Génération overlay GoPro lancée",
     "goproOverlayStartError": "Impossible de lancer l'overlay GoPro",
     "goproOverlayConfirmCancel": "Êtes-vous sûr de vouloir annuler cette génération d'overlay ?",
+    "goproOverlayConfirmRegenerate": "Êtes-vous sûr de vouloir régénérer cet overlay ? L'overlay existant sera remplacé.",
     "goproOverlayCancelled": "Génération overlay GoPro annulée",
     "goproOverlayCancelError": "Impossible d'annuler l'overlay GoPro",
     "goproOverlayDownloadError": "Impossible de télécharger l'overlay GoPro",


### PR DESCRIPTION
## Summary\n- add confirmation before regenerating an existing video or GoPro overlay\n- keep direct reruns for cancelled/failed jobs without a confirmed output file\n- add coverage for accept/decline flows and translation strings\n\n## Validation\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend --run src/components/flights/video-export/FlightVideoExportControls.test.tsx src/components/flights/details/FlightDetails.test.tsx\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend\n\n## Review\n- CodeRabbit review completed with no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation prompts before replacing existing GoPro overlays or generated videos.
  * Regeneration after a cancelled operation continues without confirmation.
  * Added English and French confirmation messages.

* **Bug Fixes**
  * Declining a replacement confirmation now correctly prevents regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->