### PR TITLE
fix(gopro): align OSV offset with preview

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -189,6 +189,7 @@ def _merge_osv_files_with_gpx(
     log_path: Path | None = None,
     gpx_offset: float = 0.0,
     video_duration: float | None = None,
+    first_gpx_at: float | None = None,
 ) -> Path:
     if not osv_paths:
         return gpx_path
@@ -213,16 +214,20 @@ def _merge_osv_files_with_gpx(
             log_path,
             f"Merging {len(osv_paths)} OSV file(s) into {merged_gpx_path.name}",
         )
-    first_gpx_at: float | None = None
-    if video_duration is not None and gpx_offset:
-        first_gpx_at = max(0.0, gpx_offset)
+    effective_first_gpx_at = (
+        max(0.0, first_gpx_at) if video_duration is not None and first_gpx_at is not None else None
+    )
     command = [
         "python3",
         str(merge_script),
         "--sync",
         "gpx-start",
         *(["--video-duration", f"{video_duration:.3f}"] if video_duration is not None else []),
-        *(["--first-gpx-at", f"{first_gpx_at:.3f}"] if first_gpx_at is not None else []),
+        *(
+            ["--first-gpx-at", f"{effective_first_gpx_at:.3f}"]
+            if effective_first_gpx_at is not None
+            else []
+        ),
         *(["--gpx-offset", str(gpx_offset)] if gpx_offset else []),
         *(str(path) for path in osv_paths),
         str(gpx_path),
@@ -1307,6 +1312,22 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         source_input_dir = Path(str(job["output_path"])).parent
         osv_paths = _matching_files_by_mtime(source_input_dir, "*.osv")
         gpx_offset = _gpx_offset_from_command_metadata(command_metadata)
+        embedded_video_start = probe_video_start_time(video_path)
+        alignment_video_start = embedded_video_start
+        if alignment_video_start is None:
+            try:
+                alignment_video_start = datetime.fromtimestamp(
+                    video_path.stat().st_mtime, tz=timezone.utc
+                )
+            except OSError:
+                alignment_video_start = None
+        gpx_start = first_gpx_timestamp(render_gpx_path)
+        aligned_video_start = align_video_start_time_to_gpx(alignment_video_start, gpx_start)
+        first_gpx_at = (
+            (gpx_start - aligned_video_start).total_seconds() + gpx_offset
+            if gpx_offset and gpx_start is not None and aligned_video_start is not None
+            else None
+        )
         if osv_paths:
             _update_job(job_id, progress=10, message="Merging OSV telemetry")
             video_duration = probe_video_duration(video_path)
@@ -1317,6 +1338,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 log_path=log_path,
                 gpx_offset=gpx_offset,
                 video_duration=video_duration,
+                first_gpx_at=first_gpx_at,
             )
         else:
             _append_job_log(log_path, "No OSV files found; using GPX directly")
@@ -1328,7 +1350,7 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
                 )
 
         command_metadata["render_gpx_path"] = str(render_gpx_path)
