### PR TITLE
fix(backend): harden emagram LLM analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,8 +94,8 @@ BACKEND_GROQ_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
 
 # OpenRouter vision models: https://openrouter.ai/keys
 BACKEND_OPENROUTER_API_KEY=your_openrouter_api_key_here
-BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:free
-BACKEND_OPENROUTER_MODELS=qwen/qwen2.5-vl-72b-instruct:free,google/gemini-2.0-flash-exp:free,mistralai/mistral-small-3.2-24b-instruct:free
+BACKEND_OPENROUTER_MODEL=openrouter/free
+BACKEND_OPENROUTER_MODELS=openrouter/free
 
 # GitHub Models: https://github.com/marketplace/models
 BACKEND_GITHUB_MODELS_API_KEY=your_github_token_here

--- a/apps/backend/config.py
+++ b/apps/backend/config.py
@@ -180,11 +180,10 @@ GEMINI_MODEL = os.getenv("BACKEND_GEMINI_MODEL", "gemini-2.5-flash")
 GROQ_API_KEY = os.getenv("BACKEND_GROQ_API_KEY")
 GROQ_MODEL = os.getenv("BACKEND_GROQ_MODEL", "meta-llama/llama-4-scout-17b-16e-instruct")
 OPENROUTER_API_KEY = os.getenv("BACKEND_OPENROUTER_API_KEY")
-OPENROUTER_MODEL = os.getenv("BACKEND_OPENROUTER_MODEL", "qwen/qwen2.5-vl-72b-instruct:free")
+OPENROUTER_MODEL = os.getenv("BACKEND_OPENROUTER_MODEL", "openrouter/free")
 OPENROUTER_MODELS = _csv_env(
     "BACKEND_OPENROUTER_MODELS",
-    OPENROUTER_MODEL
-    + ",google/gemini-2.0-flash-exp:free,mistralai/mistral-small-3.2-24b-instruct:free",
+    OPENROUTER_MODEL,
 )
 GITHUB_MODELS_API_KEY = os.getenv("BACKEND_GITHUB_MODELS_API_KEY")
 GITHUB_MODELS_BASE_URL = os.getenv(

--- a/apps/backend/llm/gemini_analyzer.py
+++ b/apps/backend/llm/gemini_analyzer.py
@@ -90,6 +90,7 @@ def analyze_emagram_with_gemini(
                     "top_p": 0.8,
                     "top_k": 40,
                     "max_output_tokens": 8192,  # Increased significantly
+                    "response_mime_type": "application/json",
                 },
             )
 
@@ -254,52 +255,22 @@ def _parse_gemini_response(response_text: str) -> dict:
 
     text = text.strip()
 
-    # Try to fix incomplete JSON
-    if not text.endswith("}"):
-        logger.warning("JSON appears incomplete, attempting to close it")
-        # Count opening and closing braces
-        open_braces = text.count("{")
-        close_braces = text.count("}")
-
-        # Add missing closing braces
-        if open_braces > close_braces:
-            text += "}" * (open_braces - close_braces)
-            logger.info(f"Added {open_braces - close_braces} closing braces")
-
     try:
         analysis = json.loads(text)
-
-        # Validate required fields
-        required_fields = [
-            "plafond_thermique_m",
-            "force_thermique_ms",
-            "heures_volables",
-            "score_volabilite",
-            "conseils_vol",
-            "alertes_securite",
-            "details_analyse",
-        ]
-
-        for field in required_fields:
-            if field not in analysis:
-                logger.warning(f"Missing field in Gemini response: {field}")
-                analysis[field] = _get_default_value(field)
-
-        # Type conversions and validation
-        analysis["plafond_thermique_m"] = int(analysis["plafond_thermique_m"])
-        analysis["force_thermique_ms"] = float(analysis["force_thermique_ms"])
-        analysis["score_volabilite"] = max(0, min(100, int(analysis["score_volabilite"])))
-
-        if not isinstance(analysis["alertes_securite"], list):
-            analysis["alertes_securite"] = []
-
-        analysis.setdefault("explication_analyse", None)
-
-        return analysis
+        return _normalize_parsed_analysis(analysis)
 
     except json.JSONDecodeError as e:
+        repaired_text = _repair_truncated_json(text)
+        if repaired_text != text:
+            try:
+                analysis = json.loads(repaired_text)
+                logger.warning("Repaired truncated Gemini JSON response")
+                return _normalize_parsed_analysis(analysis)
+            except json.JSONDecodeError:
+                pass
+
         logger.error(f"Failed to parse Gemini response as JSON: {e}")
-        logger.error(f"Full response text ({len(response_text)} chars): {response_text}")
+        logger.error("Gemini response was %s characters long", len(response_text))
 
         # Return fallback analysis
         return {
@@ -312,6 +283,72 @@ def _parse_gemini_response(response_text: str) -> dict:
             "details_analyse": f"Erreur de parsing JSON: {str(e)}\n\nRéponse brute: {response_text[:1000]}",
             "explication_analyse": None,
         }
