### PR TITLE
feat(highlights): add editable generation prompt

### DIFF
--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -352,6 +352,7 @@ class HighlightVideoJob(Base):
     overlay_video_path = Column(String)
     output_path = Column(String)
     selection_json = Column(Text)
+    prompt = Column(Text)
     output_format = Column(String, nullable=False, default="original")
     overlay_offset_seconds = Column(Float, nullable=False, default=0.0)
     started_at = Column(DateTime)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -132,6 +132,7 @@ from schemas import (
     GoproOverlayLayoutsResponse,
     GoproOverlayProbeResponse,
     HighlightVideoClipResponse,
+    HighlightVideoCreateRequest,
     HighlightVideoDeleteResponse,
     HighlightVideoJobResponse,
     IntervalsPreviewResponse,
@@ -759,8 +760,7 @@ def _get_video_export_jobs_payload(
         jobs = [
             job
             for job in jobs
-            if job.get("can_cancel")
-            or job.get("status") in _VIDEO_EXPORT_IN_PROGRESS_STATUSES
+            if job.get("can_cancel") or job.get("status") in _VIDEO_EXPORT_IN_PROGRESS_STATUSES
         ]
     elif status_filter and status_filter != "all":
         jobs = [job for job in jobs if job.get("status") == status_filter]
@@ -4759,10 +4759,18 @@ def _highlight_job_payload(job: HighlightVideoJob) -> HighlightVideoJobResponse:
         output_format=job.output_format,
         overlay_offset_seconds=float(job.overlay_offset_seconds or 0.0),
         selection=selection,
+        prompt=job.prompt,
         created_at=job.created_at,
         updated_at=job.updated_at,
         completed_at=job.completed_at,
     )
+
+
+def _normalize_highlight_prompt(prompt: str | None) -> str | None:
+    """Store absent prompts consistently instead of preserving whitespace-only input."""
+    if prompt is None:
+        return None
+    return prompt.strip() or None
 
 
 @router.get(
@@ -4898,6 +4906,7 @@ def get_flight_highlight_video_thumbnail(
 def create_flight_highlight_video(
     flight_id: str,
     background_tasks: BackgroundTasks,
+    payload: HighlightVideoCreateRequest | None = None,
     db: Session = Depends(get_db),
 ) -> HighlightVideoJobResponse:
     flight = db.query(Flight).filter(Flight.id == flight_id).first()
@@ -4930,6 +4939,7 @@ def create_flight_highlight_video(
         source_video_path=str(pano_path),
         overlay_video_path=overlay_path,
         output_format="original",
+        prompt=_normalize_highlight_prompt(payload.prompt if payload else None),
         overlay_offset_seconds=float(flight.gopro_overlay_gpx_offset or 0.0),
     )
     db.add(job)
@@ -6109,7 +6119,9 @@ def list_video_export_jobs(
     active_only: bool = False,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=100),
-    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(default="all"),
+    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(
+        default="all"
+    ),
     type_filter: Literal["all", "video", "gopro"] = Query(default="all"),
     db: Session = Depends(get_db),
 ) -> VideoExportJobsResponse:
@@ -6130,7 +6142,9 @@ async def stream_video_export_jobs(
     request: Request,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=100),
-    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(default="all"),
+    status_filter: Literal["all", "active", "completed", "failed", "cancelled"] = Query(
+        default="all"
+    ),
     type_filter: Literal["all", "video", "gopro"] = Query(default="all"),
 ) -> StreamingResponse:
     """Stream video export job list updates without frontend polling."""

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -196,6 +196,10 @@ class HighlightVideoClipResponse(BaseModel):
     category: str
 
 
+class HighlightVideoCreateRequest(BaseModel):
+    prompt: str | None = Field(default=None, max_length=4000)
+
+
 class HighlightVideoJobResponse(BaseModel):
     job_id: str
     flight_id: str
@@ -206,6 +210,7 @@ class HighlightVideoJobResponse(BaseModel):
     output_format: str
     overlay_offset_seconds: float
     selection: list[HighlightVideoClipResponse] = Field(default_factory=list)
+    prompt: str | None = None
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None = None

--- a/apps/backend/sql_migrations/027_add_highlight_video_prompt.sql
+++ b/apps/backend/sql_migrations/027_add_highlight_video_prompt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE highlight_video_jobs ADD COLUMN prompt TEXT;

--- a/apps/backend/tests/unit/test_highlight_video_prompt_migration.py
+++ b/apps/backend/tests/unit/test_highlight_video_prompt_migration.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+MIGRATION = Path(__file__).parents[2] / "sql_migrations" / "027_add_highlight_video_prompt.sql"
+
+
+def test_highlight_video_prompt_migration_adds_prompt_column() -> None:
+    assert "ALTER TABLE highlight_video_jobs ADD COLUMN prompt TEXT" in MIGRATION.read_text()

--- a/apps/backend/tests/unit/test_highlight_video_schemas.py
+++ b/apps/backend/tests/unit/test_highlight_video_schemas.py
@@ -1,7 +1,24 @@
 import pytest
 from pydantic import ValidationError
 
-from schemas import HighlightVideoDeleteResponse
+from schemas import HighlightVideoCreateRequest, HighlightVideoDeleteResponse
+from routes import _normalize_highlight_prompt
+
+
+def test_highlight_video_create_request_accepts_and_limits_prompt() -> None:
+    assert (
+        HighlightVideoCreateRequest(prompt="Prioritize the thermal").prompt
+        == "Prioritize the thermal"
+    )
+
+    with pytest.raises(ValidationError):
+        HighlightVideoCreateRequest(prompt="x" * 4001)
+
+
+def test_highlight_prompt_normalization_discards_whitespace_only_input() -> None:
+    assert _normalize_highlight_prompt("  thermal moments  ") == "thermal moments"
+    assert _normalize_highlight_prompt(" \n\t ") is None
+    assert _normalize_highlight_prompt(None) is None
 
 
 def test_highlight_video_delete_response_accepts_zero_and_positive_counts() -> None:

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -937,8 +937,8 @@ export function FlightDetails({
             isGenerationPending={createHighlightVideo.isPending}
             isCancellationPending={cancelHighlightVideo.isPending}
             isDeletionPending={deleteHighlightVideo.isPending}
-            onGenerate={() => {
-              createHighlightVideo.mutate(undefined, {
+            onGenerate={(prompt) => {
+              createHighlightVideo.mutate(prompt, {
                 onSuccess: () =>
                   toast.success(t('flights.highlightVideoStarted')),
                 onError: async (error) =>

--- a/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@dashboard-parapente/design-system';
 import {
@@ -20,7 +21,7 @@ interface HighlightVideoJobCardProps {
   isGenerationPending: boolean;
   isCancellationPending: boolean;
   isDeletionPending: boolean;
-  onGenerate: () => void;
+  onGenerate: (prompt: string) => void;
   onCancel: () => void;
   onDownload: () => void;
   onDelete: () => void;
@@ -40,6 +41,8 @@ export function HighlightVideoJobCard({
   onDelete,
 }: HighlightVideoJobCardProps) {
   const { t } = useTranslation();
+  const [editedPrompt, setEditedPrompt] = useState<string | null>(null);
+  const prompt = editedPrompt ?? job?.prompt ?? '';
   const status = job?.status ?? null;
   const isProcessing = status === 'queued' || status === 'running';
   const isGenerationLocked = !hasPanoVideo;
@@ -109,6 +112,29 @@ export function HighlightVideoJobCard({
             />
           </div>
         )}
+        {!isProcessing && (
+          <div className="mt-3">
+            <label
+              htmlFor="highlight-video-prompt"
+              className="mb-1 block text-xs font-semibold text-slate-800 dark:text-slate-200"
+            >
+              {t('flights.highlightVideoPromptLabel')}
+            </label>
+            <textarea
+              id="highlight-video-prompt"
+              value={prompt}
+              onChange={(event) => setEditedPrompt(event.target.value)}
+              placeholder={t('flights.highlightVideoPromptPlaceholder')}
+              maxLength={4000}
+              rows={4}
+              className="w-full resize-y rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-violet-500 focus:ring-2 focus:ring-violet-500/30 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+              disabled={isGenerationLocked}
+            />
+            <p className="mt-1 text-right text-[11px] text-slate-500 dark:text-slate-400">
+              {prompt.length}/4000
+            </p>
+          </div>
+        )}
         {status === 'completed' && job && (
           <FlightMediaThumbnail
             path={`/flights/${flight.id}/highlight-videos/${job.job_id}/thumbnail`}
@@ -152,31 +178,30 @@ export function HighlightVideoJobCard({
             </Button>
           </div>
         )}
-        {status !== 'completed' &&
-          (isProcessing ? (
-            <Button
-              variant="danger"
-              className="mt-3 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
-              onPress={onCancel}
-              isDisabled={isCancellationPending}
-            >
-              {isCancellationPending
-                ? t('common.stopping')
-                : t('flights.highlightVideoCancel')}
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              className="mt-3 min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
-              onPress={onGenerate}
-              isDisabled={isGenerationPending || isGenerationLocked}
-            >
-              <Sparkles className="h-4 w-4" aria-hidden="true" />
-              {isGenerationPending
-                ? t('flights.highlightVideoStarting')
-                : t('flights.highlightVideoGenerate')}
-            </Button>
-          ))}
+        {isProcessing ? (
+          <Button
+            variant="danger"
+            className="mt-3 min-h-10 w-full rounded-lg px-3 py-2 text-sm"
+            onPress={onCancel}
+            isDisabled={isCancellationPending}
+          >
+            {isCancellationPending
+              ? t('common.stopping')
+              : t('flights.highlightVideoCancel')}
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            className="mt-3 min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
+            onPress={() => onGenerate(prompt)}
+            isDisabled={isGenerationPending || isGenerationLocked}
+          >
+            <Sparkles className="h-4 w-4" aria-hidden="true" />
+            {isGenerationPending
+              ? t('flights.highlightVideoStarting')
+              : t('flights.highlightVideoGenerate')}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/hooks/flights/useHighlightVideos.ts
+++ b/apps/frontend/src/hooks/flights/useHighlightVideos.ts
@@ -26,9 +26,9 @@ export function useFlightHighlightVideos(flightId: string) {
 export function useCreateFlightHighlightVideo(flightId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => {
+    mutationFn: async (prompt: string) => {
       const payload = await api
-        .post(`flights/${flightId}/highlight-videos`)
+        .post(`flights/${flightId}/highlight-videos`, { json: { prompt } })
         .json<unknown>();
       return HighlightVideoJobSchema.parse(payload);
     },
@@ -36,7 +36,9 @@ export function useCreateFlightHighlightVideo(flightId: string) {
       void queryClient.invalidateQueries({
         queryKey: ['flights', flightId, 'highlight-videos'],
       });
-      void queryClient.invalidateQueries({ queryKey: ['flights', 'summaries'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['flights', 'summaries'],
+      });
     },
   });
 }
@@ -54,7 +56,9 @@ export function useCancelFlightHighlightVideo(flightId: string) {
       void queryClient.invalidateQueries({
         queryKey: ['flights', flightId, 'highlight-videos'],
       });
-      void queryClient.invalidateQueries({ queryKey: ['flights', 'summaries'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['flights', 'summaries'],
+      });
     },
   });
 }
@@ -70,7 +74,9 @@ export function useDeleteFlightHighlightVideo(flightId: string) {
       void queryClient.invalidateQueries({
         queryKey: ['flights', flightId, 'highlight-videos'],
       });
-      void queryClient.invalidateQueries({ queryKey: ['flights', 'summaries'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['flights', 'summaries'],
+      });
     },
   });
 }

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1033,6 +1033,8 @@
     "highlightVideoLocked": "Locked",
     "highlightVideoRequiresPano": "Add the pano.mp4 file to generate best moments.",
     "highlightVideoGenerate": "Generate best moments",
+    "highlightVideoPromptLabel": "Selection instructions",
+    "highlightVideoPromptPlaceholder": "Describe which moments should be prioritized…",
     "highlightVideoDownload": "Download video",
     "highlightVideoDownloadError": "Unable to download the best-moments video.",
     "highlightVideoStarting": "Starting…",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1037,6 +1037,8 @@
     "highlightVideoLocked": "Verrouillé",
     "highlightVideoRequiresPano": "Ajoutez le fichier pano.mp4 pour générer les meilleurs moments.",
     "highlightVideoGenerate": "Générer les meilleurs moments",
+    "highlightVideoPromptLabel": "Instructions de sélection",
+    "highlightVideoPromptPlaceholder": "Décris le type de moments à privilégier…",
     "highlightVideoDownload": "Télécharger la vidéo",
     "highlightVideoDownloadError": "Impossible de télécharger la vidéo des meilleurs moments.",
     "highlightVideoStarting": "Lancement…",

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -108,6 +108,7 @@ export const HighlightVideoJobSchema = z.object({
   output_format: z.string(),
   overlay_offset_seconds: z.number(),
   selection: z.array(HighlightVideoClipSchema).default([]),
+  prompt: z.string().nullish(),
   created_at: z.string(),
   updated_at: z.string().nullish(),
   completed_at: z.string().nullish(),


### PR DESCRIPTION
## Summary
- add an editable prompt field to the best-moments card
- persist the prompt on each highlight video job
- allow regeneration with updated instructions
- normalize blank prompts and add the database migration

## Validation
- targeted backend tests: 5 passed
- Ruff: passed
- targeted frontend Oxlint: passed with one existing async warning
- frontend/shared-types type-check: passed
- frontend production build: passed
- CodeRabbit review: 0 findings

The full repository validation still reports unrelated pre-existing failures in design-system Storybook tests and gopro_overlay tests.