### PR TITLE
feat: improve video export jobs list

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -36,6 +36,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
+from pydantic import BaseModel
 
 import config
 from auth import (
@@ -704,7 +705,22 @@ def _build_video_export_jobs_payload(
     return sorted(jobs, key=_video_export_sort_value, reverse=True)
 
 
-def _get_video_export_jobs_payload(db: Session, active_only: bool = False) -> dict[str, Any]:
+class VideoExportJobsResponse(BaseModel):
+    jobs: list[dict[str, Any]]
+    page: int
+    page_size: int
+    total: int
+    total_pages: int
+
+
+def _get_video_export_jobs_payload(
+    db: Session,
+    active_only: bool = False,
+    status_filter: str | None = None,
+    type_filter: str | None = None,
+    page: int | None = None,
+    page_size: int | None = None,
+) -> dict[str, Any]:
     jobs = _build_video_export_jobs_payload(
         list_exports_manual()
         + list_exports_stream()
@@ -735,7 +751,34 @@ def _get_video_export_jobs_payload(db: Session, active_only: bool = False) -> di
             ),
             reverse=True,
         )
-    return {"jobs": jobs}
+    if type_filter == "video":
+        jobs = [job for job in jobs if job.get("mode") != "gopro_overlay"]
+    elif type_filter == "gopro":
+        jobs = [job for job in jobs if job.get("mode") == "gopro_overlay"]
+    if status_filter == "active":
+        jobs = [
+            job
+            for job in jobs
+            if job.get("can_cancel")
+            or job.get("status") in _VIDEO_EXPORT_IN_PROGRESS_STATUSES
+        ]
+    elif status_filter and status_filter != "all":
+        jobs = [job for job in jobs if job.get("status") == status_filter]
+    payload: dict[str, Any] = {"jobs": jobs}
+    if page is not None and page_size is not None:
+        total = len(jobs)
+        total_pages = max(1, math.ceil(total / page_size))
+        start = (page - 1) * page_size
+        payload.update(
+            {
+                "jobs": jobs[start : start + page_size],
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "total_pages": total_pages,
+            }
+        )
+    return payload
 
 
 def _active_deployment_job_count(db: Session) -> int:
@@ -6063,19 +6106,43 @@ def get_video_export_status(job_id: str):
 @router.get("/video-export-jobs")
 def list_video_export_jobs(
     active_only: bool = False,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(default="all"),
+    type_filter: Literal["all", "video", "gopro"] = Query(default="all"),
     db: Session = Depends(get_db),
-):
+) -> VideoExportJobsResponse:
     """List video export jobs across all flights."""
-    return _get_video_export_jobs_payload(db, active_only=active_only)
+    payload = _get_video_export_jobs_payload(
+        db,
+        active_only=active_only,
+        status_filter=status_filter,
+        type_filter=type_filter,
+        page=page,
+        page_size=page_size,
+    )
+    return VideoExportJobsResponse(**payload)
 
 
 @router.get("/video-export-jobs/stream")
-async def stream_video_export_jobs(request: Request) -> StreamingResponse:
+async def stream_video_export_jobs(
+    request: Request,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=25, ge=1, le=100),
+    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(default="all"),
+    type_filter: Literal["all", "video", "gopro"] = Query(default="all"),
+) -> StreamingResponse:
     """Stream video export job list updates without frontend polling."""
 
     def read_payload() -> dict[str, Any]:
         with SessionLocal() as db:
-            return _get_video_export_jobs_payload(db)
+            return _get_video_export_jobs_payload(
+                db,
+                status_filter=status_filter,
+                type_filter=type_filter,
+                page=page,
+                page_size=page_size,
+            )
 
     async def event_stream():
         yield "retry: 5000\n\n"

--- a/apps/backend/tests/api/test_video_export_endpoints.py
+++ b/apps/backend/tests/api/test_video_export_endpoints.py
@@ -601,6 +601,42 @@ class TestVideoExportJobsEndpoint:
             == "gpu"
         )
 
+    def test_video_export_jobs_supports_server_side_pagination(
+        self, client: TestClient, sample_flight
+    ):
+        jobs = [
+            {
+                "job_id": "job-newest",
+                "flight_id": sample_flight.id,
+                "status": "completed",
+                "updated_at": "2026-04-30T12:00:00",
+            },
+            {
+                "job_id": "job-oldest",
+                "flight_id": sample_flight.id,
+                "status": "failed",
+                "updated_at": "2026-04-30T10:00:00",
+            },
+        ]
+
+        with (
+            patch("routes.list_exports_manual", return_value=jobs),
+            patch("routes.list_exports_stream", return_value=[]),
+            patch("routes.list_gopro_overlay_jobs", return_value=[]),
+        ):
+            response = client.get(
+                f"{API_PREFIX}/video-export-jobs",
+                params={"page": 2, "page_size": 1},
+            )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["jobs"][0]["job_id"] == "job-oldest"
+        assert payload["page"] == 2
+        assert payload["page_size"] == 1
+        assert payload["total"] == 2
+        assert payload["total_pages"] == 2
+
     def test_active_jobs_include_youtube_upload_progress(
         self, client: TestClient, db_session, sample_flight
     ) -> None:

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -2102,6 +2102,7 @@ async def _export_video_manual_render(job_id: str):
                         phase=_STATUS_CAPTURING,
                         eta_seconds=eta_seconds_int,
                         frames_captured=frame_count,
