### PR TITLE
fix: show zero fps for queued video jobs

### DIFF
--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -234,6 +234,15 @@ describe('VideoExportJobsPanel', () => {
         can_resume: true,
       },
       {
+        job_id: 'job-queued',
+        flight_title: 'Vol en attente',
+        status: 'queued',
+        progress: 0,
+        fps: 15,
+        can_cancel: true,
+        can_delete: true,
+      },
+      {
         job_id: 'job-overlay-done',
         flight_name: 'Nom du vol overlay terminé',
         flight_title: 'final.mp4',

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -360,11 +360,7 @@ function FramesCell({ job }: { job: VideoExportJob }) {
 }
 
 function isActiveJob(job: VideoExportJob) {
-  return (
-    job.can_cancel ||
-    activeStatusLabels.has(job.internal_status || job.status) ||
-    ['queued', 'running', 'processing'].includes(job.status)
-  );
+  return activeStatusLabels.has(job.internal_status || job.status);
 }
 
 function FpsCell({ job }: { job: VideoExportJob }) {


### PR DESCRIPTION
Les jobs en attente ne sont pas encore en traitement : ils doivent afficher `0.0 fps`, comme les jobs terminés, échoués ou annulés.

Seuls les états de traitement réel affichent la vitesse FPS mesurée.

Validation : tests frontend ciblés 12/12.