### PR TITLE
fix(ui): surface stalled media jobs

### DIFF
--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -4760,6 +4760,7 @@ def _highlight_job_payload(job: HighlightVideoJob) -> HighlightVideoJobResponse:
         overlay_offset_seconds=float(job.overlay_offset_seconds or 0.0),
         selection=selection,
         created_at=job.created_at,
+        updated_at=job.updated_at,
         completed_at=job.completed_at,
     )
 

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -207,6 +207,7 @@ class HighlightVideoJobResponse(BaseModel):
     overlay_offset_seconds: float
     selection: list[HighlightVideoClipResponse] = Field(default_factory=list)
     created_at: datetime
+    updated_at: datetime
     completed_at: datetime | None = None
 
 

--- a/apps/backend/youtube_upload.py
+++ b/apps/backend/youtube_upload.py
@@ -252,6 +252,7 @@ def job_payload(job: YoutubeUploadJob) -> dict[str, Any]:
         "progress": job.progress or 0,
         "youtube_url": job.youtube_url,
         "error": job.error,
+        "updated_at": job.updated_at,
         "log_tail": _job_log_tail(job.id),
     }
 

--- a/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
+++ b/apps/frontend/src/components/flights/details/FlightGenerationLogsPanel.tsx
@@ -3,7 +3,7 @@ import {
   type HighlightVideoJob,
 } from '@dashboard-parapente/shared-types';
 import { ChevronDown } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { VideoExportStatusPayload } from '../../../hooks/flights/useVideoExportStatus';
 import type { YoutubeUploadJob } from '../../../hooks/flights/useYoutubeUpload';
@@ -33,8 +33,31 @@ type LogSourceCardProps = {
   progress?: number | null;
   message?: string | null;
   error?: string | null;
+  updatedAt?: string | null;
   logs?: string[] | null;
 };
