### PR TITLE
fix(frontend): show overlay progress only on active job

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -757,8 +757,8 @@ describe('FlightDetails GoPro overlay action', () => {
     openTab('Media');
 
     expect(
-      screen.getByRole('progressbar', { name: 'Overlay progress' })
-    ).toHaveAttribute('aria-valuenow', '42');
+      screen.queryByRole('progressbar', { name: 'Overlay progress' })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Cancel overlay/u }));
 
@@ -808,11 +808,11 @@ describe('FlightDetails GoPro overlay action', () => {
       screen.getByRole('button', { name: 'flights.goproOverlayDownload' })
     ).toBeInTheDocument();
     expect(screen.getByText('new-overlay.mp4')).toBeInTheDocument();
-    for (const progressbar of screen.getAllByRole('progressbar', {
+    const progressbars = screen.getAllByRole('progressbar', {
       name: 'Overlay progress',
-    })) {
-      expect(progressbar).toHaveAttribute('aria-valuenow', '61');
-    }
+    });
+    expect(progressbars).toHaveLength(1);
+    expect(progressbars[0]).toHaveAttribute('aria-valuenow', '61');
   });
 
   it('passes the GPX offset when starting overlay generation', async () => {

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -186,18 +186,6 @@ export function FlightDetails({
     t('flights.videoProcessingBadge'),
     flight.video_export_progress
   );
-  const goproOverlayProgress = Math.max(
-    0,
-    Math.min(
-      100,
-      Math.round(
-        goproOverlayJob?.progress ??
-          activePersistedGoproOverlay?.progress ??
-          flight.gopro_overlay_progress ??
-          0
-      )
-    )
-  );
   const normalizedTitle = flight.title?.trim();
   const flightTitle =
     normalizedTitle ||
@@ -932,23 +920,6 @@ export function FlightDetails({
                 {goproOverlayUnavailableReason ??
                   t('flights.goproOverlayAddCardDescription')}
               </p>
-              {isGoproOverlayRunning && (
-                <div className="mt-3">
-                  <div className="mb-1 flex items-center justify-between text-xs font-semibold text-blue-800 dark:text-blue-200">
-                    <span>{t('flights.mediaExportInProgress')}</span>
-                    <span>{goproOverlayProgress}%</span>
-                  </div>
-                  <progress
-                    aria-label={t('flights.goproOverlayProcessingBadge')}
-                    aria-valuemin={0}
-                    aria-valuemax={100}
-                    aria-valuenow={goproOverlayProgress}
-                    value={goproOverlayProgress}
-                    max={100}
-                    className="h-2 w-full accent-blue-600 dark:accent-blue-400"
-                  />
-                </div>
-              )}
             </div>
             <Button
               variant={isGoproOverlayRunning ? 'danger' : 'outline'}


### PR DESCRIPTION
## Summary

- remove the duplicated GoPro overlay progress bar from the new-overlay action card
- keep progress attached to the active overlay job card only
- retain the cancel action while processing
- update regression coverage to require exactly one active overlay progress bar

## Validation

- `FlightDetails.test.tsx`: 33 tests passed
- frontend production build passed
- frontend TypeScript check passed
- lint passed on the two changed files
- CodeRabbit CLI: no findings

## Known baseline issue

The repository-wide frontend lint still reports pre-existing errors in unrelated files on `main`; none are in this diff.