### PR TITLE
fix(backend): apply GPX offset to overlay timeline

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -213,12 +213,18 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
+    first_gpx_at: float | None = None
+    if video_duration is not None and gpx_offset:
+        gpx_duration = _gpx_duration_seconds(gpx_path)
+        if gpx_duration is not None:
+            first_gpx_at = max(0.0, max(0.0, video_duration - gpx_duration) + gpx_offset)
     command = [
         "python3",
         str(merge_script),
         "--sync",
         "gpx-start",
         *(["--video-duration", f"{video_duration:.3f}"] if video_duration is not None else []),
+        *(["--first-gpx-at", f"{first_gpx_at:.3f}"] if first_gpx_at is not None else []),
         *(["--gpx-offset", str(gpx_offset)] if gpx_offset else []),
         *(str(path) for path in osv_paths),
         str(gpx_path),
@@ -842,6 +848,27 @@ def _first_gpx_timestamp(gpx_path: Path) -> datetime | None:
             if parsed:
                 return parsed
     return None
+
+
+def _gpx_duration_seconds(gpx_path: Path) -> float | None:
+    try:
+        root = ET.parse(gpx_path).getroot()
+    except (ET.ParseError, OSError):
+        return None
+
+    timestamps: list[datetime] = []
+    for trackpoint in root.iter():
+        if trackpoint.tag.rsplit("}", 1)[-1] != "trkpt":
+            continue
+        for element in trackpoint:
+            if element.tag.rsplit("}", 1)[-1] != "time" or not element.text:
+                continue
+            if parsed := _parse_utc_datetime(element.text):
+                timestamps.append(parsed)
+            break
+    if len(timestamps) < 2:
+        return None
+    return max(0.0, (timestamps[-1] - timestamps[0]).total_seconds())
 
 
 def _pip_timeline_offsets(

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -665,9 +665,15 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
     assert run.call_args.kwargs["timeout"] == 456
 
 
+@pytest.mark.parametrize(
+    ("gpx_offset", "expected_first_gpx_at"),
+    [(15.0, "29.483"), (-15.0, "0.000")],
+)
 def test_worker_merge_osv_files_with_gpx_passes_gpx_offset_to_merge_tool(
     tmp_path,
     monkeypatch,
+    gpx_offset,
+    expected_first_gpx_at,
 ) -> None:
     gopro_root = tmp_path / "gopro-overlay"
     gopro_root.mkdir()
@@ -677,7 +683,12 @@ def test_worker_merge_osv_files_with_gpx_passes_gpx_offset_to_merge_tool(
     source_gpx = input_dir / "Zepp-track.gpx"
     osv_path = input_dir / "flight.osv"
     merged_gpx_path = input_dir / "merged-gopro-overlay.gpx"
-    source_gpx.write_text("<gpx>source</gpx>")
+    source_gpx.write_text(
+        "<gpx><metadata><time>2020-01-01T00:00:00Z</time></metadata><trk><trkseg>"
+        "<trkpt><time>2026-08-08T09:30:43Z</time></trkpt>"
+        "<trkpt><time>2026-08-08T09:37:30Z</time></trkpt>"
+        "</trkseg></trk></gpx>"
+    )
     osv_path.write_bytes(b"osv")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(gopro_root))
 
@@ -695,12 +706,14 @@ def test_worker_merge_osv_files_with_gpx_passes_gpx_offset_to_merge_tool(
             [osv_path],
             source_gpx,
             input_dir,
-            gpx_offset=-1.5,
+            gpx_offset=gpx_offset,
+            video_duration=421.483,
         )
 
     assert result == merged_gpx_path
     command = run.call_args.args[0]
-    assert command[command.index("--gpx-offset") + 1] == "-1.5"
+    assert command[command.index("--gpx-offset") + 1] == str(gpx_offset)
+    assert command[command.index("--first-gpx-at") + 1] == expected_first_gpx_at
     assert command[-3:] == [str(osv_path), str(source_gpx), str(merged_gpx_path)]
 
 


### PR DESCRIPTION
## Summary\n- keep the merged overlay video origin stable when applying a manual GPX offset\n- pass the effective first GPX position to the OSV merge tool\n- ignore GPX metadata timestamps and clamp negative offsets safely\n\n## Production reproduction\n- camera duration: 421.483 s\n- GPX duration: 407 s\n- manual offset: +15 s\n- verified first GPX position: 29.483 s instead of the previous unchanged 14.483 s\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend\n- real osv_merge.py run against the affected flight inputs\n- CodeRabbit CLI: 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization when merging video with GPX data by automatically calculating the GPX start time when timing information is available.
  - Supports both positive and negative GPX offsets for more accurate overlay alignment.
  - Handles invalid or unusable GPX timestamps safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->