+                        fps_actual=round(fps_actual, 1),
                     )
 
                     _update_job(

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.stories.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.stories.tsx
@@ -1,0 +1,34 @@
+import preview from '../../../../.storybook/preview';
+import { expect, within } from 'storybook/test';
+import { VideoExportJobsPanel } from './VideoExportJobsPanel';
+import {
+  defaultHandlers,
+  resetMockVideoJobs,
+} from '../../../pages/InfrastructurePage.stories.handlers';
+
+const meta = preview.meta({
+  title: 'Components/Infrastructure/Video Export Jobs',
+  component: VideoExportJobsPanel,
+  parameters: {
+    layout: 'padded',
+    msw: { handlers: defaultHandlers },
+  },
+  tags: ['autodocs'],
+});
+
+export const Default = meta.story({
+  name: 'Operational list',
+  args: { limit: null },
+  beforeEach: resetMockVideoJobs,
+});
+
+Default.test('opens logs in a modal', async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await expect(
+    canvas.getByRole('button', { name: 'Logs' })
+  ).toBeInTheDocument();
+  await canvas.getByRole('button', { name: 'Logs' }).click();
+  await expect(
+    within(document.body).getByText('Opening viewer')
+  ).toBeInTheDocument();
+});

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -112,7 +112,13 @@ vi.mock('../../../hooks/useToast', () => ({
 
 vi.mock('../../../hooks/flights/useVideoExportJobs', () => ({
   useVideoExportJobs: () => ({
-    data: jobs,
+    data: {
+      jobs,
+      page: 1,
+      pageSize: 25,
+      total: jobs.length,
+      totalPages: 1,
+    },
     isLoading: false,
     isError: false,
     refetch,
@@ -258,56 +264,42 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('CPU').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
     expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);
-    expect(screen.getAllByRole('button', { name: 'Stopper' })).toHaveLength(4);
     expect(
-      screen.getAllByRole('link', { name: 'Voir le vol' })[0]
-    ).toHaveAttribute('href', '/flights/flight-resumable');
-    expect(
-      screen.getAllByRole('button', { name: 'Télécharger' }).length
+      screen.getAllByRole('button', { name: 'Actions' }).length
     ).toBeGreaterThan(0);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
     expect(
-      screen.getAllByRole('button', { name: 'Reprendre' }).length
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByRole('button', { name: 'Supprimer' }).length
-    ).toBeGreaterThan(0);
+      screen.getByRole('menuitem', { name: 'Stopper' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Logs' })).toBeInTheDocument();
   });
 
-  it('keeps live logs collapsed by default and expands on demand', () => {
+  it('opens live logs in a readable modal on demand', () => {
     render(<VideoExportJobsPanel />);
 
     expect(screen.queryByText('Opening viewer')).not.toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
-    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Logs' }));
 
     expect(
       screen.getAllByText(/Captured 20\/100 frames/u).length
     ).toBeGreaterThan(0);
   });
 
-  it('keeps the same job logs open after a jobs refresh reorders rows', () => {
-    const { rerender } = render(<VideoExportJobsPanel />);
+  it('shows logs for the selected job', () => {
+    render(<VideoExportJobsPanel />);
 
-    fireEvent.click(
-      screen.getAllByRole('button', { name: /Logs en direct/u })[0]!
-    );
-
-    expect(
-      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
-    ).toBeGreaterThan(0);
-
-    const [activeJob, completedJob, ...remainingJobs] = jobs;
-    jobs.splice(0, jobs.length, completedJob!, ...remainingJobs, activeJob!);
-    rerender(<VideoExportJobsPanel />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Logs' }));
 
     expect(
       screen.getAllByText(/job-active Captured 20\/100 frames/u).length
     ).toBeGreaterThan(0);
+
     expect(
-      screen.queryAllByText(/job-done Captured 20\/100 frames/u)
-    ).toHaveLength(0);
+      screen.getAllByText(/job-active Captured 20\/100 frames/u).length
+    ).toBeGreaterThan(0);
   });
 
   it('filters jobs by status', () => {
@@ -324,9 +316,9 @@ describe('VideoExportJobsPanel', () => {
     cancelJob.mockResolvedValue(undefined);
 
     render(<VideoExportJobsPanel />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Stopper' })[0]!);
-    const stopButtons = screen.getAllByRole('button', { name: 'Stopper' });
-    fireEvent.click(stopButtons[stopButtons.length - 1]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Stopper' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Stopper' }));
 
     await waitFor(() => expect(cancelJob).toHaveBeenCalledWith('job-active'));
     expect(toastSuccess).toHaveBeenCalledWith('Génération stoppée');
@@ -336,7 +328,8 @@ describe('VideoExportJobsPanel', () => {
     resumeJob.mockResolvedValue(undefined);
 
     render(<VideoExportJobsPanel />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Reprendre' })[0]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[3]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reprendre' }));
 
     await waitFor(() =>
       expect(resumeJob).toHaveBeenCalledWith('job-resumable')
@@ -372,11 +365,9 @@ describe('VideoExportJobsPanel', () => {
     deleteJobRow.mockResolvedValue(undefined);
 
     render(<VideoExportJobsPanel />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Supprimer' })[0]!);
-    const deleteButtons = screen.getAllByRole('button', {
-      name: 'Supprimer',
-    });
-    fireEvent.click(deleteButtons[deleteButtons.length - 1]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Supprimer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Supprimer' }));
 
     await waitFor(() =>
       expect(deleteJobRow).toHaveBeenCalledWith(expect.any(String))
@@ -401,12 +392,9 @@ describe('VideoExportJobsPanel', () => {
     });
 
     render(<VideoExportJobsPanel />);
-    const deleteButtons = screen.getAllByRole('button', {
-      name: 'Supprimer',
-    });
-    fireEvent.click(deleteButtons[0]!);
-    const confirmButtons = screen.getAllByRole('button', { name: 'Supprimer' });
-    fireEvent.click(confirmButtons[confirmButtons.length - 1]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Actions' })[0]!);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Supprimer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Supprimer' }));
 
     await waitFor(() =>
       expect(deleteJobRow).toHaveBeenCalledWith('job-running-manual')

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unstable-nested-components */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   createColumnHelper,
@@ -10,12 +10,28 @@ import {
 } from '@tanstack/react-table';
 import { Button, DataTable, Modal } from '@dashboard-parapente/design-system';
 import {
+  Download,
+  FileText,
+  MoreHorizontal,
+  Play,
+  Square,
+  Trash2,
+} from 'lucide-react';
+import {
+  Button as AriaButton,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+} from 'react-aria-components';
+import {
   type VideoExportJob,
   useCancelVideoExportJob,
   useCleanupVideoExportTempFiles,
   useDeleteVideoExportJobRow,
   useResumeVideoExportJob,
   useVideoExportJobs,
+  VIDEO_EXPORT_JOBS_PAGE_SIZE,
 } from '../../../hooks/flights/useVideoExportJobs';
 import { useVideoExportStatus } from '../../../hooks/flights/useVideoExportStatus';
 import { useGoproOverlayJobStream } from '../../../hooks/gopro/useGoproOverlay';
@@ -78,9 +94,6 @@ const activeStatusLabels = new Set([
 ]);
 
 const columnHelper = createColumnHelper<VideoExportJob>();
-
-const actionButtonClassName =
-  'cursor-pointer rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500';
 
 type PendingVideoConfirm = {
   message: string;
@@ -170,6 +183,16 @@ function getDateLabel(job: VideoExportJob) {
     hour: '2-digit',
     minute: '2-digit',
   }).format(date);
+}
+
+function formatDuration(seconds?: number | null) {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0)
+    return '-';
+  const roundedSeconds = Math.round(seconds);
+  if (roundedSeconds < 60) return `${roundedSeconds} s`;
+  const minutes = Math.floor(roundedSeconds / 60);
+  const remainingSeconds = roundedSeconds % 60;
+  return `${minutes} min${remainingSeconds > 0 ? ` ${remainingSeconds} s` : ''}`;
 }
 
 function isJobInFilter(job: VideoExportJob, filter: StatusFilter) {
@@ -288,17 +311,6 @@ function ProgressMeter({ progress }: { progress: number }) {
   );
 }
 
-function JobModeBadge({ mode }: { mode: string }) {
-  const { t } = useTranslation();
-  const modeLabel = getModeLabelParts(mode);
-
-  return (
-    <span className="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-200">
-      {t(modeLabel.key, modeLabel.fallback)}
-    </span>
-  );
-}
-
 function JobTypeBadge({ job }: { job: VideoExportJob }) {
   const { t } = useTranslation();
   const typeLabel = getJobTypeLabelParts(job);
@@ -329,6 +341,32 @@ function JobRenderMethodBadge({ job }: { job: VideoExportJob }) {
     >
       {t(`videoJobs.method.${method}`, method.toUpperCase())}
     </span>
+  );
+}
+
+function FramesCell({ job }: { job: VideoExportJob }) {
+  const captured = job.frames_captured;
+  const total = job.total_frames ?? job.resume_from_frame;
+  if (typeof captured !== 'number' && typeof total !== 'number')
+    return <span>-</span>;
+  return (
+    <span className="whitespace-nowrap font-mono text-xs text-gray-700 dark:text-gray-200">
+      {typeof captured === 'number' ? captured : '-'}
+      {typeof total === 'number' && (
+        <span className="text-gray-500 dark:text-gray-400"> / {total}</span>
+      )}
+    </span>
+  );
+}
+
+function FpsCell({ job }: { job: VideoExportJob }) {
+  const fps = job.fps_actual ?? job.fps;
+  return typeof fps === 'number' && Number.isFinite(fps) ? (
+    <span className="whitespace-nowrap font-mono text-xs text-gray-700 dark:text-gray-200">
+      {fps.toFixed(1)} fps
+    </span>
+  ) : (
+    <span>-</span>
   );
 }
 
@@ -378,11 +416,27 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     useState<PendingVideoConfirm | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
-  const [openLogJobIds, setOpenLogJobIds] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(1);
+  const [selectedLogJob, setSelectedLogJob] = useState<VideoExportJob | null>(
+    null
+  );
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'last_activity', desc: true },
   ]);
-  const { data: jobs = [], isLoading, isError, refetch } = useVideoExportJobs();
+  const {
+    data: jobsPage,
+    isLoading,
+    isError,
+    refetch,
+  } = useVideoExportJobs({
+    page,
+    pageSize: VIDEO_EXPORT_JOBS_PAGE_SIZE,
+    statusFilter,
+    typeFilter,
+  });
+  const jobs = jobsPage?.jobs ?? [];
+  const totalJobs = jobsPage?.total ?? jobs.length;
+  const totalPages = jobsPage?.totalPages ?? 1;
   const cancelJob = useCancelVideoExportJob();
   const resumeJob = useResumeVideoExportJob();
   const deleteJobRow = useDeleteVideoExportJobRow();
@@ -400,6 +454,10 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
   const visibleJobs =
     typeof limit === 'number' ? filteredJobs.slice(0, limit) : filteredJobs;
   const isFiltering = statusFilter !== 'all' || typeFilter !== 'all';
+
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, typeFilter]);
 
   const activeCount = jobs.filter((job) => job.can_cancel).length;
   const completedCount = jobs.filter(
@@ -517,62 +575,76 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
 
   const renderJobActions = useCallback(
     (job: VideoExportJob) => (
-      <div className="flex flex-wrap gap-2">
-        {job.flight_id && (
-          <a
-            href={`/flights/${job.flight_id}`}
-            className={`${actionButtonClassName} border border-sky-200 bg-white text-sky-700 hover:bg-sky-50 focus-visible:outline-sky-500 dark:border-sky-800 dark:bg-gray-800 dark:text-sky-300 dark:hover:bg-sky-950/40`}
-          >
-            {t('videoJobs.viewFlight', 'Voir le vol')}
-          </a>
-        )}
-        {canDownloadJob(job) && (
-          <Button
-            onClick={() => void handleDownload(job)}
-            className={`${actionButtonClassName} bg-sky-100 text-sky-800 hover:bg-sky-200 focus-visible:outline-sky-500 dark:bg-sky-900/40 dark:text-sky-200 dark:hover:bg-sky-900/60`}
-          >
-            {t('videoJobs.download', 'Télécharger')}
-          </Button>
-        )}
-        {!isGoproOverlayJob(job) && job.can_resume && (
-          <Button
-            onClick={() => void handleResume(job)}
-            isDisabled={resumeJob.isPending}
-            className={`${actionButtonClassName} bg-green-100 text-green-800 hover:bg-green-200 focus-visible:outline-green-500 dark:bg-green-900/40 dark:text-green-200 dark:hover:bg-green-900/60`}
-          >
-            {resumeJob.isPending
-              ? t('videoJobs.resuming', 'Relance...')
-              : t('videoJobs.resume', 'Reprendre')}
-          </Button>
-        )}
-        {job.can_cancel && (
-          <Button
-            onClick={() => handleCancel(job)}
-            isDisabled={cancelJob.isPending}
-            className={`${actionButtonClassName} bg-red-600 text-white hover:bg-red-700 focus-visible:outline-red-500`}
-          >
-            {cancelJob.isPending
-              ? t('videoJobs.stopping', 'Arrêt...')
-              : t('videoJobs.stop', 'Stopper')}
-          </Button>
-        )}
-        {canDeleteJobRow(job) && (
-          <Button
-            onClick={() => handleDeleteJobRow(job)}
-            isDisabled={deleteJobRow.isPending}
-            className={`${actionButtonClassName} bg-gray-100 text-gray-800 hover:bg-gray-200 focus-visible:outline-gray-500 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600`}
-          >
-            {t('videoJobs.deleteRow', 'Supprimer')}
-          </Button>
-        )}
-        {!job.flight_id &&
-          !canDownloadJob(job) &&
-          !job.can_resume &&
-          !job.can_cancel &&
-          !canDeleteJobRow(job) && (
-            <span className="text-xs text-gray-400 dark:text-gray-500">-</span>
-          )}
-      </div>
+      <MenuTrigger>
+        <AriaButton
+          aria-label={t('videoJobs.table.actions', 'Actions')}
+          className="flex min-h-10 min-w-10 cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-700 transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700"
+        >
+          <MoreHorizontal className="h-5 w-5" aria-hidden="true" />
+        </AriaButton>
+        <Popover className="z-40 mt-2 w-56 rounded-xl border border-gray-200 bg-white p-1 shadow-xl dark:border-gray-700 dark:bg-gray-800">
+          <Menu className="outline-none">
+            {job.flight_id && (
+              <MenuItem
+                href={`/flights/${job.flight_id}`}
+                className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              >
+                {t('videoJobs.viewFlight', 'Voir le vol')}
+              </MenuItem>
+            )}
+            {canDownloadJob(job) && (
+              <MenuItem
+                onAction={() => void handleDownload(job)}
+                className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              >
+                <Download className="h-4 w-4" aria-hidden="true" />
+                {t('videoJobs.download', 'Télécharger')}
+              </MenuItem>
+            )}
+            {!isGoproOverlayJob(job) && job.can_resume && (
+              <MenuItem
+                onAction={() => void handleResume(job)}
+                isDisabled={resumeJob.isPending}
+                className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              >
+                <Play className="h-4 w-4" aria-hidden="true" />
+                {resumeJob.isPending
+                  ? t('videoJobs.resuming', 'Relance...')
+                  : t('videoJobs.resume', 'Reprendre')}
+              </MenuItem>
+            )}
+            {job.can_cancel && (
+              <MenuItem
+                onAction={() => handleCancel(job)}
+                isDisabled={cancelJob.isPending}
+                className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-red-700 outline-none hover:bg-red-50 focus:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-300 dark:hover:bg-red-950/40 dark:focus:bg-red-950/40"
+              >
+                <Square className="h-4 w-4" aria-hidden="true" />
+                {cancelJob.isPending
+                  ? t('videoJobs.stopping', 'Arrêt...')
+                  : t('videoJobs.stop', 'Stopper')}
+              </MenuItem>
+            )}
+            {canDeleteJobRow(job) && (
+              <MenuItem
+                onAction={() => handleDeleteJobRow(job)}
+                isDisabled={deleteJobRow.isPending}
+                className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                {t('videoJobs.deleteRow', 'Supprimer')}
+              </MenuItem>
+            )}
+            <MenuItem
+              onAction={() => setSelectedLogJob(job)}
+              className="flex min-h-10 cursor-pointer items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-700 outline-none hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:bg-gray-700"
+            >
+              <FileText className="h-4 w-4" aria-hidden="true" />
+              {t('videoJobs.liveLogs.show', 'Logs')}
+            </MenuItem>
+          </Menu>
+        </Popover>
+      </MenuTrigger>
     ),
     [
       cancelJob.isPending,
@@ -586,29 +658,6 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
     ]
   );
 
-  const toggleJobLogs = useCallback((jobId: string) => {
-    setOpenLogJobIds((current) => {
-      const next = new Set(current);
-      if (next.has(jobId)) {
-        next.delete(jobId);
-      } else {
-        next.add(jobId);
-      }
-      return next;
-    });
-  }, []);
-
-  const renderJobLogs = useCallback(
-    (job: VideoExportJob) => (
-      <JobLogsDetails
-        job={job}
-        isOpen={openLogJobIds.has(job.job_id)}
-        onToggle={() => toggleJobLogs(job.job_id)}
-      />
-    ),
-    [openLogJobIds, toggleJobLogs]
-  );
-
   const columns = useMemo(
     () => [
       columnHelper.accessor('status', {
@@ -618,7 +667,7 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       }),
       columnHelper.accessor((job) => getFlightLabel(job), {
         id: 'flight',
-        header: t('videoJobs.table.flight', 'Vol'),
+        header: t('videoJobs.table.flight', 'Nom'),
         cell: ({ row, getValue }) => (
           <div className="max-w-64">
             <p className="truncate font-semibold text-gray-900 dark:text-white">
@@ -645,14 +694,6 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
         cell: ({ row }) => <JobTypeBadge job={row.original} />,
         sortingFn: 'alphanumeric',
       }),
-      columnHelper.accessor('mode', {
-        header: t('videoJobs.table.mode', 'Mode'),
-        cell: ({ getValue }) => {
-          const mode = getValue();
-          return mode ? <JobModeBadge mode={mode} /> : <span>-</span>;
-        },
-        sortingFn: 'alphanumeric',
-      }),
       columnHelper.accessor('render_method', {
         header: t('videoJobs.table.method', 'Méthode'),
         cell: ({ row }) => <JobRenderMethodBadge job={row.original} />,
@@ -664,18 +705,6 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
         cell: ({ getValue }) => <ProgressMeter progress={getValue()} />,
         sortingFn: 'basic',
       }),
-      columnHelper.accessor((job) => getJobPhase(job), {
-        id: 'phase',
-        header: t('videoJobs.table.phase', 'Phase'),
-        cell: ({ getValue }) => {
-          const phase = getValue();
-          return t(
-            `videoJobs.status.${phase}`,
-            statusLabelFallbacks[phase] || phase
-          );
-        },
-        sortingFn: 'alphanumeric',
-      }),
       columnHelper.accessor((job) => getLastActivityTime(job), {
         id: 'last_activity',
         header: t('videoJobs.table.lastActivity', 'Dernière activité'),
@@ -685,39 +714,31 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
       columnHelper.display({
         id: 'frames',
         header: t('videoJobs.table.frames', 'Frames'),
-        cell: ({ row }) => {
-          const { frames_captured: frames, resume_from_frame: resumeFrom } =
-            row.original;
-          if (typeof frames !== 'number' && typeof resumeFrom !== 'number') {
-            return <span>-</span>;
-          }
-          return (
-            <span className="text-gray-700 dark:text-gray-200">
-              {typeof frames === 'number' ? frames : '-'}
-              {typeof resumeFrom === 'number' && (
-                <span className="text-gray-500 dark:text-gray-400">
-                  {' '}
-                  / {resumeFrom}
-                </span>
-              )}
-            </span>
-          );
-        },
+        cell: ({ row }) => <FramesCell job={row.original} />,
+      }),
+      columnHelper.display({
+        id: 'fps',
+        header: t('videoJobs.table.fps', 'Frame / seconde'),
+        cell: ({ row }) => <FpsCell job={row.original} />,
+      }),
+      columnHelper.display({
+        id: 'eta',
+        header: t('videoJobs.table.eta', 'Temps restant'),
+        cell: ({ row }) => (
+          <span className="whitespace-nowrap text-xs text-gray-700 dark:text-gray-200">
+            {row.original.status === 'completed'
+              ? t('videoJobs.done', 'Terminé')
+              : formatDuration(row.original.eta_seconds)}
+          </span>
+        ),
       }),
       columnHelper.display({
         id: 'actions',
         header: t('videoJobs.table.actions', 'Actions'),
         cell: ({ row }) => renderJobActions(row.original),
       }),
-      columnHelper.display({
-        id: 'logs',
-        header: t('videoJobs.table.logs', 'Logs'),
-        cell: ({ row }) => (
-          <div className="min-w-72">{renderJobLogs(row.original)}</div>
-        ),
-      }),
     ],
-    [renderJobActions, renderJobLogs, t]
+    [renderJobActions, t]
   );
 
   const table = useReactTable({
@@ -870,11 +891,16 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
           </div>
           <div className="flex flex-col gap-2 text-sm text-gray-600 dark:text-gray-300 sm:flex-row sm:items-center sm:justify-between">
             <span>
-              {isFiltering || visibleJobs.length !== jobs.length
+              {isFiltering || visibleJobs.length !== totalJobs || totalPages > 1
                 ? t(
                     'videoJobs.filteredSummary',
-                    '{{visible}} génération(s) affichée(s) sur {{total}}',
-                    { visible: visibleJobs.length, total: jobs.length }
+                    '{{visible}} génération(s) affichée(s) sur {{total}} · page {{page}}/{{pages}}',
+                    {
+                      visible: visibleJobs.length,
+                      total: totalJobs,
+                      page,
+                      pages: totalPages,
+                    }
                   )
                 : t(
                     'videoJobs.visibleSummary',
@@ -978,11 +1004,71 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                     </div>
                   </div>
 
-                  {renderJobLogs(job)}
+                  <div className="mt-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+                    <div className="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-900/50">
+                      <div className="text-gray-500 dark:text-gray-400">
+                        {t('videoJobs.table.method', 'Méthode')}
+                      </div>
+                      <div className="mt-0.5 font-semibold text-gray-800 dark:text-gray-100">
+                        {job.render_method?.toUpperCase() || '-'}
+                      </div>
+                    </div>
+                    <div className="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-900/50">
+                      <div className="text-gray-500 dark:text-gray-400">
+                        {t('videoJobs.table.frames', 'Frames')}
+                      </div>
+                      <div className="mt-0.5 font-mono font-semibold text-gray-800 dark:text-gray-100">
+                        <FramesCell job={job} />
+                      </div>
+                    </div>
+                    <div className="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-900/50">
+                      <div className="text-gray-500 dark:text-gray-400">
+                        {t('videoJobs.table.fps', 'Frame / seconde')}
+                      </div>
+                      <div className="mt-0.5 font-semibold text-gray-800 dark:text-gray-100">
+                        <FpsCell job={job} />
+                      </div>
+                    </div>
+                    <div className="rounded-lg bg-gray-50 px-3 py-2 dark:bg-gray-900/50">
+                      <div className="text-gray-500 dark:text-gray-400">
+                        {t('videoJobs.table.eta', 'Temps restant')}
+                      </div>
+                      <div className="mt-0.5 font-semibold text-gray-800 dark:text-gray-100">
+                        {formatDuration(job.eta_seconds)}
+                      </div>
+                    </div>
+                  </div>
                 </article>
               );
             })}
           </div>
+          {limit === null && totalPages > 1 && (
+            <nav
+              aria-label={t('videoJobs.pagination.label', 'Pagination')}
+              className="flex items-center justify-between border-t border-gray-100 px-4 py-3 dark:border-gray-700"
+            >
+              <Button
+                isDisabled={page === 1 || isLoading}
+                onClick={() => setPage((currentPage) => currentPage - 1)}
+                className="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100"
+              >
+                {t('videoJobs.pagination.previous', 'Précédente')}
+              </Button>
+              <span className="text-sm font-medium text-gray-600 dark:text-gray-300">
+                {t('videoJobs.pagination.page', 'Page {{page}} sur {{pages}}', {
+                  page,
+                  pages: totalPages,
+                })}
+              </span>
+              <Button
+                isDisabled={page >= totalPages || isLoading}
+                onClick={() => setPage((currentPage) => currentPage + 1)}
+                className="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-gray-100"
+              >
+                {t('videoJobs.pagination.next', 'Suivante')}
+              </Button>
+            </nav>
+          )}
         </>
       )}
       <Modal
@@ -1016,6 +1102,24 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
               </Button>
             </div>
           </div>
+        )}
+      </Modal>
+      <Modal
+        isOpen={selectedLogJob !== null}
+        onClose={() => setSelectedLogJob(null)}
+        title={
+          selectedLogJob
+            ? `${t('videoJobs.liveLogs.title', 'Logs')} — ${getFlightLabel(selectedLogJob)}`
+            : t('videoJobs.liveLogs.title', 'Logs')
+        }
+        size="lg"
+      >
+        {selectedLogJob && (
+          <JobLogsDetails
+            job={selectedLogJob}
+            isOpen
+            onToggle={() => setSelectedLogJob(null)}
+          />
         )}
       </Modal>
     </section>

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
@@ -72,9 +72,9 @@ function createWrapper() {
 }
 
 function TestHarness() {
-  const { data = [] } = useVideoExportJobs();
+  const { data } = useVideoExportJobs();
 
-  return <div>{data.map((job) => job.job_id).join(',')}</div>;
+  return <div>{data?.jobs.map((job) => job.job_id).join(',')}</div>;
 }
 
 describe('useVideoExportJobs', () => {

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -15,6 +15,10 @@ export type VideoExportJob = {
   status: string;
   internal_status?: string | null;
   progress?: number | null;
+  total_frames?: number | null;
+  fps?: number | null;
+  fps_actual?: number | null;
+  eta_seconds?: number | null;
   message?: string | null;
   error?: string | null;
   render_method?: 'cpu' | 'gpu' | null;
@@ -36,8 +40,27 @@ export type VideoExportJob = {
   can_delete: boolean;
 };
 
+export const VIDEO_EXPORT_JOBS_PAGE_SIZE = 25;
+
+export type VideoExportJobsPage = {
+  jobs: VideoExportJob[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
 type VideoExportJobsResponse = {
   jobs: VideoExportJob[];
+  page?: number;
+  page_size?: number;
+  total?: number;
+  total_pages?: number;
+};
+
+export type VideoExportJobsFilters = {
+  statusFilter?: string;
+  typeFilter?: string;
 };
 
 export type VideoExportTempCleanupResult = {
@@ -50,9 +73,7 @@ export type VideoExportTempCleanupResult = {
 
 const videoExportJobsQueryKey = ['video-export-jobs'];
 
-function toVideoExportJobsResponse(
-  value: unknown
-): VideoExportJobsResponse | null {
+function toVideoExportJobsResponse(value: unknown): VideoExportJobsPage | null {
   if (!value || typeof value !== 'object' || !('jobs' in value)) {
     return null;
   }
@@ -62,23 +83,50 @@ function toVideoExportJobsResponse(
     return null;
   }
 
-  return { jobs: jobs as VideoExportJob[] };
+  const response = value as Partial<VideoExportJobsResponse>;
+  const page = response.page ?? 1;
+  const pageSize = response.page_size ?? VIDEO_EXPORT_JOBS_PAGE_SIZE;
+  const total = response.total ?? jobs.length;
+  return {
+    jobs: jobs as VideoExportJob[],
+    page,
+    pageSize,
+    total,
+    totalPages: response.total_pages ?? Math.max(1, Math.ceil(total / pageSize)),
+  };
 }
 
-export const videoExportJobsQueryOptions = () =>
-  queryOptions<VideoExportJob[]>({
-    queryKey: videoExportJobsQueryKey,
+export const videoExportJobsQueryOptions = ({
+  page = 1,
+  pageSize = VIDEO_EXPORT_JOBS_PAGE_SIZE,
+  statusFilter = 'all',
+  typeFilter = 'all',
+}: { page?: number; pageSize?: number } & VideoExportJobsFilters = {}) =>
+  queryOptions<VideoExportJobsPage>({
+    queryKey: [...videoExportJobsQueryKey, page, pageSize],
     queryFn: async () => {
       const data = await api
-        .get('video-export-jobs')
+        .get('video-export-jobs', {
+          searchParams: {
+            page: String(page),
+            page_size: String(pageSize),
+            status_filter: statusFilter,
+            type_filter: typeFilter,
+          },
+        })
         .json<VideoExportJobsResponse>();
-      return data.jobs;
+      return toVideoExportJobsResponse(data) as VideoExportJobsPage;
     },
   });
 
-export function useVideoExportJobs() {
+export function useVideoExportJobs({
+  page = 1,
+  pageSize = VIDEO_EXPORT_JOBS_PAGE_SIZE,
+  statusFilter = 'all',
+  typeFilter = 'all',
+}: { page?: number; pageSize?: number } & VideoExportJobsFilters = {}) {
   const queryClient = useQueryClient();
-  const query = useQuery(videoExportJobsQueryOptions());
+  const query = useQuery(videoExportJobsQueryOptions({ page, pageSize }));
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -89,6 +137,10 @@ export function useVideoExportJobs() {
       '/api/video-export-jobs/stream',
       window.location.origin
     );
+    streamUrl.searchParams.set('page', String(page));
+    streamUrl.searchParams.set('page_size', String(pageSize));
+    streamUrl.searchParams.set('status_filter', statusFilter);
+    streamUrl.searchParams.set('type_filter', typeFilter);
     const eventSource = new EventSource(streamUrl.toString(), {
       withCredentials: true,
     });
@@ -107,7 +159,10 @@ export function useVideoExportJobs() {
         return;
       }
 
-      queryClient.setQueryData(videoExportJobsQueryKey, data.jobs);
+      queryClient.setQueryData(
+        [...videoExportJobsQueryKey, page, pageSize],
+        data
+      );
     };
 
     eventSource.addEventListener('jobs', handleJobsEvent);
@@ -116,7 +171,7 @@ export function useVideoExportJobs() {
       eventSource.removeEventListener('jobs', handleJobsEvent);
       eventSource.close();
     };
-  }, [queryClient]);
+  }, [page, pageSize, queryClient, statusFilter, typeFilter]);
 
   return query;
 }

--- a/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.handlers.ts
@@ -144,10 +144,20 @@ const initialMockVideoJobs: VideoExportJob[] = [
     status: 'processing',
     internal_status: 'encoding',
     progress: 68,
+    total_frames: 4200,
+    frames_captured: 2856,
+    fps: 15,
+    fps_actual: 12.4,
+    eta_seconds: 108,
     message: 'Encoding 68%',
+    render_method: 'gpu',
     mode: 'manual_fast',
     started_at: '2026-01-15T09:15:00Z',
     updated_at: '2026-01-15T10:05:00Z',
+    log_tail: [
+      '[2026-01-15T10:04:10Z] Capture completed: 2856/4200 frames',
+      '[2026-01-15T10:05:00Z] Encoding 68% (12.4 fps, ETA: 1min)',
+    ],
     can_cancel: true,
     can_delete: true,
   },
@@ -191,7 +201,7 @@ const mockVideoJobs: VideoExportJob[] = initialMockVideoJobs.map((job) => ({
   ...job,
 }));
 
-const resetMockVideoJobs = () => {
+export const resetMockVideoJobs = () => {
   mockVideoJobs.length = 0;
   mockVideoJobs.push(...initialMockVideoJobs.map((job) => ({ ...job })));
 };
@@ -424,7 +434,15 @@ export const videoExportHandlers = [
   http.get('*/api/video-export-jobs', () =>
     HttpResponse.json({
       jobs: mockVideoJobs,
+      page: 1,
+      page_size: 25,
+      total: 26,
+      total_pages: 2,
     })
+  ),
+  http.get(
+    '*/api/video-export-jobs/stream',
+    () => new HttpResponse(null, { status: 204 })
   ),
 
   http.delete('*/api/exports/:jobId/cancel', ({ params }) => {

--- a/apps/frontend/src/pages/InfrastructurePage.stories.tsx
+++ b/apps/frontend/src/pages/InfrastructurePage.stories.tsx
@@ -1,6 +1,7 @@
 import preview from '../../.storybook/preview';
 import { expect, within } from 'storybook/test';
 import InfrastructurePage from './InfrastructurePage';
+import { validateInfrastructureSearch } from '../routes/infrastructure';
 import {
   defaultHandlers,
   intervalsNoActivityTypesHandlers,
@@ -26,6 +27,23 @@ const meta = preview.meta({
 export const Default = meta.story({
   name: 'Default',
   beforeEach: resetCacheDb,
+});
+
+export const VideoExports = meta.story({
+  name: 'Video Exports',
+  beforeEach: resetCacheDb,
+  parameters: {
+    router: {
+      initialPath: '/infrastructure/video-exports',
+      routes: [
+        {
+          path: '/infrastructure/$tab',
+          element: 'story',
+          validateSearch: validateInfrastructureSearch,
+        },
+      ],
+    },
+  },
 });
 
 export const AwaitingActivityType = meta.story({


### PR DESCRIPTION
## Résumé
- ajoute la pagination côté serveur des exportations vidéo
- déplace les filtres statut/type côté API
- améliore la table, les actions regroupées et la consultation des logs
- ajoute les stories et la capture Storybook

## Validation
- tests frontend ciblés : 13/13
- tests backend ciblés : 7/7
- build frontend : OK
- Ruff backend : OK

Capture : `.codenomad/storybook-previews/video-export-jobs-pagination.png`

Note : CodeRabbit a identifié 3 remarques, corrigées localement ; une nouvelle exécution a été bloquée par la limite de revue du compte.