### PR TITLE
fix: prevent nested GoPro overlays

### DIFF
--- a/apps/backend/gopro_overlay_inputs.py
+++ b/apps/backend/gopro_overlay_inputs.py
@@ -6,15 +6,22 @@ import fnmatch
 from pathlib import Path
 
 
-def latest_matching_file(directory: Path, pattern: str) -> Path | None:
+def latest_matching_file(
+    directory: Path, pattern: str, excluded_paths: tuple[Path, ...] = ()
+) -> Path | None:
     """Return the most recently modified matching file."""
     if not directory.is_dir():
         return None
     pattern_lower = pattern.lower()
+    excluded = {path.expanduser().resolve() for path in excluded_paths}
     matches = [
         path
         for path in directory.iterdir()
-        if path.is_file() and fnmatch.fnmatchcase(path.name.lower(), pattern_lower)
+        if (
+            path.is_file()
+            and fnmatch.fnmatchcase(path.name.lower(), pattern_lower)
+            and path.resolve() not in excluded
+        )
     ]
     return max(matches, key=lambda path: (path.stat().st_mtime, path.name)) if matches else None
 
@@ -36,8 +43,12 @@ def resolve_automatic_overlay_inputs(
     input_directory: Path,
     configured_gpx_path: Path | None,
     generated_video_path: Path | None,
+    previous_overlay_path: Path | None = None,
 ) -> tuple[Path | None, Path | None]:
     """Resolve GPX and PIP using the same fallback order as the overlay route."""
     gpx_path = first_matching_file(input_directory, "Zepp*.gpx") or configured_gpx_path
-    pip_path = latest_matching_file(input_directory, "flight*.mp4") or generated_video_path
+    excluded_paths = (previous_overlay_path,) if previous_overlay_path else ()
+    pip_path = (
+        latest_matching_file(input_directory, "flight*.mp4", excluded_paths) or generated_video_path
+    )
     return gpx_path, pip_path

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -6503,7 +6503,12 @@ async def create_flight_gopro_overlay_job(
         resolved_pip_path = _resolve_gopro_paragliding_path(pip_path)
         auto_video_path = input_dir / "camera.mp4"
         auto_gpx_path = first_matching_file(input_dir, "Zepp*.gpx")
-        auto_pip_path = latest_matching_file(input_dir, "flight*.mp4")
+        previous_overlay_path = _resolve_flight_file_path(flight.gopro_overlay_file_path)
+        auto_pip_path = latest_matching_file(
+            input_dir,
+            "flight*.mp4",
+            (previous_overlay_path,) if previous_overlay_path else (),
+        )
         auto_osv_paths = _matching_files_by_mtime(input_dir, "*.osv")
         logger.info(
             "GoPro overlay auto inputs for flight %s in %s: camera=%s, gpx=%s, pip=%s, osv=%s",

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -712,17 +712,21 @@ def test_create_flight_gopro_overlay_job_uses_auto_flight_directory_files(
     second_gpx_path = input_dir / "Zepp-b.gpx"
     old_pip_path = input_dir / "flight-old.mp4"
     new_pip_path = input_dir / "flight-new.MP4"
+    previous_overlay_path = input_dir / "flight-overlay.mp4"
     camera_path.write_bytes(b"camera")
     first_gpx_path.write_text("<gpx>first</gpx>")
     second_gpx_path.write_text("<gpx>second</gpx>")
     old_pip_path.write_bytes(b"old")
     new_pip_path.write_bytes(b"new")
+    previous_overlay_path.write_bytes(b"already-overlayed")
     sample_flight.video_file_path = str(new_pip_path)
+    sample_flight.gopro_overlay_file_path = str(previous_overlay_path)
     db_session.commit()
     os.utime(first_gpx_path, (2, 2))
     os.utime(second_gpx_path, (1, 1))
     os.utime(old_pip_path, (1, 1))
     os.utime(new_pip_path, (2, 2))
+    os.utime(previous_overlay_path, (3, 3))
     monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(paragliding_root))
 
     expected = {

--- a/apps/backend/tests/unit/test_gopro_overlay_inputs.py
+++ b/apps/backend/tests/unit/test_gopro_overlay_inputs.py
@@ -38,3 +38,21 @@ def test_overlay_inputs_fall_back_to_configured_files(tmp_path: Path) -> None:
 
     assert gpx_path == configured_gpx
     assert pip_path == generated_video
+
+
+def test_overlay_inputs_skip_the_previous_overlay_output(tmp_path: Path) -> None:
+    base_video = tmp_path / "flight-base.mp4"
+    previous_overlay = tmp_path / "flight-overlay.mp4"
+    base_video.write_bytes(b"base")
+    previous_overlay.write_bytes(b"overlay")
+    os.utime(base_video, ns=(1_000_000_000, 1_000_000_000))
+    os.utime(previous_overlay, ns=(2_000_000_000, 2_000_000_000))
+
+    _gpx_path, pip_path = resolve_automatic_overlay_inputs(
+        tmp_path,
+        None,
+        base_video,
+        previous_overlay,
+    )
+
+    assert pip_path == base_video


### PR DESCRIPTION
## Summary
- Exclude the previously generated GoPro overlay from automatic PIP selection.
- Prevent already-incrusted flight videos from being reused as the next overlay input.
- Add regression coverage for the shared resolver and the flight overlay endpoint.

## Validation
- `black --check` on modified backend files: passed
- `ruff check` on modified backend files: passed
- Python compile check: passed
- CodeRabbit review: no findings
- Targeted pytest could not run because pytest is not installed in the local Python environment.
- Full Nx lint is currently blocked by pre-existing frontend/design-system lint errors.
