### PR TITLE
fix(gopro-overlay): keep PIP visible to the end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xdg-utils \
     curl \
     ffmpeg \
+    patch \
     nodejs \
     npm \
     sqlite3 \
@@ -94,7 +95,11 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
 
 # Installer GoPro Dashboard Overlay dans un venv créé dans l'image.
 COPY --from=gopro-overlay-src / /app/gopro-overlay
+# Prevent floating-point frame timestamps from repeatedly restarting the PIP decoder.
+COPY docker/gopro-overlay/video-frame-source.patch /tmp/video-frame-source.patch
 RUN rm -rf /app/gopro-overlay/venv && \
+    patch -d /app/gopro-overlay -p1 < /tmp/video-frame-source.patch && \
+    rm /tmp/video-frame-source.patch && \
     python -m venv /app/gopro-overlay/venv && \
     /app/gopro-overlay/venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
     /app/gopro-overlay/venv/bin/pip install --no-cache-dir -e /app/gopro-overlay

--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -2,6 +2,7 @@ import asyncio
 import fnmatch
 import json
 import logging
+import math
 import os
 import re
 import shlex
@@ -53,6 +54,7 @@ _UPLOAD_WORK_ROOT = Path("/tmp/dashboard-parapente/gopro-overlays")
 _PATH_WORK_DIR_NAME = ".gopro-overlay-work"
 _PROGRESS_PERCENT_RE = re.compile(r"(?P<percent>\d{1,3})\s*%")
 _LOG_TAIL_LINE_COUNT = 100
+_PIP_FRAME_RATE = 10
 
 
 def _gopro_overlay_log_dir() -> Path:
@@ -1017,11 +1019,14 @@ def _prepare_pip_video_for_overlay(
             f"{video_duration:.3f}",
         ]
     else:
-        software_filters = ["setpts=PTS-STARTPTS"]
+        software_filters = [f"fps={_PIP_FRAME_RATE}", "setpts=PTS-STARTPTS"]
         if pip_delay > 0:
-            software_filters.append(f"tpad=start_mode=add:start_duration={pip_delay:.3f}")
+            start_frames = math.ceil(pip_delay * _PIP_FRAME_RATE)
+            software_filters.append(f"tpad=start_mode=add:start={start_frames}")
         if pip_tail_duration and pip_tail_duration > 0:
-            software_filters.append(f"tpad=stop_mode=clone:stop_duration={pip_tail_duration:.3f}")
+            stop_frames = math.ceil(pip_tail_duration * _PIP_FRAME_RATE)
+            software_filters.append(f"tpad=stop_mode=clone:stop={stop_frames}")
+        software_filters.append(f"setpts=N/({_PIP_FRAME_RATE}*TB)")
         command_prefix = [
             "ffmpeg",
             "-y",

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,6 +1,8 @@
-import logging
 import json
+import logging
 import os
+import shutil
+import subprocess
 from datetime import date, datetime
 from io import BytesIO
 from pathlib import Path
@@ -1849,10 +1851,77 @@ def test_prepare_pip_video_delays_pip_until_gpx_start(tmp_path, monkeypatch):
     command = commands[0]
     assert "-ss" not in command
     video_filter = command[command.index("-vf") + 1]
+    assert "fps=10" in video_filter
     assert "setpts=PTS-STARTPTS" in video_filter
-    assert "tpad=start_mode=add:start_duration=5.000" in video_filter
-    assert "tpad=stop_mode=clone:stop_duration=15.000" in video_filter
+    assert "tpad=start_mode=add:start=50" in video_filter
+    assert "tpad=stop_mode=clone:stop=150" in video_filter
+    assert "setpts=N/(10*TB)" in video_filter
     assert command[command.index("-c:v") + 1] == "libx264"
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+def test_prepare_pip_video_keeps_a_decodable_frame_through_camera_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    video_path = tmp_path / "camera.mp4"
+    gpx_path = tmp_path / "track.gpx"
+    pip_path = tmp_path / "pip.mp4"
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    gpx_path.write_text("<gpx />")
+
+    for path, color, duration in (
+        (video_path, "blue", 3),
+        (pip_path, "red", 1),
+    ):
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                f"color=c={color}:s=32x32:r=10:d={duration}",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                str(path),
+            ],
+            check=True,
+        )
+
+    monkeypatch.setattr(gopro_overlay_export, "select_video_accelerator", lambda _: "cpu")
+
+    prepared = gopro_overlay_export._prepare_pip_video_for_overlay(
+        "job-pip", video_path, gpx_path, pip_path, work_dir
+    )
+
+    assert (gopro_overlay_export.probe_video_duration(prepared) or 0) >= 2.8
+    decoded_frame = tmp_path / "prepared-last-frame.raw"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-ss",
+            "2.5",
+            "-i",
+            str(prepared),
+            "-frames:v",
+            "1",
+            "-f",
+            "rawvideo",
+            str(decoded_frame),
+        ],
+        check=True,
+    )
+    assert decoded_frame.stat().st_size > 0
 
 
 @pytest.mark.parametrize("nvenc_failure", ["nonzero", "timeout"])
