### PR TITLE
fix(media): surface cpu gpu render method

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -365,13 +365,22 @@ def _job_preparation_metadata(
     pin_inputs: bool,
     requested_layout_id: str | None,
     gpx_offset: float = 0.0,
+    render_method: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    metadata = {
         "prepare_overlay_inputs": True,
         "pin_inputs": pin_inputs,
         "requested_layout_id": requested_layout_id,
         "gpx_offset": gpx_offset,
     }
+    if render_method:
+        metadata["render_method"] = render_method
+    return metadata
+
+
+def _queued_render_method() -> str:
+    gpu_device_path = Path(config.GOPRO_OVERLAY_RENDER_DEVICE)
+    return "gpu" if gpu_device_path.exists() and config.GOPRO_OVERLAY_PROFILE else "cpu"
 
 
 def _gpx_offset_from_command_metadata(command: Any) -> float:
@@ -1466,10 +1475,12 @@ def _create_gopro_overlay_job_from_paths(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_output_path = _temp_output_path(output_path, job_id)
     log_path = _gopro_overlay_log_path(job_id)
+    render_method = _queued_render_method()
     preparation_metadata = _job_preparation_metadata(
         pin_inputs=pin_inputs,
         requested_layout_id=layout_id,
         gpx_offset=gpx_offset,
+        render_method=render_method,
     )
 
     now = _utc_now_dt()
@@ -1493,6 +1504,7 @@ def _create_gopro_overlay_job_from_paths(
                 output_filename=output_path.name,
                 log_path=str(log_path),
                 command_json=json.dumps(preparation_metadata),
+                render_method=render_method,
                 video_width=None,
                 video_height=None,
                 created_at=now,
@@ -1523,6 +1535,7 @@ def _create_gopro_overlay_job_from_paths(
             "temp_output_path": str(temp_output_path),
             "output_filename": output_path.name,
             "log_path": str(log_path),
+            "render_method": render_method,
             "video_width": None,
             "video_height": None,
             "gpx_offset": gpx_offset,

--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -249,6 +249,7 @@ class GoproOverlayJob(Base):
     progress = Column(Integer, default=0)
     message = Column(Text)
     error = Column(Text)
+    render_method = Column(String, nullable=True)
     video_path = Column(String, nullable=False)
     gpx_path = Column(String, nullable=False)
     pip_path = Column(String)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -576,6 +576,7 @@ def _gopro_overlay_export_job_payload(job: dict[str, Any]) -> dict[str, Any]:
         "progress": job.get("progress"),
         "message": job.get("message"),
         "error": job.get("error"),
+        "render_method": job.get("render_method"),
         "gpx_path": job.get("gpx_path"),
         "mode": "gopro_overlay",
         "flight_title": job.get("output_filename") or job.get("layout_label"),

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2568,6 +2568,9 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
 def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
+def test_run_job_falls_back_to_cpu_when_render_device_missing(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     job_id = "gpu-fallback-job"
     gopro_overlay_export._JOBS[job_id] = {
         "job_id": job_id,
@@ -2596,6 +2599,7 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
             "ffmpeg_vaapi": False,
         },
     )
+    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
 
     class FailedProcess:
         stdout: list[str] = []

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2567,6 +2567,48 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
+def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
+    job_id = "gpu-fallback-job"
+    gopro_overlay_export._JOBS[job_id] = {
+        "job_id": job_id,
+        "status": "queued",
+        "progress": 0,
+        "message": "Overlay queued",
+        "gpx_path": "track.gpx",
+        "layout_path": "layout.xml",
+        "video_path": "flight.mp4",
+        "output_path": "overlay.mp4",
+        "pip_path": None,
+        "video_width": None,
+        "video_height": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
+
+    class FailedProcess:
+        stdout: list[str] = []
+
+        def wait(self) -> int:
+            return 1
+
+    try:
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
+        ):
+            gopro_overlay_export._run_job(job_id)
+
+        command = popen.call_args.args[0]
+        assert "--profile" not in command
+        assert (
+            "render device /tmp/missing-render-device is missing; falling back to CPU"
+            in caplog.text
+        )
+    finally:
+        gopro_overlay_export._JOBS.pop(job_id, None)
+        gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
 def test_run_job_falls_back_to_cpu_when_render_device_missing(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2586,6 +2586,16 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
     monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "check_gopro_overlay_dependencies",
+        lambda: {
+            "gopro_dashboard": True,
+            "ffmpeg": True,
+            "ffprobe": True,
+            "ffmpeg_vaapi": False,
+        },
+    )
 
     class FailedProcess:
         stdout: list[str] = []
@@ -2595,17 +2605,17 @@ def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatc
 
     try:
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.INFO),
             patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
         ):
             gopro_overlay_export._run_job(job_id)
 
-        command = popen.call_args.args[0]
-        assert "--profile" not in command
-        assert (
-            "render device /tmp/missing-render-device is missing; falling back to CPU"
-            in caplog.text
-        )
+        assert popen.called
+        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
+        assert job is not None
+        assert job["status"] == "failed"
+        assert job["render_method"] == "cpu"
+        assert "falling back to CPU rendering" in caplog.text
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2567,62 +2567,6 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)
         render_device_path.unlink(missing_ok=True)
-def test_run_job_skips_gpu_profile_when_render_device_missing(caplog, monkeypatch):
-def test_run_job_falls_back_to_cpu_when_render_device_missing(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    job_id = "gpu-fallback-job"
-    gopro_overlay_export._JOBS[job_id] = {
-        "job_id": job_id,
-        "status": "queued",
-        "progress": 0,
-        "message": "Overlay queued",
-        "gpx_path": "track.gpx",
-        "layout_path": "layout.xml",
-        "video_path": "flight.mp4",
-        "output_path": "overlay.mp4",
-        "pip_path": None,
-        "video_width": None,
-        "video_height": None,
-        "updated_at": "2026-01-01T00:00:00+00:00",
-    }
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_RENDER_DEVICE", "/tmp/missing-render-device")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nnvgpu")
-    monkeypatch.setattr(config, "GOPRO_OVERLAY_EXTRA_ARGS", "--double-buffer")
-    monkeypatch.setattr(
-        gopro_overlay_export,
-        "check_gopro_overlay_dependencies",
-        lambda: {
-            "gopro_dashboard": True,
-            "ffmpeg": True,
-            "ffprobe": True,
-            "ffmpeg_vaapi": False,
-        },
-    )
-    monkeypatch.setattr(gopro_overlay_export, "_ffmpeg_can_use_vaapi_device", lambda *_: False)
-
-    class FailedProcess:
-        stdout: list[str] = []
-
-        def wait(self) -> int:
-            return 1
-
-    try:
-        with (
-            caplog.at_level(logging.INFO),
-            patch("gopro_overlay_export.subprocess.Popen", return_value=FailedProcess()) as popen,
-        ):
-            gopro_overlay_export._run_job(job_id)
-
-        assert popen.called
-        job = gopro_overlay_export.get_gopro_overlay_job(job_id)
-        assert job is not None
-        assert job["status"] == "failed"
-        assert job["render_method"] == "cpu"
-        assert "falling back to CPU rendering" in caplog.text
-    finally:
-        gopro_overlay_export._JOBS.pop(job_id, None)
-        gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
 def test_run_job_falls_back_to_cpu_when_render_device_missing(

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -474,6 +474,7 @@ class TestVideoExportJobsEndpoint:
                 "flight_id": sample_flight.id,
                 "status": "processing",
                 "internal_status": "capturing",
+                "render_method": "cpu",
                 "progress": 42,
                 "message": "Capturing frames",
                 "mode": "manual_fast",
@@ -484,6 +485,7 @@ class TestVideoExportJobsEndpoint:
                 "flight_id": sample_flight.id,
                 "status": "failed",
                 "internal_status": "cancelled",
+                "render_method": "cpu",
                 "progress": 10,
                 "message": "Export cancelled by user",
                 "mode": "manual",
@@ -500,6 +502,7 @@ class TestVideoExportJobsEndpoint:
                     {
                         "job_id": "job-overlay",
                         "status": "running",
+                        "render_method": "gpu",
                         "progress": 50,
                         "message": "Rendering overlay",
                         "layout_label": "Parapente 1920x1080",
@@ -516,6 +519,7 @@ class TestVideoExportJobsEndpoint:
         assert jobs[0]["job_id"] == "job-overlay"
         assert jobs[0]["status"] == "running"
         assert jobs[0]["mode"] == "gopro_overlay"
+        assert jobs[0]["render_method"] == "gpu"
         assert jobs[0]["can_cancel"] is True
         assert jobs[0]["can_delete"] is False
         assert jobs[0]["flight_id"] == sample_flight.id
@@ -523,6 +527,7 @@ class TestVideoExportJobsEndpoint:
         assert jobs[0]["flight_title"] == sample_flight.name
         assert jobs[1]["job_id"] == "job-running"
         assert jobs[1]["status"] == "processing"
+        assert jobs[1]["render_method"] == "cpu"
         assert jobs[1]["can_cancel"] is True
         assert jobs[1]["can_delete"] is True
         assert jobs[1]["flight_name"] == sample_flight.name
@@ -542,6 +547,7 @@ class TestVideoExportJobsEndpoint:
                         "flight_id": "flight-1",
                         "status": "processing",
                         "internal_status": "queued",
+                        "render_method": "cpu",
                     },
                     {
                         "job_id": "job-done",
@@ -558,6 +564,7 @@ class TestVideoExportJobsEndpoint:
                         "job_id": "job-stream-encoding",
                         "flight_id": "flight-1",
                         "status": "encoding",
+                        "render_method": "gpu",
                     }
                 ],
             ),
