### PR TITLE
fix(youtube): allow reupload after remote deletion

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -198,6 +198,7 @@ from youtube_upload import (
     job_payload as youtube_upload_job_payload,
     latest_job as latest_youtube_upload_job,
     remove_youtube_video,
+    youtube_video_availability,
     youtube_video_associations,
 )
 
@@ -988,8 +989,29 @@ def start_flight_youtube_upload(
         completed_source_query = completed_source_query.filter(
             YoutubeUploadJob.gopro_overlay_job_id == overlay.id
         )
-    if completed_source_query.first() is not None:
-        raise HTTPException(status_code=409, detail="This video is already published on YouTube")
+    completed_source_jobs = completed_source_query.all()
+    if completed_source_jobs:
+        video_ids_by_user: dict[int, set[str]] = {}
+        for completed_job in completed_source_jobs:
+            if completed_job.youtube_video_id is not None:
+                video_ids_by_user.setdefault(completed_job.user_id, set()).add(
+                    completed_job.youtube_video_id
+                )
+        availability = youtube_video_availability(video_ids_by_user)
+        if any(
+            completed_job.youtube_video_id is None
+            or availability.get(completed_job.youtube_video_id) is not False
+            for completed_job in completed_source_jobs
+        ):
+            raise HTTPException(
+                status_code=409, detail="This video is already published on YouTube"
+            )
+        deleted_urls = {
+            completed_job.youtube_url
+            for completed_job in completed_source_jobs
+            if completed_job.youtube_url is not None
+        }
+        flight.youtube_urls = [url for url in flight.youtube_urls if url not in deleted_urls]
     existing_job = active_youtube_upload_job(db, flight_id)
     if existing_job is not None:
         raise HTTPException(status_code=409, detail="A YouTube upload is already in progress")

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -512,6 +512,7 @@ class YoutubeVideoAssociation(BaseModel):
     url: str
     video_id: str = Field(pattern=YOUTUBE_VIDEO_ID_PATTERN.pattern)
     can_delete_from_youtube: bool
+    exists_on_youtube: bool | None = None
 
 
 class YoutubeVideoRemoveRequest(BaseModel):

--- a/apps/backend/tests/api/test_youtube_upload_endpoints.py
+++ b/apps/backend/tests/api/test_youtube_upload_endpoints.py
@@ -474,6 +474,48 @@ def test_start_youtube_upload_allows_an_overlay_with_an_existing_youtube_video(
     assert response.status_code == 202
 
 
+def test_start_youtube_upload_replaces_a_source_deleted_directly_from_youtube(
+    client: TestClient,
+    db_session: Session,
+    sample_flight: Flight,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_youtube(monkeypatch)
+    overlay_path = tmp_path / "overlay.mp4"
+    overlay_path.write_bytes(b"video")
+    overlay = _create_completed_overlay(db_session, sample_flight, overlay_path)
+    youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    sample_flight.youtube_urls = [youtube_url]
+    completed_job = _completed_youtube_job(db_session, sample_flight)
+    completed_job.gopro_overlay_job_id = overlay.id
+    db_session.add(
+        YoutubeCredential(
+            user_id=1,
+            refresh_token_encrypted=encrypt_secret("refresh-token"),
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "routes.youtube_video_availability",
+        lambda _video_ids_by_user: {"dQw4w9WgXcQ": False},
+    )
+    monkeypatch.setattr("routes.enqueue_youtube_upload", lambda _job_id: None)
+
+    response = client.post(
+        f"{API_PREFIX}/flights/{sample_flight.id}/youtube-upload",
+        json={
+            "gopro_overlay_job_id": overlay.id,
+            "title": "Nouvel envoi",
+            "privacy_status": "private",
+        },
+    )
+
+    assert response.status_code == 202
+    db_session.refresh(sample_flight)
+    assert sample_flight.youtube_urls == []
+
+
 def test_database_rejects_two_active_uploads_for_the_same_flight(db_session, sample_flight):
     first = YoutubeUploadJob(
         id="youtube-job-1",
@@ -610,7 +652,10 @@ def _completed_youtube_job(
 
 
 def test_youtube_video_metadata_marks_only_current_users_completed_upload_as_deletable(
-    client: TestClient, db_session: Session, sample_flight: Flight
+    client: TestClient,
+    db_session: Session,
+    sample_flight: Flight,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sample_flight.youtube_urls = [
         "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -632,6 +677,11 @@ def test_youtube_video_metadata_marks_only_current_users_completed_upload_as_del
         )
     )
     db_session.commit()
+    monkeypatch.setattr(
+        youtube_upload,
+        "youtube_video_availability",
+        lambda _video_ids_by_user: {"dQw4w9WgXcQ": True},
+    )
 
     response = client.get(f"{API_PREFIX}/flights/{sample_flight.id}/youtube-videos")
 
@@ -641,16 +691,19 @@ def test_youtube_video_metadata_marks_only_current_users_completed_upload_as_del
             "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             "video_id": "dQw4w9WgXcQ",
             "can_delete_from_youtube": True,
+            "exists_on_youtube": True,
         },
         {
             "url": "https://www.youtube.com/watch?v=abcdefghijk",
             "video_id": "abcdefghijk",
             "can_delete_from_youtube": False,
+            "exists_on_youtube": None,
         },
         {
             "url": "https://www.youtube.com/watch?v=Zyxwvutsr_1",
             "video_id": "Zyxwvutsr_1",
             "can_delete_from_youtube": False,
+            "exists_on_youtube": None,
         },
     ]
 
@@ -671,6 +724,42 @@ def test_youtube_video_metadata_disables_remote_deletion_when_disconnected(
             "url": youtube_url,
             "video_id": "dQw4w9WgXcQ",
             "can_delete_from_youtube": False,
+            "exists_on_youtube": None,
+        }
+    ]
+
+
+def test_youtube_video_metadata_reports_a_video_deleted_directly_from_youtube(
+    client: TestClient,
+    db_session: Session,
+    sample_flight: Flight,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    youtube_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    sample_flight.youtube_urls = [youtube_url]
+    _completed_youtube_job(db_session, sample_flight)
+    db_session.add(
+        YoutubeCredential(
+            user_id=1,
+            refresh_token_encrypted=encrypt_secret("refresh-token"),
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        youtube_upload,
+        "youtube_video_availability",
+        lambda _video_ids_by_user: {"dQw4w9WgXcQ": False},
+    )
+
+    response = client.get(f"{API_PREFIX}/flights/{sample_flight.id}/youtube-videos")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "url": youtube_url,
+            "video_id": "dQw4w9WgXcQ",
+            "can_delete_from_youtube": True,
+            "exists_on_youtube": False,
         }
     ]
 

--- a/apps/backend/youtube_upload.py
+++ b/apps/backend/youtube_upload.py
@@ -68,6 +68,7 @@ class YoutubeVideoAssociationPayload(TypedDict):
     url: str
     video_id: str
     can_delete_from_youtube: bool
+    exists_on_youtube: bool | None
 
 
 def _youtube_upload_log_path(job_id: str) -> Path:
@@ -269,9 +270,13 @@ def latest_job(
     return query.order_by(YoutubeUploadJob.created_at.desc()).first()
 
 
-def existing_youtube_video_ids(video_ids_by_user: dict[int, set[str]]) -> set[str]:
-    """Return uploaded video IDs that YouTube still exposes to their owner."""
-    existing_ids: set[str] = set()
+def youtube_video_availability(
+    video_ids_by_user: dict[int, set[str]],
+) -> dict[str, bool | None]:
+    """Return remote availability, preserving unknown results when YouTube is unavailable."""
+    availability = {
+        video_id: None for video_ids in video_ids_by_user.values() for video_id in video_ids
+    }
     for user_id, video_ids in video_ids_by_user.items():
         try:
             access_token = _access_token(user_id)
@@ -291,14 +296,25 @@ def existing_youtube_video_ids(video_ids_by_user: dict[int, set[str]]) -> set[st
                 )
                 response.raise_for_status()
                 items = response.json().get("items", [])
-                existing_ids.update(
+                existing_ids = {
                     item["id"]
                     for item in items
                     if isinstance(item, dict) and isinstance(item.get("id"), str)
-                )
+                }
+                for video_id in batch:
+                    availability[video_id] = video_id in existing_ids
             except (httpx.HTTPError, ValueError, AttributeError) as exc:
                 logger.warning("Unable to verify YouTube video batch: %s", _safe_log_error(exc))
-    return existing_ids
+    return availability
+
+
+def existing_youtube_video_ids(video_ids_by_user: dict[int, set[str]]) -> set[str]:
+    """Return uploaded video IDs that YouTube still exposes to their owner."""
+    return {
+        video_id
+        for video_id, exists in youtube_video_availability(video_ids_by_user).items()
+        if exists is True
+    }
 
 
 def youtube_video_associations(
@@ -322,11 +338,17 @@ def youtube_video_associations(
         )
         if video_id is not None
     }
+    availability = (
+        youtube_video_availability({user_id: deletable_video_ids})
+        if youtube_connected and deletable_video_ids
+        else {}
+    )
     return [
         {
             "url": url,
             "video_id": video_id,
             "can_delete_from_youtube": youtube_connected and video_id in deletable_video_ids,
+            "exists_on_youtube": availability.get(video_id),
         }
         for url, video_id in associations
     ]

--- a/apps/frontend/src/components/flights/details/FlightYoutubeUploadControls.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightYoutubeUploadControls.test.tsx
@@ -16,6 +16,7 @@ const {
   useYoutubeAuthorizationUrl,
   useYoutubeStatus,
   useYoutubeUpload,
+  useYoutubeVideoAssociations,
 } = vi.hoisted(() => ({
   cancelUpload: vi.fn(),
   startUpload: vi.fn(),
@@ -26,6 +27,7 @@ const {
   useYoutubeAuthorizationUrl: vi.fn(),
   useYoutubeStatus: vi.fn(),
   useYoutubeUpload: vi.fn(),
+  useYoutubeVideoAssociations: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -56,6 +58,7 @@ vi.mock('../../../hooks/flights/useYoutubeUpload', () => ({
   useYoutubeAuthorizationUrl,
   useYoutubeStatus,
   useYoutubeUpload,
+  useYoutubeVideoAssociations,
   youtubeVideoAssociationsQueryKey: (flightId: string) => [
     'youtube-video-associations',
     flightId,
@@ -79,6 +82,7 @@ describe('FlightYoutubeUploadControls', () => {
       },
       isLoading: false,
     });
+    useYoutubeVideoAssociations.mockReturnValue({ data: [] });
     useStartYoutubeUpload.mockReturnValue({
       mutateAsync: startUpload,
       isPending: false,
@@ -230,6 +234,16 @@ describe('FlightYoutubeUploadControls', () => {
   });
 
   it('disables a source whose uploaded video is still associated', () => {
+    useYoutubeVideoAssociations.mockReturnValue({
+      data: [
+        {
+          url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+          video_id: 'dQw4w9WgXcQ',
+          can_delete_from_youtube: true,
+          exists_on_youtube: true,
+        },
+      ],
+    });
     useYoutubeUpload.mockReturnValue({
       data: {
         status: 'completed',
@@ -255,6 +269,51 @@ describe('FlightYoutubeUploadControls', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Déjà publiée' })).toBeDisabled();
+  });
+
+  it('allows reupload when the associated video was deleted from YouTube', () => {
+    useYoutubeUpload.mockReturnValue({
+      data: {
+        status: 'completed',
+        youtube_url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      },
+      isLoading: false,
+    });
+    useYoutubeVideoAssociations.mockReturnValue({
+      data: [
+        {
+          url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+          video_id: 'dQw4w9WgXcQ',
+          can_delete_from_youtube: true,
+          exists_on_youtube: false,
+        },
+      ],
+    });
+    const queryClient = new QueryClient();
+    const flight = {
+      id: 'flight-1',
+      flight_date: '2026-08-19',
+      name: 'Vol test',
+      youtube_urls: ['https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+    } as Flight;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FlightYoutubeUploadControls
+          flight={flight}
+          source={{ source_type: 'pano' }}
+        />
+      </QueryClientProvider>
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Publier sur YouTube',
+    });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(
+      screen.getByRole('button', { name: "Lancer l'envoi" })
+    ).toBeInTheDocument();
   });
 
   it('refreshes YouTube associations when an upload completes', async () => {

--- a/apps/frontend/src/components/flights/details/FlightYoutubeUploadControls.tsx
+++ b/apps/frontend/src/components/flights/details/FlightYoutubeUploadControls.tsx
@@ -10,6 +10,7 @@ import {
   useYoutubeAuthorizationUrl,
   useYoutubeStatus,
   useYoutubeUpload,
+  useYoutubeVideoAssociations,
   youtubeVideoAssociationsQueryKey,
   type YoutubeUploadSource,
 } from '../../../hooks/flights/useYoutubeUpload';
@@ -52,6 +53,7 @@ export function FlightYoutubeUploadControls({
   const connection = useYoutubeStatus();
   const upload = useYoutubeUpload(flight.id, source);
   const activeUpload = useYoutubeUpload(flight.id);
+  const associations = useYoutubeVideoAssociations(flight.id);
   const startUpload = useStartYoutubeUpload(flight.id);
   const cancelUpload = useCancelYoutubeUpload(flight.id);
   const authorizationUrl = useYoutubeAuthorizationUrl();
@@ -73,7 +75,10 @@ export function FlightYoutubeUploadControls({
   const isPublished = Boolean(
     upload.data?.status === 'completed' &&
     upload.data.youtube_url &&
-    flight.youtube_urls?.includes(upload.data.youtube_url)
+    flight.youtube_urls?.includes(upload.data.youtube_url) &&
+    associations.data?.find(
+      (association) => association.url === upload.data?.youtube_url
+    )?.exists_on_youtube !== false
   );
 
   useEffect(() => {

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -94,6 +94,7 @@ export const YoutubeVideoAssociationSchema = z.object({
   url: z.string().url(),
   video_id: z.string().min(1),
   can_delete_from_youtube: z.boolean(),
+  exists_on_youtube: z.boolean().nullish(),
 });
 
 export const YoutubeVideoAssociationsSchema = z.array(


### PR DESCRIPTION
## Summary

- verify whether completed uploads still exist on YouTube
- re-enable upload controls when the remote video was deleted
- remove stale local YouTube links when starting the replacement upload
- keep uploads blocked when remote availability cannot be confirmed
- add frontend and backend regression coverage

## Validation

- CodeRabbit CLI: no findings
- frontend production build: passed
- frontend type-check: passed
- targeted frontend tests: 7 passed
- targeted backend YouTube tests: 36 passed
- full backend test suite: 1,044 passed
- lint and formatting for all modified files: passed

## Known baseline failures

The repository-wide affected run still reports unrelated existing frontend lint errors and Storybook/MSW browser-test aborts. No reported lint error targets a modified file.