### PR TITLE
fix(frontend): stop autoplaying 3d replay in flight media

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -206,6 +206,7 @@ vi.mock('react-i18next', () => ({
         'flights.logsTab': 'Processing',
         'flights.mediaPageTitle': 'Flight media',
         'flights.mediaReplayTitle': 'Flight replay',
+        'flights.open3dReplay': 'Open 3D replay',
         'flights.mediaFilesTitle': 'Available files',
         'flights.mediaCreationTitle': 'Create and publish',
         'flights.youtubeVideos': 'YouTube videos',
@@ -396,6 +397,12 @@ describe('FlightDetails GoPro overlay action', () => {
       'src',
       'https://www.youtube-nocookie.com/embed/9bZkp7q19f0'
     );
+    expect(
+      screen.getByRole('button', { name: 'Open 3D replay' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('flights.loading3dViewer')
+    ).not.toBeInTheDocument();
   });
 
   it('removes a YouTube association from the media tab', async () => {

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -187,35 +187,6 @@ export function FlightDetails({
       });
     })();
   useEffect(() => {
-    activeFlightIdRef.current = flight.id;
-    setActiveTab('infos');
-    setHasOpenedReplay(false);
-    setEditingMode(false);
-    setEditingNotes(false);
-    setGoproOverlayJobId(null);
-    setGoproOverlayJobToken(null);
-    setIsGoproOverlayDialogOpen(false);
-    setGoproOverlayOutputResolution('auto');
-    setIsCancellingGoproOverlay(false);
-    setDownloadingMedia(null);
-    setDeletingGoproOverlayJobId(null);
-    setDeletedGoproOverlayJobIds([]);
-    setRemovingYoutubeUrl(null);
-    resetGoproOverlayJob();
-  }, [flight.id, resetGoproOverlayJob]);
-
-  useEffect(() => {
-    if (!isGoproOverlayDialogOpen) {
-      setGoproOverlayGpxOffset(String(flight.gopro_overlay_gpx_offset ?? 0));
-      setGoproOverlayInitialGpxOffset(null);
-    }
-  }, [flight.gopro_overlay_gpx_offset, isGoproOverlayDialogOpen]);
-
-  useEffect(() => {
-    setNotesText(flight.notes ?? '');
-  }, [flight.notes]);
-
-  useEffect(() => {
     if (
       streamedGoproOverlayJob?.status === 'completed' ||
       streamedGoproOverlayJob?.status === 'failed' ||
@@ -769,6 +740,19 @@ export function FlightDetails({
       compact={mobileMode}
     />
   );
+  const replayContent =
+    hasGpx && !hasOpenedReplay ? (
+      <Button
+        variant="secondary"
+        className="ml-12 min-h-10 rounded-lg px-4 py-2 text-sm"
+        onPress={() => setHasOpenedReplay(true)}
+      >
+        <Play className="h-4 w-4" aria-hidden="true" />
+        {t('flights.open3dReplay')}
+      </Button>
+    ) : (
+      replayCard
+    );
 
   const logsPanel = (
     <FlightGenerationLogsPanel
@@ -836,7 +820,7 @@ export function FlightDetails({
               </p>
             </div>
           </div>
-          {hasOpenedReplay ? replayCard : null}
+          {replayContent}
         </section>
 
         <FlightMediaBadges
@@ -942,9 +926,6 @@ export function FlightDetails({
           onSelectionChange={(key) => {
             const tab = key as FlightDetailsTab;
             setActiveTab(tab);
-            if (tab === 'replay') {
-              setHasOpenedReplay(true);
-            }
           }}
           className="space-y-4"
         >
@@ -986,9 +967,6 @@ export function FlightDetails({
       onSelectionChange={(key) => {
         const tab = key as FlightDetailsTab;
         setActiveTab(tab);
-        if (tab === 'replay') {
-          setHasOpenedReplay(true);
-        }
       }}
       className="space-y-4"
     >

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1011,6 +1011,7 @@
     "mediaPageDescription": "Find the replay, generated files, and publications associated with this flight.",
     "mediaReplayTitle": "Flight replay",
     "mediaReplayDescription": "Explore the track in 3D before creating or publishing your videos.",
+    "open3dReplay": "Open 3D replay",
     "mediaFilesTitle": "Available files",
     "mediaFilesDescription": "Download sources and exports that are ready to use.",
     "mediaFilesEmpty": "No media files are available for this flight yet.",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1015,6 +1015,7 @@
     "mediaPageDescription": "Retrouvez le replay, les fichiers générés et les publications associés à ce vol.",
     "mediaReplayTitle": "Replay du vol",
     "mediaReplayDescription": "Explorez la trace en 3D avant de créer ou publier vos vidéos.",
+    "open3dReplay": "Ouvrir le replay 3D",
     "mediaFilesTitle": "Fichiers disponibles",
     "mediaFilesDescription": "Téléchargez les sources et les exports prêts à être utilisés.",
     "mediaFilesEmpty": "Aucun fichier média n’est encore disponible pour ce vol.",

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -418,7 +418,7 @@ export const MobileFlowWithReplay = meta.story({
 });
 
 MobileFlowWithReplay.test(
-  'loads GPX data only when Replay tab is selected',
+  'loads GPX data only when the 3D replay is opened',
   async ({ canvas, userEvent, step }) => {
     let requestsAfterOpeningFlight = 0;
 
@@ -443,17 +443,28 @@ MobileFlowWithReplay.test(
       expect(gpxRequestCount).toBe(requestsAfterOpeningFlight);
     });
 
-    await step('switches to Replay and shows loading state', async () => {
+    await step('switches to Media without loading the 3D replay', async () => {
       await userEvent.click(
         canvas.getByRole('tab', { name: i18n.t('flights.replayTab') })
       );
 
       await expect(
-        await canvas.findByText(i18n.t('flights.loading3dViewer'))
+        canvas.getByRole('button', { name: i18n.t('flights.open3dReplay') })
       ).toBeInTheDocument();
+      await expect(
+        canvas.queryByText(i18n.t('flights.loading3dViewer'))
+      ).not.toBeInTheDocument();
+      expect(gpxRequestCount).toBe(requestsAfterOpeningFlight);
     });
 
-    await step('triggers GPX loading once Replay is active', async () => {
+    await step('triggers GPX loading once the replay is opened', async () => {
+      await userEvent.click(
+        canvas.getByRole('button', { name: i18n.t('flights.open3dReplay') })
+      );
+
+      await expect(
+        await canvas.findByText(i18n.t('flights.loading3dViewer'))
+      ).toBeInTheDocument();
       await waitFor(() => {
         expect(gpxRequestCount).toBeGreaterThan(requestsAfterOpeningFlight);
       });


### PR DESCRIPTION
## Summary\n- avoid auto-mounting the 3D replay when opening flight media\n- add an explicit "Open 3D replay" action\n- keep YouTube embeds available without Cesium competing for GPU\n\n## Validation\n- \n- \n- \n- \n\nCodeRabbit review: passed.