@@ -587,6 +594,25 @@ class TestVideoExportJobsEndpoint:
             "job-overlay-running",
         }
         assert all(job["can_cancel"] is True for job in jobs)
+        assert (
+            next(job for job in jobs if job["job_id"] == "job-stream-encoding")["render_method"]
+            == "gpu"
+        )
+
+    def test_export_status_passthrough_keeps_render_method(self, client: TestClient):
+        with patch(
+            "routes._resolve_export_status",
+            return_value={
+                "job_id": "job-status",
+                "status": "processing",
+                "internal_status": "capturing",
+                "render_method": "gpu",
+            },
+        ):
+            response = client.get(f"{API_PREFIX}/exports/job-status/status")
+
+        assert response.status_code == 200
+        assert response.json()["render_method"] == "gpu"
 
     def test_video_export_jobs_stream_serializes_jobs_event(self, db_session):
         with (

--- a/apps/backend/video_export.py
+++ b/apps/backend/video_export.py
@@ -21,6 +21,39 @@ export_jobs: dict[str, dict] = {}
 
 _TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 
+_WEBGL_RENDERER_SCRIPT = """
+    () => {
+        const canvas = document.querySelector('canvas');
+        if (!canvas) {
+            return { available: false, vendor: '', renderer: '' };
+        }
+
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) {
+            return { available: false, vendor: '', renderer: '' };
+        }
+
+        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        return {
+            available: true,
+            vendor: debugInfo
+                ? String(gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) || '')
+                : String(gl.getParameter(gl.VENDOR) || ''),
+            renderer: debugInfo
+                ? String(gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) || '')
+                : String(gl.getParameter(gl.RENDERER) || ''),
+        };
+    }
+"""
+
+
+def _is_software_webgl_renderer(renderer: str) -> bool:
+    normalized = renderer.lower()
+    return any(
+        marker in normalized
+        for marker in ("swiftshader", "llvmpipe", "softpipe", "software rasterizer", "swrast")
+    )
+
 
 def _video_export_dir() -> Path:
     return Path(config.VIDEO_EXPORT_DIR)
@@ -133,6 +166,7 @@ def start_video_export_background(
             "started_at": datetime.now().isoformat(),
             "video_path": None,
             "error": None,
+            "render_method": None,
         }
 
         # Start export in background thread
@@ -287,6 +321,13 @@ async def _export_video_playwright(
             # Give it a bit more time for initialization
             await asyncio.sleep(3)
             _raise_if_cancelled(job_id)
+
+            renderer_info = await page.evaluate(_WEBGL_RENDERER_SCRIPT)
+            renderer = str(renderer_info.get("renderer") or "unknown")
+            if not renderer_info.get("available") or _is_software_webgl_renderer(renderer):
+                export_jobs[job_id]["render_method"] = "cpu"
+            else:
+                export_jobs[job_id]["render_method"] = "gpu"
 
             # Wait for terrain textures to load by checking terrainReady state
             export_jobs[job_id]["message"] = "Waiting for terrain textures..."

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -104,8 +104,10 @@ _WORKER_LOCK = threading.Lock()
 _JOB_UPDATE_DB_LOCK = threading.Lock()
 _EXPORT_JOBS_LOCK = threading.Lock()
 _JOB_RUNTIME_LOCK = threading.Lock()
+_JOB_RENDER_METHOD_LOCK = threading.Lock()
 _JOB_UPDATE_DB: dict[str, bool] = {}
 _JOB_RUNTIME: dict[str, dict[str, Any]] = {}
+_JOB_RENDER_METHODS: dict[str, str] = {}
 _JOB_CANCEL_REQUESTS: set[str] = set()
 
 _CANCEL_CHECK_INTERVAL = 10
@@ -356,6 +358,7 @@ def _snapshot_from_job(job: VideoExportJob) -> dict[str, Any]:
         "quality": job.quality,
         "speed": job.speed,
         "mode": job.mode,
+        "render_method": _get_job_render_method(job.id),
         "created_at": _to_iso(job.created_at),
         "updated_at": _to_iso(job.updated_at),
         "cancelled_at": _to_iso(job.cancelled_at),
@@ -386,6 +389,24 @@ def _set_job_runtime(job_id: str, **kwargs: Any) -> None:
 def _clear_job_runtime(job_id: str) -> None:
     with _JOB_RUNTIME_LOCK:
         _JOB_RUNTIME.pop(job_id, None)
+
+
+def _set_job_render_method(job_id: str, render_method: str | None) -> None:
+    with _JOB_RENDER_METHOD_LOCK:
+        if render_method in {"cpu", "gpu"}:
+            _JOB_RENDER_METHODS[job_id] = render_method
+        else:
+            _JOB_RENDER_METHODS.pop(job_id, None)
+
+
+def _get_job_render_method(job_id: str) -> str | None:
+    with _JOB_RENDER_METHOD_LOCK:
+        return _JOB_RENDER_METHODS.get(job_id)
+
+
+def _clear_job_render_method(job_id: str) -> None:
+    with _JOB_RENDER_METHOD_LOCK:
+        _JOB_RENDER_METHODS.pop(job_id, None)
 
 
 def _set_job_cancel_requested(job_id: str) -> None:
@@ -1082,6 +1103,7 @@ def delete_video_export_job(job_id: str) -> dict[str, Any] | None:
 
     _set_memory_snapshot(job_id, None)
     _clear_job_runtime(job_id)
+    _clear_job_render_method(job_id)
     _clear_job_cancel_requested(job_id)
     _clear_job_auth_token(job_id)
     return {"job_id": job_id, "deleted": True, **cleanup}
@@ -1733,15 +1755,18 @@ async def _export_video_manual_render(job_id: str):
             vendor = str(renderer_info.get("vendor") or "unknown")
             if not renderer_info.get("available"):
                 _log_job(job_id, "WebGL renderer unavailable")
+                _set_job_render_method(job_id, "cpu")
             elif _is_software_webgl_renderer(renderer):
                 _log_job(
                     job_id,
                     f"WebGL renderer is software: vendor={vendor}, renderer={renderer}",
                 )
+                _set_job_render_method(job_id, "cpu")
             else:
                 _log_job(
                     job_id, f"WebGL renderer is hardware: vendor={vendor}, renderer={renderer}"
                 )
+                _set_job_render_method(job_id, "gpu")
 
             _update_job(job_id, message="Configuring manual render mode")
 

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -316,6 +316,7 @@ describe('FlightDetails GoPro overlay action', () => {
       job_id: 'video-job',
       status: 'running',
       internal_status: 'encoding',
+      render_method: 'cpu',
       progress: 78,
       message: 'Encoding with FFmpeg',
       log_tail: ['Captured frames', 'Encoding with FFmpeg'],
@@ -343,6 +344,7 @@ describe('FlightDetails GoPro overlay action', () => {
 
     expect(videoToggle).toHaveAttribute('aria-expanded', 'true');
     expect(overlayToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getAllByText('CPU').length).toBeGreaterThan(0);
     expect(screen.getAllByText('GPU').length).toBeGreaterThan(0);
     expect(screen.getByText('Encoding with FFmpeg')).toBeInTheDocument();
     expect(

--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -216,6 +216,7 @@ export function FlightGenerationLogsPanel({
           <LogSourceCard
             key={`video-${videoStatus?.job_id ?? videoJobId ?? 'fallback'}`}
             title={t('flights.generationLogs.videoTitle')}
+            renderMethod={videoStatus?.render_method ?? null}
             status={videoStatusValue}
             isInProgress={Boolean(
               videoStatusValue &&

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.test.tsx
@@ -65,6 +65,7 @@ beforeEach(() => {
       job_id: 'job-123',
       status: 'completed',
       internal_status: 'completed',
+      render_method: 'gpu',
       log_tail: ['Persisted export log'],
     }),
   });
@@ -79,6 +80,7 @@ describe('toStatusPayload', () => {
       job_id: 'job-123',
       status: 'processing',
       internal_status: 'encoding',
+      render_method: 'gpu',
       progress: 62,
       eta_seconds: 540,
       message: 'Encoding 32%',
@@ -94,6 +96,7 @@ describe('toStatusPayload', () => {
       job_id: 'job-123',
       status: 'processing',
       internal_status: 'encoding',
+      render_method: 'gpu',
       progress: 62,
       eta_seconds: 540,
       message: 'Encoding 32%',

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
@@ -16,6 +16,7 @@ export type VideoExportStatusPayload = {
   job_id: string;
   status: string;
   internal_status?: string;
+  render_method?: 'cpu' | 'gpu' | null;
   progress?: number;
   message?: string | null;
   error?: string | null;
@@ -60,6 +61,10 @@ export const toStatusPayload = (
     internal_status:
       typeof value.internal_status === 'string'
         ? value.internal_status
+        : undefined,
+    render_method:
+      value.render_method === 'cpu' || value.render_method === 'gpu'
+        ? value.render_method
         : undefined,
     progress: typeof value.progress === 'number' ? value.progress : undefined,
     message: typeof value.message === 'string' ? value.message : null,


### PR DESCRIPTION
Expose CPU/GPU render method for video exports and GoPro overlays, and display it in flight generation logs.

Validation:
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend
- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend
- targeted pytest for video export and overlay endpoints
- targeted vitest for video export status and flight details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Video and GoPro overlay exports now identify whether rendering uses CPU or GPU.
  - Render method is automatically selected based on available rendering hardware and shown in job status details.
  - Flight generation logs and GoPro overlay cards display CPU/GPU badges when available.
  - Job lists and status responses preserve render-method information for active and completed exports.
- **Tests**
  - Added coverage confirming render-method values are tracked, returned, and displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->