### PR TITLE
fix: prefer flight gpx in overlay preview

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -355,9 +355,9 @@ def _flight_gopro_camera_path(db: Session, flight: Flight) -> Path:
 def _flight_gopro_preview_inputs(db: Session, flight: Flight) -> tuple[Path, Path]:
     camera_path = _flight_gopro_camera_path(db, flight)
     input_dir = camera_path.parent
-    gpx_path = _first_matching_file(input_dir, "Zepp*.gpx") or _resolve_flight_file_path(
-        flight.gpx_file_path
-    )
+    gpx_path = _resolve_flight_file_path(flight.gpx_file_path)
+    if not gpx_path or not gpx_path.is_file():
+        gpx_path = _first_matching_file(input_dir, "Zepp*.gpx")
     if not gpx_path or not gpx_path.is_file():
         raise HTTPException(status_code=404, detail="Flight GPX file not found")
     return camera_path, gpx_path

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -95,6 +95,44 @@ def test_gopro_overlay_preview_falls_back_to_camera_mtime_when_creation_time_is_
     assert response.json()["alignment"]["automatic_offset_seconds"] == 10.0
 
 
+def test_gopro_overlay_preview_prefers_flight_gpx_over_zepp_folder_file(
+    client: TestClient, db_session, sample_flight, tmp_path, monkeypatch
+) -> None:
+    input_dir = tmp_path / sample_flight.flight_date.strftime("%Y%m%d") / "01"
+    input_dir.mkdir(parents=True)
+    camera_path = input_dir / "camera.mp4"
+    camera_path.write_bytes(b"video")
+    (input_dir / "Zepp-track.gpx").write_text(
+        "<gpx><trk><trkseg>"
+        '<trkpt lat="45" lon="5"><time>2026-03-15T10:10:10Z</time></trkpt>'
+        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:11:10Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
+    flight_gpx_path = tmp_path / "flight.gpx"
+    flight_gpx_path.write_text(
+        "<gpx><trk><trkseg>"
+        '<trkpt lat="45" lon="5"><time>2026-03-15T10:00:10Z</time></trkpt>'
+        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:01:10Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
+    sample_flight.gpx_file_path = str(flight_gpx_path)
+    sample_flight.gopro_overlay_gpx_offset = 0.0
+    db_session.commit()
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+
+    with (
+        patch("routes.probe_video_duration", return_value=120.0),
+        patch(
+            "routes.probe_video_start_time",
+            return_value=datetime.fromisoformat("2026-03-15T10:00:00+00:00"),
+        ),
+    ):
+        response = client.get(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay/preview")
+
+    assert response.status_code == 200
+    assert response.json()["gpx"]["start_time"] == "2026-03-15T10:00:10Z"
+
+
 def test_gopro_camera_endpoint_serves_the_flight_camera(
     client: TestClient, sample_flight, tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary\n- Prefer the flight GPX file for GoPro preview alignment, falling back to Zepp folder files only when needed\n- Keep the camera mtime fallback for missing video creation_time\n- Add regression tests for both behaviors\n\n## Validation\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend -- tests/api/test_gopro_overlay_endpoints.py -q\n\n## Notes\n- CodeRabbit was not rerun for this follow-up fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GoPro overlay previews now use the flight’s configured GPX track when available.
  * Previews fall back to a matching GPX file in the input folder if no configured track exists.
  * Improved preview accuracy by ensuring overlays start at the correct flight timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->