### PR TITLE
fix(gopro-overlay): select layouts from source resolution

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -60,10 +60,6 @@ _OUTPUT_RESOLUTIONS: dict[str, tuple[int, int] | None] = {
     "1080p": (1920, 1080),
     "4k": (3840, 2160),
 }
-_OUTPUT_LAYOUT_FILENAMES = {
-    "1080p": "layout_parapente_1080.xml",
-    "4k": "layout_parapente_3840.xml",
-}
 
 
 def _gopro_overlay_log_dir() -> Path:
@@ -1393,15 +1389,11 @@ def _prepare_queued_job(job_id: str, job: dict[str, Any]) -> dict[str, Any] | No
         if output_resolution not in _OUTPUT_RESOLUTIONS:
             raise ValueError("Unknown output resolution")
         requested_layout_id = metadata.get("requested_layout_id")
-        output_layout_filename = _OUTPUT_LAYOUT_FILENAMES.get(output_resolution)
-        if output_layout_filename:
-            selected_layout = next(
-                (layout for layout in _LAYOUTS if layout.path == output_layout_filename), None
-            )
-        elif requested_layout_id:
-            selected_layout = _find_layout(str(requested_layout_id))
-        else:
-            selected_layout = _nearest_layout(width, height)
+        selected_layout = (
+            _find_layout(str(requested_layout_id))
+            if requested_layout_id
+            else _nearest_layout(width, height)
+        )
         if not selected_layout:
             raise ValueError("Unknown layout")
         source_layout_path = _layout_path(selected_layout)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -2499,24 +2499,33 @@ def test_auto_layout_selection_uses_4k_layout_for_4k_source():
         (
             (3840, 2160),
             "1080p",
+            None,
             "parapente-3840",
-            "parapente-1080",
-            "layout_parapente_1080.xml",
+            "layout_parapente_3840.xml",
             (1920, 1080),
             ("220", "100", "50"),
         ),
         (
             (1920, 1080),
             "4k",
+            None,
             "parapente-1080",
-            "parapente-3840",
-            "layout_parapente_3840.xml",
+            "layout_parapente_1080.xml",
             (3840, 2160),
             ("440", "200", "100"),
         ),
+        (
+            (3840, 2160),
+            "1080p",
+            "parapente-1080",
+            "parapente-1080",
+            "layout_parapente_1080.xml",
+            (1920, 1080),
+            ("220", "100", "50"),
+        ),
     ],
 )
