### PR TITLE
fix(gopro-overlay): bind layout to output resolution

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -60,6 +60,10 @@ _OUTPUT_RESOLUTIONS: dict[str, tuple[int, int] | None] = {
     "1080p": (1920, 1080),
     "4k": (3840, 2160),
 }
+_OUTPUT_LAYOUT_FILENAMES = {
+    "1080p": "layout_parapente_1080.xml",
+    "4k": "layout_parapente_3840.xml",
+}
 
 
 def _gopro_overlay_log_dir() -> Path:
@@ -1388,14 +1392,16 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         output_resolution = str(metadata.get("output_resolution") or "source")
         if output_resolution not in _OUTPUT_RESOLUTIONS:
             raise ValueError("Unknown output resolution")
-        requested_dimensions = _OUTPUT_RESOLUTIONS[output_resolution]
-        selection_width, selection_height = requested_dimensions or (width, height)
         requested_layout_id = metadata.get("requested_layout_id")
-        selected_layout = (
-            _find_layout(str(requested_layout_id))
-            if requested_layout_id
-            else _nearest_layout(selection_width, selection_height)
-        )
+        output_layout_filename = _OUTPUT_LAYOUT_FILENAMES.get(output_resolution)
+        if output_layout_filename:
+            selected_layout = next(
+                (layout for layout in _LAYOUTS if layout.path == output_layout_filename), None
+            )
+        elif requested_layout_id:
+            selected_layout = _find_layout(str(requested_layout_id))
+        else:
+            selected_layout = _nearest_layout(width, height)
         if not selected_layout:
             raise ValueError("Unknown layout")
         source_layout_path = _layout_path(selected_layout)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2420,16 +2420,59 @@ def test_auto_layout_selection_uses_4k_layout_for_4k_source():
     assert selected.id == "parapente-3840"
 
 
-def test_worker_preparation_uses_requested_1080p_size_for_4k_source(
+@pytest.mark.parametrize(
+    (
+        "source_resolution",
+        "output_resolution",
+        "requested_layout_id",
+        "expected_layout_id",
+        "expected_layout_filename",
+        "expected_resolution",
+        "expected_geometry",
+    ),
+    [
+        (
+            (3840, 2160),
+            "1080p",
+            "parapente-3840",
+            "parapente-1080",
+            "layout_parapente_1080.xml",
+            (1920, 1080),
+            ("220", "100", "50"),
+        ),
+        (
+            (1920, 1080),
+            "4k",
+            "parapente-1080",
+            "parapente-3840",
+            "layout_parapente_3840.xml",
+            (3840, 2160),
+            ("440", "200", "100"),
+        ),
+    ],
+)
+def test_worker_preparation_uses_layout_matching_output_resolution(
     tmp_path,
     monkeypatch,
     test_db,
+    source_resolution,
+    output_resolution,
+    requested_layout_id,
+    expected_layout_id,
+    expected_layout_filename,
+    expected_resolution,
+    expected_geometry,
 ):
     layout_dir = tmp_path / "layouts"
     layout_dir.mkdir()
     (layout_dir / "layout_parapente_1080.xml").write_text(
         '<layout width="1920" height="1080">'
         '<component type="video" size="220" x="100" y="50" width="300" height="100" />'
+        "</layout>"
+    )
+    (layout_dir / "layout_parapente_3840.xml").write_text(
+        '<layout width="3840" height="2160">'
+        '<component type="video" size="440" x="200" y="100" width="600" height="200" />'
         "</layout>"
     )
     video_path = tmp_path / "source.mp4"
@@ -2441,16 +2484,16 @@ def test_worker_preparation_uses_requested_1080p_size_for_4k_source(
     monkeypatch.setattr(config, "GOPRO_OVERLAY_LAYOUT_DIR", str(layout_dir))
     monkeypatch.setattr(config, "GOPRO_OVERLAY_MAX_AUTO_LAYOUT_WIDTH", 1920)
     monkeypatch.setattr(config, "GOPRO_OVERLAY_MAX_AUTO_LAYOUT_HEIGHT", 1080)
-    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: (3840, 2160))
+    monkeypatch.setattr(gopro_overlay_export, "probe_video_resolution", lambda _: source_resolution)
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
 
     job = create_gopro_overlay_job_from_paths(
         video_path=video_path,
         gpx_path=gpx_path,
         pip_path=pip_path,
-        layout_id="parapente-1080",
+        layout_id=requested_layout_id,
         output_filename="overlay.mp4",
-        output_resolution="1080p",
+        output_resolution=output_resolution,
     )
     queued_job = gopro_overlay_export.get_gopro_overlay_job(job["job_id"], include_command=True)
     assert queued_job is not None
@@ -2458,16 +2501,17 @@ def test_worker_preparation_uses_requested_1080p_size_for_4k_source(
     prepared = gopro_overlay_export._prepare_queued_job(job["job_id"], queued_job)
 
     assert prepared is not None
-    assert prepared["layout_id"] == "parapente-1080"
-    assert prepared["video_width"] == 1920
-    assert prepared["video_height"] == 1080
+    assert prepared["layout_id"] == expected_layout_id
+    assert Path(prepared["layout_path"]).name == expected_layout_filename
+    assert prepared["video_width"] == expected_resolution[0]
+    assert prepared["video_height"] == expected_resolution[1]
     prepared_layout = Path(prepared["layout_path"]).read_text()
-    assert 'width="1920"' in prepared_layout
-    assert 'height="1080"' in prepared_layout
+    assert f'width="{expected_resolution[0]}"' in prepared_layout
+    assert f'height="{expected_resolution[1]}"' in prepared_layout
     assert 'id="pip"' in prepared_layout
-    assert 'size="220"' in prepared_layout
-    assert 'x="100"' in prepared_layout
-    assert 'y="50"' in prepared_layout
+    assert f'size="{expected_geometry[0]}"' in prepared_layout
+    assert f'x="{expected_geometry[1]}"' in prepared_layout
+    assert f'y="{expected_geometry[2]}"' in prepared_layout
 
 
 def test_worker_preparation_merges_osv_files_before_rendering(


### PR DESCRIPTION
## Summary\n- Force GoPro overlay layout selection from the selected output resolution\n- Add regression coverage for 1080p and 4k output presets\n\n## Validation\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e --base=origin/main\n- CodeRabbit: no findings