### PR TITLE
fix(flights): remove generated overlay thumbnail mocks

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
@@ -142,12 +142,6 @@ const defaultHandlers = [
       { headers: { 'Content-Type': 'image/svg+xml' } }
     )
   ),
-  http.get('*/api/gopro-overlays/jobs/:id/thumbnail', () =>
-    HttpResponse.text(
-      '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360"><rect width="640" height="360" fill="#164e63"/><path d="M0 285 165 135 305 255 455 105 640 275V360H0Z" fill="#a5f3fc"/><text x="28" y="48" fill="white" font-size="22">1920 x 1080</text></svg>',
-      { headers: { 'Content-Type': 'image/svg+xml' } }
-    )
-  ),
   http.get(
     '*/api/flights/:id/gopro-camera/preview',
     () =>
@@ -365,13 +359,6 @@ MediaThumbnails.test(
     ).toBeVisible();
     await expect(
       await canvas.findByAltText(i18n.t('flights.goproOverlayThumbnailAlt'))
-    ).toBeVisible();
-    await expect(
-      await canvas.findByAltText(
-        i18n.t('flights.goproOverlayJobThumbnailAlt', {
-          name: 'vol-arguel-1080p.mp4',
-        })
-      )
     ).toBeVisible();
   }
 );

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
@@ -3,7 +3,6 @@ import { Button } from '@dashboard-parapente/design-system';
 import { Download, Trash2 } from 'lucide-react';
 import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
 import type { Flight } from '../../../types';