+
+const STALLED_JOB_THRESHOLD_MS = 5 * 60 * 1000;
+
+function getStalledJobMinutes(
+  status: string | null,
+  updatedAt?: string | null,
+  now = Date.now()
+): number | null {
+  if (
+    !status ||
+    ['queued', 'cancelled', 'completed', 'failed'].includes(status)
+  ) {
+    return null;
+  }
+  if (!updatedAt) return null;
+  const lastActivity = new Date(updatedAt).getTime();
+  if (!Number.isFinite(lastActivity)) return null;
+  const elapsedMs = now - lastActivity;
+  if (elapsedMs < STALLED_JOB_THRESHOLD_MS) return null;
+  const minutes = Math.max(1, Math.floor(elapsedMs / 60000));
+  return minutes;
+}
 
 function clampProgress(progress?: number | null) {
   if (typeof progress !== 'number' || !Number.isFinite(progress)) {
@@ -69,6 +92,7 @@ function LogSourceCard({
   progress,
   message,
   error,
+  updatedAt,
   logs,
 }: LogSourceCardProps) {
   const { t } = useTranslation();
@@ -84,6 +108,16 @@ function LogSourceCard({
   const isLive = Boolean(
     status && !['cancelled', 'completed', 'failed'].includes(status)
   );
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!isLive) return;
+
+    const interval = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(interval);
+  }, [isLive]);
+
+  const stalledJobMinutes = getStalledJobMinutes(status, updatedAt, now);
   const renderMethodLabel =
     renderMethod && ['cpu', 'gpu'].includes(renderMethod)
       ? t(`flights.generationLogs.method.${renderMethod}`)
@@ -158,6 +192,14 @@ function LogSourceCard({
               <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono leading-relaxed">
                 {error}
               </pre>
+            </div>
+          )}
+
+          {stalledJobMinutes && !error && (
+            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-2 text-xs font-medium text-red-800 dark:border-red-900 dark:bg-red-950/30 dark:text-red-100">
+              {t('flights.generationLogs.stalled', {
+                minutes: stalledJobMinutes,
+              })}
             </div>
           )}
 
@@ -245,6 +287,7 @@ export function FlightGenerationLogsPanel({
             progress={videoStatus?.progress ?? videoFallbackProgress}
             message={videoStatus?.message}
             error={videoStatus?.error}
+            updatedAt={videoStatus?.updated_at}
             logs={videoStatus?.log_tail}
           />
         )}
@@ -253,7 +296,8 @@ export function FlightGenerationLogsPanel({
             key={`gopro-${goproOverlayJob?.job_id ?? goproOverlayJobId ?? 'fallback'}`}
             title={t('flights.generationLogs.goproOverlayTitle')}
             renderMethod={
-              goproOverlayJob && ['running', 'completed', 'failed', 'cancelled'].includes(
+              goproOverlayJob &&
+              ['running', 'completed', 'failed', 'cancelled'].includes(
                 goproOverlayJob.status
               )
                 ? (goproOverlayJob.render_method ?? null)
@@ -269,6 +313,7 @@ export function FlightGenerationLogsPanel({
             progress={goproOverlayJob?.progress ?? goproOverlayFallbackProgress}
             message={goproOverlayJob?.message}
             error={goproOverlayJob?.error}
+            updatedAt={goproOverlayJob?.updated_at}
             logs={goproOverlayJob?.log_tail}
           />
         )}
@@ -285,6 +330,7 @@ export function FlightGenerationLogsPanel({
             )}
             progress={youtubeUploadJob.progress}
             error={youtubeUploadJob.error}
+            updatedAt={youtubeUploadJob.updated_at}
             logs={youtubeUploadJob.log_tail}
           />
         )}
@@ -300,6 +346,7 @@ export function FlightGenerationLogsPanel({
             progress={highlightVideo.progress}
             message={highlightVideo.message}
             error={highlightVideo.error}
+            updatedAt={highlightVideo.updated_at}
           />
         )}
       </div>

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -289,6 +289,27 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getByRole('menuitem', { name: 'Logs' })).toBeInTheDocument();
   });
 
+  it('shows a stuck warning when an active job has not updated recently', () => {
+    jobs.push({
+      job_id: 'job-stuck',
+      flight_title: 'Vol bloqué',
+      status: 'processing',
+      internal_status: 'capturing',
+      progress: 0,
+      updated_at: '2020-01-01T00:00:00.000Z',
+      can_cancel: true,
+      can_delete: true,
+    });
+
+    render(<VideoExportJobsPanel limit={null} />);
+
+    expect(screen.getAllByText('Bloqué').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Aucune progression depuis .* Le traitement semble bloqué/u)
+        .length
+    ).toBeGreaterThan(0);
+  });
+
   it('opens live logs in a readable modal on demand', () => {
     render(<VideoExportJobsPanel />);
 

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -92,6 +92,7 @@ const activeStatusLabels = new Set([
   'encoding',
   'processing',
 ]);
+const STALLED_JOB_THRESHOLD_MS = 5 * 60 * 1000;
 
 const columnHelper = createColumnHelper<VideoExportJob>();
 
@@ -159,6 +160,17 @@ function getLastActivityTime(job: VideoExportJob) {
 
   const time = new Date(rawDate).getTime();
   return Number.isNaN(time) ? 0 : time;
+}
+
+function getStalledJobMinutes(job: VideoExportJob): number | null {
+  const phase = getJobPhase(job);
+  if (!activeStatusLabels.has(phase) || !job.updated_at) return null;
+  const lastActivity = new Date(job.updated_at).getTime();
+  if (!Number.isFinite(lastActivity)) return null;
+  const elapsedMs = Date.now() - lastActivity;
+  return elapsedMs >= STALLED_JOB_THRESHOLD_MS
+    ? Math.max(1, Math.floor(elapsedMs / 60000))
+    : null;
 }
 
 function getDateLabel(job: VideoExportJob) {
@@ -280,8 +292,11 @@ function canDeleteJobRow(job: VideoExportJob) {
 function JobStatusBadge({ job }: { job: VideoExportJob }) {
   const { t } = useTranslation();
   const phase = getJobPhase(job);
+  const stalled = getStalledJobMinutes(job) !== null;
   const statusLabel = getStatusLabelParts(job);
   const statusClassName =
+    (stalled &&
+      'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300') ||
     statusClassNames[job.status] ||
     statusClassNames[phase] ||
     statusClassNames.processing;
@@ -290,7 +305,9 @@ function JobStatusBadge({ job }: { job: VideoExportJob }) {
     <span
       className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${statusClassName}`}
     >
-      {t(statusLabel.key, statusLabel.fallback)}
+      {stalled
+        ? t('videoJobs.status.stalled', 'Bloqué')
+        : t(statusLabel.key, statusLabel.fallback)}
     </span>
   );
 }
@@ -984,6 +1001,17 @@ export function VideoExportJobsPanel({ limit = 6 }: { limit?: number | null }) {
                       <h3 className="mt-2 truncate text-sm font-semibold text-gray-900 dark:text-white">
                         {getFlightLabel(job)}
                       </h3>
+                      {getStalledJobMinutes(job) !== null && !job.error && (
+                        <p className="mt-1 text-sm font-medium text-red-600 dark:text-red-300">
+                          {t(
+                            'videoJobs.stalled',
+                            'Aucune progression depuis {{minutes}} min. Le traitement semble bloqué.',
+                            {
+                              minutes: getStalledJobMinutes(job),
+                            }
+                          )}
+                        </p>
+                      )}
                       {(job.message || job.error) && (
                         <p
                           className={`mt-1 text-sm ${

--- a/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportStatus.ts
@@ -20,6 +20,7 @@ export type VideoExportStatusPayload = {
   progress?: number;
   message?: string | null;
   error?: string | null;
+  updated_at?: string | null;
   eta_seconds?: number;
   can_resume?: boolean;
   frames_captured?: number;
@@ -69,6 +70,7 @@ export const toStatusPayload = (
     progress: typeof value.progress === 'number' ? value.progress : undefined,
     message: typeof value.message === 'string' ? value.message : null,
     error: typeof value.error === 'string' ? value.error : null,
+    updated_at: typeof value.updated_at === 'string' ? value.updated_at : null,
     eta_seconds:
       typeof value.eta_seconds === 'number'
         ? Math.max(0, value.eta_seconds)

--- a/apps/frontend/src/hooks/flights/useYoutubeUpload.ts
+++ b/apps/frontend/src/hooks/flights/useYoutubeUpload.ts
@@ -20,6 +20,7 @@ export interface YoutubeUploadJob {
   progress: number;
   youtube_url?: string | null;
   error?: string | null;
+  updated_at?: string | null;
   log_tail: string[];
 }
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -86,6 +86,7 @@
     "cleanupPartialError": "{{count}} item(s) deleted, but some files could not be removed",
     "cleanupError": "Unable to delete temporary files",
     "loadError": "Unable to load video generations",
+    "stalled": "No progress for {{minutes}} min. The job appears to be stuck.",
     "empty": "No video generation yet.",
     "confirmDeleteRow": "Delete this row and its temporary files?",
     "deleteRow": "Delete",
@@ -135,6 +136,7 @@
       "processing": "In progress",
       "completed": "Completed",
       "failed": "Error",
+      "stalled": "Stuck",
       "cancelled": "Cancelled"
     }
   },
@@ -603,6 +605,7 @@
       "loadError": "Error loading weather sources",
       "active": "Active",
       "error": "Error",
+      "stalled": "No progress for {{minutes}} min. The job appears to be stuck. You can stop it and retry.",
       "disabled": "Disabled",
       "untested": "Untested",
       "cannotDisableLast": "Cannot disable the last active source. At least one source must remain active.",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -86,6 +86,7 @@
     "cleanupPartialError": "{{count}} élément(s) supprimé(s), mais certains fichiers n’ont pas pu être supprimés",
     "cleanupError": "Impossible de supprimer les fichiers temporaires",
     "loadError": "Impossible de charger les générations vidéo",
+    "stalled": "Aucune progression depuis {{minutes}} min. Le traitement semble bloqué.",
     "empty": "Aucune génération vidéo pour le moment.",
     "confirmDeleteRow": "Supprimer cette ligne et ses fichiers temporaires ?",
     "deleteRow": "Supprimer",
@@ -135,6 +136,7 @@
       "processing": "En cours",
       "completed": "Terminé",
       "failed": "Erreur",
+      "stalled": "Bloqué",
       "cancelled": "Annulé"
     }
   },
@@ -603,6 +605,7 @@
       "loadError": "Erreur lors du chargement des sources météo",
       "active": "Actif",
       "error": "Erreur",
+      "stalled": "Aucune progression depuis {{minutes}} min. Le traitement semble bloqué. Vous pouvez l’arrêter et le relancer.",
       "disabled": "Désactivé",
       "untested": "Non testé",
       "cannotDisableLast": "Impossible de désactiver la dernière source active. Au moins une source doit rester activée.",

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -109,6 +109,7 @@ export const HighlightVideoJobSchema = z.object({
   overlay_offset_seconds: z.number(),
   selection: z.array(HighlightVideoClipSchema).default([]),
   created_at: z.string(),
+  updated_at: z.string().nullish(),
   completed_at: z.string().nullish(),
 });
 


### PR DESCRIPTION
## Résumé
- expose `updated_at` pour les jobs vidéo, GoPro, highlights et YouTube
- affiche un avertissement explicite quand un job actif n'a plus progressé depuis 5 minutes
- ajoute une horloge périodique pour détecter le blocage même si le SSE reste silencieux
- couvre le badge et le message de job bloqué par un test ciblé

## Validation
- VideoExportJobsPanel : 13/13 tests
- frontend type-check : OK
- compilation Python ciblée : OK
- CodeRabbit : 0 finding

Le hook pre-commit local n'a pas pu s'exécuter car `apps/backend/.venv/bin/ruff` est absent ; Ruff exécuté séparément : OK. Le lint global conserve des erreurs préexistantes hors de cette modification.