### PR TITLE
fix(gopro): surface heart rate in preview

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -355,9 +355,9 @@ def _flight_gopro_camera_path(db: Session, flight: Flight) -> Path:
 def _flight_gopro_preview_inputs(db: Session, flight: Flight) -> tuple[Path, Path]:
     camera_path = _flight_gopro_camera_path(db, flight)
     input_dir = camera_path.parent
-    gpx_path = _first_matching_file(input_dir, "Zepp*.gpx") or _resolve_flight_file_path(
-        flight.gpx_file_path
-    )
+    gpx_path = _resolve_flight_file_path(flight.gpx_file_path)
+    if not gpx_path or not gpx_path.is_file():
+        gpx_path = _first_matching_file(input_dir, "Zepp*.gpx")
     if not gpx_path or not gpx_path.is_file():
         raise HTTPException(status_code=404, detail="Flight GPX file not found")
     return camera_path, gpx_path

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4931,7 +4931,20 @@ def parse_gpx_file_from_string(gpx_content: str) -> list[dict]:
         else:
             timestamp = 0
 
-        coordinates.append({"lat": lat, "lon": lon, "elevation": elevation, "timestamp": timestamp})
+        heart_rate_elem = trkpt.find("gpx:hr", ns) if ns else None
+        if heart_rate_elem is None:
+            heart_rate_elem = trkpt.find("hr")
+        heart_rate = None
+        if heart_rate_elem is not None and heart_rate_elem.text:
+            try:
+                heart_rate = int(float(heart_rate_elem.text))
+            except Exception as e:
+                print(f"⚠️ DEBUG Parse heart rate failed: {e}")
+
+        coordinate = {"lat": lat, "lon": lon, "elevation": elevation, "timestamp": timestamp}
+        if heart_rate is not None:
+            coordinate["heart_rate"] = heart_rate
+        coordinates.append(coordinate)
 
     if coordinates:
         print(

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -81,6 +81,7 @@ class GoproOverlayPreviewCoordinate(BaseModel):
     lon: float
     elevation: float
     timestamp: float
+    heart_rate: int | None = None
 
 
 class GoproOverlayPreviewGpx(BaseModel):

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -95,6 +95,44 @@ def test_gopro_overlay_preview_falls_back_to_camera_mtime_when_creation_time_is_
     assert response.json()["alignment"]["automatic_offset_seconds"] == 10.0
 
 
+def test_gopro_overlay_preview_prefers_flight_gpx_over_zepp_folder_file(
+    client: TestClient, db_session, sample_flight, tmp_path, monkeypatch
+) -> None:
+    input_dir = tmp_path / sample_flight.flight_date.strftime("%Y%m%d") / "01"
+    input_dir.mkdir(parents=True)
+    camera_path = input_dir / "camera.mp4"
+    camera_path.write_bytes(b"video")
+    (input_dir / "Zepp-track.gpx").write_text(
+        "<gpx><trk><trkseg>"
+        '<trkpt lat="45" lon="5"><time>2026-03-15T10:10:10Z</time></trkpt>'
+        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:11:10Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
+    flight_gpx_path = tmp_path / "flight.gpx"
+    flight_gpx_path.write_text(
+        "<gpx><trk><trkseg>"
+        '<trkpt lat="45" lon="5"><time>2026-03-15T10:00:10Z</time></trkpt>'
+        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:01:10Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
+    sample_flight.gpx_file_path = str(flight_gpx_path)
+    sample_flight.gopro_overlay_gpx_offset = 0.0
+    db_session.commit()
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+
+    with (
+        patch("routes.probe_video_duration", return_value=120.0),
+        patch(
+            "routes.probe_video_start_time",
+            return_value=datetime.fromisoformat("2026-03-15T10:00:00+00:00"),
+        ),
+    ):
+        response = client.get(f"{API_PREFIX}/flights/{sample_flight.id}/gopro-overlay/preview")
+
+    assert response.status_code == 200
+    assert response.json()["gpx"]["start_time"] == "2026-03-15T10:00:10Z"
+
+
 def test_gopro_camera_endpoint_serves_the_flight_camera(
     client: TestClient, sample_flight, tmp_path, monkeypatch
 ) -> None:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -36,8 +36,8 @@ def test_gopro_overlay_preview_returns_shared_timeline(
     gpx_path = input_dir / "Zepp-track.gpx"
     gpx_path.write_text(
         "<gpx><trk><trkseg>"
-        '<trkpt lat="45" lon="5"><time>2026-03-15T10:00:10Z</time></trkpt>'
-        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:01:10Z</time></trkpt>'
+        '<trkpt lat="45" lon="5"><time>2026-03-15T10:00:10Z</time><hr>120</hr></trkpt>'
+        '<trkpt lat="45.1" lon="5.1"><time>2026-03-15T10:01:10Z</time><hr>126</hr></trkpt>'
         "</trkseg></trk></gpx>"
     )
     sample_flight.gopro_overlay_gpx_offset = 1.5
@@ -57,6 +57,7 @@ def test_gopro_overlay_preview_returns_shared_timeline(
     assert response.json()["video"]["duration_seconds"] == 120.0
     assert response.json()["gpx"]["duration_seconds"] == 60.0
     assert len(response.json()["gpx"]["coordinates"]) == 2
+    assert response.json()["gpx"]["coordinates"][0]["heart_rate"] == 120
     assert response.json()["alignment"] == {
         "automatic_offset_seconds": 10.0,
         "manual_offset_seconds": 1.5,

--- a/apps/frontend/src/components/flights/details/GoproOverlaySyncPreview.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlaySyncPreview.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Gauge, MapPin, Mountain, TimerReset } from 'lucide-react';
+import { Gauge, HeartPulse, MapPin, Mountain, TimerReset } from 'lucide-react';
 import { useGoproOverlayPreview } from '../../../hooks/gopro/useGoproOverlay';
 import { getApiUrlWithSearchParams } from '../../../lib/api';
 import { useAuthStore } from '../../../stores/authStore';
@@ -41,6 +41,7 @@ export function GoproOverlaySyncPreview({
         gpxStart + (videoTime - automaticOffset - manualOffset) * 1000
       )
     : null;
+  const heartRate = telemetry?.heart_rate ?? null;
   const videoUrl = getApiUrlWithSearchParams(
     `flights/${flightId}/gopro-camera`,
     { access_token: token }
@@ -113,6 +114,20 @@ export function GoproOverlaySyncPreview({
             <div className="font-mono text-lg font-semibold">
               {telemetry ? `${telemetry.speedKmh.toFixed(1)} km/h` : '--'}
             </div>
+          </div>
+        </div>
+        <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
+          <HeartPulse
+            className="mb-2 h-4 w-4 text-emerald-600"
+            aria-hidden="true"
+          />
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            {t('flights.goproOverlayHeartRate')}
+          </div>
+          <div className="font-mono text-lg font-semibold">
+            {heartRate === null
+              ? t('flights.goproOverlayHeartRateUnavailable')
+              : `${heartRate} bpm`}
           </div>
         </div>
         <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">

--- a/apps/frontend/src/components/flights/details/goproSyncTelemetry.ts
+++ b/apps/frontend/src/components/flights/details/goproSyncTelemetry.ts
@@ -51,6 +51,7 @@ export function telemetryAtTimestamp(
     elevation:
       previous.elevation + (next.elevation - previous.elevation) * progress,
     timestamp,
+    heart_rate: previous.heart_rate ?? next.heart_rate,
     speedKmh,
   };
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -978,6 +978,8 @@
     "goproOverlayPreviewError": "Preview is unavailable. Check the video and GPX timestamps.",
     "goproOverlayCameraPreview": "GoPro video preview",
     "goproOverlayVideoTime": "Video time",
+    "goproOverlayHeartRate": "Heart rate",
+    "goproOverlayHeartRateUnavailable": "BPM unavailable",
     "goproOverlayGpxPosition": "GPX position",
     "goproOverlayOutsideTrack": "Outside GPX track",
     "goproOverlayEffectiveOffset": "Total offset",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -982,6 +982,8 @@
     "goproOverlayPreviewError": "La prévisualisation n’est pas disponible. Vérifiez les horodatages de la vidéo et du GPX.",
     "goproOverlayCameraPreview": "Prévisualisation de la vidéo GoPro",
     "goproOverlayVideoTime": "Temps vidéo",
+    "goproOverlayHeartRate": "Fréquence cardiaque",
+    "goproOverlayHeartRateUnavailable": "BPM non disponible",
     "goproOverlayGpxPosition": "Position GPX",
     "goproOverlayOutsideTrack": "Hors de la trace GPX",
     "goproOverlayEffectiveOffset": "Décalage total",

--- a/apps/frontend/src/types/flight.ts
+++ b/apps/frontend/src/types/flight.ts
@@ -7,4 +7,5 @@ export interface GeoPoint {
   lon: number;
   elevation: number;
   timestamp: number;
+  heart_rate?: number;
 }


### PR DESCRIPTION
## Summary\n- expose GPX heart rate in the GoPro overlay preview\n- show BPM in the frontend preview with a fallback message\n- add regression coverage for GPX heart rate parsing\n\n## Validation\n- nx test backend -- tests/api/test_gopro_overlay_endpoints.py -q\n- nx lint backend\n- nx lint frontend