### PR TITLE
fix(frontend): make flight logs collapsible

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -331,11 +331,28 @@ describe('FlightDetails GoPro overlay action', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
 
     expect(screen.getByText('Generation logs')).toBeInTheDocument();
-    expect(screen.getByText('Flight video')).toBeInTheDocument();
-    expect(screen.getByText('GoPro overlay')).toBeInTheDocument();
+    const videoToggle = screen.getByRole('button', {
+      name: /Flight video/u,
+    });
+    const overlayToggle = screen.getByRole('button', {
+      name: /GoPro overlay/u,
+    });
+
+    expect(videoToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(overlayToggle).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getByText('Encoding with FFmpeg')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Overlay failed on frame 42')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(overlayToggle);
+
     expect(screen.getByText('Overlay failed on frame 42')).toBeInTheDocument();
     expect(screen.getAllByText(/Frame 42 failed/u).length).toBeGreaterThan(0);
+
+    fireEvent.click(videoToggle);
+
+    expect(screen.queryByText('Encoding with FFmpeg')).not.toBeInTheDocument();
   });
 
   it('does not render an empty generation logs panel', () => {
@@ -365,8 +382,76 @@ describe('FlightDetails GoPro overlay action', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
 
     expect(screen.getByText('Generation logs')).toBeInTheDocument();
-    expect(screen.getByText('Flight video')).toBeInTheDocument();
+    const videoToggle = screen.getByRole('button', {
+      name: 'Flight video',
+    });
+    expect(videoToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('No logs yet.')).not.toBeInTheDocument();
+
+    fireEvent.click(videoToggle);
+
     expect(screen.getByText('No logs yet.')).toBeInTheDocument();
+  });
+
+  it('opens GoPro logs by default while the overlay job is running', () => {
+    overlayJobStreamMock.current = {
+      job_id: 'overlay-job',
+      status: 'running',
+      progress: 43,
+      message: 'Rendering overlay',
+      error: null,
+      layout_id: 'layout',
+      layout_label: 'Parapente',
+      output_filename: 'final.mp4',
+      created_at: '2026-03-15T14:00:00Z',
+      updated_at: '2026-03-15T14:10:00Z',
+      log_tail: ['Starting overlay'],
+    };
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
+
+    expect(
+      screen.getByRole('button', { name: /GoPro overlay/u })
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Rendering overlay')).toBeInTheDocument();
+  });
+
+  it('preserves a manual toggle while a fallback-only job changes status', () => {
+    mockFlight.video_export_status = 'running';
+
+    const view = render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Logs' }));
+    const videoToggle = screen.getByRole('button', {
+      name: /Flight video/u,
+    });
+    fireEvent.click(videoToggle);
+    expect(videoToggle).toHaveAttribute('aria-expanded', 'false');
+
+    mockFlight.video_export_status = 'encoding';
+    view.rerender(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    expect(videoToggle).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('regenerates overlay after cancellation', () => {

--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -1,6 +1,10 @@
+import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
+import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { VideoExportStatusPayload } from '../../../hooks/flights/useVideoExportStatus';
 import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
+import { isGoproOverlayInProgress } from '../../../lib/flightMediaState';
 import { JobLogViewer } from '../job-logs/JobLogViewer';
 
 type FlightGenerationLogsPanelProps = {
@@ -18,6 +22,7 @@ type LogSourceCardProps = {
   title: string;
   status: string | null;
   statusLabel: string | null;
+  isInProgress: boolean;
   progress?: number | null;
   message?: string | null;
   error?: string | null;
@@ -52,12 +57,15 @@ function LogSourceCard({
   title,
   status,
   statusLabel,
+  isInProgress,
   progress,
   message,
   error,
   logs,
 }: LogSourceCardProps) {
   const { t } = useTranslation();
+  const [openOverride, setOpenOverride] = useState<boolean | null>(null);
+  const isOpen = openOverride ?? isInProgress;
   const lines = logs?.filter(Boolean) ?? [];
   const normalizedProgress = clampProgress(progress);
   const hasDetails = Boolean(message || error || lines.length > 0);
@@ -70,64 +78,83 @@ function LogSourceCard({
   );
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900/70">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div>
+    <section className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/70">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 p-3 text-left hover:bg-slate-50 dark:hover:bg-slate-800/60"
+        aria-expanded={isOpen}
+        onClick={() => setOpenOverride(!isOpen)}
+      >
+        <div className="min-w-0">
           <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
             {title}
           </h4>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {statusLabel && (
+            <span
+              className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${statusTone}`}
+            >
+              {statusLabel}
+            </span>
+          )}
+          <ChevronDown
+            aria-hidden="true"
+            className={`size-4 text-slate-500 transition-transform dark:text-slate-400 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="border-t border-slate-200 p-3 dark:border-slate-700">
           {showCurrentMessage && (
-            <p className="mt-1 text-xs text-slate-600 dark:text-slate-300">
+            <p className="text-xs text-slate-600 dark:text-slate-300">
               {message}
             </p>
           )}
-        </div>
-        {statusLabel && (
-          <span
-            className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${statusTone}`}
-          >
-            {statusLabel}
-          </span>
-        )}
-      </div>
 
-      {normalizedProgress !== null && (
-        <div className="mt-3" aria-label={t('flights.generationLogs.progress')}>
-          <div className="mb-1 flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
-            <span>{t('flights.generationLogs.progress')}</span>
-            <span>{normalizedProgress}%</span>
-          </div>
-          <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+          {normalizedProgress !== null && (
             <div
-              className="h-full rounded-full bg-sky-500 transition-all"
-              style={{ width: `${normalizedProgress}%` }}
+              className="mt-3"
+              aria-label={t('flights.generationLogs.progress')}
+            >
+              <div className="mb-1 flex items-center justify-between text-xs text-slate-600 dark:text-slate-300">
+                <span>{t('flights.generationLogs.progress')}</span>
+                <span>{normalizedProgress}%</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                <div
+                  className="h-full rounded-full bg-sky-500 transition-all"
+                  style={{ width: `${normalizedProgress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-3 rounded-lg border border-red-200 bg-red-950 p-2 text-xs text-red-50 dark:border-red-900">
+              <div className="mb-1 font-semibold">
+                {t('flights.generationLogs.error')}
+              </div>
+              <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono leading-relaxed">
+                {error}
+              </pre>
+            </div>
+          )}
+
+          <div className="mt-3">
+            <JobLogViewer
+              logs={lines}
+              isLive={isLive}
+              emptyLabel={
+                hasDetails
+                  ? t('flights.generationLogs.noRawLogs')
+                  : t('flights.generationLogs.noLogs')
+              }
             />
           </div>
         </div>
       )}
-
-      {error && (
-        <div className="mt-3 rounded-lg border border-red-200 bg-red-950 p-2 text-xs text-red-50 dark:border-red-900">
-          <div className="mb-1 font-semibold">
-            {t('flights.generationLogs.error')}
-          </div>
-          <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono leading-relaxed">
-            {error}
-          </pre>
-        </div>
-      )}
-
-      <div className="mt-3">
-        <JobLogViewer
-          logs={lines}
-          isLive={isLive}
-          emptyLabel={
-            hasDetails
-              ? t('flights.generationLogs.noRawLogs')
-              : t('flights.generationLogs.noLogs')
-          }
-        />
-      </div>
     </section>
   );
 }
@@ -174,8 +201,13 @@ export function FlightGenerationLogsPanel({
       <div className="space-y-3">
         {hasVideoLogSource && (
           <LogSourceCard
+            key={`video-${videoStatus?.job_id ?? videoJobId ?? 'fallback'}`}
             title={t('flights.generationLogs.videoTitle')}
             status={videoStatusValue}
+            isInProgress={Boolean(
+              videoStatusValue &&
+              VIDEO_EXPORT_IN_PROGRESS_STATUSES.has(videoStatusValue)
+            )}
             statusLabel={
               videoStatusValue
                 ? t(`flights.generationLogs.status.${videoStatusValue}`)
@@ -189,8 +221,10 @@ export function FlightGenerationLogsPanel({
         )}
         {hasGoproOverlayLogSource && (
           <LogSourceCard
+            key={`gopro-${goproOverlayJob?.job_id ?? goproOverlayJobId ?? 'fallback'}`}
             title={t('flights.generationLogs.goproOverlayTitle')}
             status={goproOverlayStatusValue}
+            isInProgress={isGoproOverlayInProgress(goproOverlayStatusValue)}
             statusLabel={
               goproOverlayStatusValue
                 ? t(`flights.generationLogs.status.${goproOverlayStatusValue}`)


### PR DESCRIPTION
## Summary
- Make the flight generation logs sections collapsible
- Open them by default only while the related job is in progress
- Keep manual open/close state stable across status updates

## Validation
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e --uncommitted
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e --uncommitted
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:type-check
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test frontend -- src/components/flights/details/FlightDetails.test.tsx
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx run frontend:test:storybook -- src/components/flights/details/FlightDetails.stories.tsx

## Notes
- CodeRabbit review passed with no findings.
- The full frontend Vitest run hit an unrelated browser-closure error in  after 191 passing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible sections for video and GoPro generation logs.
  * Active log sections open automatically and display a toggle control.
  * Users can manually expand or collapse sections, with their choices preserved as statuses change.
  * Empty logs can now be opened to view their state.

* **Bug Fixes**
  * Improved log visibility and expansion behavior across different generation statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->