@@ -1958,7 +2027,7 @@ def test_prepare_pip_video_trims_pip_when_camera_starts_after_gpx(tmp_path, monk
     assert prepared.exists()
     command = commands[0]
     assert command[command.index("-ss") + 1] == "5.000"
-    assert "tpad=stop_mode=clone:stop_duration=15.000" in command[command.index("-vf") + 1]
+    assert "tpad=stop_mode=clone:stop=150" in command[command.index("-vf") + 1]
     assert command[command.index("-c:v") + 1] == "libx264"
 
 
@@ -2006,7 +2075,7 @@ def test_prepare_pip_video_auto_aligns_start_time_by_timezone_offset(tmp_path, m
     assert prepared == work_dir / "pip-prepared-job-pip.mp4"
     assert prepared.read_bytes() == b"prepared"
     command = commands[0]
-    assert "tpad=stop_mode=clone:stop_duration=20.000" in command[command.index("-vf") + 1]
+    assert "tpad=stop_mode=clone:stop=200" in command[command.index("-vf") + 1]
     assert command[command.index("-c:v") + 1] == "libx264"
 
 
@@ -2054,8 +2123,8 @@ def test_prepare_pip_video_uses_merged_gpx_timeline_without_creation_time(tmp_pa
     command = commands[0]
     assert "-ss" not in command
     video_filter = command[command.index("-vf") + 1]
-    assert "tpad=start_mode=add:start_duration=14.483" in video_filter
-    assert "stop_duration" not in video_filter
+    assert "tpad=start_mode=add:start=145" in video_filter
+    assert "stop_mode" not in video_filter
 
 
 def test_prepare_pip_video_applies_manual_gpx_offset_to_shared_timeline(tmp_path, monkeypatch):
@@ -2099,7 +2168,7 @@ def test_prepare_pip_video_applies_manual_gpx_offset_to_shared_timeline(tmp_path
     )
 
     video_filter = commands[0][commands[0].index("-vf") + 1]
-    assert "tpad=start_mode=add:start_duration=16.983" in video_filter
+    assert "tpad=start_mode=add:start=170" in video_filter
 
 
 def test_prepare_queued_job_uses_prepared_pip_path(tmp_path, monkeypatch, test_db):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,7 @@ services:
     command: ['python', 'gopro_overlay_worker.py']
     cpus: '${GOPRO_OVERLAY_WORKER_CPUS:-4.0}'
     mem_limit: ${GOPRO_OVERLAY_WORKER_MEM_LIMIT:-12g}
-    pids_limit: ${GOPRO_OVERLAY_WORKER_PIDS_LIMIT:-256}
+    pids_limit: ${GOPRO_OVERLAY_WORKER_PIDS_LIMIT:-1024}
     labels:
       project: dashboard-parapente
       service: gopro-overlay-worker

--- a/docker/gopro-overlay/video-frame-source.patch
+++ b/docker/gopro-overlay/video-frame-source.patch
@@ -1,0 +1,41 @@
+diff --git a/gopro_overlay/widgets/video.py b/gopro_overlay/widgets/video.py
+index e9649ce..35b486d 100755
+--- a/gopro_overlay/widgets/video.py
++++ b/gopro_overlay/widgets/video.py
+@@ -42,15 +42,13 @@ class VideoFrameSource:
+         if seconds < 0:
+             return None
+
+-        wanted_index = int(seconds * self.fps)
++        wanted_index = round(seconds * self.fps)
+
+         if self.process is None or self.next_index is None or wanted_index < self.next_index:
+-            self._open(seconds)
+-            wanted_index = 0
++            self._open(seconds, wanted_index)
+
+         if wanted_index > self.next_index + int(self.fps * 2):
+-            self._open(seconds)
+-            wanted_index = 0
++            self._open(seconds, wanted_index)
+
+         while self.next_index < wanted_index:
+             if self._read_frame_bytes() is None:
+@@ -64,7 +62,7 @@ class VideoFrameSource:
+         self.next_index += 1
+         return Image.frombytes(mode="RGBA", size=self.dimensions.tuple(), data=data)
+
+-    def _open(self, seconds: float):
++    def _open(self, seconds: float, next_index: int):
+         self.close()
+         cmd = [
+             str(self.ffmpeg._path()),
+@@ -76,7 +74,7 @@ class VideoFrameSource:
+             "-",
+         ]
+         self.process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+-        self.next_index = 0
++        self.next_index = next_index
+
+     def _read_frame_bytes(self):
+         data = self.process.stdout.read(self.frame_bytes)


### PR DESCRIPTION
## Summary\n- Stabilize PIP frame indexing and padding so the overlay stays visible through the camera tail\n- Add a regression test for a decodable frame past camera end\n- Package the runtime patch and raise the worker PID limit\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend --parallel=5\n- Full affected run: failed in unrelated frontend/design-system tests