### PR TITLE
feat(youtube): show upload progress in flight badge

### DIFF
--- a/apps/backend/flight_summaries.py
+++ b/apps/backend/flight_summaries.py
@@ -459,6 +459,8 @@ def list_flight_summaries(
                 _flight_directory(row.flight_date, row.flight_sequence) / "camera.mp4"
             ).is_file(),
             has_youtube_video=bool(uploaded_youtube_ids[row.id] & existing_youtube_ids),
+            youtube_upload_status=None,
+            youtube_upload_progress=None,
             gopro_overlay_job_id=row.gopro_overlay_job_id,
             gopro_overlay_status=row.gopro_overlay_status,
             gopro_overlay_progress=None,

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -728,6 +728,28 @@ def _get_video_export_jobs_payload(db: Session, active_only: bool = False) -> di
     )
     if active_only:
         jobs = [job for job in jobs if job.get("can_cancel")]
+        jobs.extend(
+            {
+                "job_id": job.id,
+                "flight_id": job.flight_id,
+                "status": job.status,
+                "progress": job.progress,
+                "mode": "youtube",
+                "can_cancel": True,
+                "created_at": job.created_at,
+                "updated_at": job.updated_at,
+            }
+            for job in db.query(YoutubeUploadJob)
+            .filter(YoutubeUploadJob.status.in_(("queued", "uploading")))
+            .all()
+        )
+        jobs.sort(
+            key=lambda job: (
+                _video_export_sort_value(job),
+                str(job.get("job_id") or ""),
+            ),
+            reverse=True,
+        )
     return {"jobs": jobs}
 
 

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -598,6 +598,8 @@ class FlightSummary(BaseModel):
     has_video: bool
     has_camera: bool
     has_youtube_video: bool
+    youtube_upload_status: str | None = None
+    youtube_upload_progress: int | None = None
     gopro_overlay_job_id: str | None = None
     gopro_overlay_status: str | None = None
     gopro_overlay_progress: int | None = None

--- a/apps/backend/tests/api/test_routes_flight_summaries.py
+++ b/apps/backend/tests/api/test_routes_flight_summaries.py
@@ -92,6 +92,8 @@ def test_summaries_filter_search_sort_and_hide_paths(client, db_session, arguel_
     assert item["has_video"] is False
     assert item["has_camera"] is False
     assert item["has_youtube_video"] is False
+    assert item["youtube_upload_status"] is None
+    assert item["youtube_upload_progress"] is None
     assert item["has_gopro_overlay"] is False
     assert item["video_export_job_id"] == "video-job"
     assert item["gopro_overlay_job_id"] == "overlay-job"

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -6,6 +6,7 @@ Covers fallback behavior between manual/stream modes and internal status guards.
 
 import json
 import tempfile
+from datetime import datetime
 from unittest.mock import patch
 
 from pathlib import Path
@@ -13,6 +14,7 @@ from pathlib import Path
 from fastapi.testclient import TestClient
 
 from auth import create_job_token
+from models import YoutubeUploadJob
 from routes import _get_video_export_jobs_payload, serialize_sse_event
 
 API_PREFIX = "/api"
@@ -598,6 +600,54 @@ class TestVideoExportJobsEndpoint:
             next(job for job in jobs if job["job_id"] == "job-stream-encoding")["render_method"]
             == "gpu"
         )
