### PR TITLE
fix(frontend): use visual overlay card stack

### DIFF
--- a/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
@@ -28,32 +28,13 @@ export function GoproOverlayJobStack({
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  if (jobs.length === 1) {
-    const [job] = jobs;
-    return (
-      <div className="grid min-w-0 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
-        <GoproOverlayJobCard
-          job={job}
-          youtubeUploadFlight={
-            job.status === 'completed' ? youtubeUploadFlight : undefined
-          }
-          isDownloadingAnyMedia={isDownloadingAnyMedia}
-          isDeleting={deletingJobId === job.job_id}
-          onDownload={() => onDownload(job)}
-          onDelete={() => onDelete(job)}
-        />
-        {generationCard}
-      </div>
-    );
-  }
-
   return (
     <div
       className={`min-w-0 ${isExpanded ? 'sm:col-span-2 2xl:col-span-3' : ''}`}
     >
       <button
         type="button"
-        className="group flex min-h-24 w-full cursor-pointer items-center gap-3 rounded-xl border border-cyan-200 bg-white p-3 text-left shadow-sm transition-colors duration-200 hover:border-cyan-400 hover:bg-cyan-50/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:border-cyan-800 dark:bg-slate-900/60 dark:hover:border-cyan-600 dark:hover:bg-cyan-950/20 dark:focus-visible:ring-offset-slate-900"
+        className="group relative flex min-h-64 w-full cursor-pointer items-center justify-center overflow-hidden rounded-xl border border-cyan-200 bg-slate-950 p-4 text-left shadow-sm transition-colors duration-200 hover:border-cyan-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:border-cyan-800 dark:focus-visible:ring-offset-slate-900"
         aria-expanded={isExpanded}
         aria-controls="gopro-overlay-job-stack-panel"
         aria-label={t(
@@ -63,27 +44,28 @@ export function GoproOverlayJobStack({
         )}
         onClick={() => setIsExpanded((expanded) => !expanded)}
       >
-        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-700 dark:bg-cyan-950/60 dark:text-cyan-300">
-          <Layers3 className="h-5 w-5" aria-hidden="true" />
+        <span className="relative block h-48 w-44" aria-hidden="true">
+          <span className="absolute inset-x-5 top-2 h-40 rotate-12 rounded-xl border border-slate-200 bg-white shadow-lg transition-transform duration-200 group-hover:rotate-[16deg]" />
+          <span className="absolute inset-x-3 top-1 h-[10.5rem] -rotate-6 rounded-xl border border-slate-200 bg-white shadow-lg transition-transform duration-200 group-hover:-rotate-12" />
+          <span className="absolute inset-x-1 top-4 h-40 rotate-3 rounded-xl border border-cyan-100 bg-white shadow-xl transition-transform duration-200 group-hover:rotate-6" />
+          <span className="absolute inset-x-4 top-7 flex h-36 -rotate-2 flex-col items-center justify-center rounded-xl border border-cyan-200 bg-white p-3 text-center text-slate-900 shadow-2xl transition-transform duration-200 group-hover:rotate-0">
+            <Layers3 className="h-7 w-7 text-cyan-600" />
+            <span className="mt-2 text-sm font-bold">
+              {t('flights.goproOverlayStackTitle')}
+            </span>
+            <span className="mt-1 text-xs text-slate-500">
+              {t('flights.goproOverlayStackCount', { count: jobs.length })}
+            </span>
+          </span>
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-            {t('flights.goproOverlayStackTitle')}
-          </span>
-          <span className="mt-1 block text-xs text-slate-600 dark:text-slate-300">
-            {t('flights.goproOverlayStackCount', { count: jobs.length })}
-          </span>
-        </span>
-        <span className="flex shrink-0 items-center gap-2 text-xs font-semibold text-cyan-700 dark:text-cyan-300">
-          <span className="hidden sm:inline">
-            {t(
-              isExpanded
-                ? 'flights.goproOverlayStackCollapse'
-                : 'flights.goproOverlayStackExpand'
-            )}
-          </span>
+        <span className="absolute bottom-3 left-0 right-0 flex items-center justify-center gap-2 text-xs font-semibold text-white">
+          {t(
+            isExpanded
+              ? 'flights.goproOverlayStackCollapse'
+              : 'flights.goproOverlayStackExpand'
+          )}
           <ChevronDown
-            className={`h-5 w-5 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+            className={`h-4 w-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
             aria-hidden="true"
           />
         </span>
@@ -106,11 +88,9 @@ export function GoproOverlayJobStack({
               onDelete={() => onDelete(job)}
             />
           ))}
+          {generationCard}
         </div>
       )}
-      <div className="mt-3 grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
-        {generationCard}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Résumé
- remplace l’ancienne carte compacte par une pile visuelle de cartes superposées
- conserve le clic pour afficher toutes les cartes overlay côte à côte
- affiche aussi la carte de génération dans la grille dépliée

## Validation
- lint ciblé passé
- tests FlightDetails déjà passés sur la base de cette fonctionnalité