### PR TITLE
fix(youtube): restore 360 controls in embedded videos

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -428,12 +428,13 @@ describe('FlightDetails GoPro overlay action', () => {
     expect(players).toHaveLength(2);
     expect(players[0]).toHaveAttribute(
       'src',
-      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'
+      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?enablejsapi=1&origin=http%3A%2F%2Flocalhost%3A3000'
     );
     expect(players[0]).not.toHaveAttribute('sandbox');
+    expect(players[0]).toHaveAttribute('referrerpolicy', 'origin');
     expect(players[1]).toHaveAttribute(
       'src',
-      'https://www.youtube-nocookie.com/embed/9bZkp7q19f0'
+      'https://www.youtube-nocookie.com/embed/9bZkp7q19f0?enablejsapi=1&origin=http%3A%2F%2Flocalhost%3A3000'
     );
     expect(
       screen.getByRole('button', { name: 'Flight replay' })

--- a/apps/frontend/src/components/flights/details/FlightYoutubeVideos.tsx
+++ b/apps/frontend/src/components/flights/details/FlightYoutubeVideos.tsx
@@ -47,8 +47,8 @@ export function FlightYoutubeVideos({
               title={t('flights.youtubeVideoTitle', { count: index + 1 })}
               className="aspect-video w-full"
               loading="lazy"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              referrerPolicy="strict-origin-when-cross-origin"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; xr-spatial-tracking"
+              referrerPolicy="origin"
               allowFullScreen
             />
             <div className="flex items-center justify-between gap-2 bg-gray-900 px-3 py-2">

--- a/apps/frontend/src/lib/youtube.test.ts
+++ b/apps/frontend/src/lib/youtube.test.ts
@@ -22,8 +22,13 @@ describe('YouTube URL parsing', () => {
   });
 
   it('uses the privacy-enhanced embed domain', () => {
-    expect(getYoutubeEmbedUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(
-      'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ'
+    const embedUrl = new URL(
+      getYoutubeEmbedUrl('https://youtu.be/dQw4w9WgXcQ') ?? ''
     );
+
+    expect(embedUrl.origin).toBe('https://www.youtube-nocookie.com');
+    expect(embedUrl.pathname).toBe('/embed/dQw4w9WgXcQ');
+    expect(embedUrl.searchParams.get('enablejsapi')).toBe('1');
+    expect(embedUrl.searchParams.get('origin')).toBe(window.location.origin);
   });
 });

--- a/apps/frontend/src/lib/youtube.ts
+++ b/apps/frontend/src/lib/youtube.ts
@@ -34,5 +34,12 @@ export function getYoutubeVideoId(rawUrl: string): string | null {
 
 export function getYoutubeEmbedUrl(rawUrl: string): string | null {
   const videoId = getYoutubeVideoId(rawUrl);
-  return videoId ? `https://www.youtube-nocookie.com/embed/${videoId}` : null;
+  if (!videoId) return null;
+
+  const embedUrl = new URL(`https://www.youtube-nocookie.com/embed/${videoId}`);
+  embedUrl.searchParams.set('enablejsapi', '1');
+  if (typeof window !== 'undefined' && window.location.origin !== 'null') {
+    embedUrl.searchParams.set('origin', window.location.origin);
+  }
+  return embedUrl.toString();
 }


### PR DESCRIPTION
## Résumé

- ajoute l’identité d’intégration YouTube (`origin` et `enablejsapi`)
- force l’envoi d’un référent d’origine pour éviter l’erreur YouTube 153
- autorise le suivi spatial XR nécessaire aux vidéos 360°
- met à jour les tests d’URL et d’iframe

## Validation

- 40 tests frontend ciblés
- Oxlint/Oxfmt
- build frontend production

CodeRabbit n’a pas pu être exécuté : quota de revues atteint sur le compte GitHub.