+
+    def test_active_jobs_include_youtube_upload_progress(
+        self, client: TestClient, db_session, sample_flight
+    ) -> None:
+        db_session.add(
+            YoutubeUploadJob(
+                id="youtube-uploading",
+                flight_id=sample_flight.id,
+                user_id=1,
+                status="uploading",
+                progress=42,
+                title="Flight upload",
+                created_at=datetime(2026, 5, 2, 9),
+                updated_at=datetime(2026, 5, 2, 10),
+            )
+        )
+        db_session.commit()
+
+        with (
+            patch(
+                "routes.list_exports_manual",
+                return_value=[
+                    {
+                        "job_id": "video-exporting",
+                        "flight_id": sample_flight.id,
+                        "status": "processing",
+                        "progress": 12,
+                        "mode": "manual",
+                        "updated_at": "2026-05-01T10:00:00",
+                    }
+                ],
+            ),
+            patch("routes.list_exports_stream", return_value=[]),
+            patch("routes.list_gopro_overlay_jobs", return_value=[]),
+        ):
+            response = client.get(f"{API_PREFIX}/video-export-jobs?active_only=true")
+
+        assert response.status_code == 200
+        jobs = response.json()["jobs"]
+        assert [job["job_id"] for job in jobs] == [
+            "youtube-uploading",
+            "video-exporting",
+        ]
+        assert jobs[0]["flight_id"] == sample_flight.id
+        assert jobs[0]["status"] == "uploading"
+        assert jobs[0]["progress"] == 42
+        assert jobs[0]["mode"] == "youtube"
+        assert jobs[0]["can_cancel"] is True
 
     def test_export_status_passthrough_keeps_render_method(self, client: TestClient):
         with patch(

--- a/apps/frontend/src/components/flights/table/Flight.stories.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.stories.tsx
@@ -20,6 +20,8 @@ const mockFlight: FlightSummary = {
   has_video: true,
   has_camera: true,
   has_youtube_video: false,
+  youtube_upload_status: null,
+  youtube_upload_progress: null,
   has_gopro_overlay: true,
   has_pano_video: false,
   video_export_job_id: null,

--- a/apps/frontend/src/components/flights/table/Flight.test.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.test.tsx
@@ -57,6 +57,8 @@ const flight = {
   has_video: false,
   has_camera: false,
   has_youtube_video: false,
+  youtube_upload_status: null,
+  youtube_upload_progress: null,
   has_gopro_overlay: false,
   has_pano_video: false,
   video_export_job_id: null,
@@ -158,4 +160,26 @@ test('renders a panorama badge when pano.mp4 exists', () => {
   );
 
   expect(screen.getByText('flights.panoBadge')).toBeInTheDocument();
+});
+
+test('renders YouTube upload progress in the media badge', () => {
+  render(
+    <Flight
+      flight={{
+        ...flight,
+        youtube_upload_status: 'uploading',
+        youtube_upload_progress: 42,
+      }}
+      isActive={false}
+      isSelected={false}
+      selectionMode={false}
+      onSelectFlight={() => undefined}
+      onDeleteFlight={() => undefined}
+    />
+  );
+
+  expect(screen.getByText('flights.youtubeBadge 42%')).toHaveAttribute(
+    'aria-live',
+    'polite'
+  );
 });

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -66,6 +66,9 @@ export function Flight({
   const hasVideo = flight.has_video;
   const hasCamera = flight.has_camera;
   const hasYoutubeVideo = flight.has_youtube_video;
+  const isYoutubeUploadRunning =
+    flight.youtube_upload_status === 'queued' ||
+    flight.youtube_upload_status === 'uploading';
   const hasPanoVideo = flight.has_pano_video;
   const hasPersistedGoproOverlay = flight.has_gopro_overlay;
   const isGoproOverlayRunning = isGoproOverlayInProgress(
@@ -87,6 +90,10 @@ export function Flight({
     t('flights.goproOverlayProcessingBadge'),
     flight.gopro_overlay_progress
   );
+  const youtubeLabel = formatMediaProgressLabel(
+    t('flights.youtubeBadge'),
+    isYoutubeUploadRunning ? flight.youtube_upload_progress : null
+  );
   const selectFlight = () => {
     if (!selectionMode) {
       onSelectFlight(flight);
@@ -106,6 +113,7 @@ export function Flight({
     hasVideo ||
     hasCamera ||
     hasYoutubeVideo ||
+    isYoutubeUploadRunning ||
     hasPanoVideo ||
     isVideoExportRunning ||
     isVideoExportFailed ||
@@ -194,10 +202,13 @@ export function Flight({
                   {t('flights.goproOverlayBadge')}
                 </span>
               )}
-              {hasYoutubeVideo && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+              {(hasYoutubeVideo || isYoutubeUploadRunning) && (
+                <span
+                  aria-live={isYoutubeUploadRunning ? 'polite' : undefined}
+                  className="inline-flex items-center gap-1 rounded-full border border-red-200 bg-red-50 px-2 py-0.5 text-[11px] font-medium text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200"
+                >
                   <Play className="h-3 w-3" aria-hidden="true" />
-                  {t('flights.youtubeBadge')}
+                  {youtubeLabel}
                 </span>
               )}
               {hasPanoVideo && (

--- a/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
+++ b/apps/frontend/src/components/flights/table/FlightsTable.stories.tsx
@@ -155,6 +155,8 @@ const summarizeFlight = (flight: Flight): FlightSummary => ({
   has_video: Boolean(flight.video_file_path),
   has_camera: flight.gopro_camera_file_exists === true,
   has_youtube_video: Boolean(flight.youtube_urls?.length),
+  youtube_upload_status: null,
+  youtube_upload_progress: null,
   has_gopro_overlay: Boolean(flight.gopro_overlay_file_path),
   has_pano_video: Boolean(flight.pano_video_file_exists),
   video_export_job_id: flight.video_export_job_id ?? null,

--- a/apps/frontend/src/hooks/flights/useFlightSummaries.test.ts
+++ b/apps/frontend/src/hooks/flights/useFlightSummaries.test.ts
@@ -28,6 +28,8 @@ const summary = FlightSummariesResponseSchema.parse({
       has_video: false,
       has_camera: false,
       has_youtube_video: false,
+      youtube_upload_status: null,
+      youtube_upload_progress: null,
       has_gopro_overlay: false,
       has_pano_video: false,
       video_export_job_id: null,
@@ -89,7 +91,7 @@ describe('flight summary queries', () => {
     ).toBeUndefined();
   });
 
-  it('merges active video and overlay progress without refetching pages', () => {
+  it('merges active video, overlay, and YouTube progress without refetching pages', () => {
     const [flight] = mergeActiveMediaJobs(summary.flights, [
       {
         job_id: 'video-job',
@@ -105,9 +107,18 @@ describe('flight summary queries', () => {
         progress: 24,
         mode: 'gopro_overlay',
       },
+      {
+        job_id: 'youtube-job',
+        flight_id: 'flight-1',
+        status: 'uploading',
+        progress: 68,
+        mode: 'youtube',
+      },
     ]);
     expect(flight.video_export_progress).toBe(42);
     expect(flight.gopro_overlay_progress).toBe(24);
+    expect(flight.youtube_upload_status).toBe('uploading');
+    expect(flight.youtube_upload_progress).toBe(68);
   });
 
   it('identifies flights whose active jobs disappeared', () => {

--- a/apps/frontend/src/hooks/flights/useFlightSummaries.ts
+++ b/apps/frontend/src/hooks/flights/useFlightSummaries.ts
@@ -90,8 +90,11 @@ export function mergeActiveMediaJobs(
   return flights.map((flight) => {
     const flightJobs = jobsByFlight.get(flight.id);
     if (!flightJobs) return flight;
-    const videoJob = flightJobs.find((job) => job.mode !== 'gopro_overlay');
+    const videoJob = flightJobs.find(
+      (job) => job.mode !== 'gopro_overlay' && job.mode !== 'youtube'
+    );
     const overlayJob = flightJobs.find((job) => job.mode === 'gopro_overlay');
+    const youtubeJob = flightJobs.find((job) => job.mode === 'youtube');
     return {
       ...flight,
       ...(videoJob && {
@@ -103,6 +106,10 @@ export function mergeActiveMediaJobs(
         gopro_overlay_job_id: overlayJob.job_id,
         gopro_overlay_status: overlayJob.status,
         gopro_overlay_progress: overlayJob.progress ?? null,
+      }),
+      ...(youtubeJob && {
+        youtube_upload_status: youtubeJob.status,
+        youtube_upload_progress: youtubeJob.progress ?? null,
       }),
     };
   });

--- a/apps/frontend/src/hooks/flights/useYoutubeUpload.ts
+++ b/apps/frontend/src/hooks/flights/useYoutubeUpload.ts
@@ -133,6 +133,9 @@ export function useStartYoutubeUpload(flightId: string) {
         youtubeUploadQueryKey(flightId, sourceFromInput(input)),
         job
       );
+      void queryClient.invalidateQueries({
+        queryKey: ['video-export-jobs', 'active'],
+      });
     },
   });
 }
@@ -144,6 +147,9 @@ export function useCancelYoutubeUpload(flightId: string) {
       api.delete(`flights/${flightId}/youtube-upload`).json<YoutubeUploadJob>(),
     onSuccess: (job) => {
       queryClient.setQueryData(youtubeUploadQueryKey(flightId), job);
+      void queryClient.invalidateQueries({
+        queryKey: ['video-export-jobs', 'active'],
+      });
       void queryClient.invalidateQueries({
         queryKey: ['youtube-upload', flightId],
       });

--- a/apps/frontend/src/pages/FlightHistory.stories.tsx
+++ b/apps/frontend/src/pages/FlightHistory.stories.tsx
@@ -168,6 +168,8 @@ const toSummary = (flight: Record<string, unknown>) => ({
   has_camera: flight.gopro_camera_file_exists === true,
   has_youtube_video:
     Array.isArray(flight.youtube_urls) && flight.youtube_urls.length > 0,
+  youtube_upload_status: null,
+  youtube_upload_progress: null,
   has_gopro_overlay: Boolean(flight.gopro_overlay_file_path),
   has_pano_video: Boolean(flight.pano_video_file_exists),
   video_export_job_id: flight.video_export_job_id ?? null,

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -190,6 +190,8 @@ export const FlightSummarySchema = z.object({
   has_video: z.boolean(),
   has_camera: z.boolean(),
   has_youtube_video: z.boolean(),
+  youtube_upload_status: z.string().nullable(),
+  youtube_upload_progress: z.number().nullable(),
   has_gopro_overlay: z.boolean(),
   has_pano_video: z.boolean(),
   video_export_job_id: z.string().nullable(),


### PR DESCRIPTION
## Summary

- expose active YouTube uploads through the existing active media job feed
- show live YouTube upload percentage in the flight list badge
- refresh active job tracking when uploads start or stop
- keep mixed active jobs deterministically ordered
- announce live badge updates to assistive technologies

## Validation

- backend suite: 1,043 tests passed
- targeted backend suite: 35 tests passed
- targeted frontend suite: 16 tests passed
- frontend production build passed
- targeted lint and formatting passed
- pre-commit lint, formatting, and Knip hooks passed

## Review notes

- CodeRabbit reported two minor findings; both were addressed
- the follow-up CodeRabbit review could not run because the temporary review quota was exhausted
- the full affected frontend lint remains blocked by pre-existing React Compiler findings outside this change
- the full frontend test process stalled without output and was stopped; targeted tests for all changed behavior passed