### PR TITLE
fix: align video job status with logs

### DIFF
--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -45,6 +45,17 @@ def test_video_export_log_survives_temp_cleanup_until_job_deletion(tmp_path, mon
     assert not log_path.exists()
 
 
+def test_video_export_log_refreshes_runtime_activity(tmp_path, monkeypatch):
+    monkeypatch.setattr(video_export_manual, "_video_export_dir", lambda: tmp_path)
+    video_export_manual._JOB_RUNTIME.clear()
+
+    video_export_manual._log_job("job-activity", "Captured 10/100 frames")
+
+    updated_at = video_export_manual._JOB_RUNTIME["job-activity"]["updated_at"]
+    assert datetime.fromisoformat(updated_at).tzinfo is not None
+    video_export_manual._JOB_RUNTIME.clear()
+
+
 def test_resolve_frontend_url_uses_backend_static_in_production(monkeypatch):
     """Production should avoid localhost:5173 when static frontend is bundled."""
     monkeypatch.setattr(video_export_manual.Path, "exists", lambda _self: True)

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -81,6 +81,7 @@ def _log_job(job_id: str, message: str) -> None:
         log_path = _job_log_path(job_id)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        _set_job_runtime(job_id, updated_at=timestamp)
         with log_path.open("a", encoding="utf-8") as log_file:
             log_file.write(f"[{timestamp}] {message}\n")
     except OSError:

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -377,7 +377,13 @@ function FramesCell({ job }: { job: VideoExportJob }) {
 }
 
 function isActiveJob(job: VideoExportJob) {
-  return activeStatusLabels.has(job.internal_status || job.status);
+  if (['queued', 'blocked', 'stalled'].includes(job.status)) {
+    return false;
+  }
+  return (
+    activeStatusLabels.has(job.status) ||
+    activeStatusLabels.has(job.internal_status || '')
+  );
 }
 
 function FpsCell({ job }: { job: VideoExportJob }) {


### PR DESCRIPTION
## Résumé
- rafraîchit `updated_at` lors de chaque écriture de log
- évite de déclarer à tort un job bloqué alors que ses logs progressent
- affiche 0 FPS pour les états `queued`, `blocked` et `stalled`

## Validation
- tests frontend ciblés : 13/13
- tests backend ciblés : 2/2

Capture Storybook existante : `.codenomad/storybook-previews/video-export-jobs-fps-zero-inactive.png`.