### PR TITLE
fix(gopro): ship overlay offset fix

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1330,6 +1330,9 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 )
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
+        command_metadata["video_time_start"] = (
+            "video-created" if probe_video_start_time(video_path) is not None else "file-modified"
+        )
         _append_job_log(log_path, f"Render GPX: {render_gpx_path.name}")
 
         if pip_path:
@@ -1764,6 +1767,8 @@ def _run_job(job_id: str) -> None:
         "--use-gpx-only",
         "--gpx",
         str(render_gpx_path),
+        "--video-time-start",
+        str(prepared_command.get("video_time_start") or "video-created"),
         "--layout",
         "xml",
         "--layout-xml",

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2062,12 +2062,21 @@ def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_d
     pip_path = tmp_path / "pip.mp4"
     prepared_pip_path = tmp_path / "prepared-pip.mp4"
     video_path.write_bytes(b"video")
-    gpx_path.write_text("<gpx />")
+    gpx_path.write_text(
+        '<gpx xmlns="http://www.topografix.com/GPX/1/1"><trk><trkseg>'
+        '<trkpt lat="45" lon="5"><time>2026-08-08T09:30:43Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
     pip_path.write_bytes(b"pip")
     prepared_pip_path.write_bytes(b"prepared")
     pip_calls: list[dict] = []
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-08-08T09:30:28.517Z"),
+    )
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
 
     def fake_prepare_pip(*_args, **kwargs):
@@ -2094,6 +2103,39 @@ def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_d
     assert pip_calls[0]["gpx_offset"] == 0.0
     render_gpx_path = Path(prepared["command"]["render_gpx_path"])
     assert render_gpx_path.name.startswith("gpx-offset-")
+    assert "2026-08-08T09:30:45.500000Z" in render_gpx_path.read_text()
+    assert prepared["command"]["video_time_start"] == "video-created"
+
+
+def test_prepare_queued_job_falls_back_to_file_mtime_for_render_timeline(
+    tmp_path, monkeypatch, test_db
+):
+    layout_dir = tmp_path / "layouts"
+    layout_dir.mkdir()
+    (layout_dir / "layout_parapente_1080.xml").write_text("<layout />")
+    video_path = tmp_path / "source.mp4"
+    gpx_path = tmp_path / "source.gpx"
+    video_path.write_bytes(b"video")
+    gpx_path.write_text("<gpx />")
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_start_time", lambda _: None)
+    monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+
+    job = create_gopro_overlay_job_from_paths(
+        video_path=video_path,
+        gpx_path=gpx_path,
+        pip_path=None,
+        layout_id="parapente-1080",
+        output_filename="overlay.mp4",
+    )
+    queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
+    assert queued_job is not None
+
+    prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
+
+    assert prepared is not None
+    assert prepared["command"]["video_time_start"] == "file-modified"
 
 
 @pytest.mark.asyncio
@@ -2726,6 +2768,11 @@ def test_run_job_prepares_inputs_before_starting_process(
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PROFILE", "nvgpu")
     monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_duration", lambda _: 421.483)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-08-08T09:30:28.517Z"),
+    )
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     monkeypatch.setattr(gopro_overlay_export, "_verify_video_output", lambda _: (True, None))
     monkeypatch.setattr(
@@ -2777,6 +2824,7 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
     assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
     assert command[command.index("--overlay-size") + 1] == "1920x1080"
+    assert command[command.index("--video-time-start") + 1] == "video-created"
     assert "--gpx-offset" not in command
     assert Path(command[-2]) == video_path
     assert Path(command[-1]) == Path(job["temp_output_path"])
@@ -2809,6 +2857,11 @@ def test_run_job_keeps_manual_gpx_offset_out_of_pip_preparation(
     monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(tmp_path / "runner-root"))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (1920, 1080))
     monkeypatch.setattr(gopro_overlay_export, "probe_video_duration", lambda _: 421.483)
+    monkeypatch.setattr(
+        gopro_overlay_export,
+        "probe_video_start_time",
+        lambda _: gopro_overlay_export._parse_utc_datetime("2026-08-08T09:30:28.517Z"),
+    )
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     monkeypatch.setattr(gopro_overlay_export, "_verify_video_output", lambda _: (True, None))
     monkeypatch.setattr(

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -400,7 +400,7 @@ describe('FlightDetails GoPro overlay action', () => {
         name: 'flights.goproOverlayGenerateTitle',
       })
     ).toBeInTheDocument();
