### PR TITLE
fix(flights): show ISO timestamps in job logs

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -438,12 +438,16 @@ def _render_method_from_command(command: Any) -> str | None:
     return None
 
 
+def _format_job_log_line(message: str) -> str:
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return f"[{timestamp}] {message}\n"
+
+
 def _append_job_log(log_path: Path, message: str) -> None:
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
         with log_path.open("a", encoding="utf-8") as log_file:
-            log_file.write(f"[{timestamp}] {message}\n")
+            log_file.write(_format_job_log_line(message))
     except OSError:
         pass
 
@@ -1966,11 +1970,11 @@ def _run_job(job_id: str) -> None:
     output_lines: list[str] = []
     try:
         with log_path.open("a", encoding="utf-8") as log_file:
-            log_file.write(f"[{_utc_now()}] Starting GoPro overlay job {job_id}\n")
-            log_file.write("Command: " + " ".join(command) + "\n")
+            log_file.write(_format_job_log_line(f"Starting GoPro overlay job {job_id}"))
+            log_file.write(_format_job_log_line("Command: " + " ".join(command)))
             log_file.flush()
             for line in _read_process_updates_from_process(process, job_id):
-                log_file.write(line + "\n")
+                log_file.write(_format_job_log_line(line))
                 log_file.flush()
                 output_lines.append(line)
                 if len(output_lines) > 50:
@@ -2016,10 +2020,12 @@ def _run_job(job_id: str) -> None:
                         return
                     _PROCESSES[job_id] = process
                 with log_path.open("a", encoding="utf-8") as log_file:
-                    log_file.write("CPU fallback command: " + " ".join(cpu_command) + "\n")
+                    log_file.write(
+                        _format_job_log_line("CPU fallback command: " + " ".join(cpu_command))
+                    )
                     log_file.flush()
                     for line in _read_process_updates_from_process(process, job_id):
-                        log_file.write(line + "\n")
+                        log_file.write(_format_job_log_line(line))
                         log_file.flush()
                         output_lines.append(line)
                         if len(output_lines) > 50:

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 from datetime import date, datetime
@@ -1890,7 +1891,10 @@ def test_overlay_log_survives_work_directory_cleanup(tmp_path, monkeypatch):
     )
 
     assert not work_dir.exists()
-    assert "Overlay ready" in log_path.read_text()
+    assert re.fullmatch(
+        r"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00\] Overlay ready\n",
+        log_path.read_text(),
+    )
 
 
 def test_reconcile_gopro_overlay_flight_refs_clears_missing_active_job(test_db, monkeypatch):

--- a/apps/frontend/src/components/flights/job-logs/JobLogViewer.test.tsx
+++ b/apps/frontend/src/components/flights/job-logs/JobLogViewer.test.tsx
@@ -39,6 +39,23 @@ describe('JobLogViewer', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Succès:')).toBeInTheDocument();
     expect(screen.getByText('Erreur:')).toBeInTheDocument();
+    expect(screen.getByText('2026-07-31T10:15:20Z')).toHaveAttribute(
+      'datetime',
+      '2026-07-31T10:15:20Z'
+    );
+    expect(screen.getByText('2026-07-31T10:16:20Z')).toBeInTheDocument();
+  });
+
+  it('keeps events without a timestamp readable', () => {
+    render(
+      <JobLogViewer
+        logs={['Legacy export event']}
+        emptyLabel="Aucun événement"
+      />
+    );
+
+    expect(screen.getAllByText('Legacy export event')).toHaveLength(2);
+    expect(document.querySelector('time')).not.toBeInTheDocument();
   });
 
   it('keeps raw technical lines in a collapsed section', () => {

--- a/apps/frontend/src/components/flights/job-logs/JobLogViewer.tsx
+++ b/apps/frontend/src/components/flights/job-logs/JobLogViewer.tsx
@@ -73,15 +73,11 @@ function parseLogLine(line: string) {
   return { message: match[2] || line, timestamp: match[1] || null };
 }
 
-function formatLogTime(timestamp: string | null, locale?: string) {
+function formatLogTimestamp(timestamp: string | null) {
   if (!timestamp) return null;
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return timestamp;
-  return new Intl.DateTimeFormat(locale, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  }).format(date);
+  return date.toISOString().replace(/\.\d{3}Z$/u, 'Z');
 }
 
 export function JobLogViewer({
@@ -89,7 +85,7 @@ export function JobLogViewer({
   emptyLabel,
   isLive = false,
 }: JobLogViewerProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const lines = logs?.filter(Boolean) ?? [];
 
@@ -119,7 +115,7 @@ export function JobLogViewer({
           {lines.map((line, index) => {
             const entry = parseLogLine(line);
             const tone = getLogTone(entry.message);
-            const time = formatLogTime(entry.timestamp, i18n?.language);
+            const timestamp = formatLogTimestamp(entry.timestamp);
             return (
               <li
                 key={`${index}-${line}`}
@@ -133,12 +129,12 @@ export function JobLogViewer({
                   )}
                   :
                 </span>
-                {time && (
+                {timestamp && (
                   <time
-                    dateTime={entry.timestamp ?? undefined}
+                    dateTime={timestamp}
                     className="shrink-0 font-mono text-[11px] opacity-70"
                   >
-                    {time}
+                    {timestamp}
                   </time>
                 )}
                 <span className="min-w-0 break-words">{entry.message}</span>


### PR DESCRIPTION
## Summary\n- show UTC ISO timestamps in job log UI instead of localized time-only strings\n- ensure GoPro overlay log lines are always persisted with timestamps\n- add coverage for timestamped and legacy log lines\n\n## Validation\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx affected -t build,lint,type-check,test --parallel=5 --exclude=e2e\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx affected -t build,type-check --parallel=2 --exclude=e2e\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx lint frontend\n- NX_NO_CLOUD=true NX_DAEMON=false pnpm nx test frontend\n- pytest apps/backend/tests/api/test_gopro_overlay_endpoints.py::test_overlay_log_survives_work_directory_cleanup -q --tb=short --no-header --no-cov\n- ruff/black and oxlint/oxfmt on touched files