### PR TITLE
fix(ops): keep GoPro worker supervised

### DIFF
--- a/.github/workflows/deploy-portainer.yml
+++ b/.github/workflows/deploy-portainer.yml
@@ -724,6 +724,13 @@ jobs:
                 print_backend_diagnostics
                 return 1
               fi
+              # Compose can report success while a worker exits during its
+              # startup preflight. Re-apply the worker once before failing the
+              # deployment; its restart policy then keeps it supervised.
+              if ! verify_workers_started; then
+                echo "RQ worker readiness check failed; restarting GoPro worker once"
+                compose_cmd up -d --no-deps --force-recreate gopro-overlay-worker || true
+              fi
               verify_workers_started || {
                 print_backend_diagnostics
                 return 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,7 +292,11 @@ services:
   gopro-overlay-worker:
     image: ${CI_BACKEND_IMAGE:-ghcr.io/capic2/dashboard-parapente/backend:main}
     container_name: parapente-gopro-overlay-worker
-    restart: unless-stopped
+    # This worker may be stopped during a deployment while an ffmpeg child is
+    # still running. Always restart it so queued jobs cannot remain orphaned.
+    restart: always
+    init: true
+    stop_grace_period: 30s
     command: ['python', 'gopro_overlay_worker.py']
     cpus: '${GOPRO_OVERLAY_WORKER_CPUS:-4.0}'
     mem_limit: ${GOPRO_OVERLAY_WORKER_MEM_LIMIT:-12g}


### PR DESCRIPTION
## Résumé
- relance automatiquement le worker GoPro après un arrêt inattendu ou un redémarrage de déploiement
- ajoute un init process et un délai de terminaison pour les processus FFmpeg enfants
- relance une fois le worker si la vérification RQ échoue après déploiement

## Diagnostic
Le worker de production avait reçu un arrêt propre (`SIGTERM`) pendant un traitement, puis le conteneur était sorti en 137 avec `OOMKilled=false`. Le worker n'étant pas revenu, 40 jobs sont restés dans Redis (`39` previews, `1` overlay).

## Validation
- `docker compose config --quiet` : OK avec variables de test
- validation YAML du workflow : OK
- `git diff --check` : OK
- tests Python : non exécutés, pytest absent du worktree
- CodeRabbit : service indisponible, WebSocket fermée