-    expect(screen.getByLabelText('GPX offset (seconds)')).toHaveValue(8);
+    expect(screen.getByLabelText('GPX offset (seconds)')).toHaveValue(0);
 
     fireEvent.change(screen.getByLabelText('GPX offset (seconds)'), {
       target: { value: '2.5' },
@@ -416,7 +416,7 @@ describe('FlightDetails GoPro overlay action', () => {
     expect(formData.get('gpx_offset')).toBe('2.5');
   });
 
-  it('prefills the GPX offset from the computed preview value', () => {
+  it('keeps the automatic alignment separate from the manual GPX offset', () => {
     previewMock.current = {
       isPending: false,
       data: {
@@ -460,7 +460,7 @@ describe('FlightDetails GoPro overlay action', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Generate overlay/u }));
 
-    expect(screen.getByLabelText('GPX offset (seconds)')).toHaveValue(8);
+    expect(screen.getByLabelText('GPX offset (seconds)')).toHaveValue(0);
   });
 
   it('requests a longer low-resolution preview from the duration slider', async () => {
@@ -552,7 +552,7 @@ describe('FlightDetails GoPro overlay action', () => {
     ).toBeInTheDocument();
   });
 
-  it('resets the GPX offset to the original computed value', async () => {
+  it('resets the manual GPX offset without applying automatic alignment', async () => {
     previewMock.current = {
       isPending: false,
       data: {
@@ -598,13 +598,13 @@ describe('FlightDetails GoPro overlay action', () => {
 
     const offsetInput = screen.getByLabelText('GPX offset (seconds)');
     await waitFor(() => {
-      expect(offsetInput).toHaveValue(8);
+      expect(offsetInput).toHaveValue(0);
     });
 
     fireEvent.change(offsetInput, { target: { value: '2.5' } });
     fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
 
-    expect(offsetInput).toHaveValue(8);
+    expect(offsetInput).toHaveValue(0);
   });
 
   it('shows video and GoPro job details in the logs tab', () => {

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -20,7 +20,6 @@ import {
 import { useVideoExportStatus } from '../../../hooks/flights/useVideoExportStatus';
 import {
   useCreateFlightGoproOverlayJob,
-  useGoproOverlayPreview,
   useGoproOverlayJobStream,
 } from '../../../hooks/gopro/useGoproOverlay';
 import { useToast } from '../../../hooks/useToast';
@@ -86,7 +85,7 @@ export function FlightDetails({
   const [isCancellingGoproOverlay, setIsCancellingGoproOverlay] =
     useState(false);
   const [goproOverlayGpxOffset, setGoproOverlayGpxOffset] = useState(
-    String(flight.gopro_overlay_gpx_offset ?? '')
+    String(flight.gopro_overlay_gpx_offset ?? 0)
   );
   const [goproOverlayInitialGpxOffset, setGoproOverlayInitialGpxOffset] =
     useState<string | null>(null);
@@ -96,10 +95,6 @@ export function FlightDetails({
   const hasGpx = Boolean(flight.gpx_file_path);
   const hasVideo = hasFlightVideo(flight);
   const hasGoproCameraVideo = flight.gopro_camera_file_exists === true;
-  const goproOverlayPreview = useGoproOverlayPreview(
-    flight.id,
-    hasGpx && hasGoproCameraVideo
-  );
   const hasPersistedGoproOverlay = hasFlightGoproOverlay(flight);
   const effectiveGoproOverlayJobId =
     goproOverlayJobId ?? flight.gopro_overlay_job_id ?? null;
@@ -150,9 +145,6 @@ export function FlightDetails({
         date: localDate.toLocaleDateString(i18n.language),
       });
     })();
-  const automaticGoproOverlayOffset =
-    goproOverlayPreview.data?.alignment.automatic_offset_seconds ?? null;
-
   useEffect(() => {
     activeFlightIdRef.current = flight.id;
     setActiveTab('infos');
@@ -169,28 +161,10 @@ export function FlightDetails({
 
   useEffect(() => {
     if (!isGoproOverlayDialogOpen) {
-      setGoproOverlayGpxOffset(String(flight.gopro_overlay_gpx_offset ?? ''));
+      setGoproOverlayGpxOffset(String(flight.gopro_overlay_gpx_offset ?? 0));
       setGoproOverlayInitialGpxOffset(null);
     }
   }, [flight.gopro_overlay_gpx_offset, isGoproOverlayDialogOpen]);
-
-  useEffect(() => {
-    if (
-      isGoproOverlayDialogOpen &&
-      flight.gopro_overlay_gpx_offset == null &&
-      automaticGoproOverlayOffset != null &&
-      !goproOverlayGpxOffset.trim()
-    ) {
-      const automaticOffset = String(automaticGoproOverlayOffset);
-      setGoproOverlayInitialGpxOffset(automaticOffset);
-      setGoproOverlayGpxOffset(automaticOffset);
-    }
-  }, [
-    automaticGoproOverlayOffset,
-    flight.gopro_overlay_gpx_offset,
-    goproOverlayGpxOffset,
-    isGoproOverlayDialogOpen,
-  ]);
 
   useEffect(() => {
     setNotesText(flight.notes ?? '');
@@ -332,16 +306,8 @@ export function FlightDetails({
       setGoproOverlayGpxOffset(storedOffset);
       return;
     }
-    if (automaticGoproOverlayOffset != null) {
-      const automaticOffset = String(automaticGoproOverlayOffset);
-      setGoproOverlayInitialGpxOffset(automaticOffset);
-      setGoproOverlayGpxOffset(automaticOffset);
-      return;
-    }
-    setGoproOverlayInitialGpxOffset(null);
-    if (!goproOverlayGpxOffset.trim()) {
-      setGoproOverlayGpxOffset('');
-    }
+    setGoproOverlayInitialGpxOffset('0');
+    setGoproOverlayGpxOffset('0');
   };
 
   const downloadBlob = async (


### PR DESCRIPTION
## Summary\n- separate the automatic preview offset from the manual overlay offset in the frontend\n- anchor GPX rendering to the video timeline in the backend\n- add regression coverage for the fallback video timestamp path\n\n## Validation\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend -- tests/api/test_gopro_overlay_endpoints.py -q -k "prepare_queued_job_uses_prepared_pip_path or prepare_queued_job_falls_back_to_file_mtime_for_render_timeline or run_job_prepares_inputs_before_starting_process or run_job_keeps_manual_gpx_offset_out_of_pip_preparation"\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- git diff --check\n- pre-commit hook passed during commit after adding local-only shims for missing backend venv binaries\n\n## Notes\n- CodeRabbit review was run earlier and had no remaining findings after the follow-up test was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GoPro overlay rendering now uses the video’s creation timestamp for timeline alignment, with a fallback to the file’s modification time when unavailable.
  - Manual GPX offsets are no longer automatically prefilled from synchronization previews.
  - Overlay offset fields now start and reset to `0`, while preserving explicitly entered values during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->