-        if probe_video_start_time(video_path) is not None:
+        if embedded_video_start is not None:
             command_metadata["video_time_start"] = "video-created"
         else:
             command_metadata.pop("video_time_start", None)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -930,13 +930,14 @@ def test_worker_merge_osv_files_with_gpx_uses_configured_timeout(
 
 
 @pytest.mark.parametrize(
-    ("gpx_offset", "expected_first_gpx_at"),
-    [(15.0, "15.000"), (-15.0, "0.000")],
+    ("gpx_offset", "first_gpx_at", "expected_first_gpx_at"),
+    [(295.9, 5.0, "5.000"), (-15.0, -20.0, "0.000")],
 )
-def test_worker_merge_osv_files_with_gpx_uses_manual_offset_without_auto_offset(
+def test_worker_merge_osv_files_with_gpx_uses_effective_start_offset(
     tmp_path,
     monkeypatch,
     gpx_offset,
+    first_gpx_at,
     expected_first_gpx_at,
 ) -> None:
     gopro_root = tmp_path / "gopro-overlay"
@@ -972,6 +973,7 @@ def test_worker_merge_osv_files_with_gpx_uses_manual_offset_without_auto_offset(
             input_dir,
             gpx_offset=gpx_offset,
             video_duration=421.483,
+            first_gpx_at=first_gpx_at,
         )
 
     assert result == merged_gpx_path
@@ -2745,7 +2747,7 @@ def test_cancel_queued_gopro_overlay_job_removes_rq_job(monkeypatch):
         gopro_overlay_export._PROCESSES.pop(job_id, None)
 
 
-def test_run_job_prepares_inputs_before_starting_process(
+def test_run_job_uses_preview_effective_offset_for_osv_merge(
     tmp_path,
     monkeypatch,
     test_db,
@@ -2757,8 +2759,14 @@ def test_run_job_prepares_inputs_before_starting_process(
     gpx_path = tmp_path / "source.gpx"
     osv_path = tmp_path / "source.osv"
     video_path.write_bytes(b"video")
-    gpx_path.write_text("<gpx />")
+    gpx_path.write_text(
+        '<gpx xmlns="http://www.topografix.com/GPX/1/1"><trk><trkseg>'
+        '<trkpt lat="45" lon="5"><time>2026-08-08T09:30:43Z</time></trkpt>'
+        "</trkseg></trk></gpx>"
+    )
     osv_path.write_bytes(b"osv")
+    video_mtime = datetime.fromisoformat("2026-08-08T09:35:33.900+00:00").timestamp()
+    os.utime(video_path, (video_mtime, video_mtime))
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
     monkeypatch.setattr(config, "GOPRO_OVERLAY_BIN", "gopro-dashboard.py")
     monkeypatch.setattr(config, "GOPRO_OVERLAY_ROOT", str(tmp_path / "runner-root"))
@@ -2771,7 +2779,7 @@ def test_run_job_prepares_inputs_before_starting_process(
     monkeypatch.setattr(
         gopro_overlay_export,
         "probe_video_start_time",
-        lambda _: gopro_overlay_export._parse_utc_datetime("2026-08-08T09:30:28.517Z"),
+        lambda _: None,
     )
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
     monkeypatch.setattr(gopro_overlay_export, "_verify_video_output", lambda _: (True, None))
@@ -2800,7 +2808,7 @@ def test_run_job_prepares_inputs_before_starting_process(
         pip_path=None,
         layout_id="parapente-1080",
         output_filename="overlay.mp4",
-        gpx_offset=-1.5,
+        gpx_offset=295.9,
     )
     work_dir = tmp_path / ".gopro-overlay-work" / job["job_id"]
 
@@ -2824,13 +2832,14 @@ def test_run_job_prepares_inputs_before_starting_process(
     assert popen.call_args.kwargs["cwd"] == str(tmp_path / "runner-root")
     assert Path(command[command.index("--layout-xml") + 1]).parent == work_dir
     assert command[command.index("--overlay-size") + 1] == "1920x1080"
-    assert command[command.index("--video-time-start") + 1] == "video-created"
+    assert "--video-time-start" not in command
     assert "--gpx-offset" not in command
     assert Path(command[-2]) == video_path
     assert Path(command[-1]) == Path(job["temp_output_path"])
     assert len(merge_calls) == 1
     assert merge_calls[0][0] == [osv_path]
-    assert merge_calls[0][3]["gpx_offset"] == -1.5
+    assert merge_calls[0][3]["gpx_offset"] == 295.9
+    assert merge_calls[0][3]["first_gpx_at"] == pytest.approx(5.0)
     assert merge_calls[0][3]["video_duration"] == 421.483
     assert gopro_overlay_export.get_gopro_overlay_job(job["job_id"])["status"] == "completed"
     assert Path(job["output_path"]).read_bytes() == b"video"


### PR DESCRIPTION
## Summary\n- compute OSV first-gpx-at from the same effective alignment as the preview\n- preserve manual GPX offsets while keeping video-start probing as the timeline anchor\n- add regression coverage for the 295.9s / 5.0s case\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint --parallel=5 --exclude=e2e\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test --parallel=5 --exclude=e2e\n- CodeRabbit review: no findings\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPX and video timeline alignment during GoPro overlay processing.
  * Corrected synchronization when video creation time is unavailable by using the file’s modification time.
  * Improved handling of manual offsets and video durations to produce more accurate overlays.
* **Tests**
  * Added coverage for effective GPX start times, missing camera timestamps, large manual offsets, and preview-derived synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->