### PR TITLE
fix: make best moments delete action visible

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -719,6 +719,9 @@ describe('FlightDetails GoPro overlay action', () => {
     expect(
       screen.getByRole('button', { name: 'Download video' })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'flights.highlightVideoDelete' })
+    ).toBeInTheDocument();
 
     openTab('Processing');
     expect(screen.getByText('Best moments')).toBeInTheDocument();

--- a/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
@@ -247,6 +247,19 @@ export function FlightMediaBadges({
                     {t('flights.mediaFileAvailable')}
                   </span>
                 </span>
+                {highlightVideo?.status === 'completed' && (
+                  <Button
+                    variant="danger"
+                    className="shrink-0 rounded-lg px-2.5 py-2 text-xs sm:px-3 sm:text-sm"
+                    onPress={onDeleteHighlightVideo}
+                    isDisabled={isHighlightDeletionPending}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    {isHighlightDeletionPending
+                      ? t('flights.highlightVideoDeleting')
+                      : t('flights.highlightVideoDelete')}
+                  </Button>
+                )}
               </div>
               <div className="mt-3">
                 <FlightYoutubeUploadControls
@@ -332,17 +345,6 @@ export function FlightMediaBadges({
                   >
                     <Download className="h-4 w-4" aria-hidden="true" />
                     {t('flights.highlightVideoDownload')}
-                  </Button>
-                  <Button
-                    variant="danger"
-                    className="min-h-10 w-full rounded-lg px-3 py-2 text-sm"
-                    onPress={onDeleteHighlightVideo}
-                    isDisabled={isHighlightDeletionPending}
-                  >
-                    <Trash2 className="h-4 w-4" aria-hidden="true" />
-                    {isHighlightDeletionPending
-                      ? t('flights.highlightVideoDeleting')
-                      : t('flights.highlightVideoDelete')}
                   </Button>
                   <FlightYoutubeUploadControls
                     flight={flight}

--- a/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
@@ -247,19 +247,6 @@ export function FlightMediaBadges({
                     {t('flights.mediaFileAvailable')}
                   </span>
                 </span>
-                {highlightVideo?.status === 'completed' && (
-                  <Button
-                    variant="danger"
-                    className="shrink-0 rounded-lg px-2.5 py-2 text-xs sm:px-3 sm:text-sm"
-                    onPress={onDeleteHighlightVideo}
-                    isDisabled={isHighlightDeletionPending}
-                  >
-                    <Trash2 className="h-4 w-4" aria-hidden="true" />
-                    {isHighlightDeletionPending
-                      ? t('flights.highlightVideoDeleting')
-                      : t('flights.highlightVideoDelete')}
-                  </Button>
-                )}
               </div>
               <div className="mt-3">
                 <FlightYoutubeUploadControls
@@ -353,6 +340,23 @@ export function FlightMediaBadges({
                       highlight_video_job_id: highlightVideo.job_id,
                     }}
                   />
+                </div>
+              )}
+              {['completed', 'failed', 'cancelled'].includes(
+                highlightVideo?.status ?? ''
+              ) && (
+                <div className="mt-2 flex justify-end">
+                  <Button
+                    variant="ghost"
+                    className="min-h-10 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed dark:text-red-300 dark:hover:bg-red-950/30"
+                    onPress={onDeleteHighlightVideo}
+                    isDisabled={isHighlightDeletionPending}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    {isHighlightDeletionPending
+                      ? t('flights.highlightVideoDeleting')
+                      : t('flights.highlightVideoDelete')}
+                  </Button>
                 </div>
               )}
               {highlightVideo?.status !== 'completed' &&


### PR DESCRIPTION
## Résumé
- déplace l’action de suppression dans l’en-tête de la carte des meilleurs moments
- ajoute un test vérifiant la présence du bouton sur une vidéo terminée

## Validation
- test ciblé FlightDetails : 35 tests passés
- formatage oxfmt : OK
- CodeRabbit : aucun finding

## Contexte
La fonctionnalité initiale a été mergée dans la PR #1733 avant le correctif de visibilité.