### PR TITLE
fix(deploy): harden NVIDIA EGL mount

### DIFF
--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -11,6 +11,14 @@ services:
       - BACKEND_VIDEO_ACCELERATOR=nvidia
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-compute,video,graphics,utility}
+      - __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    volumes:
+      - type: bind
+        source: ${NVIDIA_EGL_VENDOR_JSON:-/usr/share/glvnd/egl_vendor.d/10_nvidia.json}
+        target: /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+        read_only: true
+        bind:
+          create_host_path: false
 
   backend-worker:
     deploy:
@@ -24,6 +32,14 @@ services:
       - BACKEND_VIDEO_ACCELERATOR=nvidia
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - NVIDIA_DRIVER_CAPABILITIES=${NVIDIA_DRIVER_CAPABILITIES:-compute,video,graphics,utility}
+      - __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    volumes:
+      - type: bind
+        source: ${NVIDIA_EGL_VENDOR_JSON:-/usr/share/glvnd/egl_vendor.d/10_nvidia.json}
+        target: /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+        read_only: true
+        bind:
+          create_host_path: false
 
   gopro-overlay-worker:
     deploy:


### PR DESCRIPTION
## Summary\n- Make the NVIDIA EGL vendor JSON mount explicit and non-creating on the host.\n- Keep Chromium/ANGLE pointed at the NVIDIA EGL vendor file in backend and backend-worker.\n\n## Validation\n-  on the prod stack overlay: passed\n- : passed\n- Existing runtime checks already validated NVENC, NVIDIA runtime, and Chromium WebGL on the host\n\n## Notes\n- CodeRabbit previously flagged the bind-mount safety issue; the fix is included here. A follow-up CodeRabbit rerun was rate-limited.