-import { FlightMediaThumbnail } from './FlightMediaThumbnail';
 import { FlightYoutubeUploadControls } from './FlightYoutubeUploadControls';
 
 interface GoproOverlayJobCardProps {
@@ -60,16 +59,6 @@ export function GoproOverlayJobCard({
           {t(`flights.goproOverlayStatus.${job.status}`)}
         </span>
       </div>
-      {job.status === 'completed' && (
-        <div className="overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700">
-          <FlightMediaThumbnail
-            path={`/gopro-overlays/jobs/${job.job_id}/thumbnail`}
-            alt={t('flights.goproOverlayJobThumbnailAlt', {
-              name: job.output_filename,
-            })}
-          />
-        </div>
-      )}
       {job.status === 'completed' && (
         <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-2.5 dark:border-emerald-800 dark:bg-emerald-950/30">
           <span className="text-xs font-semibold text-emerald-900 dark:text-emerald-100">

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1031,7 +1031,6 @@
     "mediaThumbnailUnavailable": "Thumbnail unavailable",
     "videoThumbnailAlt": "Flight video thumbnail",
     "goproOverlayThumbnailAlt": "GoPro overlay thumbnail",
-    "goproOverlayJobThumbnailAlt": "Thumbnail for overlay {{name}}",
     "mediaCreationTitle": "Create and publish",
     "mediaCreationDescription": "Generate a video, add an overlay, or publish to YouTube.",
     "mediaGeneratedOverlaysTitle": "Generated overlays",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1035,7 +1035,6 @@
     "mediaThumbnailUnavailable": "Miniature indisponible",
     "videoThumbnailAlt": "Miniature de la vidéo du vol",
     "goproOverlayThumbnailAlt": "Miniature de l’overlay GoPro",
-    "goproOverlayJobThumbnailAlt": "Miniature de l’overlay {{name}}",
     "mediaCreationTitle": "Créer et publier",
     "mediaCreationDescription": "Générez une vidéo, ajoutez un overlay ou publiez sur YouTube.",
     "mediaGeneratedOverlaysTitle": "Overlays générés",


### PR DESCRIPTION
## Summary\n- Remove the generated overlay thumbnail mock from the FlightDetails story.\n- Keep the thumbnail only in the available files card.\n\n## Validation\n- 
 NX   Running target type-check for project frontend and 1 task it depends on:



> nx run frontend:build:production  [existing outputs match the cache, left as is]

[1m[33mThe `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.[39m[22m
[33m(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (apps/frontend/vite.config.ts:9:42). Use `import.meta.dirname` instead
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.[39m
[33m(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:9:42). Use `import.meta.dirname` instead
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.[39m
[36mvite v8.2.2 [32mbuilding client environment for production...[36m[39m
transforming...
[32m✓[0m 4984 modules transformed.
rendering chunks...
computing gzip size...
[2mdist/apps/frontend/[0m[32mindex.html                                    [0m[1;2m  1.01 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[35mindex-g0Q-0HM0.css                     [0m[1;2m148.52 kB[0m[2m │ gzip:  20.77 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights.lazy-B7nWQj2E.js               [0m[1;2m  0.14 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mflights._flightId.lazy-CGqneJMu.js     [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure.lazy-DupIvWxV.js        [0m[1;2m  0.15 kB[0m[2m │ gzip:   0.14 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36minfrastructure._tab.lazy-EiV8euKG.js   [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msearch-CkS-u8pN.js                     [0m[1;2m  0.16 kB[0m[2m │ gzip:   0.16 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museToast-Co0cMCsM.js                   [0m[1;2m  0.47 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mtrash-2-ma7HYjQ4.js                    [0m[1;2m  0.49 kB[0m[2m │ gzip:   0.28 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museAppSettings-BskQfRUL.js             [0m[1;2m  0.61 kB[0m[2m │ gzip:   0.30 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museFlightGPX-BGotDv2u.js               [0m[1;2m  0.63 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mrolldown-runtime-hePW80VL.js           [0m[1;2m  0.71 kB[0m[2m │ gzip:   0.42 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museIsMobile-CXkkRUc7.js                [0m[1;2m  0.98 kB[0m[2m │ gzip:   0.53 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mModal-Dxip-wVw.js                      [0m[1;2m  1.54 kB[0m[2m │ gzip:   0.80 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mappSettingsStore-DdQMiWFO.js           [0m[1;2m  1.60 kB[0m[2m │ gzip:   0.72 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mexport-viewer.lazy-CIWliQri.js         [0m[1;2m  1.61 kB[0m[2m │ gzip:   0.78 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mTabs-B5bo2LvT.js                       [0m[1;2m  1.68 kB[0m[2m │ gzip:   0.67 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mviewer._flightId.lazy-BqfKsf1g.js      [0m[1;2m  1.71 kB[0m[2m │ gzip:   0.86 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36museCityWeather-Ct94d6NI.js             [0m[1;2m  2.41 kB[0m[2m │ gzip:   0.83 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mDataTable-BO6wSK2m.js                  [0m[1;2m  2.71 kB[0m[2m │ gzip:   1.19 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mSelect-DxN8DSqy.js                     [0m[1;2m  6.41 kB[0m[2m │ gzip:   1.68 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mJobLiveLogsPanel-YmF9lzqU.js           [0m[1;2m 10.06 kB[0m[2m │ gzip:   3.73 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mthermal.lazy-Btizuy1N.js               [0m[1;2m 10.56 kB[0m[2m │ gzip:   3.30 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mEmagramExplanationTooltip-Cq8K2mi1.js  [0m[1;2m 25.30 kB[0m[2m │ gzip:   7.58 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightViewer3D-BK35y407.js             [0m[1;2m 33.57 kB[0m[2m │ gzip:  10.15 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msites.lazy-9oO_6a5D.js                 [0m[1;2m 36.23 kB[0m[2m │ gzip:   9.26 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mInfrastructurePage-DB-eNYiK.js         [0m[1;2m 42.96 kB[0m[2m │ gzip:  10.38 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36msettings.lazy-CZuV2x5S.js              [0m[1;2m 49.58 kB[0m[2m │ gzip:   9.60 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-i18n-6eQfuhPS.js                [0m[1;2m 74.11 kB[0m[2m │ gzip:  24.67 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mweather.lazy-De7uu-rs.js               [0m[1;2m108.31 kB[0m[2m │ gzip:  24.49 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mFlightHistory-BDwjt3rz.js              [0m[1;2m146.87 kB[0m[2m │ gzip:  34.92 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mschemas-DcikZxLp.js                    [0m[1;2m162.43 kB[0m[2m │ gzip:  42.34 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-CEAuJIzq.js               [0m[1;2m182.12 kB[0m[2m │ gzip:  57.31 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-tanstack-CAn-lm0T.js            [0m[1;2m226.41 kB[0m[2m │ gzip:  64.35 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mindex-981ePxTq.js                      [0m[1;2m235.92 kB[0m[2m │ gzip:  71.03 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36mvendor-react-aria-Djf7F9Jn.js          [0m[1;2m412.37 kB[0m[2m │ gzip: 127.66 kB[0m
[2mdist/apps/frontend/[0m[2massets/[0m[36manalytics.lazy-CsIU5hLP.js             [0m[1;2m454.29 kB[0m[2m │ gzip: 126.05 kB[0m

[32m✓ built in 3.29s[39m

> nx run frontend:type-check  [existing outputs match the cache, left as is]

> tsc --noEmit




 NX   Successfully ran target type-check for project frontend and 1 task it depends on

Nx read the output from the cache instead of running the command for 2 out of 2 tasks.

  Run duration:      100ms
  Cache:             2/2 hit (100%)
  Critical path:     28ms (2 tasks)
  Recoverable time:  <1ms\n\n## Notes\n- This is the follow-up correction after the merged media thumbnails PR.