### PR TITLE
fix(gopro): honor manual overlay offset

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -215,9 +215,7 @@ def _merge_osv_files_with_gpx(
         )
     first_gpx_at: float | None = None
     if video_duration is not None and gpx_offset:
-        gpx_duration = gpx_duration_seconds(gpx_path)
-        if gpx_duration is not None:
-            first_gpx_at = max(0.0, max(0.0, video_duration - gpx_duration) + gpx_offset)
+        first_gpx_at = max(0.0, gpx_offset)
     command = [
         "python3",
         str(merge_script),

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -931,9 +931,9 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
 
 @pytest.mark.parametrize(
     ("gpx_offset", "expected_first_gpx_at"),
-    [(15.0, "29.483"), (-15.0, "0.000")],
+    [(15.0, "15.000"), (-15.0, "0.000")],
 )
-def test_worker_merge_osv_files_with_gpx_passes_gpx_offset_to_merge_tool(
+def test_worker_merge_osv_files_with_gpx_uses_manual_offset_without_auto_offset(
     tmp_path,
     monkeypatch,
     gpx_offset,


### PR DESCRIPTION
## Summary\n- treat a non-zero dialog offset as the explicit GPX start position\n- skip the automatic `video duration - GPX duration` adjustment when a manual offset is supplied\n- keep the existing automatic calculation when no manual correction is supplied\n\n## Root cause\nFor an entered offset of 295.900s, the backend added the automatically calculated 14.483s gap and passed 310.383s to the OSV merge. Manual values must override that calculation rather than be added to it.\n\n## Validation\n- targeted backend tests: 5 passed\n- backend lint: passed\n- git diff --check: passed\n- CodeRabbit: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GPX synchronization for video overlays using manually configured offsets.
  * Positive GPX offsets now align relative to the video timeline without an unintended duration-based adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->