### PR TITLE
fix(youtube): preserve panorama 360 playback

### DIFF
--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -76,6 +76,11 @@ isort==8.0.1
 python-multipart==0.0.32
 
 # ============================================
+# 360 Video Metadata
+# ============================================
+spatialmedia @ https://github.com/google/spatial-media/archive/2308497c39bb604a7c3ba56ac17e302f2b1b6a96.zip
+
+# ============================================
 # Meteorology & Scientific Computing
 # ============================================
 metpy==1.7.1

--- a/apps/backend/tests/api/test_youtube_upload_endpoints.py
+++ b/apps/backend/tests/api/test_youtube_upload_endpoints.py
@@ -342,6 +342,73 @@ def test_worker_resolves_panorama_from_the_flight_directory(
     assert youtube_upload._source_video_path(db_session, job) == pano_path
 
 
+def test_worker_injects_spherical_metadata_for_panorama_uploads(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "pano.mp4"
+    source_path.write_bytes(b"flat panorama")
+    monkeypatch.setattr(config, "VIDEO_EXPORT_DIR", str(tmp_path / "exports"))
+    injected: list[tuple[Path, Path, str | None]] = []
+
+    def inject_metadata(source, destination, metadata, _console) -> None:
+        destination_path = Path(destination)
+        destination_path.write_bytes(b"spherical panorama")
+        injected.append((Path(source), destination_path, metadata.video))
+
+    parsed_metadata = youtube_upload.metadata_utils.ParsedMetadata()
+    parsed_metadata.video["Track 0"] = {
+        "Spherical": "true",
+        "ProjectionType": "equirectangular",
+    }
+    monkeypatch.setattr(youtube_upload.metadata_utils, "inject_metadata", inject_metadata)
+    monkeypatch.setattr(
+        youtube_upload.metadata_utils,
+        "parse_metadata",
+        lambda _path, _console: parsed_metadata,
+    )
+
+    upload_path = youtube_upload._prepare_upload_video("youtube-pano", "pano", source_path)
+
+    assert upload_path.read_bytes() == b"spherical panorama"
+    assert injected[0][0] == source_path
+    assert injected[0][1].name == "youtube-pano.spherical.part.mp4"
+    assert "<GSpherical:Spherical>true</GSpherical:Spherical>" in (injected[0][2] or "")
+    assert "<GSpherical:ProjectionType>equirectangular</GSpherical:ProjectionType>" in (
+        injected[0][2] or ""
+    )
+
+
+def test_worker_rejects_unverified_spherical_metadata(tmp_path, monkeypatch) -> None:
+    source_path = tmp_path / "pano.mp4"
+    source_path.write_bytes(b"flat panorama")
+    monkeypatch.setattr(config, "VIDEO_EXPORT_DIR", str(tmp_path / "exports"))
+
+    def inject_metadata(_source, destination, _metadata, _console) -> None:
+        Path(destination).write_bytes(b"still flat")
+
+    parsed_metadata = youtube_upload.metadata_utils.ParsedMetadata()
+    monkeypatch.setattr(youtube_upload.metadata_utils, "inject_metadata", inject_metadata)
+    monkeypatch.setattr(
+        youtube_upload.metadata_utils,
+        "parse_metadata",
+        lambda _path, _console: parsed_metadata,
+    )
+
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        youtube_upload._prepare_upload_video("youtube-flat", "pano", source_path)
+
+    upload_path = youtube_upload._panorama_upload_path("youtube-flat")
+    assert not upload_path.exists()
+    assert not upload_path.with_suffix(".part.mp4").exists()
+
+
+def test_worker_keeps_standard_youtube_upload_source_unchanged(tmp_path) -> None:
+    source_path = tmp_path / "overlay.mp4"
+
+    assert (
+        youtube_upload._prepare_upload_video("youtube-overlay", "gopro_overlay", source_path)
+        == source_path
+    )
+
+
 def test_start_youtube_upload_allows_an_overlay_with_an_existing_youtube_video(
     client, db_session, sample_flight, tmp_path, monkeypatch
 ):

--- a/apps/backend/tests/api/test_youtube_upload_endpoints.py
+++ b/apps/backend/tests/api/test_youtube_upload_endpoints.py
@@ -400,6 +400,46 @@ def test_worker_rejects_unverified_spherical_metadata(tmp_path, monkeypatch) -> 
     assert not upload_path.with_suffix(".part.mp4").exists()
 
 
+def test_worker_regenerates_stale_panorama_without_spherical_metadata(
+    tmp_path, monkeypatch
+) -> None:
+    source_path = tmp_path / "pano.mp4"
+    source_path.write_bytes(b"flat panorama")
+    monkeypatch.setattr(config, "VIDEO_EXPORT_DIR", str(tmp_path / "exports"))
+    upload_path = youtube_upload._panorama_upload_path("youtube-stale")
+    upload_path.parent.mkdir(parents=True)
+    upload_path.write_bytes(b"stale artifact")
+    injected: list[Path] = []
+
+    def inject_metadata(_source, destination, _metadata, _console) -> None:
+        destination_path = Path(destination)
+        destination_path.write_bytes(b"regenerated spherical panorama")
+        injected.append(destination_path)
+
+    valid_metadata = youtube_upload.metadata_utils.ParsedMetadata()
+    valid_metadata.video["Track 0"] = {
+        "Spherical": "true",
+        "ProjectionType": "equirectangular",
+    }
+
+    def parse_metadata(path, _console):
+        parsed_metadata = youtube_upload.metadata_utils.ParsedMetadata()
+        return (
+            valid_metadata
+            if Path(path).read_bytes().startswith(b"regenerated")
+            else parsed_metadata
+        )
+
+    monkeypatch.setattr(youtube_upload.metadata_utils, "inject_metadata", inject_metadata)
+    monkeypatch.setattr(youtube_upload.metadata_utils, "parse_metadata", parse_metadata)
+
+    prepared_path = youtube_upload._prepare_upload_video("youtube-stale", "pano", source_path)
+
+    assert prepared_path == upload_path
+    assert prepared_path.read_bytes() == b"regenerated spherical panorama"
+    assert len(injected) == 1
+
+
 def test_worker_keeps_standard_youtube_upload_source_unchanged(tmp_path) -> None:
     source_path = tmp_path / "overlay.mp4"
 

--- a/apps/backend/youtube_upload.py
+++ b/apps/backend/youtube_upload.py
@@ -19,6 +19,7 @@ from cryptography.fernet import Fernet, InvalidToken
 from jose import JWTError, jwt
 from sqlalchemy import func
 from sqlalchemy.orm import Session
+from spatialmedia import metadata_utils
 
 import config
 from database import SessionLocal
@@ -599,8 +600,57 @@ def _source_video_path(db: Session, job: YoutubeUploadJob) -> Path:
     return Path(overlay.output_path)
 
 
+def _panorama_upload_path(job_id: str) -> Path:
+    return Path(config.VIDEO_EXPORT_DIR) / ".youtube-uploads" / f"{job_id}.spherical.mp4"
+
+
+def _prepare_upload_video(job_id: str, source_type: str, source_path: Path) -> Path:
+    """Return a YouTube-ready source, injecting 360 metadata for panoramas."""
+    if source_type != "pano":
+        return source_path
+
+    upload_path = _panorama_upload_path(job_id)
+    if upload_path.is_file() and upload_path.stat().st_size > 0:
+        return upload_path
+
+    upload_path.parent.mkdir(parents=True, exist_ok=True)
+    partial_path = upload_path.with_suffix(".part.mp4")
+    partial_path.unlink(missing_ok=True)
+    spherical_xml = metadata_utils.generate_spherical_xml("equirectangular")
+    if not isinstance(spherical_xml, str):
+        raise RuntimeError("Unable to generate panorama metadata")
+    metadata = metadata_utils.Metadata()
+    metadata.video = spherical_xml
+
+    def debug_metadata(message: object, *extra: object) -> None:
+        logger.debug("Spatial metadata injector: %s", " ".join(map(str, (message, *extra))))
+
+    try:
+        metadata_utils.inject_metadata(
+            str(source_path), str(partial_path), metadata, debug_metadata
+        )
+        if not partial_path.is_file() or partial_path.stat().st_size <= 0:
+            raise RuntimeError("Unable to inject panorama metadata")
+        parsed_metadata = metadata_utils.parse_metadata(str(partial_path), debug_metadata)
+        parsed_video = getattr(parsed_metadata, "video", {})
+        has_spherical_projection = isinstance(parsed_video, dict) and any(
+            isinstance(track_metadata, dict)
+            and track_metadata.get("Spherical") == "true"
+            and track_metadata.get("ProjectionType") == "equirectangular"
+            for track_metadata in parsed_video.values()
+        )
+        if not has_spherical_projection:
+            raise RuntimeError("Injected panorama metadata could not be verified")
+        partial_path.replace(upload_path)
+    except Exception:
+        partial_path.unlink(missing_ok=True)
+        raise
+    return upload_path
+
+
 def process_youtube_upload(job_id: str) -> None:
     """RQ/thread job target for a resumable YouTube upload."""
+    prepared_video_path: Path | None = None
     try:
         _log_job(job_id, "Starting YouTube upload")
         _require_configuration()
@@ -627,12 +677,20 @@ def process_youtube_upload(job_id: str) -> None:
             if job is None:
                 return
             video_path = _source_video_path(db, job)
+            source_type = job.source_type
             user_id = job.user_id
             encrypted_session = job.upload_session_encrypted
             db.expunge(job)
 
         if not video_path.is_file():
             raise RuntimeError("Source video is no longer available")
+        source_size = video_path.stat().st_size
+        if source_size <= 0:
+            raise RuntimeError("Source video is empty")
+        video_path = _prepare_upload_video(job_id, source_type, video_path)
+        if source_type == "pano":
+            prepared_video_path = video_path
+            _log_job(job_id, "Panorama metadata ready for interactive 360° playback")
         total_size = video_path.stat().st_size
         if total_size <= 0:
             raise RuntimeError("Source video is empty")
@@ -721,6 +779,11 @@ def process_youtube_upload(job_id: str) -> None:
         _log_job(job_id, f"YouTube upload failed: {safe_error}")
         _update_active_job(job_id, status="failed", error=safe_error)
     finally:
+        if prepared_video_path is not None:
+            try:
+                prepared_video_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Unable to remove prepared panorama for YouTube upload %s", job_id)
         with _SUBMITTED_LOCK:
             _SUBMITTED.discard(job_id)
 

--- a/apps/backend/youtube_upload.py
+++ b/apps/backend/youtube_upload.py
@@ -604,6 +604,24 @@ def _panorama_upload_path(job_id: str) -> Path:
     return Path(config.VIDEO_EXPORT_DIR) / ".youtube-uploads" / f"{job_id}.spherical.mp4"
 
 
+def _has_spherical_panorama_metadata(video_path: Path) -> bool:
+    def debug_metadata(message: object, *extra: object) -> None:
+        logger.debug("Spatial metadata inspector: %s", " ".join(map(str, (message, *extra))))
+
+    try:
+        parsed_metadata = metadata_utils.parse_metadata(str(video_path), debug_metadata)
+    except Exception:
+        logger.debug("Unable to parse spatial metadata from %s", video_path, exc_info=True)
+        return False
+    parsed_video = getattr(parsed_metadata, "video", {})
+    return isinstance(parsed_video, dict) and any(
+        isinstance(track_metadata, dict)
+        and track_metadata.get("Spherical") == "true"
+        and track_metadata.get("ProjectionType") == "equirectangular"
+        for track_metadata in parsed_video.values()
+    )
+
+
 def _prepare_upload_video(job_id: str, source_type: str, source_path: Path) -> Path:
     """Return a YouTube-ready source, injecting 360 metadata for panoramas."""
     if source_type != "pano":
@@ -611,7 +629,9 @@ def _prepare_upload_video(job_id: str, source_type: str, source_path: Path) -> P
 
     upload_path = _panorama_upload_path(job_id)
     if upload_path.is_file() and upload_path.stat().st_size > 0:
-        return upload_path
+        if _has_spherical_panorama_metadata(upload_path):
+            return upload_path
+        upload_path.unlink()
 
     upload_path.parent.mkdir(parents=True, exist_ok=True)
     partial_path = upload_path.with_suffix(".part.mp4")
@@ -631,15 +651,7 @@ def _prepare_upload_video(job_id: str, source_type: str, source_path: Path) -> P
         )
         if not partial_path.is_file() or partial_path.stat().st_size <= 0:
             raise RuntimeError("Unable to inject panorama metadata")
-        parsed_metadata = metadata_utils.parse_metadata(str(partial_path), debug_metadata)
-        parsed_video = getattr(parsed_metadata, "video", {})
-        has_spherical_projection = isinstance(parsed_video, dict) and any(
-            isinstance(track_metadata, dict)
-            and track_metadata.get("Spherical") == "true"
-            and track_metadata.get("ProjectionType") == "equirectangular"
-            for track_metadata in parsed_video.values()
-        )
-        if not has_spherical_projection:
+        if not _has_spherical_panorama_metadata(partial_path):
             raise RuntimeError("Injected panorama metadata could not be verified")
         partial_path.replace(upload_path)
     except Exception:


### PR DESCRIPTION
## Summary
- inject Google Spatial Media metadata before uploading panorama videos to YouTube
- verify spherical equirectangular metadata before upload and before reusing a prepared artifact
- clean up temporary panorama copies and regenerate invalid stale artifacts

## Validation
- Nx backend lint passed
- Nx backend test passed: 1,041 tests
- targeted YouTube upload tests passed: 34 tests
- CodeRabbit findings were addressed; final re-run was blocked by the temporary review quota

## User impact
Panorama videos uploaded after this fix are recognized by YouTube as interactive 360-degree videos. Existing flat uploads must be deleted or dissociated and uploaded again.