### PR TITLE
fix(frontend): align highlight generation layout

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -715,7 +715,9 @@ describe('FlightDetails GoPro overlay action', () => {
     );
 
     openTab('Media');
-    expect(screen.getByText('Best moments thumbnail')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Best moments thumbnail')
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Download video' })
     ).toBeInTheDocument();

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -60,6 +60,7 @@ import { formatMediaProgressLabel } from '../table/mediaProgress';
 import type { DownloadableFlightMedia } from './FlightDetails.types';
 import { FlightGenerationLogsPanel } from './FlightGenerationLogsPanel';
 import { FlightMediaBadges } from './FlightMediaBadges';
+import { HighlightVideoJobCard } from './HighlightVideoJobCard';
 import { FlightNotesSection } from './FlightNotesSection';
 import { FlightReplayCard } from './FlightReplayCard';
 import { FlightStatsGrid } from './FlightStatsGrid';
@@ -927,56 +928,62 @@ export function FlightDetails({
           onDownloadPersistedGoproOverlay={() =>
             void handleDownloadPersistedGoproOverlay()
           }
-          highlightVideo={latestHighlightVideo}
-          isHighlightGenerationPending={createHighlightVideo.isPending}
-          isHighlightCancellationPending={cancelHighlightVideo.isPending}
-          onGenerateHighlightVideo={() => {
-            createHighlightVideo.mutate(undefined, {
-              onSuccess: () =>
-                toast.success(t('flights.highlightVideoStarted')),
-              onError: async (error) =>
-                toast.error(
-                  await getApiErrorMessage(
-                    error,
-                    t('flights.highlightVideoStartError')
-                  )
-                ),
-            });
-          }}
-          onDownloadHighlightVideo={() => void handleDownloadHighlightVideo()}
-          isHighlightDeletionPending={deleteHighlightVideo.isPending}
-          onDeleteHighlightVideo={() => {
-            if (
-              !latestHighlightVideo ||
-              !confirm(t('flights.highlightVideoConfirmDelete'))
-            ) {
-              return;
-            }
-            deleteHighlightVideo.mutate(latestHighlightVideo.job_id, {
-              onSuccess: () =>
-                toast.success(t('flights.highlightVideoDeleted')),
-              onError: async (error) =>
-                toast.error(
-                  await getApiErrorMessage(
-                    error,
-                    t('flights.highlightVideoDeleteError')
-                  )
-                ),
-            });
-          }}
-          onCancelHighlightVideo={() => {
-            if (!latestHighlightVideo) return;
-            cancelHighlightVideo.mutate(latestHighlightVideo.job_id, {
-              onError: async (error) =>
-                toast.error(
-                  await getApiErrorMessage(
-                    error,
-                    t('flights.highlightVideoCancelError')
-                  )
-                ),
-            });
-          }}
         >
+          {hasPanoVideo && (
+            <HighlightVideoJobCard
+              job={latestHighlightVideo}
+              flight={flight}
+              isDownloadingAnyMedia={isDownloadingAnyMedia}
+              isGenerationPending={createHighlightVideo.isPending}
+              isCancellationPending={cancelHighlightVideo.isPending}
+              isDeletionPending={deleteHighlightVideo.isPending}
+              onGenerate={() => {
+                createHighlightVideo.mutate(undefined, {
+                  onSuccess: () =>
+                    toast.success(t('flights.highlightVideoStarted')),
+                  onError: async (error) =>
+                    toast.error(
+                      await getApiErrorMessage(
+                        error,
+                        t('flights.highlightVideoStartError')
+                      )
+                    ),
+                });
+              }}
+              onDownload={() => void handleDownloadHighlightVideo()}
+              onDelete={() => {
+                if (
+                  !latestHighlightVideo ||
+                  !confirm(t('flights.highlightVideoConfirmDelete'))
+                ) {
+                  return;
+                }
+                deleteHighlightVideo.mutate(latestHighlightVideo.job_id, {
+                  onSuccess: () =>
+                    toast.success(t('flights.highlightVideoDeleted')),
+                  onError: async (error) =>
+                    toast.error(
+                      await getApiErrorMessage(
+                        error,
+                        t('flights.highlightVideoDeleteError')
+                      )
+                    ),
+                });
+              }}
+              onCancel={() => {
+                if (!latestHighlightVideo) return;
+                cancelHighlightVideo.mutate(latestHighlightVideo.job_id, {
+                  onError: async (error) =>
+                    toast.error(
+                      await getApiErrorMessage(
+                        error,
+                        t('flights.highlightVideoCancelError')
+                      )
+                    ),
+                });
+              }}
+            />
+          )}
           {visibleGoproOverlays.length > 0 && (
             <GoproOverlayJobStack
               jobs={visibleGoproOverlays}

--- a/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@dashboard-parapente/design-system';
-import type { HighlightVideoJob } from '@dashboard-parapente/shared-types';
 import {
   CircleAlert,
   Camera,
@@ -11,8 +10,6 @@ import {
   FolderDown,
   LoaderCircle,
   Orbit,
-  Sparkles,
-  Trash2,
   Video,
   Wand2,
 } from 'lucide-react';
@@ -39,14 +36,6 @@ interface FlightMediaBadgesProps {
   onUploadGpx: () => void;
   onDownloadVideo: () => void;
   onDownloadPersistedGoproOverlay: () => void;
-  highlightVideo: HighlightVideoJob | null;
-  isHighlightGenerationPending: boolean;
-  isHighlightCancellationPending: boolean;
-  onGenerateHighlightVideo: () => void;
-  onCancelHighlightVideo: () => void;
-  onDownloadHighlightVideo: () => void;
-  isHighlightDeletionPending: boolean;
-  onDeleteHighlightVideo: () => void;
   children: ReactNode;
 }
 
@@ -67,14 +56,6 @@ export function FlightMediaBadges({
   onUploadGpx,
   onDownloadVideo,
   onDownloadPersistedGoproOverlay,
-  highlightVideo,
-  isHighlightGenerationPending,
-  isHighlightCancellationPending,
-  onGenerateHighlightVideo,
-  onCancelHighlightVideo,
-  onDownloadHighlightVideo,
-  isHighlightDeletionPending,
-  onDeleteHighlightVideo,
   children,
 }: FlightMediaBadgesProps) {
   const { t } = useTranslation();
@@ -84,8 +65,6 @@ export function FlightMediaBadges({
     0,
     Math.min(100, Math.round(flight.video_export_progress ?? 0))
   );
-  const isHighlightProcessing =
-    highlightVideo?.status === 'queued' || highlightVideo?.status === 'running';
   let videoStatusLabel = t('flights.videoNotGenerated');
   if (hasVideo) {
     videoStatusLabel = t('flights.mediaFileAvailable');
@@ -353,118 +332,6 @@ export function FlightMediaBadges({
             </div>
           </div>
         )}
-        <div className="overflow-hidden rounded-xl border border-violet-200 bg-white shadow-sm dark:border-violet-800 dark:bg-slate-900/60">
-          {highlightVideo?.status === 'completed' && (
-            <FlightMediaThumbnail
-              path={`/flights/${flightId}/highlight-videos/${highlightVideo.job_id}/thumbnail`}
-              alt={t('flights.highlightVideoThumbnailAlt')}
-            />
-          )}
-          {!highlightVideo?.status && (
-            <div className="flex aspect-video items-center justify-center bg-violet-50 p-6 text-center dark:bg-violet-950/20">
-              <Sparkles
-                className="h-8 w-8 text-violet-500"
-                aria-hidden="true"
-              />
-            </div>
-          )}
-          <div className="p-3">
-            <div className="flex items-center gap-3">
-              <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 dark:bg-violet-950/60 dark:text-violet-300">
-                <Wand2 className="h-5 w-5" aria-hidden="true" />
-              </span>
-              <span className="min-w-0 flex-1">
-                <span className="block font-semibold text-slate-950 dark:text-white">
-                  {t('flights.highlightVideoTitle')}
-                </span>
-                <span className="block text-xs text-slate-600 dark:text-slate-300">
-                  {highlightVideo?.status === 'completed'
-                    ? t('flights.mediaFileAvailable')
-                    : (highlightVideo?.message ??
-                      (highlightVideo
-                        ? t(
-                            `flights.generationLogs.status.${highlightVideo.status}`
-                          )
-                        : t('flights.videoNotGenerated')))}
-                </span>
-              </span>
-            </div>
-            {highlightVideo?.status === 'running' && (
-              <progress
-                className="mt-3 h-2 w-full accent-violet-600"
-                value={highlightVideo.progress}
-                max={100}
-                aria-label={t('flights.generationLogs.progress')}
-              />
-            )}
-            {highlightVideo?.status === 'completed' && (
-              <div className="mt-3 space-y-2">
-                <Button
-                  variant="outline"
-                  className="min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
-                  onPress={onDownloadHighlightVideo}
-                  isDisabled={isDownloadingAnyMedia}
-                >
-                  <Download className="h-4 w-4" aria-hidden="true" />
-                  {t('flights.highlightVideoDownload')}
-                </Button>
-                <FlightYoutubeUploadControls
-                  flight={flight}
-                  source={{
-                    source_type: 'highlight',
-                    highlight_video_job_id: highlightVideo.job_id,
-                  }}
-                />
-              </div>
-            )}
-            {['completed', 'failed', 'cancelled'].includes(
-              highlightVideo?.status ?? ''
-            ) && (
-              <div className="mt-2 flex justify-end">
-                <Button
-                  variant="ghost"
-                  className="min-h-10 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed dark:text-red-300 dark:hover:bg-red-950/30"
-                  onPress={onDeleteHighlightVideo}
-                  isDisabled={isHighlightDeletionPending}
-                >
-                  <Trash2 className="h-4 w-4" aria-hidden="true" />
-                  {isHighlightDeletionPending
-                    ? t('flights.highlightVideoDeleting')
-                    : t('flights.highlightVideoDelete')}
-                </Button>
-              </div>
-            )}
-            {highlightVideo?.status !== 'completed' &&
-              (isHighlightProcessing ? (
-                <Button
-                  variant="danger"
-                  className="mt-3 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
-                  onPress={onCancelHighlightVideo}
-                  isDisabled={isHighlightCancellationPending}
-                >
-                  {isHighlightCancellationPending
-                    ? t('common.stopping')
-                    : t('flights.highlightVideoCancel')}
-                </Button>
-              ) : (
-                <Button
-                  variant="outline"
-                  className="mt-3 min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
-                  onPress={onGenerateHighlightVideo}
-                  isDisabled={
-                    !hasVideo ||
-                    isHighlightGenerationPending ||
-                    isHighlightProcessing
-                  }
-                >
-                  <Sparkles className="h-4 w-4" aria-hidden="true" />
-                  {isHighlightGenerationPending
-                    ? t('flights.highlightVideoStarting')
-                    : t('flights.highlightVideoGenerate')}
-                </Button>
-              ))}
-          </div>
-        </div>
         {children}
       </div>
     </section>

--- a/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
@@ -1,0 +1,149 @@
+import { useTranslation } from 'react-i18next';
+import { Button } from '@dashboard-parapente/design-system';
+import { Download, LoaderCircle, Sparkles, Trash2 } from 'lucide-react';
+import type { HighlightVideoJob } from '@dashboard-parapente/shared-types';
+import type { Flight } from '../../../types';
+import { FlightYoutubeUploadControls } from './FlightYoutubeUploadControls';
+
+interface HighlightVideoJobCardProps {
+  job: HighlightVideoJob | null;
+  flight: Flight;
+  isDownloadingAnyMedia: boolean;
+  isGenerationPending: boolean;
+  isCancellationPending: boolean;
+  isDeletionPending: boolean;
+  onGenerate: () => void;
+  onCancel: () => void;
+  onDownload: () => void;
+  onDelete: () => void;
+}
+
+export function HighlightVideoJobCard({
+  job,
+  flight,
+  isDownloadingAnyMedia,
+  isGenerationPending,
+  isCancellationPending,
+  isDeletionPending,
+  onGenerate,
+  onCancel,
+  onDownload,
+  onDelete,
+}: HighlightVideoJobCardProps) {
+  const { t } = useTranslation();
+  const status = job?.status ?? null;
+  const isProcessing = status === 'queued' || status === 'running';
+  const progress = Math.max(0, Math.min(100, Math.round(job?.progress ?? 0)));
+  const statusLabel = status
+    ? t(`flights.generationLogs.status.${status}`)
+    : t('flights.videoNotGenerated');
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-violet-200 bg-white shadow-sm dark:border-violet-800 dark:bg-slate-900/60">
+      <div className="p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 dark:bg-violet-950/60 dark:text-violet-300">
+              <Sparkles className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                {t('flights.highlightVideoTitle')}
+              </p>
+              <p className="truncate text-xs text-slate-600 dark:text-slate-300">
+                {job?.message ?? statusLabel}
+              </p>
+            </div>
+          </div>
+          <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+            {statusLabel}
+          </span>
+        </div>
+        {isProcessing && (
+          <div className="mt-3">
+            <div className="mb-1 flex items-center justify-between text-xs font-semibold text-blue-800 dark:text-blue-200">
+              <span className="flex items-center gap-1.5">
+                <LoaderCircle
+                  className="h-3.5 w-3.5 motion-safe:animate-spin"
+                  aria-hidden="true"
+                />
+                {t('flights.mediaExportInProgress')}
+              </span>
+              <span>{progress}%</span>
+            </div>
+            <progress
+              aria-label={t('flights.generationLogs.progress')}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={progress}
+              value={progress}
+              max={100}
+              className="h-2 w-full accent-blue-600 dark:accent-blue-400"
+            />
+          </div>
+        )}
+        {status === 'completed' && job && (
+          <div className="mt-3 space-y-2">
+            <Button
+              type="button"
+              className="min-h-10 w-full cursor-pointer rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed"
+              onPress={onDownload}
+              isDisabled={isDownloadingAnyMedia}
+            >
+              <Download className="h-4 w-4" aria-hidden="true" />
+              {t('flights.highlightVideoDownload')}
+            </Button>
+            <FlightYoutubeUploadControls
+              flight={flight}
+              source={{
+                source_type: 'highlight',
+                highlight_video_job_id: job.job_id,
+              }}
+            />
+          </div>
+        )}
+        {['completed', 'failed', 'cancelled'].includes(status ?? '') && job && (
+          <div className="mt-2 flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              className="min-h-10 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold text-red-700 hover:bg-red-50 disabled:cursor-not-allowed dark:text-red-300 dark:hover:bg-red-950/30"
+              onPress={onDelete}
+              isDisabled={isDeletionPending}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+              {isDeletionPending
+                ? t('flights.highlightVideoDeleting')
+                : t('flights.highlightVideoDelete')}
+            </Button>
+          </div>
+        )}
+        {status !== 'completed' &&
+          (isProcessing ? (
+            <Button
+              variant="danger"
+              className="mt-3 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
+              onPress={onCancel}
+              isDisabled={isCancellationPending}
+            >
+              {isCancellationPending
+                ? t('common.stopping')
+                : t('flights.highlightVideoCancel')}
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              className="mt-3 min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
+              onPress={onGenerate}
+              isDisabled={isGenerationPending}
+            >
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+              {isGenerationPending
+                ? t('flights.highlightVideoStarting')
+                : t('flights.highlightVideoGenerate')}
+            </Button>
+          ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé

- aligne la carte de génération des meilleurs moments sur le layout des jobs overlay
- retire la miniature vidéo du bloc de génération
- conserve génération, progression, annulation, téléchargement, suppression et upload YouTube

## Validation

- test ciblé FlightDetails : 35/35
- build frontend : OK
- formatage : OK
- lint global : erreurs préexistantes hors fichiers modifiés