### PR TITLE
fix(frontend): order flight media cards and tags

### DIFF
--- a/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
+++ b/apps/frontend/src/components/flights/details/FlightMediaBadges.tsx
@@ -97,7 +97,7 @@ export function FlightMediaBadges({
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
-        <div className="overflow-hidden rounded-xl border border-emerald-200 bg-white shadow-sm dark:border-emerald-800 dark:bg-slate-900/60">
+        <div className="order-1 overflow-hidden rounded-xl border border-emerald-200 bg-white shadow-sm dark:border-emerald-800 dark:bg-slate-900/60">
           {hasGpx && <FlightGpxThumbnail flightId={flightId} />}
           {!hasGpx && (
             <div className="flex aspect-video items-center justify-center bg-emerald-50/70 p-6 text-center dark:bg-emerald-950/20">
@@ -143,7 +143,7 @@ export function FlightMediaBadges({
             </Button>
           </div>
         </div>
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="order-3 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
           {hasGoproCameraVideo ? (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/gopro-camera/thumbnail`}
@@ -173,7 +173,7 @@ export function FlightMediaBadges({
             </span>
           </div>
         </div>
-        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+        <div className="order-2 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
           {hasVideo && (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/video/thumbnail`}
@@ -268,7 +268,7 @@ export function FlightMediaBadges({
             </div>
           </div>
         </div>
-        <div className="overflow-hidden rounded-xl border border-violet-200 bg-white shadow-sm dark:border-violet-800 dark:bg-slate-900/60">
+        <div className="order-4 overflow-hidden rounded-xl border border-violet-200 bg-white shadow-sm dark:border-violet-800 dark:bg-slate-900/60">
           {hasPanoVideo ? (
             <FlightMediaThumbnail
               path={`/flights/${flightId}/pano/thumbnail`}
@@ -306,7 +306,7 @@ export function FlightMediaBadges({
           </div>
         </div>
         {showPersistedOverlayBadge && (
-          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
+          <div className="order-5 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900/60">
             <FlightMediaThumbnail
               path={`/flights/${flightId}/gopro-overlay/thumbnail`}
               videoPath={`/flights/${flightId}/gopro-overlay`}

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobStack.tsx
@@ -40,7 +40,7 @@ export function GoproOverlayJobStack({
 
   return (
     <div
-      className={`min-w-0 ${isExpanded ? 'sm:col-span-2 2xl:col-span-3' : ''}`}
+      className={`order-5 min-w-0 ${isExpanded ? 'sm:col-span-2 2xl:col-span-3' : ''}`}
     >
       {isCollapsed ? (
         <button

--- a/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
@@ -51,7 +51,7 @@ export function HighlightVideoJobCard({
   return (
     <div
       aria-disabled={isGenerationLocked}
-      className={`overflow-hidden rounded-xl border bg-white shadow-sm dark:bg-slate-900/60 ${
+      className={`order-6 overflow-hidden rounded-xl border bg-white shadow-sm dark:bg-slate-900/60 ${
         isGenerationLocked
           ? 'border-slate-300 opacity-75 dark:border-slate-700'
           : 'border-violet-200 dark:border-violet-800'

--- a/apps/frontend/src/components/flights/table/Flight.test.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.test.tsx
@@ -122,6 +122,8 @@ test('renders available media badges in the expected order', () => {
         has_video: true,
         has_camera: true,
         has_gopro_overlay: true,
+        has_pano_video: true,
+        has_highlight_video: true,
         has_youtube_video: true,
       }}
       isActive={false}
@@ -136,7 +138,9 @@ test('renders available media badges in the expected order', () => {
     'flights.gpxBadge',
     'flights.videoBadge',
     'flights.cameraBadge',
+    'flights.panoBadge',
     'flights.goproOverlayBadge',
+    'flights.highlightVideoBadge',
     'flights.youtubeBadge',
   ].map((label) => screen.getByText(label));
 

--- a/apps/frontend/src/components/flights/table/Flight.tsx
+++ b/apps/frontend/src/components/flights/table/Flight.tsx
@@ -198,10 +198,22 @@ export function Flight({
                   {t('flights.cameraBadge')}
                 </span>
               )}
+              {hasPanoVideo && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-200">
+                  <Orbit className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.panoBadge')}
+                </span>
+              )}
               {hasCompletedGoproOverlay && (
                 <span className="inline-flex items-center gap-1 rounded-full border border-cyan-200 bg-cyan-50 px-2 py-0.5 text-[11px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-200">
                   <Wand2 className="h-3 w-3" aria-hidden="true" />
                   {t('flights.goproOverlayBadge')}
+                </span>
+              )}
+              {hasHighlightVideo && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-50 px-2 py-0.5 text-[11px] font-medium text-fuchsia-800 dark:border-fuchsia-800 dark:bg-fuchsia-950/40 dark:text-fuchsia-200">
+                  <Wand2 className="h-3 w-3" aria-hidden="true" />
+                  {t('flights.highlightVideoBadge')}
                 </span>
               )}
               {(hasYoutubeVideo || isYoutubeUploadRunning) && (
@@ -211,18 +223,6 @@ export function Flight({
                 >
                   <Play className="h-3 w-3" aria-hidden="true" />
                   {youtubeLabel}
-                </span>
-              )}
-              {hasPanoVideo && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-violet-200 bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-200">
-                  <Orbit className="h-3 w-3" aria-hidden="true" />
-                  {t('flights.panoBadge')}
-                </span>
-              )}
-              {hasHighlightVideo && (
-                <span className="inline-flex items-center gap-1 rounded-full border border-fuchsia-200 bg-fuchsia-50 px-2 py-0.5 text-[11px] font-medium text-fuchsia-800 dark:border-fuchsia-800 dark:bg-fuchsia-950/40 dark:text-fuchsia-200">
-                  <Wand2 className="h-3 w-3" aria-hidden="true" />
-                  {t('flights.highlightVideoBadge')}
                 </span>
               )}
               {isVideoExportRunning && (


### PR DESCRIPTION
## Summary
- order flight media cards as GPX, video, camera, pano, overlay, then best moments
- apply the same order to flight list media tags with YouTube last
- update the media badge ordering test

## Validation
- targeted Flight test: passed (6/6)
- frontend build: passed
- targeted format and oxlint: passed
- global frontend lint has pre-existing failures outside this change
- FlightDetails test has one pre-existing failure related to the best moments thumbnail expectation