### PR TITLE
fix(backend): use cuda pix_fmt for nvenc overlay scaling

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1204,6 +1204,7 @@ def _ensure_video_output_resolution(
                 quality="18",
                 cpu_preset="medium",
                 include_audio=True,
+                pixel_format="cuda",
             ),
             "-movflags",
             "+faststart",

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -1362,8 +1362,10 @@ def test_gopro_overlay_output_resolution_retries_cuda_failure_on_cpu(
     assert commands[0][commands[0].index("-hwaccel") + 1] == "cuda"
     assert commands[0][commands[0].index("-vf") + 1] == ("scale_cuda=w=3840:h=2160:format=yuv420p")
     assert commands[0][commands[0].index("-c:v") + 1] == "h264_nvenc"
+    assert commands[0][commands[0].index("-pix_fmt") + 1] == "cuda"
     assert commands[1][commands[1].index("-vf") + 1] == ("scale=w=3840:h=2160:flags=lanczos")
     assert commands[1][commands[1].index("-c:v") + 1] == "libx264"
+    assert commands[1][commands[1].index("-pix_fmt") + 1] == "yuv420p"
     assert timeouts == [8429, 8429]
     log = log_path.read_text()
     expected_detail = (

--- a/apps/backend/video_acceleration.py
+++ b/apps/backend/video_acceleration.py
@@ -103,6 +103,7 @@ def h264_encode_args(
     quality: str,
     cpu_preset: str,
     include_audio: bool,
+    pixel_format: str = "yuv420p",
 ) -> list[str]:
     if accelerator == "nvidia":
         args = [
@@ -119,7 +120,7 @@ def h264_encode_args(
             "-b:v",
             "0",
             "-pix_fmt",
-            "yuv420p",
+            pixel_format,
         ]
     else:
         args = [
@@ -130,7 +131,7 @@ def h264_encode_args(
             "-crf",
             quality,
             "-pix_fmt",
-            "yuv420p",
+            pixel_format,
         ]
     audio_args = ["-c:a", "copy"] if include_audio else ["-an"]
     return [*args, *audio_args]


### PR DESCRIPTION
## Summary\n- allow CUDA output frames to reach h264_nvenc without auto_scale conversion\n- keep CPU fallback on the resolution correction path\n- add regression coverage for both CUDA and CPU scaling commands\n\n## Validation\n- /media/usb/data-m2/developement/dashboard-parapente/.venv/bin/pytest tests/api/test_gopro_overlay_endpoints.py::test_gopro_overlay_output_resolution_retries_cuda_failure_on_cpu tests/unit/test_video_acceleration.py -q --tb=short --no-header --no-cov\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint,test --parallel=5 --exclude=e2e\n- NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend