### PR TITLE
fix(backend): clean gopro temp files and add preview audio

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -1155,7 +1155,7 @@ def _unlink_if_exists(path: Path) -> None:
         if path.exists():
             path.unlink()
     except OSError:
-        pass
+        logger.exception("Failed to delete temporary GoPro overlay file %s", path)
 
 
 def _ensure_video_output_resolution(
@@ -2351,21 +2351,24 @@ def process_gopro_overlay_job(job_id: str) -> None:
 
 
 def _mark_interrupted_jobs_failed() -> None:
+    jobs_to_clean: list[dict[str, Any]] = []
     try:
         with SessionLocal() as db:
             jobs = (
                 db.query(GoproOverlayJob)
-                .filter(GoproOverlayJob.status.in_(_INTERRUPTIBLE_STATUSES))
+                .filter(GoproOverlayJob.status.in_(_INTERRUPTIBLE_STATUSES | _TERMINAL_STATUSES))
                 .all()
             )
             for job in jobs:
-                job.status = _STATUS_FAILED
-                job.progress = 100
-                job.message = "Overlay interrupted by backend restart"
-                job.error = "The backend stopped while the overlay process was running"
-                job.completed_at = _utc_now_dt()
-                job.updated_at = _utc_now_dt()
-                _sync_flights_from_job(db, job)
+                if job.status in _INTERRUPTIBLE_STATUSES:
+                    job.status = _STATUS_FAILED
+                    job.progress = 100
+                    job.message = "Overlay interrupted by backend restart"
+                    job.error = "The backend stopped while the overlay process was running"
+                    job.completed_at = _utc_now_dt()
+                    job.updated_at = _utc_now_dt()
+                    _sync_flights_from_job(db, job)
+                jobs_to_clean.append(_job_to_payload(job))
             db.commit()
     except OperationalError as exc:
         if "no such table: gopro_overlay_jobs" not in str(exc):
@@ -2381,6 +2384,11 @@ def _mark_interrupted_jobs_failed() -> None:
                         completed_at=_utc_now(),
                         updated_at=_utc_now(),
                     )
+                if job.get("status") in _TERMINAL_STATUSES:
+                    jobs_to_clean.append(job.copy())
+
+    for job in jobs_to_clean:
+        _cleanup_gopro_overlay_temp_files(job)
 
 
 def _worker_loop() -> None:

--- a/apps/backend/gopro_preview_proxy.py
+++ b/apps/backend/gopro_preview_proxy.py
@@ -28,7 +28,7 @@ PREVIEW_FILENAME = "camera.preview.mp4"
 MANIFEST_FILENAME = ".camera.preview.json"
 LOCK_FILENAME = ".camera.preview.lock"
 STATE_LOCK_FILENAME = ".camera.preview.state.lock"
-PROFILE_VERSION = 2
+PROFILE_VERSION = 3
 
 PreviewStatus = Literal["missing", "generating", "ready", "failed"]
 
@@ -83,8 +83,11 @@ def _write_manifest(camera_path: Path, manifest: dict[str, Any]) -> None:
     temporary_path = manifest_path.with_suffix(
         f"{manifest_path.suffix}.{os.getpid()}.{threading.get_ident()}.tmp"
     )
-    temporary_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
-    temporary_path.replace(manifest_path)
+    try:
+        temporary_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+        temporary_path.replace(manifest_path)
+    finally:
+        _unlink_temp_file(temporary_path)
 
 
 def _manifest_matches_source(manifest: dict[str, Any], fingerprint: SourceFingerprint) -> bool:
@@ -164,6 +167,38 @@ def _probe_duration(video_path: Path) -> float | None:
     except (FileNotFoundError, subprocess.SubprocessError, ValueError):
         return None
     return duration if result.returncode == 0 and duration > 0 else None
+
+
+def _has_audio_stream(video_path: Path) -> bool:
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "a:0",
+                "-show_entries",
+                "stream=index",
+                "-of",
+                "csv=p=0",
+                str(video_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, TimeoutError):
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _unlink_temp_file(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        logger.warning("Failed to delete temporary GoPro preview file %s", path, exc_info=True)
 
 
 def _generation_is_active(manifest: dict[str, Any]) -> bool:
@@ -339,6 +374,7 @@ def _ffmpeg_command(
     output_path: Path,
     segments: list[PreviewSegment] | int,
     accelerator: Literal["cpu", "nvidia"],
+    include_audio: bool,
 ) -> list[str]:
     if isinstance(segments, int):
         segments = preview_segments(float(segments), segments)
@@ -355,14 +391,33 @@ def _ffmpeg_command(
         if segment.source_start_seconds > 0:
             input_args.extend(["-ss", f"{segment.source_start_seconds:g}"])
         input_args.extend(["-i", str(camera_path)])
-        output_label = "outv" if len(segments) == 1 else f"v{index}"
+        video_label = "outv" if len(segments) == 1 else f"v{index}"
         filters.append(
             f"[{index}:v:0]trim=duration={segment.duration_seconds:g},"
-            f"setpts=PTS-STARTPTS,{scale}[{output_label}]"
+            f"setpts=PTS-STARTPTS,{scale}[{video_label}]"
         )
+        if include_audio:
+            audio_label = "outa" if len(segments) == 1 else f"a{index}"
+            filters.append(
+                f"[{index}:a:0]atrim=duration={segment.duration_seconds:g},"
+                f"asetpts=PTS-STARTPTS[{audio_label}]"
+            )
     if len(segments) > 1:
-        inputs = "".join(f"[v{index}]" for index in range(len(segments)))
-        filters.append(f"{inputs}concat=n={len(segments)}:v=1:a=0[outv]")
+        if include_audio:
+            inputs = "".join(f"[v{index}][a{index}]" for index in range(len(segments)))
+            filters.append(f"{inputs}concat=n={len(segments)}:v=1:a=1[outv][outa]")
+        else:
+            inputs = "".join(f"[v{index}]" for index in range(len(segments)))
+            filters.append(f"{inputs}concat=n={len(segments)}:v=1:a=0[outv]")
+    encode_args = h264_encode_args(
+        accelerator,
+        quality=str(config.GOPRO_PREVIEW_QUALITY),
+        cpu_preset="veryfast",
+        include_audio=False,
+    )
+    if include_audio:
+        encode_args.remove("-an")
+        encode_args.extend(["-c:a", "aac", "-b:a", "128k"])
     return [
         "ffmpeg",
         "-hide_banner",
@@ -374,12 +429,8 @@ def _ffmpeg_command(
         ";".join(filters),
         "-map",
         "[outv]",
-        *h264_encode_args(
-            accelerator,
-            quality=str(config.GOPRO_PREVIEW_QUALITY),
-            cpu_preset="veryfast",
-            include_audio=False,
-        ),
+        *(["-map", "[outa]"] if include_audio else []),
+        *encode_args,
         "-g",
         "30",
         "-movflags",
@@ -390,13 +441,14 @@ def _ffmpeg_command(
 
 def _run_ffmpeg(camera_path: Path, output_path: Path, segments: list[PreviewSegment]) -> None:
     selected = select_video_accelerator(config.VIDEO_ACCELERATOR)
+    include_audio = _has_audio_stream(camera_path)
     accelerators: list[Literal["cpu", "nvidia"]] = [selected]
     if selected == "nvidia":
         accelerators.append("cpu")
     last_error = "ffmpeg failed"
     for accelerator in accelerators:
         result = subprocess.run(
-            _ffmpeg_command(camera_path, output_path, segments, accelerator),
+            _ffmpeg_command(camera_path, output_path, segments, accelerator, include_audio),
             check=False,
             capture_output=True,
             text=True,
@@ -404,7 +456,7 @@ def _run_ffmpeg(camera_path: Path, output_path: Path, segments: list[PreviewSegm
         )
         if result.returncode == 0:
             return
-        output_path.unlink(missing_ok=True)
+        _unlink_temp_file(output_path)
         last_error = (result.stderr or last_error).strip()[-1000:]
     raise RuntimeError(last_error)
 
@@ -508,7 +560,7 @@ def process_preview_job(
             logger.warning("GoPro preview generation failed for %s: %s", camera_path, error)
             manifest.update(status="failed", generation_started_at=None, error=str(error)[:1000])
         finally:
-            temporary_path.unlink(missing_ok=True)
+            _unlink_temp_file(temporary_path)
             if not _preview_path(camera_path).is_file() or manifest.get("status") != "ready":
                 with _state_lock(camera_path):
                     latest_manifest = _load_manifest(camera_path)
@@ -531,6 +583,22 @@ def process_preview_job(
 _STABILITY_OBSERVATIONS: dict[Path, tuple[SourceFingerprint, float]] = {}
 
 
+def _cleanup_stale_preview_temp_files(camera_path: Path) -> None:
+    cutoff = time.time() - config.GOPRO_PREVIEW_TIMEOUT_SECONDS
+    patterns = (f".{PREVIEW_FILENAME}.*.part.mp4", f"{MANIFEST_FILENAME}.*.tmp")
+    for pattern in patterns:
+        for temporary_path in camera_path.parent.glob(pattern):
+            try:
+                if temporary_path.stat().st_mtime < cutoff:
+                    _unlink_temp_file(temporary_path)
+            except OSError:
+                logger.warning(
+                    "Failed to inspect temporary GoPro preview file %s",
+                    temporary_path,
+                    exc_info=True,
+                )
+
+
 def scan_for_gopro_previews() -> int:
     root = Path(config.GOPRO_OVERLAY_PARAGLIDING_ROOT)
     if not root.is_dir():
@@ -539,6 +607,7 @@ def scan_for_gopro_previews() -> int:
     observed_paths: set[Path] = set()
     for camera_path in root.glob("[0-9]" * 8 + "/[0-9][0-9]/camera.mp4"):
         try:
+            _cleanup_stale_preview_temp_files(camera_path)
             observed_paths.add(camera_path)
             fingerprint = _source_fingerprint(camera_path)
             previous = _STABILITY_OBSERVATIONS.get(camera_path)

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -18,6 +18,7 @@ from starlette.datastructures import UploadFile
 import config
 import gopro_overlay_export
 import gopro_overlay_worker
+import gopro_preview_proxy
 from auth import create_job_token
 import routes
 from gopro_overlay_export import _prepare_layout_file
@@ -203,7 +204,7 @@ def test_gopro_camera_preview_endpoint_serves_current_proxy(
     (input_dir / ".camera.preview.json").write_text(
         json.dumps(
             {
-                "profile_version": 2,
+                "profile_version": gopro_preview_proxy.PROFILE_VERSION,
                 "source": {
                     "size": fingerprint.st_size,
                     "mtime_ns": fingerprint.st_mtime_ns,
@@ -238,7 +239,7 @@ def test_gopro_camera_preview_endpoint_falls_back_for_a_different_target(
     (input_dir / ".camera.preview.json").write_text(
         json.dumps(
             {
-                "profile_version": 2,
+                "profile_version": gopro_preview_proxy.PROFILE_VERSION,
                 "source": {
                     "size": fingerprint.st_size,
                     "mtime_ns": fingerprint.st_mtime_ns,
@@ -272,7 +273,7 @@ def test_gopro_camera_preview_endpoint_falls_back_when_proxy_file_is_missing(
     (input_dir / ".camera.preview.json").write_text(
         json.dumps(
             {
-                "profile_version": 2,
+                "profile_version": gopro_preview_proxy.PROFILE_VERSION,
                 "source": {
                     "size": fingerprint.st_size,
                     "mtime_ns": fingerprint.st_mtime_ns,
@@ -2078,13 +2079,26 @@ def test_reconcile_gopro_overlay_flight_refs_clears_missing_active_job(test_db, 
         session.close()
 
 
-def test_mark_interrupted_jobs_failed_marks_active_rows_failed(test_db, monkeypatch):
+def test_mark_interrupted_jobs_failed_marks_active_rows_failed(
+    test_db: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(gopro_overlay_export, "SessionLocal", test_db)
+    final_output = tmp_path / "final.mp4"
+    final_output.write_bytes(b"completed")
     session = test_db()
     try:
         from models import GoproOverlayJob
 
-        for job_id, status in (("job-preparing", "preparing"), ("job-running", "running")):
+        jobs = (
+            ("job-preparing", "preparing", ".final.job-preparing.part.mp4"),
+            ("job-running", "running", ".Vol_test.job-running.part.mp4"),
+            ("job-already-failed", "failed", ".final.job-already-failed.part.mp4"),
+        )
+        temporary_paths = []
+        for job_id, status, temporary_name in jobs:
+            temporary_path = tmp_path / temporary_name
+            temporary_path.write_bytes(b"partial")
+            temporary_paths.append(temporary_path)
             session.add(
                 GoproOverlayJob(
                     id=job_id,
@@ -2096,8 +2110,8 @@ def test_mark_interrupted_jobs_failed_marks_active_rows_failed(test_db, monkeypa
                     layout_id="parapente-1080",
                     layout_label="Parapente 1920x1080",
                     layout_path="layout.xml",
-                    output_path="final.mp4",
-                    temp_output_path=f".final.{job_id}.part.mp4",
+                    output_path=str(final_output),
+                    temp_output_path=str(temporary_path),
                     output_filename="final.mp4",
                 )
             )
@@ -2122,6 +2136,11 @@ def test_mark_interrupted_jobs_failed_marks_active_rows_failed(test_db, monkeypa
             refreshed_flight = session.get(Flight, f"flight-{job_id}")
             assert refreshed_flight is not None
             assert refreshed_flight.gopro_overlay_status == "failed"
+        already_failed = gopro_overlay_export.get_gopro_overlay_job("job-already-failed")
+        assert already_failed is not None
+        assert already_failed["message"] == "Rendering overlay"
+        assert all(not temporary_path.exists() for temporary_path in temporary_paths)
+        assert final_output.read_bytes() == b"completed"
     finally:
         session.close()
 

--- a/apps/backend/tests/unit/test_gopro_preview_proxy.py
+++ b/apps/backend/tests/unit/test_gopro_preview_proxy.py
@@ -1,4 +1,6 @@
 import json
+import os
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -16,7 +18,9 @@ def test_ffmpeg_command_concatenates_start_and_target_tail_without_audio(
     output_path = tmp_path / "preview.mp4"
 
     segments = gopro_preview_proxy.preview_segments(1000, 180)
-    command = gopro_preview_proxy._ffmpeg_command(camera_path, output_path, segments, "cpu")
+    command = gopro_preview_proxy._ffmpeg_command(
+        camera_path, output_path, segments, "cpu", include_audio=False
+    )
 
     filters = command[command.index("-filter_complex") + 1]
     assert "[0:v:0]trim=duration=180" in filters
@@ -29,6 +33,28 @@ def test_ffmpeg_command_concatenates_start_and_target_tail_without_audio(
     assert "-an" in command
     assert command[command.index("-movflags") + 1] == "+faststart"
     assert command[command.index("-g") + 1] == "30"
+
+
+def test_ffmpeg_command_concatenates_audio_with_video(tmp_path: Path) -> None:
+    camera_path = tmp_path / "camera.mp4"
+    output_path = tmp_path / "preview.mp4"
+
+    command = gopro_preview_proxy._ffmpeg_command(
+        camera_path,
+        output_path,
+        gopro_preview_proxy.preview_segments(1000, 180),
+        "cpu",
+        include_audio=True,
+    )
+
+    filters = command[command.index("-filter_complex") + 1]
+    assert "[0:a:0]atrim=duration=180,asetpts=PTS-STARTPTS[a0]" in filters
+    assert "[1:a:0]atrim=duration=180,asetpts=PTS-STARTPTS[a1]" in filters
+    assert "[v0][a0][v1][a1]concat=n=2:v=1:a=1[outv][outa]" in filters
+    assert command.count("-map") == 2
+    assert "[outa]" in command
+    assert command[command.index("-c:a") + 1] == "aac"
+    assert "-an" not in command
 
 
 def test_preview_segments_use_one_continuous_segment_when_extremities_overlap() -> None:
@@ -708,3 +734,28 @@ def test_scanner_waits_for_stable_camera_observation(tmp_path: Path, monkeypatch
         assert gopro_preview_proxy.scan_for_gopro_previews() == 1
 
     assert requested == [(camera_path, config.GOPRO_PREVIEW_DEFAULT_SECONDS)]
+
+
+def test_scanner_removes_only_stale_preview_temporary_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    camera_path = tmp_path / "20260315" / "01" / "camera.mp4"
+    camera_path.parent.mkdir(parents=True)
+    camera_path.write_bytes(b"camera")
+    stale_video = camera_path.with_name(".camera.preview.mp4.123.part.mp4")
+    stale_manifest = camera_path.with_name(".camera.preview.json.123.456.tmp")
+    recent_video = camera_path.with_name(".camera.preview.mp4.789.part.mp4")
+    for path in (stale_video, stale_manifest, recent_video):
+        path.write_bytes(b"temporary")
+    stale_mtime = time.time() - 301
+    os.utime(stale_video, (stale_mtime, stale_mtime))
+    os.utime(stale_manifest, (stale_mtime, stale_mtime))
+    monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))
+    monkeypatch.setattr(config, "GOPRO_PREVIEW_TIMEOUT_SECONDS", 300)
+    gopro_preview_proxy._STABILITY_OBSERVATIONS.clear()
+
+    assert gopro_preview_proxy.scan_for_gopro_previews() == 0
+
+    assert not stale_video.exists()
+    assert not stale_manifest.exists()
+    assert recent_video.exists()


### PR DESCRIPTION
## Summary\n- delete stale GoPro overlay and preview temporary files after interrupted jobs or stale scans\n- keep preview lock files for synchronization\n- include audio in generated previews when the source has an audio stream\n- bump preview cache profile version and add regression tests\n\n## Validation\n- TESTING=true BACKEND_DATABASE_URL=sqlite:///./test.db BACKEND_WEATHERAPI_KEY=test_key BACKEND_METEOBLUE_API_KEY=test_key ../../../.venv/bin/pytest tests/unit/test_gopro_preview_proxy.py tests/api/test_gopro_overlay_endpoints.py::test_mark_interrupted_jobs_failed_marks_active_rows_failed -q --tb=short --no-header --no-cov\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx lint backend\n- NX_DAEMON=false NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx test backend\n- CodeRabbit review: no findings