### PR TITLE
fix(flights): show YouTube badge in flight list

### DIFF
--- a/apps/backend/flight_summaries.py
+++ b/apps/backend/flight_summaries.py
@@ -62,6 +62,14 @@ class InvalidFlightSummaryCursor(ValueError):
     pass
 
 
+def _has_youtube_video(value: str | None) -> bool:
+    try:
+        urls = json.loads(value or "[]")
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return isinstance(urls, list) and bool(urls)
+
+
 def _encode_cursor(payload: dict[str, Any]) -> str:
     body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
     signature = hmac.new(_CURSOR_SIGNING_KEY, body, hashlib.sha256).digest()
@@ -248,6 +256,7 @@ def list_flight_summaries(
         Flight.video_export_job_id,
         Flight.video_export_status,
         Flight.video_file_path,
+        Flight.youtube_urls_json,
         Flight.gopro_overlay_job_id,
         Flight.gopro_overlay_status,
         Flight.gopro_overlay_file_path,
@@ -287,6 +296,7 @@ def list_flight_summaries(
             video_export_status=row.video_export_status,
             video_export_progress=None,
             has_video=bool(row.video_file_path),
+            has_youtube_video=_has_youtube_video(row.youtube_urls_json),
             gopro_overlay_job_id=row.gopro_overlay_job_id,
             gopro_overlay_status=row.gopro_overlay_status,
             gopro_overlay_progress=None,

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -567,6 +567,7 @@ class FlightSummary(BaseModel):
     video_export_status: str | None = None
     video_export_progress: int | None = None
     has_video: bool
+    has_youtube_video: bool
     gopro_overlay_job_id: str | None = None
     gopro_overlay_status: str | None = None
     gopro_overlay_progress: int | None = None

--- a/apps/backend/tests/api/test_routes_flight_summaries.py
+++ b/apps/backend/tests/api/test_routes_flight_summaries.py
@@ -25,6 +25,9 @@ def _add_flights(db_session, *, count: int, site_id: str = "site-arguel") -> Non
                 video_file_path="private/video.mp4" if index == 1 else None,
                 video_export_job_id="video-job" if index == 1 else None,
                 video_export_status="completed" if index == 1 else None,
+                youtube_urls_json=(
+                    '["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]' if index == 1 else "[]"
+                ),
                 gopro_overlay_file_path="private/overlay.mp4" if index == 1 else None,
                 gopro_overlay_job_id="overlay-job" if index == 1 else None,
                 gopro_overlay_status="completed" if index == 1 else None,
@@ -86,10 +89,12 @@ def test_summaries_filter_search_sort_and_hide_paths(client, db_session, arguel_
     assert item["site_region"] == "Doubs"
     assert item["has_gpx"] is True
     assert item["has_video"] is True
+    assert item["has_youtube_video"] is True
     assert item["has_gopro_overlay"] is True
     assert item["video_export_job_id"] == "video-job"
     assert item["gopro_overlay_job_id"] == "overlay-job"
     assert not any("path" in key for key in item)
+    assert body["flights"][1]["has_youtube_video"] is False
 
 
 def test_summaries_search_is_case_and_accent_insensitive(client, db_session) -> None:
@@ -106,6 +111,40 @@ def test_summaries_search_is_case_and_accent_insensitive(client, db_session) -> 
 
     assert response.status_code == 200
     assert [item["id"] for item in response.json()["flights"]] == ["accented-flight"]
+
+
+def test_summaries_only_report_non_empty_youtube_url_lists(client, db_session) -> None:
+    stored_values = {
+        "youtube-empty-spaced": "[ ]",
+        "youtube-null": "null",
+        "youtube-object": "{}",
+        "youtube-invalid": "not-json",
+        "youtube-present": '["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]',
+    }
+    db_session.add_all(
+        [
+            Flight(
+                id=flight_id,
+                title=flight_id,
+                flight_date=date(2026, 1, 1),
+                youtube_urls_json=stored_value,
+            )
+            for flight_id, stored_value in stored_values.items()
+        ]
+    )
+    db_session.commit()
+
+    response = client.get(API_URL)
+    flags_by_id = {item["id"]: item["has_youtube_video"] for item in response.json()["flights"]}
+
+    assert response.status_code == 200
+    assert flags_by_id == {
+        "youtube-empty-spaced": False,
+        "youtube-invalid": False,
+        "youtube-null": False,
+        "youtube-object": False,
+        "youtube-present": True,
+    }
 
 
 def test_summaries_put_nulls_last_and_keyset_ties_by_id(client, db_session, arguel_site):

--- a/apps/frontend/src/components/flights/table/Flight.stories.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.stories.tsx
@@ -18,6 +18,7 @@ const mockFlight: FlightSummary = {
   elevation_gain_m: 800,
   has_gpx: true,
   has_video: true,
+  has_youtube_video: false,
   has_gopro_overlay: true,
   video_export_job_id: null,
   video_export_status: null,
@@ -115,6 +116,27 @@ export const WithGpxVideo = meta.story({
     <div className="max-w-sm">
       <Flight
         flight={{ ...mockFlight, has_gopro_overlay: false }}
+        isActive={false}
+        isSelected={false}
+        selectionMode={false}
+        onSelectFlight={fn()}
+        onDeleteFlight={fn()}
+      />
+    </div>
+  ),
+});
+
+export const WithYoutubeVideo = meta.story({
+  name: 'With YouTube Video',
+  render: () => (
+    <div className="max-w-sm">
+      <Flight
+        flight={{
+          ...mockFlight,
+          has_video: false,
+          has_youtube_video: true,
+          has_gopro_overlay: false,
+        }}
         isActive={false}
         isSelected={false}
         selectionMode={false}

--- a/apps/frontend/src/components/flights/table/Flight.test.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.test.tsx
@@ -55,6 +55,7 @@ const flight = {
   elevation_gain_m: null,
   has_gpx: false,
   has_video: false,
+  has_youtube_video: false,
   has_gopro_overlay: false,
   video_export_job_id: null,
   video_export_status: null,
@@ -104,4 +105,20 @@ test('renders media as a passive status in the flight list', () => {
   expect(
     screen.queryByRole('button', { name: 'flights.downloadGpx' })
   ).not.toBeInTheDocument();
+  expect(screen.queryByText('flights.youtubeBadge')).not.toBeInTheDocument();
+});
+
+test('renders a YouTube badge when the flight has a YouTube video', () => {
+  render(
+    <Flight
+      flight={{ ...flight, has_youtube_video: true }}
+      isActive={false}
+      isSelected={false}
+      selectionMode={false}
+      onSelectFlight={() => undefined}
+      onDeleteFlight={() => undefined}
+    />
+  );
+
+  expect(screen.getByText('flights.youtubeBadge')).toBeInTheDocument();
 });

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -6,6 +6,7 @@ import {
   FileText,
   MapPin,
   Mountain,
+  Play,
   Ruler,
   Trash2,
   Video,
@@ -61,6 +62,7 @@ export function Flight({
   const isHighlighted = isActive || isSelected;
   const hasGpx = flight.has_gpx;
   const hasVideo = flight.has_video;
+  const hasYoutubeVideo = flight.has_youtube_video;
   const hasPersistedGoproOverlay = flight.has_gopro_overlay;
   const isGoproOverlayRunning = isGoproOverlayInProgress(
     flight.gopro_overlay_status
@@ -98,6 +100,7 @@ export function Flight({
   const hasMediaStatus =
     hasGpx ||
     hasVideo ||
+    hasYoutubeVideo ||
     isVideoExportRunning ||
     isVideoExportFailed ||
     hasPersistedGoproOverlay ||
@@ -171,6 +174,12 @@ export function Flight({
                 <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/40 dark:text-indigo-200">
                   <Video className="h-3 w-3" aria-hidden="true" />
                   {t('flights.videoBadge')}
+                </span>
+              )}
+              {hasYoutubeVideo && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+                  <Play className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.youtubeBadge')}
                 </span>
               )}
               {isVideoExportRunning && (

--- a/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
@@ -153,6 +153,7 @@ const summarizeFlight = (flight: Flight): FlightSummary => ({
   elevation_gain_m: flight.elevation_gain_m ?? null,
   has_gpx: Boolean(flight.gpx_file_path),
   has_video: Boolean(flight.video_file_path),
+  has_youtube_video: Boolean(flight.youtube_urls?.length),
   has_gopro_overlay: Boolean(flight.gopro_overlay_file_path),
   video_export_job_id: flight.video_export_job_id ?? null,
   video_export_status: flight.video_export_status ?? null,

--- a/apps/frontend/src/hooks/flights/useFlightSummaries.test.ts
+++ b/apps/frontend/src/hooks/flights/useFlightSummaries.test.ts
@@ -26,6 +26,7 @@ const summary = FlightSummariesResponseSchema.parse({
       elevation_gain_m: null,
       has_gpx: false,
       has_video: false,
+      has_youtube_video: false,
       has_gopro_overlay: false,
       video_export_job_id: null,
       video_export_status: null,

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1000,6 +1000,7 @@
     "youtubeUploadError": "Unable to upload the video to YouTube",
     "gpxBadge": "GPX",
     "videoBadge": "Video",
+    "youtubeBadge": "YouTube",
     "videoProcessingBadge": "Video: in progress",
     "videoErrorBadge": "Video: error",
     "goproOverlayBadge": "GoPro overlay",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1004,6 +1004,7 @@
     "youtubeUploadError": "Impossible d'envoyer la vidéo sur YouTube",
     "gpxBadge": "GPX",
     "videoBadge": "Vidéo",
+    "youtubeBadge": "YouTube",
     "videoProcessingBadge": "Vidéo: en cours",
     "videoErrorBadge": "Vidéo: erreur",
     "goproOverlayBadge": "Overlay GoPro",

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -165,6 +165,8 @@ const toSummary = (flight: Record<string, unknown>) => ({
   elevation_gain_m: flight.elevation_gain_m ?? null,
   has_gpx: Boolean(flight.gpx_file_path),
   has_video: Boolean(flight.video_file_path),
+  has_youtube_video:
+    Array.isArray(flight.youtube_urls) && flight.youtube_urls.length > 0,
   has_gopro_overlay: Boolean(flight.gopro_overlay_file_path),
   video_export_job_id: flight.video_export_job_id ?? null,
   video_export_status: flight.video_export_status ?? null,

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -177,6 +177,7 @@ export const FlightSummarySchema = z.object({
   elevation_gain_m: z.number().nullable(),
   has_gpx: z.boolean(),
   has_video: z.boolean(),
+  has_youtube_video: z.boolean(),
   has_gopro_overlay: z.boolean(),
   video_export_job_id: z.string().nullable(),
   video_export_status: z.string().nullable(),


### PR DESCRIPTION
## Summary
- add `has_youtube_video` to flight summaries and shared types
- show a YouTube badge in the flight list when a flight has YouTube links
- add backend/frontend tests and story fixtures

## Validation
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t lint backend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test backend --parallel=5` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx build frontend` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx type-check frontend` ✅
- targeted frontend unit tests for `Flight.test.tsx` and `useFlightSummaries.test.ts` ✅
- `NX_NO_CLOUD=true /home/capic/.local/share/pnpm/pnpm nx affected -t test frontend --parallel=5` hit pre-existing Storybook/test failures outside this change