### PR TITLE
fix(gopro): avoid unreliable file timestamp fallback

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1330,9 +1330,10 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 )
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
-        command_metadata["video_time_start"] = (
-            "video-created" if probe_video_start_time(video_path) is not None else "file-modified"
-        )
+        if probe_video_start_time(video_path) is not None:
+            command_metadata["video_time_start"] = "video-created"
+        else:
+            command_metadata.pop("video_time_start", None)
         _append_job_log(log_path, f"Render GPX: {render_gpx_path.name}")
 
         if pip_path:
@@ -1767,13 +1768,13 @@ def _run_job(job_id: str) -> None:
         "--use-gpx-only",
         "--gpx",
         str(render_gpx_path),
-        "--video-time-start",
-        str(prepared_command.get("video_time_start") or "video-created"),
         "--layout",
         "xml",
         "--layout-xml",
         job["layout_path"],
     ]
+    if video_time_start := prepared_command.get("video_time_start"):
+        command[4:4] = ["--video-time-start", str(video_time_start)]
     if config.GOPRO_OVERLAY_FONT:
         command.extend(["--font", config.GOPRO_OVERLAY_FONT])
     if config.GOPRO_OVERLAY_CONFIG_DIR:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2107,7 +2107,7 @@ def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_d
     assert prepared["command"]["video_time_start"] == "video-created"
 
 
-def test_prepare_queued_job_falls_back_to_file_mtime_for_render_timeline(
+def test_prepare_queued_job_omits_unreliable_file_time_for_render_timeline(
     tmp_path, monkeypatch, test_db
 ):
     layout_dir = tmp_path / "layouts"
@@ -2135,7 +2135,7 @@ def test_prepare_queued_job_falls_back_to_file_mtime_for_render_timeline(
     prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
 
     assert prepared is not None
-    assert prepared["command"]["video_time_start"] == "file-modified"
+    assert "video_time_start" not in prepared["command"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- omit `--video-time-start` when camera metadata has no embedded creation time\n- avoid using the mutable filesystem mtime as a video timeline anchor\n- update regression coverage for videos without creation metadata\n\n## Root cause\nThe production camera file had no embedded creation time. Its filesystem mtime was 2026-08-08 19:50:34, while the video timeline started around 09:30. Passing `file-modified` produced no GPX/video overlap and gopro-dashboard exited with code 1.\n\n## Validation\n- targeted backend overlay tests: 5 passed\n- backend lint: passed\n- git diff --check: passed\n- CodeRabbit: no new findings