### PR TITLE
fix(frontend): keep overlay generation in stack

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -985,37 +985,70 @@ export function FlightDetails({
               deletingJobId={deletingGoproOverlayJobId}
               onDownload={(overlay) => void handleDownloadGoproOverlay(overlay)}
               onDelete={(overlay) => void handleDeleteGoproOverlay(overlay)}
+              generationCard={
+                <div className="flex min-h-48 flex-col justify-between rounded-xl border border-dashed border-cyan-300 bg-cyan-50/60 p-3 dark:border-cyan-800 dark:bg-cyan-950/20">
+                  <div>
+                    <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-950/60 dark:text-cyan-300">
+                      <Wand2 className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <p className="mt-3 font-semibold text-slate-950 dark:text-white">
+                      {t('flights.goproOverlayAddCardTitle')}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-300">
+                      {goproOverlayUnavailableReason ??
+                        t('flights.goproOverlayAddCardDescription')}
+                    </p>
+                  </div>
+                  <Button
+                    variant={isGoproOverlayRunning ? 'danger' : 'outline'}
+                    className="mt-4 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
+                    onPress={goproOverlayAction}
+                    isDisabled={
+                      !canUseGoproOverlayAction ||
+                      createGoproOverlayJob.isPending ||
+                      isCancellingGoproOverlay
+                    }
+                    title={goproOverlayTitle}
+                    aria-label={goproOverlayLabel}
+                  >
+                    <Wand2 className="h-4 w-4" aria-hidden="true" />
+                    {goproOverlayCompactLabel}
+                  </Button>
+                </div>
+              }
             />
           )}
-          <div className="flex min-h-48 flex-col justify-between rounded-xl border border-dashed border-cyan-300 bg-cyan-50/60 p-3 dark:border-cyan-800 dark:bg-cyan-950/20">
-            <div>
-              <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-950/60 dark:text-cyan-300">
-                <Wand2 className="h-5 w-5" aria-hidden="true" />
-              </span>
-              <p className="mt-3 font-semibold text-slate-950 dark:text-white">
-                {t('flights.goproOverlayAddCardTitle')}
-              </p>
-              <p className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-300">
-                {goproOverlayUnavailableReason ??
-                  t('flights.goproOverlayAddCardDescription')}
-              </p>
+          {visibleGoproOverlays.length === 0 && (
+            <div className="flex min-h-48 flex-col justify-between rounded-xl border border-dashed border-cyan-300 bg-cyan-50/60 p-3 dark:border-cyan-800 dark:bg-cyan-950/20">
+              <div>
+                <span className="flex h-11 w-11 items-center justify-center rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-950/60 dark:text-cyan-300">
+                  <Wand2 className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <p className="mt-3 font-semibold text-slate-950 dark:text-white">
+                  {t('flights.goproOverlayAddCardTitle')}
+                </p>
+                <p className="mt-1 text-xs leading-5 text-slate-600 dark:text-slate-300">
+                  {goproOverlayUnavailableReason ??
+                    t('flights.goproOverlayAddCardDescription')}
+                </p>
+              </div>
+              <Button
+                variant={isGoproOverlayRunning ? 'danger' : 'outline'}
+                className="mt-4 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
+                onPress={goproOverlayAction}
+                isDisabled={
+                  !canUseGoproOverlayAction ||
+                  createGoproOverlayJob.isPending ||
+                  isCancellingGoproOverlay
+                }
+                title={goproOverlayTitle}
+                aria-label={goproOverlayLabel}
+              >
+                <Wand2 className="h-4 w-4" aria-hidden="true" />
+                {goproOverlayCompactLabel}
+              </Button>
             </div>
-            <Button
-              variant={isGoproOverlayRunning ? 'danger' : 'outline'}
-              className="mt-4 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
-              onPress={goproOverlayAction}
-              isDisabled={
-                !canUseGoproOverlayAction ||
-                createGoproOverlayJob.isPending ||
-                isCancellingGoproOverlay
-              }
-              title={goproOverlayTitle}
-              aria-label={goproOverlayLabel}
-            >
-              <Wand2 className="h-4 w-4" aria-hidden="true" />
-              {goproOverlayCompactLabel}
-            </Button>
-          </div>
+          )}
         </FlightMediaBadges>
 
         {(flight.youtube_urls?.length ?? 0) > 0 && (

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, Layers3 } from 'lucide-react';
 import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
@@ -12,6 +13,7 @@ interface GoproOverlayJobStackProps {
   deletingJobId: string | null;
   onDownload: (job: GoproOverlayJob) => void;
   onDelete: (job: GoproOverlayJob) => void;
+  generationCard: ReactNode;
 }
 
 export function GoproOverlayJobStack({
@@ -21,6 +23,7 @@ export function GoproOverlayJobStack({
   deletingJobId,
   onDownload,
   onDelete,
+  generationCard,
 }: GoproOverlayJobStackProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -28,16 +31,19 @@ export function GoproOverlayJobStack({
   if (jobs.length === 1) {
     const [job] = jobs;
     return (
-      <GoproOverlayJobCard
-        job={job}
-        youtubeUploadFlight={
-          job.status === 'completed' ? youtubeUploadFlight : undefined
-        }
-        isDownloadingAnyMedia={isDownloadingAnyMedia}
-        isDeleting={deletingJobId === job.job_id}
-        onDownload={() => onDownload(job)}
-        onDelete={() => onDelete(job)}
-      />
+      <div className="grid min-w-0 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+        <GoproOverlayJobCard
+          job={job}
+          youtubeUploadFlight={
+            job.status === 'completed' ? youtubeUploadFlight : undefined
+          }
+          isDownloadingAnyMedia={isDownloadingAnyMedia}
+          isDeleting={deletingJobId === job.job_id}
+          onDownload={() => onDownload(job)}
+          onDelete={() => onDelete(job)}
+        />
+        {generationCard}
+      </div>
     );
   }
 
@@ -102,6 +108,9 @@ export function GoproOverlayJobStack({
           ))}
         </div>
       )}
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+        {generationCard}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Résumé
- regroupe la carte de génération avec la stack des overlays
- conserve la carte de génération seule lorsqu’aucun overlay n’existe
- affiche la génération à côté de l’overlay unique ou dans le bloc stack développé

## Validation
- `FlightDetails.test.tsx` : 35 tests passés
- lint ciblé et formatage passés