### PR TITLE
fix(backend): keep gpx offset without osv

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1285,7 +1285,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 work_dir,
                 log_path=log_path,
                 timeline_start=_first_gpx_timestamp(render_gpx_path),
-                gpx_offset=gpx_offset if osv_paths else 0.0,
+                gpx_offset=gpx_offset,
             )
         else:
             _append_job_log(log_path, "No PIP video configured")

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1814,7 +1814,7 @@ def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_d
 
     assert prepared is not None
     assert Path(prepared["pip_path"]) == prepared_pip_path
-    assert pip_calls[0]["gpx_offset"] == 0.0
+    assert pip_calls[0]["gpx_offset"] == 2.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Preserve manual gpx_offset when regenerating GoPro overlays without OSV inputs.

## Validation
- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend
- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPX offsets are now consistently applied when preparing PIP videos, including jobs without OSV files.
  * Corrected video preparation to preserve the requested offset instead of resetting it to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->