### PR TITLE
perf(backend): accelerate GoPro previews with CUDA

### DIFF
--- a/apps/backend/gopro_preview_proxy.py
+++ b/apps/backend/gopro_preview_proxy.py
@@ -385,16 +385,27 @@ def _ffmpeg_command(
         f"h='min({config.GOPRO_PREVIEW_MAX_HEIGHT},ih)':"
         "force_original_aspect_ratio=decrease:force_divisible_by=2"
     )
+    use_cuda = accelerator == "nvidia"
     input_args: list[str] = []
     filters: list[str] = []
     for index, segment in enumerate(segments):
         if segment.source_start_seconds > 0:
             input_args.extend(["-ss", f"{segment.source_start_seconds:g}"])
+        if use_cuda:
+            input_args.extend(["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"])
         input_args.extend(["-i", str(camera_path)])
         video_label = "outv" if len(segments) == 1 else f"v{index}"
+        video_scale = scale
+        if use_cuda:
+            video_scale = (
+                f"scale_cuda=w={config.GOPRO_PREVIEW_MAX_WIDTH}:"
+                f"h={config.GOPRO_PREVIEW_MAX_HEIGHT}:"
+                "force_original_aspect_ratio=decrease:force_divisible_by=2,"
+                "hwdownload,format=yuv420p"
+            )
         filters.append(
             f"[{index}:v:0]trim=duration={segment.duration_seconds:g},"
-            f"setpts=PTS-STARTPTS,{scale}[{video_label}]"
+            f"setpts=PTS-STARTPTS,{video_scale}[{video_label}]"
         )
         if include_audio:
             audio_label = "outa" if len(segments) == 1 else f"a{index}"

--- a/apps/backend/tests/unit/test_gopro_preview_proxy.py
+++ b/apps/backend/tests/unit/test_gopro_preview_proxy.py
@@ -57,6 +57,28 @@ def test_ffmpeg_command_concatenates_audio_with_video(tmp_path: Path) -> None:
     assert "-an" not in command
 
 
+def test_ffmpeg_command_uses_cuda_decode_and_scaling_for_nvidia(
+    tmp_path: Path,
+) -> None:
+    camera_path = tmp_path / "camera.mp4"
+    output_path = tmp_path / "preview.mp4"
+
+    command = gopro_preview_proxy._ffmpeg_command(
+        camera_path,
+        output_path,
+        gopro_preview_proxy.preview_segments(1000, 180),
+        "nvidia",
+        include_audio=False,
+    )
+
+    assert command.count("-hwaccel") == 2
+    assert command.count("cuda") >= 4
+    filters = command[command.index("-filter_complex") + 1]
+    assert "scale_cuda" in filters
+    assert "hwdownload,format=yuv420p" in filters
+    assert "h264_nvenc" in command
+
+
 def test_preview_segments_use_one_continuous_segment_when_extremities_overlap() -> None:
     assert gopro_preview_proxy.preview_segments(300, 180) == [
         gopro_preview_proxy.PreviewSegment(0.0, 0.0, 300.0)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,7 +298,7 @@ services:
     init: true
     stop_grace_period: 30s
     command: ['python', 'gopro_overlay_worker.py']
-    cpus: '${GOPRO_OVERLAY_WORKER_CPUS:-4.0}'
+    cpus: '${GOPRO_OVERLAY_WORKER_CPUS:-8.0}'
     mem_limit: ${GOPRO_OVERLAY_WORKER_MEM_LIMIT:-12g}
     pids_limit: ${GOPRO_OVERLAY_WORKER_PIDS_LIMIT:-1024}
     labels:


### PR DESCRIPTION
## Résumé
- augmente la limite CPU du worker GoPro de 4 à 8 CPU
- active le décodage CUDA et le redimensionnement `scale_cuda` pour les previews NVIDIA
- conserve le repli CPU et ajoute un test unitaire de construction de commande FFmpeg

## Validation
- `python3 -m compileall -q apps/backend/gopro_preview_proxy.py` ✅
- `git diff --check` ✅
- Ruff via la cible Nx ✅
- pytest ciblé non exécuté : pytest absent dans l’environnement
- lint Nx bloqué par un formatage Black préexistant dans `apps/backend/gopro_overlay_export.py`, hors périmètre
- CodeRabbit bloqué par la limite du compte (revues incluses épuisées)

## Déploiement
Le worker n’a pas été redémarré afin de ne pas interrompre le job actuellement en cours.