### PR TITLE
fix(frontend): polish overlay stack interaction

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.test.tsx
@@ -880,6 +880,9 @@ describe('FlightDetails GoPro overlay action', () => {
     openTab('Media');
 
     expect(screen.getByText('Legacy overlay thumbnail')).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show overlay versions' })
+    );
     expect(
       screen.getByRole('button', { name: 'flights.goproOverlayDownload' })
     ).toBeInTheDocument();
@@ -937,8 +940,9 @@ describe('FlightDetails GoPro overlay action', () => {
 
     expect(screen.getByText('Generated overlays')).toBeInTheDocument();
     expect(screen.getByText('2 overlay versions')).toBeInTheDocument();
-    expect(screen.queryByText('overlay-1080p.mp4')).not.toBeInTheDocument();
-    expect(screen.queryByText('overlay-4k.mp4')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Delete overlay' })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Show overlay versions' })
@@ -1674,6 +1678,10 @@ describe('FlightDetails GoPro overlay action', () => {
     );
 
     openTab('Media');
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show overlay versions' })
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete overlay' }));
 

--- a/apps/frontend/src/components/flights/details/FlightMediaThumbnail.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaThumbnail.tsx
@@ -8,32 +8,43 @@ import { api } from '../../../lib/api';
 interface FlightMediaThumbnailProps {
   path: string;
   alt: string;
+  interactive?: boolean;
 }
 
-function ThumbnailUnavailable() {
+function ThumbnailUnavailable({ inline = false }: { inline?: boolean }) {
   const { t } = useTranslation();
+  const Container = inline ? 'span' : 'div';
   return (
-    <div className="flex aspect-video w-full items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+    <Container className="flex aspect-video w-full items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
       <ImageOff className="h-7 w-7" aria-hidden="true" />
       <span className="sr-only">{t('flights.mediaThumbnailUnavailable')}</span>
-    </div>
+    </Container>
   );
 }
 
-function ThumbnailLoading() {
+function ThumbnailLoading({ inline = false }: { inline?: boolean }) {
   const { t } = useTranslation();
+  const Container = inline ? 'span' : 'div';
   return (
-    <div className="flex aspect-video w-full items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
+    <Container className="flex aspect-video w-full items-center justify-center bg-slate-200 text-slate-500 dark:bg-slate-800 dark:text-slate-400">
       <LoaderCircle
         className="h-6 w-6 motion-safe:animate-spin"
         aria-hidden="true"
       />
       <span className="sr-only">{t('common.loading')}</span>
-    </div>
+    </Container>
   );
 }
 
-function LoadedThumbnail({ blob, alt }: { blob: Blob; alt: string }) {
+function LoadedThumbnail({
+  blob,
+  alt,
+  interactive,
+}: {
+  blob: Blob;
+  alt: string;
+  interactive: boolean;
+}) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -46,8 +57,25 @@ function LoadedThumbnail({ blob, alt }: { blob: Blob; alt: string }) {
     return () => URL.revokeObjectURL(objectUrl);
   }, [blob]);
 
-  if (hasError) return <ThumbnailUnavailable />;
-  if (!src) return <ThumbnailLoading />;
+  if (hasError) return <ThumbnailUnavailable inline={!interactive} />;
+  if (!src) return <ThumbnailLoading inline={!interactive} />;
+
+  if (!interactive) {
+    return (
+      <span className="relative block aspect-video w-full overflow-hidden bg-slate-200 dark:bg-slate-800">
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          className="h-full w-full object-cover"
+          onError={() => {
+            URL.revokeObjectURL(src);
+            setHasError(true);
+          }}
+        />
+      </span>
+    );
+  }
 
   return (
     <>
@@ -81,17 +109,26 @@ function LoadedThumbnail({ blob, alt }: { blob: Blob; alt: string }) {
   );
 }
 
-export function FlightMediaThumbnail({ path, alt }: FlightMediaThumbnailProps) {
+export function FlightMediaThumbnail({
+  path,
+  alt,
+  interactive = true,
+}: FlightMediaThumbnailProps) {
   const { data, dataUpdatedAt, isError } = useQuery({
     queryKey: ['flight-media-thumbnail', path],
     queryFn: ({ signal }) => api.get(path, { signal }).blob(),
     retry: false,
   });
 
-  if (isError) return <ThumbnailUnavailable />;
-  if (!data) return <ThumbnailLoading />;
+  if (isError) return <ThumbnailUnavailable inline={!interactive} />;
+  if (!data) return <ThumbnailLoading inline={!interactive} />;
 
   return (
-    <LoadedThumbnail key={`${path}:${dataUpdatedAt}`} blob={data} alt={alt} />
+    <LoadedThumbnail
+      key={`${path}:${dataUpdatedAt}`}
+      blob={data}
+      alt={alt}
+      interactive={interactive}
+    />
   );
 }

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { ChevronDown, Layers3 } from 'lucide-react';
 import type { GoproOverlayJob } from '../../../hooks/gopro/useGoproOverlay';
 import type { Flight } from '../../../types';
+import { FlightMediaThumbnail } from './FlightMediaThumbnail';
 import { GoproOverlayJobCard } from './GoproOverlayJobCard';
 
 interface GoproOverlayJobStackProps {
@@ -16,6 +17,12 @@ interface GoproOverlayJobStackProps {
   generationCard: ReactNode;
 }
 
+const previewCardClasses = [
+  'inset-x-4 top-4 -rotate-6 group-hover:-rotate-12',
+  'inset-x-2 top-2 rotate-3 group-hover:rotate-6',
+  'inset-x-0 top-0 rotate-12 group-hover:rotate-[16deg]',
+];
+
 export function GoproOverlayJobStack({
   jobs,
   youtubeUploadFlight,
@@ -27,52 +34,74 @@ export function GoproOverlayJobStack({
 }: GoproOverlayJobStackProps) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
+  const isCollapsed = !isExpanded;
+  const previewJobs = jobs.slice(0, 3);
+  const panelId = 'gopro-overlay-job-stack-panel';
 
   return (
     <div
       className={`min-w-0 ${isExpanded ? 'sm:col-span-2 2xl:col-span-3' : ''}`}
     >
-      <button
-        type="button"
-        className="group relative flex min-h-64 w-full cursor-pointer items-center justify-center overflow-hidden rounded-xl border border-cyan-200 bg-slate-950 p-4 text-left shadow-sm transition-colors duration-200 hover:border-cyan-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:border-cyan-800 dark:focus-visible:ring-offset-slate-900"
-        aria-expanded={isExpanded}
-        aria-controls="gopro-overlay-job-stack-panel"
-        aria-label={t(
-          isExpanded
-            ? 'flights.goproOverlayStackCollapse'
-            : 'flights.goproOverlayStackExpand'
-        )}
-        onClick={() => setIsExpanded((expanded) => !expanded)}
-      >
-        <span className="relative block h-48 w-44" aria-hidden="true">
-          <span className="absolute inset-x-5 top-2 h-40 rotate-12 rounded-xl border border-slate-200 bg-white shadow-lg transition-transform duration-200 group-hover:rotate-[16deg]" />
-          <span className="absolute inset-x-3 top-1 h-[10.5rem] -rotate-6 rounded-xl border border-slate-200 bg-white shadow-lg transition-transform duration-200 group-hover:-rotate-12" />
-          <span className="absolute inset-x-1 top-4 h-40 rotate-3 rounded-xl border border-cyan-100 bg-white shadow-xl transition-transform duration-200 group-hover:rotate-6" />
-          <span className="absolute inset-x-4 top-7 flex h-36 -rotate-2 flex-col items-center justify-center rounded-xl border border-cyan-200 bg-white p-3 text-center text-slate-900 shadow-2xl transition-transform duration-200 group-hover:rotate-0">
-            <Layers3 className="h-7 w-7 text-cyan-600" />
-            <span className="mt-2 text-sm font-bold">
-              {t('flights.goproOverlayStackTitle')}
-            </span>
-            <span className="mt-1 text-xs text-slate-500">
-              {t('flights.goproOverlayStackCount', { count: jobs.length })}
+      {isCollapsed ? (
+        <button
+          type="button"
+          className="group relative flex min-h-64 w-full cursor-pointer items-center justify-center overflow-hidden rounded-xl border border-cyan-200 bg-slate-950 p-4 text-left shadow-sm transition-colors duration-200 hover:border-cyan-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 dark:border-cyan-800 dark:focus-visible:ring-offset-slate-900"
+          aria-expanded={false}
+          aria-controls={panelId}
+          aria-label={t('flights.goproOverlayStackExpand')}
+          onClick={() => setIsExpanded(true)}
+        >
+          <span className="relative block h-48 w-44" aria-hidden="true">
+            {previewJobs.map((job, index) => (
+              <span
+                key={job.job_id}
+                className={`absolute ${previewCardClasses[index]} h-40 overflow-hidden rounded-xl border border-cyan-100 bg-white shadow-xl transition-transform duration-200`}
+              >
+                {job.status === 'completed' ? (
+                  <FlightMediaThumbnail
+                    path={`/gopro-overlays/jobs/${job.job_id}/thumbnail`}
+                    alt={job.output_filename}
+                    interactive={false}
+                  />
+                ) : (
+                  <span className="flex h-full items-center justify-center bg-slate-100 text-cyan-600">
+                    <Layers3 className="h-8 w-8" aria-hidden="true" />
+                  </span>
+                )}
+              </span>
+            ))}
+            <span className="absolute inset-x-4 top-7 flex h-36 -rotate-2 flex-col items-center justify-center rounded-xl border border-cyan-200 bg-white/75 p-3 text-center text-slate-900 shadow-2xl backdrop-blur-[1px] transition-transform duration-200 group-hover:rotate-0">
+              <Layers3 className="h-7 w-7 text-cyan-600" aria-hidden="true" />
+              <span className="mt-2 text-sm font-bold">
+                {t('flights.goproOverlayStackTitle')}
+              </span>
+              <span className="mt-1 text-xs text-slate-500">
+                {t('flights.goproOverlayStackCount', { count: jobs.length })}
+              </span>
             </span>
           </span>
-        </span>
-        <span className="absolute bottom-3 left-0 right-0 flex items-center justify-center gap-2 text-xs font-semibold text-white">
-          {t(
-            isExpanded
-              ? 'flights.goproOverlayStackCollapse'
-              : 'flights.goproOverlayStackExpand'
-          )}
-          <ChevronDown
-            className={`h-4 w-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
-            aria-hidden="true"
-          />
-        </span>
-      </button>
+          <span className="absolute bottom-3 left-0 right-0 flex items-center justify-center gap-2 text-xs font-semibold text-white">
+            {t('flights.goproOverlayStackExpand')}
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          </span>
+        </button>
+      ) : (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-md px-2 py-1 text-xs font-semibold text-slate-600 transition-colors hover:text-cyan-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 dark:text-slate-300 dark:hover:text-cyan-300"
+            aria-expanded
+            aria-controls={panelId}
+            onClick={() => setIsExpanded(false)}
+          >
+            {t('flights.goproOverlayStackCollapse')}
+            <ChevronDown className="h-4 w-4 rotate-180" aria-hidden="true" />
+          </button>
+        </div>
+      )}
       {isExpanded && (
         <div
-          id="gopro-overlay-job-stack-panel"
+          id={panelId}
           className="mt-3 grid gap-3 sm:grid-cols-2 2xl:grid-cols-3"
         >
           {jobs.map((job) => (


### PR DESCRIPTION
## Correction\n\n- affiche les vraies miniatures des overlays dans la stack repliée\n- conserve la stack uniquement avant ouverture\n- remplace la stack ouverte par les cartes d'overlays et la carte de génération côte à côte\n- conserve les états chargement/erreur sans boutons imbriqués\n- met à jour les tests de comportement\n\n## Validation\n\n- tests ciblés FlightDetails : 35/35\n- build frontend : réussi\n- lint ciblé : réussi\n- CodeRabbit : aucun nouveau finding