-def test_worker_preparation_uses_layout_matching_output_resolution(
+def test_worker_preparation_uses_source_layout_unless_explicitly_requested(
     tmp_path,
     monkeypatch,
     test_db,


### PR DESCRIPTION
## Summary\n- Select GoPro overlay layouts from the source video resolution when auto-picking\n- Keep explicit layout choices as the priority override\n- Update regression coverage for source-vs-output resolution behavior\n\n## Validation\n- 
no tests ran in 0.00s\n- 
 NX   Running targets lint, test for project backend:

- backend



> nx run backend:test  [local cache]

> command -v ../../../.venv/bin/pytest >/dev/null 2>&1 && PYTEST=../../../.venv/bin/pytest || PYTEST=pytest; $PYTEST tests/ -m 'not integration and not slow' -q --tb=short --no-header --cov=. --cov-config=.coveragerc --cov-report=term-missing --cov-report=xml:../../coverage/apps/backend/coverage.xml

[1m============================= test session starts ==============================[0m
collected 962 items / 3 deselected / 959 selected

tests/api/test_admin_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                       [  2%][0m
tests/api/test_deployment_drain.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [  2%][0m
tests/api/test_gopro_overlay_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [  5%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 13%]
[0m[32m.[0m[32m.[0m[33m                                                                       [ 13%][0m
tests/api/test_intervals_sync.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 14%][0m
tests/api/test_metrics.py [32m.[0m[32m.[0m[33m                                             [ 14%][0m
tests/api/test_routes_azba_airspace.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                              [ 15%][0m
tests/api/test_routes_flight_decision.py [32m.[0m[32m.[0m[32m.[0m[33m                             [ 15%][0m
tests/api/test_routes_flight_summaries.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                      [ 16%][0m
tests/api/test_routes_flights.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 20%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                          [ 22%][0m
tests/api/test_routes_landings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                        [ 23%][0m
tests/api/test_routes_live_wind.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                 [ 24%][0m
tests/api/test_routes_settings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                 [ 26%][0m
tests/api/test_routes_spots.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 30%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                  [ 31%][0m
tests/api/test_routes_version.py [32m.[0m[32m.[0m[33m                                      [ 31%][0m
tests/api/test_routes_weather_simple.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                [ 33%][0m
tests/api/test_video_export_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 36%]
[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                      [ 36%][0m
tests/scrapers/test_met_no.py [32m.[0m[33m                                          [ 37%][0m
tests/scrapers/test_meteo_parapente.py [33mx[0m[33m                                 [ 37%][0m
tests/scrapers/test_meteoblue.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 37%][0m
tests/scrapers/test_meteociel.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                   [ 38%][0m
tests/scrapers/test_open_meteo.py [33mX[0m[32m.[0m[32m.[0m[32m.[0m[33m                                   [ 38%][0m
tests/scrapers/test_openweathermap.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 39%][0m
tests/scrapers/test_weatherapi.py [33mX[0m[32m.[0m[33m                                     [ 39%][0m
tests/test_admin.py [32m.[0m[32m.[0m[32m.[0m[33m                                                  [ 39%][0m
tests/test_emagram.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                           [ 42%][0m
tests/test_emagram_endpoints.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m              [ 45%][0m
tests/test_models.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                             [ 47%][0m
tests/test_routes.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                     [ 49%][0m
tests/test_scrapers.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                           [ 49%][0m
tests/unit/test_app_settings.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                         [ 51%][0m
tests/unit/test_azba_airspace.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                [ 52%][0m
tests/unit/test_best_spot.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m    [ 56%][0m
tests/unit/test_best_spot_algorithm.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 59%]
[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                      [ 60%][0m
tests/unit/test_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                       [ 61%][0m
tests/unit/test_codex_analyzer.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                              [ 62%][0m
tests/unit/test_e2e_db_utils.py [32m.[0m[33m                                        [ 62%][0m
tests/unit/test_emagram_cache.py [32m.[0m[32m.[0m[32m.[0m[33m                                     [ 62%][0m
tests/unit/test_emagram_generation_failures.py [32m.[0m[32m.[0m[33m                        [ 62%][0m
tests/unit/test_emagram_llm_fallback.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                 [ 64%][0m
tests/unit/test_emagram_thermal_validation.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                       [ 64%][0m
tests/unit/test_external_flight_import.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                          [ 65%][0m
tests/unit/test_external_identity_migration.py [32m.[0m[32m.[0m[33m                        [ 65%][0m
tests/unit/test_flight_decision.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                     [ 67%][0m
tests/unit/test_flight_naming.py [32m.[0m[32m.[0m[33m                                      [ 67%][0m
tests/unit/test_flight_storage.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                               [ 68%][0m
tests/unit/test_flight_summary_migration.py [32m.[0m[33m                            [ 68%][0m
tests/unit/test_flight_tracks.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                            [ 69%][0m
tests/unit/test_gopro_overlay_render_method_migration.py [32m.[0m[33m               [ 69%][0m
tests/unit/test_gopro_overlay_worker.py [32m.[0m[33m                                [ 69%][0m
tests/unit/test_gopro_preview_proxy.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m           [ 72%][0m
tests/unit/test_intervals_config.py [32m.[0m[32m.[0m[32m.[0m[33m                                  [ 72%][0m
tests/unit/test_intervals_icu.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                  [ 73%][0m
tests/unit/test_intervals_sync.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                 [ 73%][0m
tests/unit/test_job_queue.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                        [ 74%][0m
tests/unit/test_main.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                           [ 74%][0m
tests/unit/test_max_speed_backfill.py [32m.[0m[33m                                  [ 75%][0m
tests/unit/test_meteociel_emagram_screenshot.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m              [ 76%][0m
tests/unit/test_metrics_helpers.py [32m.[0m[33m                                     [ 76%][0m
tests/unit/test_open_meteo_emagram_sources.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                [ 77%][0m
tests/unit/test_para_index.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m     [ 81%][0m
tests/unit/test_required_env.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                            [ 82%][0m
tests/unit/test_scheduler.py [32m.[0m[32m.[0m[33ms[0m[33ms[0m[33ms[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33ms[0m[33ms[0m[33m                       [ 84%][0m
tests/unit/test_screenshot_inputs.py [32m.[0m[33m                                   [ 85%][0m
tests/unit/test_seed_weather_sources.py [32m.[0m[32m.[0m[33m                               [ 85%][0m
tests/unit/test_spotair_live_wind.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                          [ 86%][0m
tests/unit/test_spots_distance.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m               [ 88%][0m
tests/unit/test_versioning.py [32m.[0m[32m.[0m[32m.[0m[33m                                        [ 89%][0m
tests/unit/test_video_acceleration.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                            [ 89%][0m
tests/unit/test_video_export_manual.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m [ 93%]
[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                 [ 97%][0m
tests/unit/test_video_export_stream_admission.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                   [ 98%][0m
tests/unit/test_weather_pipeline_cache.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                        [ 98%][0m
tests/unit/test_weather_pipeline_sources.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                         [ 99%][0m
tests/unit/test_weather_sources_registry.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                     [100%][0m

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.13.5-final-0 ________________

Name                                  Stmts   Miss   Cover   Missing
--------------------------------------------------------------------
__init__.py                               2      0 100.00%
api/__init__.py                           0      0 100.00%
api/routes/__init__.py                    0      0 100.00%
app_settings.py                          59      0 100.00%
auth.py                                 102     51  50.00%   32-34, 38-40, 44-46, 52, 56, 75, 114-126, 131-134, 139-173
azba_airspace.py                        240     31  87.08%   49-53, 63, 70, 78, 87, 93-95, 103, 115, 121, 150, 157, 164, 180, 182, 187, 205, 208, 259, 273, 277-278, 280, 294-295, 336
benchmark_flight_summaries.py            52     52   0.00%   3-97
best_spot.py                            344     73  78.78%   34-36, 126, 160-161, 222, 227, 249-250, 256, 291, 297-303, 307, 311, 313, 345-347, 389-403, 407-409, 417-419, 505-508, 512-515, 548, 554-556, 571-572, 589-590, 594, 621, 649-651, 655-656, 664-666, 698-699, 712-715, 727-730, 748-752, 788-789
cache.py                                143     39  72.73%   72-79, 117-131, 197-198, 221-224, 228-229, 259-260, 277-299
config.py                               158     17  89.24%   66-68, 72, 270-271, 325-338
database.py                              27      8  70.37%   16-24, 42-46
deployment_drain.py                     179     58  67.60%   148, 156-159, 165, 193-200, 222-234, 241, 248-261, 268, 274-278, 284-289, 306-351
e2e_db_utils.py                           7      0 100.00%
emagram_aggregator.py                    33     33   0.00%   6-181
emagram_freshness.py                     11      0 100.00%
emagram_multi_source.py                 410    107  73.90%   67-68, 78, 84, 98, 291, 296-297, 317, 362, 375-376, 393-394, 406, 512, 538, 571, 625-626, 629-630, 659-662, 722-738, 754-811, 828-842, 862-865, 1021-1026, 1039-1040, 1044-1045, 1104-1163
env_utils.py                              9      0 100.00%
external_flight_import.py               164     25  84.76%   32, 76, 79-80, 90, 94, 97-98, 138, 179-182, 231, 235-241, 243-248
flight_backfill.py                       27     27   0.00%   1-53
flight_decision.py                      270     29  89.26%   235, 239-240, 311, 335, 337, 375, 392, 398, 421, 562, 564, 585-611, 656, 756, 758-764, 766, 768
flight_naming.py                          6      0 100.00%
flight_storage.py                        44      7  84.09%   17, 31, 52-54, 63-64
flight_summaries.py                     122     16  86.89%   77, 80, 82-85, 110, 145-149, 163, 179, 222, 297
flight_tracks.py                        221     17  92.31%   40, 43, 55, 62, 67, 115, 158, 160, 176, 189, 191, 207, 211, 237, 245, 247, 314
gopro_overlay_export.py                1383    384  72.23%   145-149, 169-177, 182, 202, 206, 211, 253-257, 260-263, 269-271, 286, 322, 328, 425-428, 434, 447-448, 495, 508, 510-512, 516, 522, 525, 527, 535, 540, 542, 553-559, 567, 580-582, 595-597, 600-602, 609, 628-629, 646-661, 668-676, 684-685, 695-721, 747-748, 757-758, 760, 765-779, 783-804, 835-836, 874-875, 883, 888, 899, 1018, 1074-1077, 1112-1116, 1119-1123, 1125-1129, 1131-1133, 1147-1148, 1157, 1161, 1167, 1202-1204, 1207-1233, 1259, 1274, 1279, 1307, 1334-1335, 1390, 1398, 1401, 1432, 1456-1462, 1473, 1483, 1496, 1547, 1593-1597, 1600, 1606-1607, 1662-1664, 1681, 1692, 1738-1740, 1743, 1810, 1841-1842, 1882-1885, 1890, 1899-1909, 1925-1926, 1936-1945, 1955, 1978-1979, 1985-1994, 2000-2002, 2009, 2030-2039, 2043-2051, 2059-2067, 2079-2081, 2115-2131, 2136, 2139-2142, 2149-2150, 2154-2155, 2170, 2176, 2187, 2198-2200, 2204-2217, 2243, 2259, 2262, 2265, 2271, 2291-2297, 2308-2315, 2327-2335, 2341, 2347, 2349, 2364-2370, 2377-2380, 2394-2396, 2412-2414, 2426, 2428, 2431, 2449-2465, 2472-2473, 2477-2490, 2526-2527, 2532-2561
gopro_overlay_worker.py                  32      4  87.50%   41, 45, 50, 57
gopro_preview_proxy.py                  308     57  81.49%   109-110, 117, 141-142, 146-166, 252-253, 309-311, 344, 346, 392-409, 429, 436, 441, 443, 447, 464, 485-486, 506, 537, 550, 562-564, 566, 575-580, 585-591, 597
init_e2e_db.py                           10     10   0.00%   4-20
intervals_icu.py                        108     24  77.78%   54, 57-58, 109, 121, 138, 140-141, 143, 165-178, 180
intervals_sync.py                        50      9  82.00%   51-53, 61-62, 85-88
job_queue.py                             44     12  72.73%   19, 28, 36, 49, 53-60
job_worker.py                            18     18   0.00%   3-31
main.py                                 268    157  41.42%   43-266, 316-342, 351-421, 427-428, 446-448, 470-472, 483-484, 500, 504-506, 617-636
meteorology/__init__.py                   0      0 100.00%
meteorology/classic_analysis.py         211     66  68.72%   56, 85, 100, 103-105, 111, 114-116, 126-128, 144-146, 152-154, 161-163, 170, 176-179, 185-192, 197, 200-205, 231-232, 255-264, 274, 297, 315, 320, 322, 326, 335-336, 365-366, 369-370, 379-380, 395-396, 425, 427, 436, 452, 458
metrics.py                              119      3  97.48%   84, 118, 212
models.py                               316      7  97.78%   338, 345, 360, 363-367, 524
para_index.py                           254     26  89.76%   56-57, 71, 144, 150, 170-171, 254-255, 259-260, 267-268, 343, 391-401, 434, 440, 458
pipeline/__init__.py                      0      0 100.00%
routes.py                              3027   1035  65.81%   197, 267, 280, 294, 306, 339, 346-347, 355, 366, 398, 402, 412, 421-423, 455, 502, 506, 535-537, 539-540, 542, 575, 599-600, 626, 686, 846, 861, 876, 900-916, 922, 954-967, 974, 1008-1031, 1045-1047, 1071, 1075, 1103-1104, 1157, 1168, 1178, 1234, 1236, 1240, 1250, 1254, 1260, 1268, 1283-1309, 1340, 1376-1445, 1517-1519, 1536-1537, 1561-1564, 1609-1634, 1666, 1671, 1677, 1715-1718, 1745-1747, 1762-1765, 1808-1811, 1864, 1901-1903, 1942, 1982-2073, 2135, 2139-2141, 2158-2175, 2301-2305, 2326-2329, 2348-2362, 2378-2402, 2410-2444, 2459-2461, 2465, 2477, 2488-2489, 2516-2517, 2571, 2583-2605, 2637, 2642, 2649, 2662, 2717, 2728-2730, 2787-2789, 2805-2808, 2816, 2822-2824, 2834-2888, 2914, 2960, 2991-2992, 3088-3094, 3106-3174, 3268, 3284, 3388-3413, 3512-3536, 3556-3562, 3571-3573, 3629-3630, 3634-3638, 3699-3701, 3997, 4000-4003, 4089, 4174-4176, 4209-4211, 4230-4233, 4244, 4249-4276, 4285-4307, 4315, 4320-4327, 4335, 4341, 4351, 4355, 4373, 4404-4407, 4455, 4490-4491, 4500-4503, 4524-4661, 4683-4686, 4697-4700, 4714-4743, 4764, 4784-4796, 4830-4921, 4963-4967, 4981-4982, 5017-5018, 5035-5064, 5071-5152, 5170-5183, 5192-5201, 5208-5211, 5217, 5271-5272, 5335, 5354-5363, 5394, 5399, 5403, 5420, 5457, 5475-5505, 5535, 5541, 5543, 5546-5562, 5570, 5577, 5581, 5583, 5589, 5627, 5632-5650, 5708, 5711, 5714, 5730-5731, 5737-5738, 5747, 5754-5758, 5767-5775, 5784, 5796, 5804-5805, 5810, 5812, 5816, 5857, 5870, 5897, 5940, 5947, 5961, 5993, 5997, 6019, 6027, 6072-6082, 6122-6123, 6134, 6144-6146, 6159-6161, 6169, 6175, 6183, 6187, 6189, 6215-6216, 6222-6223, 6235-6236, 6260, 6325, 6344-6363, 6384-6412, 6431-6456, 6481-6554, 6591, 6622-6656, 6693, 6741, 6772, 6778-6780, 6864, 6896-6898, 6950-6952, 6973-7075, 7113-7137, 7153-7182, 7186-7207, 7228-7242, 7245, 7248-7250, 7290-7313, 7339, 7343-7352, 7383-7416, 7441, 7444, 7449-7450, 7456-7457, 7490, 7492, 7513-7528, 7531, 7535, 7548-7549, 7606-7608, 7618-7619, 7637-7654, 7753-7754, 7854-7855, 7860, 7879-7884
scheduler.py                            157     60  61.78%   61-158, 182-183, 228, 279, 285-286, 317-323, 332-333
schemas.py                              789     44  94.42%   206-208, 212-214, 218-220, 224-226, 230-232, 236-238, 349, 355, 379-381, 387, 393-395, 442-450, 852, 856, 1068, 1073, 1078-1083
scrapers/__init__.py                      6      0 100.00%
scrapers/base.py                         95     49  48.42%   103-130, 163, 172-179, 204-223, 241-243, 247-266
scrapers/config.py                       13     13   0.00%   3-122
scrapers/exceptions.py                   12     12   0.00%   4-37
scrapers/met_no.py                       42     16  61.90%   16-43, 56, 60, 71, 75
scrapers/meteo_parapente.py             174    123  29.31%   21-23, 37, 53-56, 102-125, 144-145, 155-156, 167-171, 186-193, 234-312, 359-393, 413-480
scrapers/meteo_parapente_emagram.py      72     72   0.00%   6-224
scrapers/meteoblue.py                   246    103  58.13%   94-102, 139-141, 156-236, 265-266, 277-278, 305, 318, 330, 354-361, 373, 385, 400-402, 415, 425-436, 452, 464, 468, 474-477, 492-514, 533-534
scrapers/meteociel.py                   235     74  68.51%   22-24, 63-96, 126-131, 160-161, 164-166, 197, 205, 228-235, 261, 266, 280, 312, 407-410, 419, 438-463, 501-502
scrapers/open_meteo.py                   61     35  42.62%   37-39, 65-74, 115-146, 166-226
scrapers/openweathermap.py               50      7  86.00%   24, 63-64, 77, 81, 101, 105
scrapers/sources/__init__.py              0      0 100.00%
scrapers/utils.py                        68     68   0.00%   3-205
scrapers/weatherapi.py                   34     21  38.24%   36-38, 51-52, 72-108
spotair_live_wind.py                    101     19  81.19%   65, 72, 97-117, 120-121, 131, 136-137, 145-146
spots/__init__.py                         5      0 100.00%
spots/data_fetcher.py                   161     73  54.66%   58-116, 147-148, 156-157, 164, 206-208, 213-218, 244-301, 347-348, 367-372, 382-384, 400-403
spots/distance.py                        31      9  70.97%   100-113
spots/geocoding.py                       93     60  35.48%   66-75, 80-82, 104-105, 118-123, 132-197, 206-208, 218
spots/search.py                          82     30  63.41%   107-165, 207-208, 252, 316
spots/site_updater.py                    70     54  22.86%   45-120, 127-131, 144-160
versioning.py                            69      8  88.41%   31-32, 44-46, 52-53, 119
video_acceleration.py                    35      4  88.57%   40-41, 55-56
weather_pipeline.py                     335    157  53.13%   51, 55, 91-139, 184-186, 196-233, 245-250, 265-289, 293-295, 332, 359-364, 381-422, 460, 490-491, 509-510, 656, 668-669, 747-748, 801-866, 899-928
weather_sources.py                       83      6  92.77%   63, 90, 119, 134, 277, 297
--------------------------------------------------------------------
TOTAL                                 11897   3519  70.42%
Coverage XML written to file ../../coverage/apps/backend/coverage.xml
[33m= [32m949 passed[0m, [33m[1m5 skipped[0m, [33m[1m3 deselected[0m, [33m[1m1 xfailed[0m, [33m[1m4 xpassed[0m, [33m[1m1347 warnings[0m[33m in 88.29s (0:01:28)[0m[33m =[0m

> nx run backend:lint  [existing outputs match the cache, left as is]

> command -v ../../../.venv/bin/ruff >/dev/null 2>&1 && RUFF=../../../.venv/bin/ruff || RUFF=ruff; $RUFF check . --output-format=github

> command -v ../../../.venv/bin/black >/dev/null 2>&1 && BLACK=../../../.venv/bin/black || BLACK=black; $BLACK --check --diff .

All done! ✨ 🍰 ✨
202 files would be left unchanged.



 NX   Successfully ran targets lint, test for project backend

Nx read the output from the cache instead of running the command for 2 out of 2 tasks.

  Run duration:      61ms
  Cache:             2/2 hit (100%)
  Critical path:     12ms (1 task)
  Recoverable time:  <1ms\n- CodeRabbit: no findings\n