### PR TITLE
feat(frontend): play flight media from thumbnails

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4681,6 +4681,23 @@ def get_flight_pano_thumbnail(flight_id: str, db: Session = Depends(get_db)) -> 
     return _video_thumbnail_response(pano_path)
 
 
+@router.get("/flights/{flight_id}/pano")
+def stream_flight_pano(flight_id: str, db: Session = Depends(get_db)) -> FileResponse:
+    """Stream the flight Pano video in the browser."""
+    flight = db.query(Flight).filter(Flight.id == flight_id).first()
+    if not flight:
+        raise HTTPException(status_code=404, detail="Flight not found")
+    pano_path = _resolve_flight_file_path(flight.pano_video_file_path)
+    if not pano_path or not pano_path.is_file():
+        raise HTTPException(status_code=404, detail="No Pano video available for this flight")
+    return FileResponse(
+        path=pano_path,
+        media_type="video/mp4",
+        filename=pano_path.name,
+        content_disposition_type="inline",
+    )
+
+
 def _highlight_job_payload(job: HighlightVideoJob) -> HighlightVideoJobResponse:
     try:
         raw_selection = json.loads(job.selection_json) if job.selection_json else []
@@ -4741,7 +4758,12 @@ def download_flight_highlight_video(
     output_path = Path(job.output_path)
     if not output_path.is_file():
         raise HTTPException(status_code=404, detail="Highlight video file not found")
-    return FileResponse(path=output_path, media_type="video/mp4", filename=output_path.name)
+    return FileResponse(
+        path=output_path,
+        media_type="video/mp4",
+        filename=output_path.name,
+        content_disposition_type="inline",
+    )
 
 
 @router.delete(
@@ -4911,7 +4933,12 @@ def download_flight_gopro_overlay(flight_id: str, db: Session = Depends(get_db))
     if not overlay_path:
         raise HTTPException(status_code=404, detail="No GoPro overlay available for this flight")
 
-    return FileResponse(path=overlay_path, media_type="video/mp4", filename=overlay_path.name)
+    return FileResponse(
+        path=overlay_path,
+        media_type="video/mp4",
+        filename=overlay_path.name,
+        content_disposition_type="inline",
+    )
 
 
 @router.get("/flights/{flight_id}/gopro-overlay/thumbnail")
@@ -6761,7 +6788,12 @@ def download_gopro_overlay_render_job(job_id: str) -> FileResponse:
     if not output_path:
         raise HTTPException(status_code=400, detail="GoPro overlay video is not ready")
 
-    return FileResponse(path=output_path, media_type="video/mp4", filename=output_path.name)
+    return FileResponse(
+        path=output_path,
+        media_type="video/mp4",
+        filename=output_path.name,
+        content_disposition_type="inline",
+    )
 
 
 @router.get("/gopro-overlays/jobs/{job_id}/thumbnail")

--- a/apps/backend/tests/api/test_routes_flights.py
+++ b/apps/backend/tests/api/test_routes_flights.py
@@ -547,6 +547,51 @@ class TestFlightsListEndpoint:
         assert response.status_code == 404
         assert response.json()["detail"] == "No Pano video available for this flight"
 
+    def test_stream_flight_pano(self, client, db_session, tmp_path):
+        pano_path = tmp_path / "pano.mp4"
+        pano_path.write_bytes(b"pano")
+        flight = Flight(
+            id="flight-pano-stream",
+            name="Flight Pano stream",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+            pano_video_file_path=str(pano_path),
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/pano")
+
+        assert response.status_code == 200
+        assert response.content == b"pano"
+        assert response.headers["content-type"] == "video/mp4"
+        assert response.headers["content-disposition"].startswith("inline")
+
+    def test_stream_flight_pano_returns_404_when_unavailable(self, client, db_session, tmp_path):
+        response = client.get(f"{API_PREFIX}/flights/missing-flight/pano")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Flight not found"
+
+        flight = Flight(
+            id="flight-no-pano-stream",
+            name="Flight without Pano stream",
+            flight_date=date(2026, 3, 15),
+            site_id="site-arguel",
+        )
+        db_session.add(flight)
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/pano")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No Pano video available for this flight"
+
+        flight.pano_video_file_path = str(tmp_path / "missing-pano.mp4")
+        db_session.commit()
+
+        response = client.get(f"{API_PREFIX}/flights/{flight.id}/pano")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "No Pano video available for this flight"
+
     def test_download_flight_gopro_overlay(self, client, db_session, monkeypatch, tmp_path):
         """GET /flights/{id}/gopro-overlay downloads the generated overlay."""
         monkeypatch.setattr(config, "GOPRO_OVERLAY_PARAGLIDING_ROOT", str(tmp_path))

--- a/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
@@ -147,6 +147,7 @@ export function FlightMediaBadges({
           {hasGoproCameraVideo ? (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/gopro-camera/thumbnail`}
+              videoPath={`/flights/${flightId}/gopro-camera`}
               alt={t(
                 'flights.cameraThumbnailAlt',
                 'Miniature de la vidéo caméra'
@@ -176,6 +177,7 @@ export function FlightMediaBadges({
           {hasVideo && (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/video/thumbnail`}
+              videoPath={`/flights/${flightId}/video`}
               alt={t('flights.videoThumbnailAlt')}
             />
           )}
@@ -270,6 +272,7 @@ export function FlightMediaBadges({
           {hasPanoVideo ? (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/pano/thumbnail`}
+              videoPath={`/flights/${flightId}/pano`}
               alt={t('flights.panoThumbnailAlt')}
             />
           ) : (
@@ -306,6 +309,7 @@ export function FlightMediaBadges({
           <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
             <FlightMediaThumbnail
               path={`/flights/${flightId}/gopro-overlay/thumbnail`}
+              videoPath={`/flights/${flightId}/gopro-overlay`}
               alt={t('flights.goproOverlayThumbnailAlt')}
             />
             <div className="flex items-center gap-3 p-3">

--- a/apps/frontend/src/components/flights/details/FlightMediaThumbnail.test.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaThumbnail.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@dashboard-parapente/design-system', () => ({
 
 vi.mock('../../../lib/api', () => ({
   api: { get: apiGet },
+  getApiUrlWithSearchParams: (path: string) => `/api${path}`,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -93,6 +94,33 @@ describe('FlightMediaThumbnail', () => {
       screen.getByText('flights.mediaThumbnailUnavailable')
     ).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('starts the video instead of opening the image lightbox when a video path is provided', async () => {
+    renderThumbnail(
+      <FlightMediaThumbnail
+        path="/flights/flight-1/video/thumbnail"
+        videoPath="/flights/flight-1/video"
+        alt="Flight video thumbnail"
+      />
+    );
+
+    await waitFor(() => expect(screen.getByRole('img')).toBeInTheDocument());
+    fireEvent.click(
+      screen.getByRole('button', { name: 'flights.playMediaVideo' })
+    );
+
+    await waitFor(() =>
+      expect(document.querySelector('video')).toBeInTheDocument()
+    );
+    expect(document.querySelector('video')).toHaveAttribute(
+      'src',
+      'blob:thumbnail'
+    );
+    expect(apiGet).toHaveBeenLastCalledWith('/flights/flight-1/video', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('loads a new thumbnail after the path changes', async () => {

--- a/apps/frontend/src/components/flights/details/FlightMediaThumbnail.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaThumbnail.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { Lightbox } from '@dashboard-parapente/design-system';
-import { ImageOff, LoaderCircle, Maximize2 } from 'lucide-react';
+import { ImageOff, LoaderCircle, Maximize2, Play } from 'lucide-react';
 import { api } from '../../../lib/api';
 
 interface FlightMediaThumbnailProps {
   path: string;
   alt: string;
   interactive?: boolean;
+  videoPath?: string;
 }
 
 function ThumbnailUnavailable({ inline = false }: { inline?: boolean }) {
@@ -40,13 +41,18 @@ function LoadedThumbnail({
   blob,
   alt,
   interactive,
+  videoPath,
 }: {
   blob: Blob;
   alt: string;
   interactive: boolean;
+  videoPath?: string;
 }) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [videoSrc, setVideoSrc] = useState<string | null>(null);
+  const [isVideoLoading, setIsVideoLoading] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [src, setSrc] = useState<string | null>(null);
 
@@ -56,6 +62,39 @@ function LoadedThumbnail({
     setSrc(objectUrl);
     return () => URL.revokeObjectURL(objectUrl);
   }, [blob]);
+
+  useEffect(() => {
+    if (!isPlaying || !videoPath) return;
+
+    const controller = new AbortController();
+    let isActive = true;
+    setIsVideoLoading(true);
+    void api
+      .get(videoPath, { signal: controller.signal })
+      .blob()
+      .then((videoBlob) => {
+        if (!isActive) return;
+        setVideoSrc(URL.createObjectURL(videoBlob));
+        setIsVideoLoading(false);
+      })
+      .catch(() => {
+        if (isActive) {
+          setHasError(true);
+          setIsVideoLoading(false);
+        }
+      });
+
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [isPlaying, videoPath]);
+
+  useEffect(() => {
+    return () => {
+      if (videoSrc) URL.revokeObjectURL(videoSrc);
+    };
+  }, [videoSrc]);
 
   if (hasError) return <ThumbnailUnavailable inline={!interactive} />;
   if (!src) return <ThumbnailLoading inline={!interactive} />;
@@ -77,13 +116,38 @@ function LoadedThumbnail({
     );
   }
 
+  if (videoPath && isPlaying && isVideoLoading) {
+    return <ThumbnailLoading />;
+  }
+
+  if (videoPath && isPlaying && videoSrc) {
+    return (
+      <div className="relative block aspect-video w-full overflow-hidden bg-black">
+        <video
+          className="h-full w-full object-contain"
+          src={videoSrc}
+          controls
+          autoPlay
+          preload="metadata"
+          aria-label={alt}
+        >
+          <track kind="captions" />
+        </video>
+      </div>
+    );
+  }
+
   return (
     <>
       <button
         type="button"
         className="group/thumbnail relative block aspect-video w-full cursor-pointer overflow-hidden bg-slate-200 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-indigo-500 dark:bg-slate-800"
-        onClick={() => setIsOpen(true)}
-        aria-label={t('flights.openMediaThumbnail', { name: alt })}
+        onClick={() => (videoPath ? setIsPlaying(true) : setIsOpen(true))}
+        aria-label={
+          videoPath
+            ? t('flights.playMediaVideo', { name: alt })
+            : t('flights.openMediaThumbnail', { name: alt })
+        }
       >
         <img
           src={src}
@@ -96,8 +160,14 @@ function LoadedThumbnail({
           }}
         />
         <span className="absolute bottom-2 right-2 flex items-center gap-1 rounded-full bg-slate-950/75 px-2 py-1 text-xs font-semibold text-white">
-          <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
-          {t('flights.enlargeMediaThumbnail')}
+          {videoPath ? (
+            <Play className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          {videoPath
+            ? t('flights.playMediaVideoShort')
+            : t('flights.enlargeMediaThumbnail')}
         </span>
       </button>
       <Lightbox
@@ -113,6 +183,7 @@ export function FlightMediaThumbnail({
   path,
   alt,
   interactive = true,
+  videoPath,
 }: FlightMediaThumbnailProps) {
   const { data, dataUpdatedAt, isError } = useQuery({
     queryKey: ['flight-media-thumbnail', path],
@@ -129,6 +200,7 @@ export function FlightMediaThumbnail({
       blob={data}
       alt={alt}
       interactive={interactive}
+      videoPath={videoPath}
     />
   );
 }

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
@@ -25,9 +25,16 @@ export function GoproOverlayJobCard({
   onDelete,
 }: GoproOverlayJobCardProps) {
   const { t } = useTranslation();
-  const renderHasStarted = ['running', 'completed', 'failed', 'cancelled'].includes(job.status);
+  const renderHasStarted = [
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+  ].includes(job.status);
   const renderMethodLabel =
-    renderHasStarted && job.render_method && ['cpu', 'gpu'].includes(job.render_method)
+    renderHasStarted &&
+    job.render_method &&
+    ['cpu', 'gpu'].includes(job.render_method)
       ? t(`flights.generationLogs.method.${job.render_method}`)
       : null;
   const resolutionLabel =
@@ -42,6 +49,7 @@ export function GoproOverlayJobCard({
       {job.status === 'completed' && (
         <FlightMediaThumbnail
           path={`/gopro-overlays/jobs/${job.job_id}/thumbnail`}
+          videoPath={`/gopro-overlays/jobs/${job.job_id}/download`}
           alt={t('flights.goproOverlayJobThumbnailAlt', {
             name: job.output_filename,
           })}

--- a/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
@@ -4,6 +4,7 @@ import { Download, LoaderCircle, Sparkles, Trash2 } from 'lucide-react';
 import type { HighlightVideoJob } from '@dashboard-parapente/shared-types';
 import type { Flight } from '../../../types';
 import { FlightYoutubeUploadControls } from './FlightYoutubeUploadControls';
+import { FlightMediaThumbnail } from './FlightMediaThumbnail';
 
 interface HighlightVideoJobCardProps {
   job: HighlightVideoJob | null;
@@ -81,6 +82,13 @@ export function HighlightVideoJobCard({
               className="h-2 w-full accent-blue-600 dark:accent-blue-400"
             />
           </div>
+        )}
+        {status === 'completed' && job && (
+          <FlightMediaThumbnail
+            path={`/flights/${flight.id}/highlight-videos/${job.job_id}/thumbnail`}
+            videoPath={`/flights/${flight.id}/highlight-videos/${job.job_id}/download`}
+            alt={t('flights.highlightVideoThumbnailAlt')}
+          />
         )}
         {status === 'completed' && job && (
           <div className="mt-3 space-y-2">

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1048,6 +1048,8 @@
     "mediaFileAvailable": "Ready to download",
     "openMediaThumbnail": "Enlarge {{name}}",
     "enlargeMediaThumbnail": "Enlarge",
+    "playMediaVideo": "Play {{name}}",
+    "playMediaVideoShort": "Play",
     "mediaThumbnailUnavailable": "Thumbnail unavailable",
     "gpxThumbnailAlt": "Flight GPS track preview",
     "gpxThumbnailUnavailable": "GPS track unavailable",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1052,6 +1052,8 @@
     "mediaFileAvailable": "Prêt à télécharger",
     "openMediaThumbnail": "Agrandir {{name}}",
     "enlargeMediaThumbnail": "Agrandir",
+    "playMediaVideo": "Lire {{name}}",
+    "playMediaVideoShort": "Lire",
     "mediaThumbnailUnavailable": "Miniature indisponible",
     "gpxThumbnailAlt": "Aperçu de la trace GPS du vol",
     "gpxThumbnailUnavailable": "Trace GPS indisponible",


### PR DESCRIPTION
## Résumé
- lance la lecture des vidéos caméra, vol, pano, meilleurs moments et overlays depuis leurs miniatures
- conserve l’ouverture de la stack d’overlays au clic
- ajoute le streaming inline du pano et les tests associés
- évite d’exposer le JWT dans l’URL vidéo

## Validation
- test miniature frontend ciblé : 4/4
- tests backend pano ciblés : 5/5
- build frontend : OK
- type-check frontend : OK
- formatage ciblé : OK
- `git diff --check` : OK

La validation Nx globale reste en échec sur des erreurs préexistantes dans des fichiers non modifiés et des tests GoPro sans lien avec cette PR.