+
+
+def _normalize_parsed_analysis(analysis: dict) -> dict:
+    """Fill and normalize the fields shared by all Gemini responses."""
+    required_fields = [
+        "plafond_thermique_m",
+        "force_thermique_ms",
+        "heures_volables",
+        "score_volabilite",
+        "conseils_vol",
+        "alertes_securite",
+        "details_analyse",
+    ]
+
+    for field in required_fields:
+        if field not in analysis:
+            logger.warning("Missing field in Gemini response: %s", field)
+            analysis[field] = _get_default_value(field)
+
+    analysis["plafond_thermique_m"] = int(analysis["plafond_thermique_m"])
+    analysis["force_thermique_ms"] = float(analysis["force_thermique_ms"])
+    analysis["score_volabilite"] = max(0, min(100, int(analysis["score_volabilite"])))
+
+    if not isinstance(analysis["alertes_securite"], list):
+        analysis["alertes_securite"] = []
+
+    analysis.setdefault("explication_analyse", None)
+    return analysis
+
+
+def _repair_truncated_json(text: str) -> str:
+    """Close JSON truncated by an LLM while preserving its completed values."""
+    output = text.rstrip()
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+
+    for char in output:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char in "[{":
+            stack.append(char)
+        elif char in "]}":
+            matching = (char == "]" and stack[-1:] == ["["]) or (
+                char == "}" and stack[-1:] == ["{"]
+            )
+            if stack and matching:
+                stack.pop()
+
+    if not in_string and not stack:
+        return output
+
+    repaired = output
+    if in_string:
+        repaired += '"'
+    repaired += "".join("}" if opener == "{" else "]" for opener in reversed(stack))
+    return repaired
 
 
 def _get_default_value(field: str):

--- a/apps/backend/tests/unit/test_gemini_analyzer.py
+++ b/apps/backend/tests/unit/test_gemini_analyzer.py
@@ -1,0 +1,27 @@
+import json
+
+from llm.gemini_analyzer import _parse_gemini_response
+
+
+def test_parse_gemini_response_repairs_truncated_string() -> None:
+    response = json.dumps(
+        {
+            "plafond_thermique_m": 2400,
+            "force_thermique_ms": 2.1,
+            "heures_volables": "12h-17h",
+            "score_volabilite": 70,
+            "conseils_vol": "Vol possible avec prudence.",
+            "alertes_securite": [],
+            "details_analyse": "L'inversion limite probablement les thermiques.",
+        },
+        ensure_ascii=False,
+    )
+    truncated = response[:-12]
+
+    result = _parse_gemini_response(truncated)
+
+    assert result["plafond_thermique_m"] == 2400
+    assert result["force_thermique_ms"] == 2.1
+    assert result["score_volabilite"] == 70
+    assert result["details_analyse"].startswith("L'inversion")
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,8 @@ services:
       - BACKEND_GROQ_API_KEY=${BACKEND_GROQ_API_KEY}
       - BACKEND_GROQ_MODEL=${BACKEND_GROQ_MODEL:-meta-llama/llama-4-scout-17b-16e-instruct}
       - BACKEND_OPENROUTER_API_KEY=${BACKEND_OPENROUTER_API_KEY}
-      - BACKEND_OPENROUTER_MODEL=${BACKEND_OPENROUTER_MODEL:-qwen/qwen2.5-vl-72b-instruct:free}
-      - BACKEND_OPENROUTER_MODELS=${BACKEND_OPENROUTER_MODELS:-qwen/qwen2.5-vl-72b-instruct:free,google/gemini-2.0-flash-exp:free,mistralai/mistral-small-3.2-24b-instruct:free}
+      - BACKEND_OPENROUTER_MODEL=${BACKEND_OPENROUTER_MODEL:-openrouter/free}
+      - BACKEND_OPENROUTER_MODELS=${BACKEND_OPENROUTER_MODELS:-openrouter/free}
       - BACKEND_GITHUB_MODELS_API_KEY=${BACKEND_GITHUB_MODELS_API_KEY}
       - BACKEND_GITHUB_MODELS_BASE_URL=${BACKEND_GITHUB_MODELS_BASE_URL:-https://models.github.ai/inference/v1/chat/completions}
       - BACKEND_GITHUB_MODELS_MODELS=${BACKEND_GITHUB_MODELS_MODELS:-openai/gpt-4o-mini}

--- a/env.portainer
+++ b/env.portainer
@@ -116,7 +116,7 @@ BACKEND_GROQ_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
 BACKEND_OPENROUTER_API_KEY="<redacted: configured in Portainer>"
 
 # OpenRouter model currently configured in Portainer.
-BACKEND_OPENROUTER_MODEL=qwen/qwen2.5-vl-72b-instruct:free
+BACKEND_OPENROUTER_MODEL=openrouter/free
 
 # Codex uses the default model available to the authenticated ChatGPT Plus account.
 BACKEND_CODEX_MODEL=


### PR DESCRIPTION
## Résumé
- répare les réponses JSON Gemini tronquées pendant l’analyse des émagrammes
- active la sortie JSON structurée Gemini
- remplace les modèles OpenRouter gratuits obsolètes par le routeur `openrouter/free`
- ajoute un test de régression du parseur Gemini

## Validation
- compilation Python : OK
- `git diff --check` : OK
- pytest ciblé : non exécuté, pytest absent du worktree
- CodeRabbit : service indisponible, WebSocket fermé lors de deux tentatives

## Cause observée dans les logs Portainer
Les captures d’émagrammes réussissaient (`4/4`), mais les modèles Groq/OpenRouter renvoyaient `404` et Gemini retournait un JSON incomplet, provoquant des erreurs `503`.