### PR TITLE
fix(gopro): support cpu fallback and badge

### DIFF
--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2568,6 +2568,9 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
 def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
+def test_run_job_falls_back_to_cpu_when_render_device_missing(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     job_id = "gpu-fallback-job"
     gopro_overlay_export._JOBS[job_id] = {
         "job_id": job_id,
@@ -2596,6 +2599,7 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
             "ffmpeg_vaapi": False,
         },
     )
+    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
 
     class FailedProcess:
         stdout: list[str] = []

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2586,6 +2586,16 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
     monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "check_gopro_overlay_dependencies",
+        lambda: {
+            "gopro_dashboard": True,
+            "ffmpeg": True,
+            "ffprobe": True,
+            "ffmpeg_vaapi": False,
+        },
+    )
 
     class FailedProcess:
         stdout: list[str] = []
@@ -2595,17 +2605,17 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
 
     try:
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.INFO),
             patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
         ):
             gopro_overlay_export._run_job(job_id)
 
-        command = popen.call_args.args[0]
-        assert "--profile" not in command
-        assert (
-            "render device /tmp/missing-render-device is missing; falling back to CPU"
-            in caplog.text
-        )
+        assert popen.called
+        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
+        assert job is not None
+        assert job["status"] == "failed"
+        assert job["render_method"] == "cpu"
+        assert "falling back to CPU rendering" in caplog.text
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
@@ -2715,6 +2725,63 @@ def test_run_job_marks_unexpected_start_error_failed(caplog, monkeypatch):
         assert job["message"] == "Overlay rendering failed to start"
         assert job["error"] == "boom"
         assert "Failed to start GoPro overlay job start-error-job" in caplog.text
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
+
+
+def test_run_job_falls_back_to_cpu_when_render_device_missing(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    job_id = "gpu-fallback-job"
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "check_gopro_overlay_dependencies",
+        lambda: {
+            "gopro_dashboard": True,
+            "ffmpeg": True,
+            "ffprobe": True,
+            "ffmpeg_vaapi": False,
+        },
+    )
+    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
+
+    class FailedProcess:
+        stdout: list[str] = []
+
+        def wait(self) -> int:
+            return 1
+
+    try:
+        with (
+            caplog.at_level(logging.INFO),
+            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
+        ):
+            gopro_overlay_export._run_job(job_id)
+
+        assert popen.called
+        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
+        assert job is not None
+        assert job["status"] == "failed"
+        assert job["render_method"] == "cpu"
+        assert "falling back to CPU rendering" in caplog.text
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2567,6 +2567,48 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
+def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
+    job_id = "gpu-fallback-job"
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
+
+    class FailedProcess:
+        stdout: list[str] = []
+
+        def wait(self) -> int:
+            return 1
+
+    try:
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
+        ):
+            gopro_overlay_export._run_job(job_id)
+
+        command = popen.call_args.args[0]
+        assert "--profile" not in command
+        assert (
+            "render device /tmp/missing-render-device is missing; falling back to CPU"
+            in caplog.text
+        )
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
 def test_run_job_falls_back_to_cpu_when_render_device_missing(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2567,62 +2567,6 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
-def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
-def test_run_job_falls_back_to_cpu_when_render_device_missing(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    job_id = "gpu-fallback-job"
-    gopro_overlay_export._JOBS[job_id] = {
-        "job_id": job_id,
-        "status": "queued",
-        "progress": 0,
-        "message": "Overlay queued",
-        "gpx_path": "track.gpx",
-        "layout_path": "layout.xml",
-        "video_path": "flight.mp4",
-        "output_path": "overlay.mp4",
-        "pip_path": None,
-        "video_width": None,
-        "video_height": None,
-        "updated_at": "2026-01-01T00:00:00+00:00",
-    }
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
-    monkeypatch.setattr(
-        gopro_overlay_export,
-        "check_gopro_overlay_dependencies",
-        lambda: {
-            "gopro_dashboard": True,
-            "ffmpeg": True,
-            "ffprobe": True,
-            "ffmpeg_vaapi": False,
-        },
-    )
-    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
-
-    class FailedProcess:
-        stdout: list[str] = []
-
-        def wait(self) -> int:
-            return 1
-
-    try:
-        with (
-            caplog.at_level(logging.INFO),
-            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
-        ):
-            gopro_overlay_export._run_job(job_id)
-
-        assert popen.called
-        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
-        assert job is not None
-        assert job["status"] == "failed"
-        assert job["render_method"] == "cpu"
-        assert "falling back to CPU rendering" in caplog.text
-    finally:
-        gopro_overlay_export._JOBS.pop(job_id, None)
-        gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
 def test_run_job_falls_back_to_cpu_when_render_device_missing(
@@ -2732,64 +2676,6 @@ def test_run_job_marks_unexpected_start_error_failed(caplog, monkeypatch):
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
-
-
-def test_run_job_falls_back_to_cpu_when_render_device_missing(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    job_id = "gpu-fallback-job"
-    gopro_overlay_export._JOBS[job_id] = {
-        "job_id": job_id,
-        "status": "queued",
-        "progress": 0,
-        "message": "Overlay queued",
-        "gpx_path": "track.gpx",
-        "layout_path": "layout.xml",
-        "video_path": "flight.mp4",
-        "output_path": "overlay.mp4",
-        "pip_path": None,
-        "video_width": None,
-        "video_height": None,
-        "updated_at": "2026-01-01T00:00:00+00:00",
-    }
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
-    monkeypatch.setattr(
-        gopro_overlay_export,
-        "check_gopro_overlay_dependencies",
-        lambda: {
-            "gopro_dashboard": True,
-            "ffmpeg": True,
-            "ffprobe": True,
-            "ffmpeg_vaapi": False,
-        },
-    )
-    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
-
-    class FailedProcess:
-        stdout: list[str] = []
-
-        def wait(self) -> int:
-            return 1
-
-    try:
-        with (
-            caplog.at_level(logging.INFO),
-            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
-        ):
-            gopro_overlay_export._run_job(job_id)
-
-        assert popen.called
-        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
-        assert job is not None
-        assert job["status"] == "failed"
-        assert job["render_method"] == "cpu"
-        assert "falling back to CPU rendering" in caplog.text
-    finally:
-        gopro_overlay_export._JOBS.pop(job_id, None)
-        gopro_overlay_export._PROCESSES.pop(job_id, None)
-        render_device_path.unlink(missing_ok=True)
 
 
 def _upload(filename: str, content: bytes) -> UploadFile:

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -343,7 +343,7 @@ describe('FlightDetails GoPro overlay action', () => {
 
     expect(videoToggle).toHaveAttribute('aria-expanded', 'true');
     expect(overlayToggle).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.getByText('GPU')).toBeInTheDocument();
+    expect(screen.getAllByText('GPU').length).toBeGreaterThan(0);
     expect(screen.getByText('Encoding with FFmpeg')).toBeInTheDocument();
     expect(
       screen.queryByText('Overlay failed on frame 42')

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
@@ -15,6 +15,10 @@ export function GoproOverlayJobCard({
   onDownload,
 }: GoproOverlayJobCardProps) {
   const { t } = useTranslation();
+  const renderMethodLabel =
+    job.render_method && ['cpu', 'gpu'].includes(job.render_method)
+      ? t(`flights.generationLogs.method.${job.render_method}`)
+      : null;
 
   return (
     <div className="mb-4 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/60">
@@ -23,9 +27,16 @@ export function GoproOverlayJobCard({
           <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
             {t('flights.goproOverlayJobTitle')}
           </p>
-          <p className="text-xs text-slate-600 dark:text-slate-300">
-            {job.layout_label} · {job.output_filename}
-          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+            <p>
+              {job.layout_label} · {job.output_filename}
+            </p>
+            {renderMethodLabel && (
+              <span className="rounded-full border border-slate-300 bg-slate-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-700 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200">
+                {renderMethodLabel}
+              </span>
+            )}
+          </div>
         </div>
         <span className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 shadow-sm dark:bg-slate-800 dark:text-slate-200">
           {t(`flights.goproOverlayStatus.${job.status}`)}


### PR DESCRIPTION
## Summary\n- add CPU fallback for GoPro overlay rendering\n- expose render_method through backend and frontend\n- show CPU/GPU badges in the flight logs and job card\n\n## Validation\n- pytest tests/api/test_gopro_overlay_endpoints.py -q --tb=short\n- vitest run src/components/flights/details/FlightDetails.test.tsx --config vitest.config.ts\n- nx lint backend\n- nx lint frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated GoPro overlay video rendering with automatic CPU fallback when GPU support is unavailable.
  * Added configurable graphics-device support for GPU rendering.
  * Added CPU/GPU rendering method details to overlay jobs and flight generation logs.
  * Added VAAPI dependency and runtime availability reporting.

* **Bug Fixes**
  * Overlay creation remains available when optional GPU/VAAPI support is missing.

* **Documentation**
  * Added English and French labels for CPU and GPU rendering methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->