### PR TITLE
feat(weather): afficher le plafond heure par heure

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -7303,6 +7303,7 @@ async def get_emagram_hours(
                 EmagramAnalysis.analysis_status,
                 EmagramAnalysis.error_message,
                 EmagramAnalysis.id,
+                EmagramAnalysis.plafond_thermique_m,
                 EmagramAnalysis.analysis_datetime,
             )
             .filter(
@@ -7375,6 +7376,9 @@ async def get_emagram_hours(
                     "hour": hour,
                     "score": (
                         latest_by_hour[hour].score_volabilite if hour in latest_by_hour else None
+                    ),
+                    "ceiling_m": (
+                        latest_by_hour[hour].plafond_thermique_m if hour in latest_by_hour else None
                     ),
                     "status": (
                         latest_by_hour[hour].analysis_status

--- a/apps/frontend/src/components/weather/HourlyForecast.tsx
+++ b/apps/frontend/src/components/weather/HourlyForecast.tsx
@@ -11,6 +11,7 @@ import {
   CloudRain,
   Cloud,
   Flame,
+  Mountain,
   CircleCheck,
   RefreshCw,
 } from 'lucide-react';
@@ -37,6 +38,7 @@ interface HourlyForecastProps {
   isForceRefreshing?: boolean;
   onForceRefresh?: () => void;
   flightDecision?: FlightDecisionResponse;
+  thermalCeilingByHour?: ReadonlyMap<number, number | null>;
 }
 
 type HourlyFlightDecision = FlightDecisionResponse['hourly'][number];
@@ -906,6 +908,7 @@ export default function HourlyForecast({
   isForceRefreshing = false,
   onForceRefresh,
   flightDecision,
+  thermalCeilingByHour,
 }: HourlyForecastProps) {
   const { t } = useTranslation();
   const {
@@ -1037,6 +1040,10 @@ export default function HourlyForecast({
   }
 
   const flyingHours = weather.hourly_forecast;
+  const getThermalCeiling = (hour: HourlyForecastItem): number | null => {
+    const hourNumber = Number.parseInt(hour.hour, 10);
+    return thermalCeilingByHour?.get(hourNumber) ?? null;
+  };
 
   const getDisplayDecisionForHour = (hour: HourlyForecastItem) => {
     const hourNumber = Number.parseInt(hour.hour, 10);
@@ -1271,6 +1278,7 @@ export default function HourlyForecast({
               hour.sources?.['open-meteo']?.wind_gust ??
               hour.sources?.['weatherapi']?.wind_gust ??
               null;
+            const thermalCeiling = getThermalCeiling(hour);
             const display = getFlyabilityDisplay(
               displayedHour,
               uiThresholds,
@@ -1397,6 +1405,18 @@ export default function HourlyForecast({
                         : '—'}
                     </div>
                   </div>
+                  <div className="rounded-xl border border-white/80 bg-white/85 p-2 dark:border-slate-800 dark:bg-slate-950/55">
+                    <span className="inline-flex items-center gap-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                      <Mountain
+                        className="h-3.5 w-3.5 text-emerald-600"
+                        aria-hidden="true"
+                      />
+                      {t('weather.hourly.ceiling')}
+                    </span>
+                    <div className="font-bold text-slate-950 dark:text-white">
+                      {thermalCeiling !== null ? `${thermalCeiling} m` : '—'}
+                    </div>
+                  </div>
                 </div>
               </article>
             );
@@ -1482,6 +1502,12 @@ export default function HourlyForecast({
                   {t('weather.hourly.thermals')}
                 </span>
               </th>
+              <th className="px-2 py-3 text-center font-bold text-gray-800 dark:text-gray-200">
+                <span className="inline-flex items-center justify-center gap-1">
+                  <Mountain size={14} aria-hidden="true" />{' '}
+                  {t('weather.hourly.ceiling')}
+                </span>
+              </th>
             </tr>
           </thead>
           <tbody className="text-gray-800 dark:text-gray-100">
@@ -1515,6 +1541,7 @@ export default function HourlyForecast({
                   hour.sources?.['open-meteo']?.wind_gust ??
                   hour.sources?.['weatherapi']?.wind_gust ??
                   null;
+                const thermalCeiling = getThermalCeiling(hour);
 
                 return (
                   <tr
@@ -1712,13 +1739,17 @@ export default function HourlyForecast({
                     <td className="py-2.5 px-2 text-center">
                       {hour.thermal_strength || t('weather.hourly.weak')}
                     </td>
+
+                    <td className="py-2.5 px-2 text-center font-semibold text-emerald-700 dark:text-emerald-300">
+                      {thermalCeiling !== null ? `${thermalCeiling} m` : '—'}
+                    </td>
                   </tr>
                 );
               })
             ) : (
               <tr>
                 <td
-                  colSpan={11}
+                  colSpan={12}
                   className="py-8 text-center text-gray-500 dark:text-gray-400"
                 >
                   {t('weather.hourly.noData')}

--- a/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
+++ b/apps/frontend/src/hooks/weather/useEmagramAnalysis.ts
@@ -55,6 +55,7 @@ export function useLatestEmagram(
 export interface EmagramHourEntry {
   hour: number;
   score: number | null;
+  ceiling_m?: number | null;
   status: string;
   error_message?: string | null;
   id: string;

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -319,6 +319,7 @@
       "precipitationWithUnit": "Precip. (mm)",
       "cloudsWithUnit": "Clouds (%)",
       "thermals": "Thermals",
+      "ceiling": "Ceiling",
       "flyability": "Flyability",
       "flightScore": "Adjusted flight score",
       "rawParaIndex": "Raw weather Para-Index",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -319,6 +319,7 @@
       "precipitationWithUnit": "Précip. (mm)",
       "cloudsWithUnit": "Nuages (%)",
       "thermals": "Thermiques",
+      "ceiling": "Plafond",
       "flyability": "Volabilité",
       "flightScore": "Note de vol corrigée",
       "rawParaIndex": "Para-Index météo brut",

--- a/apps/frontend/src/pages/WeatherPage.tsx
+++ b/apps/frontend/src/pages/WeatherPage.tsx
@@ -41,6 +41,7 @@ import {
   useFlightDecision,
 } from '../hooks/weather/useFlightDecision';
 import { useAzbaAirspace } from '../hooks/weather/useAzbaAirspace';
+import { useEmagramHours } from '../hooks/weather/useEmagramAnalysis';
 import type { FlightObjective } from '@dashboard-parapente/shared-types';
 import { useAppSettings } from '../hooks/settings/useAppSettings';
 import WeatherPageMobileLayout from './WeatherPage.mobile';
@@ -254,6 +255,7 @@ export default function WeatherPage() {
     sites[0]?.id ??
     '';
   const selectedSite = sites.find((site) => site.id === selectedSiteId);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const flightDecision = useFlightDecision(
     !selectedSearchTarget && selectedSiteId ? selectedSiteId : undefined,
     selectedDayIndex,
@@ -262,6 +264,24 @@ export default function WeatherPage() {
   const azbaAirspace = useAzbaAirspace(
     !selectedSearchTarget && selectedSiteId ? selectedSiteId : undefined,
     selectedDayIndex
+  );
+  const emagramHours = useEmagramHours(
+    selectedSearchTarget ? '' : (selectedSiteId ?? ''),
+    selectedDayIndex,
+    {
+      enabled:
+        isAuthenticated && !selectedSearchTarget && Boolean(selectedSiteId),
+    }
+  );
+  const thermalCeilingByHour = useMemo(
+    () =>
+      new Map(
+        (emagramHours.data?.hours ?? []).map((entry) => [
+          entry.hour,
+          entry.ceiling_m ?? null,
+        ])
+      ),
+    [emagramHours.data?.hours]
   );
   const selectedSearchTitle = getSearchTargetName(selectedSearchTarget);
   const selectedSearchLocation = getSearchTargetLocation(selectedSearchTarget);
@@ -286,7 +306,6 @@ export default function WeatherPage() {
     ? coordinateWeather.isError
     : false;
 
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const weatherSearch = {
     siteId: selectedSiteId,
     day: getForecastDaySearch(selectedDayIndex),
@@ -578,6 +597,7 @@ export default function WeatherPage() {
         isForceRefreshing={isForceRefreshing}
         onForceRefresh={handleForceRefresh}
         flightDecision={flightDecision.data}
+        thermalCeilingByHour={thermalCeilingByHour}
       />
     ) : undefined;
 
@@ -705,6 +725,7 @@ export default function WeatherPage() {
             isForceRefreshing={isForceRefreshing}
             onForceRefresh={handleForceRefresh}
             flightDecision={flightDecision.data}
+            thermalCeilingByHour={thermalCeilingByHour}
           />
         )}
       </div>


### PR DESCRIPTION
## Résumé
- expose le plafond thermique des analyses d’émagramme horaires dans `/emagram/hours`
- affiche le plafond en mètres dans les cartes mobiles et le tableau desktop météo
- ajoute les traductions FR/EN et conserve `—` lorsqu’aucune analyse n’est disponible

## Vérifications
- `tsc --noEmit -p apps/frontend/tsconfig.json` ✅
- tests ciblés `HourlyForecast.behavior.test.tsx` et `HourlyForecast.test.ts` : 11 tests ✅
- validation globale Nx : erreurs lint préexistantes dans plusieurs fichiers hors périmètre et suites Storybook instables
- CodeRabbit : non disponible, limite de 3 revues atteinte sur le compte

Commit: `4244af8a`