### PR TITLE
fix(backend): add CPU fallback for PIP overlay prep

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -913,6 +913,26 @@ def _gpu_ffmpeg_args(
     ]
 
 
+def _cpu_ffmpeg_args(*, software_filters: list[str] | None, include_audio: bool) -> list[str]:
+    args: list[str] = []
+    if software_filters:
+        args.extend(["-vf", ",".join(software_filters)])
+    args.extend(
+        [
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "18",
+            "-pix_fmt",
+            "yuv420p",
+            *(["-c:a", "copy"] if include_audio else ["-an"]),
+        ]
+    )
+    return args
+
+
 def _prepare_pip_video_for_overlay(
     job_id: str,
     video_path: Path,
@@ -953,8 +973,9 @@ def _prepare_pip_video_for_overlay(
     prepared_path = _prepared_pip_path(work_dir, job_id)
     _unlink_if_exists(prepared_path)
 
+    software_filters: list[str] | None = None
     if pip_delay >= video_duration or (pip_duration is not None and pip_trim >= pip_duration):
-        command = [
+        command_prefix = [
             "ffmpeg",
             "-y",
             "-f",
@@ -964,21 +985,19 @@ def _prepare_pip_video_for_overlay(
             "-t",
             f"{video_duration:.3f}",
         ]
-        command.extend(_gpu_ffmpeg_args(software_filters=None, include_audio=False))
-        command.extend(["-movflags", "+faststart", str(prepared_path)])
     else:
-        pip_filters = ["setpts=PTS-STARTPTS"]
+        software_filters = ["setpts=PTS-STARTPTS"]
         if pip_delay > 0:
-            pip_filters.append(f"tpad=start_mode=add:start_duration={pip_delay:.3f}")
+            software_filters.append(f"tpad=start_mode=add:start_duration={pip_delay:.3f}")
         if pip_tail_duration and pip_tail_duration > 0:
-            pip_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
-        command = [
+            software_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
+        command_prefix = [
             "ffmpeg",
             "-y",
         ]
         if pip_trim > 0:
-            command.extend(["-ss", f"{pip_trim:.3f}"])
-        command.extend(
+            command_prefix.extend(["-ss", f"{pip_trim:.3f}"])
+        command_prefix.extend(
             [
                 "-i",
                 str(pip_path),
@@ -986,22 +1005,63 @@ def _prepare_pip_video_for_overlay(
                 f"{video_duration:.3f}",
             ]
         )
-        command.extend(_gpu_ffmpeg_args(software_filters=pip_filters, include_audio=False))
-        command.extend(["-movflags", "+faststart", str(prepared_path)])
 
+    output_args = ["-movflags", "+faststart", str(prepared_path)]
+    command = [
+        *command_prefix,
+        *_gpu_ffmpeg_args(software_filters=software_filters, include_audio=False),
+        *output_args,
+    ]
+
+    vaapi_error: str | None = None
     try:
-        result = subprocess.run(
+        result: subprocess.CompletedProcess[str] | None = subprocess.run(
             command,
             check=False,
             capture_output=True,
             text=True,
             timeout=_ffmpeg_timeout_for_duration(video_duration),
         )
-    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError) as exc:
+    except FileNotFoundError as exc:
         _unlink_if_exists(prepared_path)
         if log_path:
             _append_job_log(log_path, f"PIP preparation failed: {exc}")
         raise ValueError(str(exc) or exc.__class__.__name__) from exc
+    except (subprocess.SubprocessError, TimeoutError) as exc:
+        result = None
+        vaapi_error = str(exc) or exc.__class__.__name__
+
+    if result is None or result.returncode != 0:
+        _unlink_if_exists(prepared_path)
+        vaapi_error = vaapi_error or (
+            result.stderr.strip() or result.stdout.strip() or "ffmpeg VAAPI pip preparation failed"
+        )
+        logger.warning(
+            "VAAPI PIP preparation failed for job %s; retrying on CPU: %s",
+            job_id,
+            vaapi_error,
+        )
+        if log_path:
+            _append_job_log(log_path, f"VAAPI PIP preparation failed: {vaapi_error}")
+            _append_job_log(log_path, "Retrying PIP preparation with CPU encoding")
+        command = [
+            *command_prefix,
+            *_cpu_ffmpeg_args(software_filters=software_filters, include_audio=False),
+            *output_args,
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_ffmpeg_timeout_for_duration(video_duration),
+            )
+        except (FileNotFoundError, subprocess.SubprocessError, TimeoutError) as exc:
+            _unlink_if_exists(prepared_path)
+            if log_path:
+                _append_job_log(log_path, f"CPU PIP preparation failed: {exc}")
+            raise ValueError(str(exc) or exc.__class__.__name__) from exc
 
     if result.returncode != 0:
         _unlink_if_exists(prepared_path)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1532,6 +1532,69 @@ def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
     assert command[command.index("-c:v") + 1] == "h264_vaapi"
 
 
+@pytest.mark.parametrize("vaapi_failure", ["nonzero", "timeout"])
+def test_prepare_pip_video_retries_on_cpu_when_vaapi_fails(tmp_path, monkeypatch, vaapi_failure):
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    log_path = tmp_path / "job.log"
+    video_path.write_bytes(b"video")
+    pip_path.write_bytes(b"pip")
+    gpx_path.write_text("<gpx><time>2026-03-15T10:00:00Z</time></gpx>")
+    work_dir.mkdir()
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_duration",
+        lambda path: 30.0 if path == video_path else 10.0,
+    )
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (640, 480))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-03-15T10:00:00Z"),
+    )
+
+    class Result:
+        def __init__(self, returncode: int, stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stderr = stderr
+            self.stdout = ""
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        if len(commands) == 1:
+            if vaapi_failure == "timeout":
+                raise gopro_overlay_export.subprocess.TimeoutExpired(command, 600)
+            return Result(1, "Failed to initialise VAAPI connection")
+        Path(command[-1]).write_bytes(b"prepared")
+        return Result(0)
+
+    monkeypatch.setattr(gopro_overlay_export.subprocess, "run", run)
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir, log_path=log_path
+    )
+
+    assert prepared.read_bytes() == b"prepared"
+    assert len(commands) == 2
+    assert commands[0][commands[0].index("-c:v") + 1] == "h264_vaapi"
+    assert "-vaapi_device" not in commands[1]
+    assert commands[1][commands[1].index("-c:v") + 1] == "libx264"
+    assert "setpts=PTS-STARTPTS" in commands[1][commands[1].index("-vf") + 1]
+    log = log_path.read_text()
+    assert "VAAPI PIP preparation failed:" in log
+    expected_detail = (
+        "Failed to initialise VAAPI connection"
+        if vaapi_failure == "nonzero"
+        else "timed out after 600 seconds"
+    )
+    assert expected_detail in log
+    assert "Retrying PIP preparation with CPU encoding" in log
+
+
 def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monkeypatch):
     video_path = tmp_path / "camera.mp4"
     gpx_path = tmp_path / "track.gpx"


### PR DESCRIPTION
## Summary\n- retry PIP overlay preparation with libx264 when VAAPI fails or times out\n- preserve the original VAAPI diagnostic in job logs\n- add regression coverage for non-zero exit and timeout fallback\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend\n\n## Notes\n- CodeRabbit review was attempted but rate-limited by the Git provider seat/quota

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic fallback to CPU-based video encoding when VAAPI processing fails or times out.
  * Preserved video filters, timing, audio, and output settings during fallback.
  * Improved diagnostics by logging the initial failure and retry details.
  * VAAPI file-not-found errors continue to fail immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->