### PR TITLE
fix: show zero fps for finished video jobs

### DIFF
--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -267,6 +267,7 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getAllByText('CPU').length).toBeGreaterThan(0);
     expect(screen.getAllByText('42%').length).toBeGreaterThan(0);
     expect(screen.getAllByText('12.4 fps').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('0.0 fps').length).toBeGreaterThan(0);
     expect(screen.queryByText('30.0 fps')).not.toBeInTheDocument();
     expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);
     expect(

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -369,7 +369,11 @@ function isActiveJob(job: VideoExportJob) {
 
 function FpsCell({ job }: { job: VideoExportJob }) {
   if (!isActiveJob(job)) {
-    return <span>-</span>;
+    return (
+      <span className="whitespace-nowrap font-mono text-xs text-gray-500 dark:text-gray-400">
+        0.0 fps
+      </span>
+    );
   }
   const fps = job.fps_actual ?? job.fps;
   return typeof fps === 'number' && Number.isFinite(fps) ? (


### PR DESCRIPTION
Les FPS représentent la vitesse de traitement en cours.

Cette PR affiche `0.0 fps` pour les jobs terminés, échoués ou annulés, tout en conservant la vitesse réelle pour les jobs actifs.

Validation : tests frontend ciblés 12/12.