### PR TITLE
fix(sync): normalize intervals flight names

### DIFF
--- a/apps/backend/external_flight_import.py
+++ b/apps/backend/external_flight_import.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
+from flight_naming import format_automatic_flight_name
 from flight_storage import ensure_flight_directory
 from flight_tracks import TrackPoint, calculate_track_stats, normalize_track
 from intervals_icu import ExternalActivity, IntervalsError
@@ -55,6 +56,17 @@ def _local_departure(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value
     return value.astimezone(PARIS_TIME_ZONE).replace(tzinfo=None)
+
+
+def _update_existing_flight(flight: Flight, activity: ExternalActivity) -> bool:
+    name = format_automatic_flight_name(flight.flight_date, flight.departure_time)
+    changed = (
+        flight.name != name or flight.title != name or flight.external_url != activity.external_url
+    )
+    flight.name = name
+    flight.title = name
+    flight.external_url = activity.external_url
+    return changed
 
 
 def _legacy_track_matches(
@@ -136,12 +148,13 @@ async def import_external_activities(
                 .first()
             )
             if existing:
-                existing.name = activity.name
-                existing.title = activity.name
-                existing.external_url = activity.external_url
+                was_updated = _update_existing_flight(existing, activity)
                 db.commit()
                 summaries.append(_flight_summary(existing))
-                skipped += 1
+                if was_updated:
+                    updated += 1
+                else:
+                    skipped += 1
                 db.rollback()
                 continue
             db.rollback()
@@ -163,7 +176,9 @@ async def import_external_activities(
                     .first()
                 )
                 if existing:
-                    outcome = "skipped"
+                    outcome = (
+                        "updated" if _update_existing_flight(existing, activity) else "skipped"
+                    )
                     pending_summary = _flight_summary(existing)
                 else:
                     legacy = _find_legacy_flight(db, activity, points, stats)
@@ -179,11 +194,12 @@ async def import_external_activities(
                         db.add(flight)
 
                         departure = _local_departure(stats["departure_time"] or activity.start_date)
+                        flight_name = format_automatic_flight_name(departure.date(), departure)
                         flight.external_provider = provider_name
                         flight.external_activity_id = activity.id
                         flight.external_url = activity.external_url
-                        flight.name = activity.name
-                        flight.title = activity.name
+                        flight.name = flight_name
+                        flight.title = flight_name
                         flight.flight_date = departure.date()
                         flight.departure_time = departure
                         flight.site_id = match_site(db, points[0])
@@ -211,6 +227,8 @@ async def import_external_activities(
             summaries.append(pending_summary)
             if outcome == "imported":
                 imported += 1
+            elif outcome == "updated":
+                updated += 1
             else:
                 skipped += 1
         except ValueError as exc:

--- a/apps/backend/flight_naming.py
+++ b/apps/backend/flight_naming.py
@@ -1,0 +1,8 @@
+from datetime import date, datetime
+
+
+def format_automatic_flight_name(flight_date: date, departure_time: datetime | None = None) -> str:
+    name = f"Vol du {flight_date.strftime('%d/%m/%Y')}"
+    if departure_time is not None:
+        name += f" à {departure_time.strftime('%H:%M')}"
+    return name

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -53,6 +53,7 @@ from deployment_drain import (
 )
 from emagram_freshness import get_emagram_cutoff_utc
 from flight_decision import build_flight_decision, normalize_objective
+from flight_naming import format_automatic_flight_name
 from flight_summaries import (
     FlightGpxStatus,
     FlightSortBy,
@@ -4498,7 +4499,7 @@ async def create_flight_from_gpx(
         # Extraire la date et heure depuis le GPX (premier trackpoint)
         flight_date = date.today()  # Default
         departure_time = None
-        flight_name = f"Vol du {flight_date.strftime('%d/%m/%Y')}"  # Default
+        flight_name = format_automatic_flight_name(flight_date)
 
         if stats.get("first_trackpoint") and stats["first_trackpoint"].get("time"):
             # Le timestamp du GPX est en UTC, on le convertit en heure locale française
@@ -4513,8 +4514,7 @@ async def create_flight_from_gpx(
                 departure_time = departure_datetime_utc.astimezone(paris_tz)
                 flight_date = departure_time.date()
 
-                # Nom du vol avec date ET heure
-                flight_name = f"Vol du {flight_date.strftime('%d/%m/%Y')} à {departure_time.strftime('%H:%M')}"
+                flight_name = format_automatic_flight_name(flight_date, departure_time)
 
                 print(
                     f"🔍 DEBUG Date/Time - UTC: {departure_datetime_utc}, Local: {departure_time}, Name: {flight_name}"

--- a/apps/backend/tests/unit/test_external_flight_import.py
+++ b/apps/backend/tests/unit/test_external_flight_import.py
@@ -19,7 +19,7 @@ class Provider:
 
 
 @pytest.mark.asyncio
-async def test_import_updates_intervals_name_on_resync(
+async def test_import_normalizes_intervals_name_and_repairs_it_on_resync(
     db_session, arguel_site, tmp_path, monkeypatch
 ):
     monkeypatch.setattr(config, "PARAGLIDING_DATA_ROOT", str(tmp_path))
@@ -35,6 +35,11 @@ async def test_import_updates_intervals_name_on_resync(
 
     first = await import_external_activities(db_session, "intervals_icu", Provider(), [activity])
     flight = db_session.query(Flight).one()
+    assert flight.name == "Vol du 01/07/2026 à 12:00"
+    assert flight.title == "Vol du 01/07/2026 à 12:00"
+    flight.name = "First title"
+    flight.title = "First title"
+    db_session.commit()
     repeated_activity = ExternalActivity(
         id=activity.id,
         name="Updated title",
@@ -50,14 +55,46 @@ async def test_import_updates_intervals_name_on_resync(
 
     flight = db_session.query(Flight).one()
     assert first["imported"] == 1
-    assert second["skipped"] == 1
+    assert second["updated"] == 1
+    assert second["skipped"] == 0
     assert db_session.query(Flight).count() == 1
     assert flight.external_provider == "intervals_icu"
     assert flight.external_activity_id == "unsafe/id"
-    assert flight.name == "Updated title"
-    assert flight.title == "Updated title"
+    assert flight.name == "Vol du 01/07/2026 à 12:00"
+    assert flight.title == "Vol du 01/07/2026 à 12:00"
     assert "intervals_unsafe_id_" in flight.gpx_file_path
     assert flight.site_id == arguel_site.id
+
+
+@pytest.mark.asyncio
+async def test_import_skips_existing_intervals_flight_with_normalized_name(db_session):
+    flight = Flight(
+        id="existing",
+        external_provider="intervals_icu",
+        external_activity_id="i-existing",
+        external_url="https://intervals.icu/activities/i-existing",
+        name="Vol du 28/07/2026 à 19:05",
+        title="Vol du 28/07/2026 à 19:05",
+        flight_date=datetime(2026, 7, 28).date(),
+        departure_time=datetime(2026, 7, 28, 19, 5),
+    )
+    db_session.add(flight)
+    db_session.commit()
+    activity = ExternalActivity(
+        id="i-existing",
+        name="Raw Intervals title",
+        start_date=datetime(2026, 7, 28, 19, 5),
+        activity_type="Other",
+        source="ZEPP",
+        file_type="GPX",
+        external_url="https://intervals.icu/activities/i-existing",
+    )
+
+    result = await import_external_activities(db_session, "intervals_icu", Provider(), [activity])
+
+    assert result["updated"] == 0
+    assert result["skipped"] == 1
+    assert flight.name == "Vol du 28/07/2026 à 19:05"
 
 
 @pytest.mark.asyncio
@@ -123,6 +160,8 @@ async def test_import_stores_track_departure_in_paris_local_time(db_session, tmp
     flight = db_session.query(Flight).one()
     assert flight.departure_time == datetime(2026, 7, 2, 0, 30)
     assert flight.flight_date.isoformat() == "2026-07-02"
+    assert flight.name == "Vol du 02/07/2026 à 00:30"
+    assert flight.title == "Vol du 02/07/2026 à 00:30"
 
 
 @pytest.mark.asyncio

--- a/apps/backend/tests/unit/test_flight_naming.py
+++ b/apps/backend/tests/unit/test_flight_naming.py
@@ -1,0 +1,14 @@
+from datetime import date, datetime
+
+from flight_naming import format_automatic_flight_name
+
+
+def test_format_automatic_flight_name_with_date_only() -> None:
+    assert format_automatic_flight_name(date(2026, 7, 8)) == "Vol du 08/07/2026"
+
+
+def test_format_automatic_flight_name_with_departure_time() -> None:
+    assert (
+        format_automatic_flight_name(date(2026, 7, 8), datetime(2026, 7, 8, 9, 5))
+        == "Vol du 08/07/2026 à 09:05"
+    )


### PR DESCRIPTION
## Summary\n- Normalize Intervals.icu flight names to the canonical French format\n- Reuse the same helper for GPX creation and Intervals imports\n- Track Intervals resync repairs as updated when the stored name was wrong\n- Add direct coverage for the naming helper and resync behavior\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend\n- /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/unit/test_flight_naming.py tests/unit/test_external_flight_import.py -q --tb=short --no-cov\n\n## Review\n- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flight names are now generated consistently from the flight date and departure time.
  * Automatically generated names use French date and time formatting.
  * External flight imports now synchronize updated flight names, titles, and links.
  * Import results distinguish between newly added, updated, and skipped flights.

* **Bug Fixes**
  * Existing flights are corrected when their generated names or titles are outdated.
  * Duplicate flights with already-correct information are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->