### PR TITLE
fix(frontend): show actual overlay render method

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -252,7 +252,13 @@ export function FlightGenerationLogsPanel({
           <LogSourceCard
             key={`gopro-${goproOverlayJob?.job_id ?? goproOverlayJobId ?? 'fallback'}`}
             title={t('flights.generationLogs.goproOverlayTitle')}
-            renderMethod={goproOverlayJob?.render_method ?? null}
+            renderMethod={
+              goproOverlayJob && ['running', 'completed', 'failed', 'cancelled'].includes(
+                goproOverlayJob.status
+              )
+                ? (goproOverlayJob.render_method ?? null)
+                : null
+            }
             status={goproOverlayStatusValue}
             isInProgress={isGoproOverlayInProgress(goproOverlayStatusValue)}
             statusLabel={

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
@@ -25,8 +25,9 @@ export function GoproOverlayJobCard({
   onDelete,
 }: GoproOverlayJobCardProps) {
   const { t } = useTranslation();
+  const renderHasStarted = ['running', 'completed', 'failed', 'cancelled'].includes(job.status);
   const renderMethodLabel =
-    job.render_method && ['cpu', 'gpu'].includes(job.render_method)
+    renderHasStarted && job.render_method && ['cpu', 'gpu'].includes(job.render_method)
       ? t(`flights.generationLogs.method.${job.render_method}`)
       : null;
   const resolutionLabel =


### PR DESCRIPTION
## Résumé
- masque le badge CPU/GPU pendant les phases `queued` et `preparing`
- affiche le mode réellement utilisé lorsque le rendu démarre ou est terminé
- reflète correctement un fallback GPU vers CPU

## Validation
- Oxlint ciblé sur les deux fichiers modifiés : OK
- CodeRabbit : 0 finding
- Les tests frontend existants nécessitent leur environnement DOM/configuration habituelle et échouent localement avant assertions.