### PR TITLE
fix(flights): make replay collapsible

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.stories.tsx
@@ -477,6 +477,11 @@ MobileWithoutGpx.test(
       name: i18n.t('flights.replayTab'),
     });
     await userEvent.click(replayTab);
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: i18n.t('flights.mediaReplayTitle'),
+      })
+    );
     await expect(
       await canvas.findByText(i18n.t('flights.replayUnavailable'))
     ).toBeInTheDocument();

--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -210,7 +210,6 @@ vi.mock('react-i18next', () => ({
         'flights.logsTab': 'Processing',
         'flights.mediaPageTitle': 'Flight media',
         'flights.mediaReplayTitle': 'Flight replay',
-        'flights.open3dReplay': 'Open 3D replay',
         'flights.mediaFilesTitle': 'Available files',
         'flights.panoBadge': 'Pano',
         'flights.panoThumbnailAlt': 'Pano thumbnail',
@@ -437,10 +436,44 @@ describe('FlightDetails GoPro overlay action', () => {
       'https://www.youtube-nocookie.com/embed/9bZkp7q19f0'
     );
     expect(
-      screen.getByRole('button', { name: 'Open 3D replay' })
+      screen.getByRole('button', { name: 'Flight replay' })
     ).toBeInTheDocument();
     expect(
       screen.queryByText('flights.loading3dViewer')
+    ).not.toBeInTheDocument();
+  });
+
+  it('unmounts the replay when its collapsible is closed', () => {
+    mockFlight.gpx_file_path = null;
+
+    render(
+      <FlightDetails
+        flight={mockFlight}
+        sites={sites}
+        onShowCreateSiteModal={() => undefined}
+      />
+    );
+
+    openTab('Media');
+    const replayToggle = screen.getByRole('button', {
+      name: 'Flight replay',
+    });
+
+    expect(replayToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.queryByText('flights.replayUnavailable')
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(replayToggle);
+
+    expect(replayToggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('flights.replayUnavailable')).toBeInTheDocument();
+
+    fireEvent.click(replayToggle);
+
+    expect(replayToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(
+      screen.queryByText('flights.replayUnavailable')
     ).not.toBeInTheDocument();
   });
 
@@ -604,7 +637,7 @@ describe('FlightDetails GoPro overlay action', () => {
       screen.getByRole('heading', { name: 'Flight media' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', { name: 'Flight replay' })
+      screen.getByRole('button', { name: 'Flight replay' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'Available files' })

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -13,7 +13,15 @@ import {
 import { VIDEO_EXPORT_IN_PROGRESS_STATUSES } from '@dashboard-parapente/shared-types';
 import type { GoproOverlayJob } from '@dashboard-parapente/shared-types';
 import type { YoutubeVideoAssociation } from '@dashboard-parapente/shared-types';
-import { CircleAlert, Edit3, FileUp, Images, Play, Wand2 } from 'lucide-react';
+import {
+  ChevronDown,
+  CircleAlert,
+  Edit3,
+  FileUp,
+  Images,
+  Play,
+  Wand2,
+} from 'lucide-react';
 import { Input, Label, TextField } from 'react-aria-components';
 import {
   useUpdateFlight,
@@ -86,7 +94,7 @@ export function FlightDetails({
   const [editingNotes, setEditingNotes] = useState(false);
   const [notesText, setNotesText] = useState(flight.notes ?? '');
   const [activeTab, setActiveTab] = useState<FlightDetailsTab>('infos');
-  const [hasOpenedReplay, setHasOpenedReplay] = useState(false);
+  const [isReplayExpanded, setIsReplayExpanded] = useState(false);
   const [isGoproOverlayDialogOpen, setIsGoproOverlayDialogOpen] =
     useState(false);
   const [goproOverlayJobId, setGoproOverlayJobId] = useState<string | null>(
@@ -809,20 +817,6 @@ export function FlightDetails({
       compact={mobileMode}
     />
   );
-  const replayContent =
-    hasGpx && !hasOpenedReplay ? (
-      <Button
-        variant="secondary"
-        className="ml-12 min-h-10 rounded-lg px-4 py-2 text-sm"
-        onPress={() => setHasOpenedReplay(true)}
-      >
-        <Play className="h-4 w-4" aria-hidden="true" />
-        {t('flights.open3dReplay')}
-      </Button>
-    ) : (
-      replayCard
-    );
-
   const logsPanel = (
     <FlightGenerationLogsPanel
       videoJobId={flight.video_export_job_id}
@@ -856,24 +850,41 @@ export function FlightDetails({
       </header>
 
       <div className="min-w-0 space-y-4">
-        <section aria-labelledby="flight-media-replay-title">
-          <div className="mb-3 flex items-start gap-3 px-1">
-            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-100">
-              <Play className="h-4 w-4" aria-hidden="true" />
+        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-gray-800">
+          <button
+            type="button"
+            className="flex w-full cursor-pointer items-center justify-between gap-3 p-4 text-left transition-colors hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-inset dark:hover:bg-slate-700/50"
+            aria-expanded={isReplayExpanded}
+            aria-controls="flight-media-replay-panel"
+            aria-label={t('flights.mediaReplayTitle')}
+            onClick={() => setIsReplayExpanded((isExpanded) => !isExpanded)}
+          >
+            <span className="flex min-w-0 items-start gap-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-200 text-slate-700 dark:bg-slate-700 dark:text-slate-100">
+                <Play className="h-4 w-4" aria-hidden="true" />
+              </span>
+              <span>
+                <span className="block font-semibold text-slate-950 dark:text-white">
+                  {t('flights.mediaReplayTitle')}
+                </span>
+                <span className="block text-sm text-slate-600 dark:text-slate-300">
+                  {t('flights.mediaReplayDescription')}
+                </span>
+              </span>
             </span>
-            <div>
-              <h3
-                id="flight-media-replay-title"
-                className="font-semibold text-slate-950 dark:text-white"
-              >
-                {t('flights.mediaReplayTitle')}
-              </h3>
-              <p className="text-sm text-slate-600 dark:text-slate-300">
-                {t('flights.mediaReplayDescription')}
-              </p>
+            <ChevronDown
+              aria-hidden="true"
+              className={`size-5 shrink-0 text-slate-500 transition-transform duration-200 dark:text-slate-400 ${isReplayExpanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isReplayExpanded && (
+            <div
+              id="flight-media-replay-panel"
+              className="border-t border-slate-200 dark:border-slate-700"
+            >
+              {replayCard}
             </div>
-          </div>
-          {replayContent}
+          )}
         </section>
 
         <FlightMediaBadges

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1021,7 +1021,6 @@
     "mediaPageDescription": "Find the replay, generated files, and publications associated with this flight.",
     "mediaReplayTitle": "Flight replay",
     "mediaReplayDescription": "Explore the track in 3D before creating or publishing your videos.",
-    "open3dReplay": "Open 3D replay",
     "mediaFilesTitle": "Available files",
     "mediaFilesDescription": "Generate, track, and publish media associated with this flight.",
     "mediaFilesEmpty": "No media files are available for this flight yet.",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1025,7 +1025,6 @@
     "mediaPageDescription": "Retrouvez le replay, les fichiers générés et les publications associés à ce vol.",
     "mediaReplayTitle": "Replay du vol",
     "mediaReplayDescription": "Explorez la trace en 3D avant de créer ou publier vos vidéos.",
-    "open3dReplay": "Ouvrir le replay 3D",
     "mediaFilesTitle": "Fichiers disponibles",
     "mediaFilesDescription": "Générez, suivez et publiez les médias associés à ce vol.",
     "mediaFilesEmpty": "Aucun fichier média n’est encore disponible pour ce vol.",

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -387,6 +387,11 @@ MobileFlow.test(
       await userEvent.click(
         canvas.getByRole('tab', { name: i18n.t('flights.replayTab') })
       );
+      await userEvent.click(
+        canvas.getByRole('button', {
+          name: i18n.t('flights.mediaReplayTitle'),
+        })
+      );
       await expect(
         await canvas.findByText(i18n.t('flights.replayUnavailable'))
       ).toBeInTheDocument();
@@ -453,8 +458,10 @@ MobileFlowWithReplay.test(
       );
 
       await expect(
-        canvas.getByRole('button', { name: i18n.t('flights.open3dReplay') })
-      ).toBeInTheDocument();
+        canvas.getByRole('button', {
+          name: i18n.t('flights.mediaReplayTitle'),
+        })
+      ).toHaveAttribute('aria-expanded', 'false');
       await expect(
         canvas.queryByText(i18n.t('flights.loading3dViewer'))
       ).not.toBeInTheDocument();
@@ -463,7 +470,9 @@ MobileFlowWithReplay.test(
 
     await step('triggers GPX loading once the replay is opened', async () => {
       await userEvent.click(
-        canvas.getByRole('button', { name: i18n.t('flights.open3dReplay') })
+        canvas.getByRole('button', {
+          name: i18n.t('flights.mediaReplayTitle'),
+        })
       );
 
       await expect(
@@ -472,6 +481,18 @@ MobileFlowWithReplay.test(
       await waitFor(() => {
         expect(gpxRequestCount).toBeGreaterThan(requestsAfterOpeningFlight);
       });
+    });
+
+    await step('unmounts the replay when it is collapsed', async () => {
+      const replayToggle = canvas.getByRole('button', {
+        name: i18n.t('flights.mediaReplayTitle'),
+      });
+      await userEvent.click(replayToggle);
+
+      await expect(replayToggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(
+        canvas.queryByText(i18n.t('flights.loading3dViewer'))
+      ).not.toBeInTheDocument();
     });
   }
 );


### PR DESCRIPTION
## Summary
- Replace open 3D replay trigger with a collapsible replay section in Flight media.
- Unmount the Cesium viewer when collapsed.
- Update tests/stories and remove the obsolete translation key.

## Validation
- Staged-file hooks ran oxlint and oxfmt.
- vitest run --config vitest.config.ts --project unit src/components/flights/details/FlightDetails.test.tsx
- nx build frontend
- git diff --check

## Notes
- Repo-wide nx lint frontend and full frontend test runs still fail on pre-existing unrelated issues outside this change.