### PR TITLE
fix(frontend): show stored GPX filename in details

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
@@ -204,6 +204,12 @@ export const Default = meta.story({
   name: 'Default',
   args: { flight: fullFlight, mobileMode: true },
 });
+Default.test('The stored track file name is displayed', async ({ canvas }) => {
+  await expect(canvas.getByText('arguel-001.gpx')).toBeInTheDocument();
+  await expect(
+    canvas.queryByText('/data/flights/arguel-001.gpx')
+  ).not.toBeInTheDocument();
+});
 Default.test(
   'The flight can be edited',
   async ({ canvas, userEvent, step }) => {

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -160,6 +160,7 @@ vi.mock('react-i18next', () => ({
         'flights.goproOverlayCancelError': 'Overlay cancel error',
         'flights.goproOverlayNeedsVideo': 'Needs video',
         'flights.goproOverlayNeedsCameraVideo': 'Needs camera video',
+        'flights.trackFileLabel': 'GPX/IGC file',
         'flights.generationLogs.title': 'Generation logs',
         'flights.generationLogs.description': 'Media job tracking',
         'flights.generationLogs.videoTitle': 'Flight video',
@@ -262,7 +263,40 @@ describe('FlightDetails GoPro overlay action', () => {
     mockFlight.video_file_path = '/exports/flight.mp4';
     mockFlight.video_file_exists = true;
     mockFlight.gopro_camera_file_exists = true;
+    mockFlight.gpx_file_path = 'sample.gpx';
     videoStatusMock.current = null;
+  });
+
+  it('shows only the stored track file name in flight information', () => {
+    mockFlight.gpx_file_path = '/private/flights/20260315/01/watch.igc';
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('GPX/IGC file')).toBeInTheDocument();
+    expect(screen.getByText('watch.igc')).toHaveAttribute('title', 'watch.igc');
+    expect(
+      screen.queryByText('/private/flights/20260315/01/watch.igc')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show track file information when no track is stored', () => {
+    mockFlight.gpx_file_path = null;
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    expect(screen.queryByText('GPX/IGC file')).not.toBeInTheDocument();
   });
 
   it('shows why overlay generation is unavailable', () => {

--- a/apps/frontend/src/components/flights/details/FlightStatsGrid.tsx
+++ b/apps/frontend/src/components/flights/details/FlightStatsGrid.tsx
@@ -48,6 +48,7 @@ export function FlightStatsGrid({ flight, sites }: FlightStatsGridProps) {
     flight.max_speed_kmh == null
       ? 'N/A'
       : formatSpeedKmh(flight.max_speed_kmh, units.speed);
+  const trackFileName = flight.gpx_file_path?.split(/[\\/]/u).pop();
 
   return (
     <div className="mb-4 grid grid-cols-2 gap-3 md:grid-cols-3">
@@ -97,6 +98,14 @@ export function FlightStatsGrid({ flight, sites }: FlightStatsGridProps) {
         <span className={labelClass}>{t('flights.maxSpeedLabel')}</span>
         <span className={valueClass}>{maxSpeedLabel}</span>
       </div>
+      {trackFileName && (
+        <div className="col-span-2 min-w-0 md:col-span-3">
+          <span className={labelClass}>{t('flights.trackFileLabel')}</span>
+          <span className={`${valueClass} truncate`} title={trackFileName}>
+            {trackFileName}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -947,6 +947,7 @@
     "maxAltitudeLabel": "Max altitude (m)",
     "elevationGainLabel": "Elevation gain (m)",
     "maxSpeedLabel": "Max speed (km/h)",
+    "trackFileLabel": "GPX/IGC file",
     "notesLabel": "Notes",
     "notesPlaceholder": "Conditions, feelings, areas for improvement...",
     "noNotes": "No notes for this flight",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -951,6 +951,7 @@
     "maxAltitudeLabel": "Altitude max (m)",
     "elevationGainLabel": "Dénivelé (m)",
     "maxSpeedLabel": "Vitesse max (km/h)",
+    "trackFileLabel": "Fichier GPX/IGC",
     "notesLabel": "Notes",
     "notesPlaceholder": "Conditions, sensations, points à améliorer...",
     "noNotes": "Aucune note pour ce vol",


### PR DESCRIPTION
## Summary\n- display the stored GPX/IGC filename in flight details\n- keep the internal path hidden\n- add tests and story coverage\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e\n- /home/capic/.local/share/pnpm/pnpm exec vitest run --config vitest.config.ts --project unit src/components/flights/details/FlightDetails.test.tsx\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint frontend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend