### PR TITLE
fix(highlights): detect flight phases from visual activity

### DIFF
--- a/apps/backend/highlight_video_worker.py
+++ b/apps/backend/highlight_video_worker.py
@@ -408,9 +408,46 @@ def select_flight_event_clips(
     track_points: list[TrackPoint] | None,
     visual_clips: list[HighlightClip],
 ) -> list[HighlightClip]:
-    """Guarantee flight phases while filling remaining slots with visual highlights."""
+    """Select visually detected phase changes and use telemetry for thermals."""
+    if not visual_clips and not track_points:
+        return []
+
+    clip_length = min(8.0, max(3.0, duration_seconds / 8))
+
+    def visual_phase_clip(category: str) -> HighlightClip | None:
+        # The visual scorer provides the evidence. If it finds no candidate in
+        # a phase window, leave that phase absent instead of inventing a fixed
+        # timestamp (the camera may have started long before takeoff).
+        if category == "takeoff":
+            candidates = [
+                clip for clip in visual_clips if clip.start_seconds <= duration_seconds * 0.5
+            ]
+            return min(candidates, key=lambda clip: clip.start_seconds) if candidates else None
+        candidates = [clip for clip in visual_clips if clip.start_seconds >= duration_seconds * 0.5]
+        return max(candidates, key=lambda clip: clip.start_seconds) if candidates else None
+
+    selected: list[HighlightClip] = []
+    takeoff_clip = visual_phase_clip("takeoff")
+    if takeoff_clip:
+        selected.append(replace(takeoff_clip, category="takeoff"))
+    landing_clip = visual_phase_clip("landing")
+    if landing_clip and (
+        takeoff_clip is None or landing_clip.start_seconds != takeoff_clip.start_seconds
+    ):
+        selected.append(replace(landing_clip, category="landing"))
+
+    def fill_with_visual_clips() -> list[HighlightClip]:
+        for clip in visual_clips:
+            if len(selected) >= 6:
+                break
+            if all(
+                abs(clip.start_seconds - chosen.start_seconds) >= clip_length for chosen in selected
+            ):
+                selected.append(clip)
+        return sorted(selected, key=lambda clip: clip.start_seconds)
+
     if not track_points:
-        return visual_clips
+        return fill_with_visual_clips()
     samples = [
         (point.get("timestamp", 0), point.get("elevation", 0.0))
         for point in track_points
@@ -418,33 +455,13 @@ def select_flight_event_clips(
     ]
     timestamps = [timestamp for timestamp, _elevation in samples]
     if len(samples) < 2:
-        return visual_clips
+        return fill_with_visual_clips()
     track_duration = max(1.0, (timestamps[-1] - timestamps[0]) / 1000)
 
     def video_time(track_seconds: float) -> float:
         return min(duration_seconds, max(0.0, track_seconds / track_duration * duration_seconds))
 
-    clip_length = min(8.0, max(3.0, duration_seconds / 8))
-    # The first useful visual movement is a better takeoff anchor than the
-    # first GPS sample: cameras often keep recording while the wing is being
-    # prepared. Keep a little lead-in so the inflation is visible.
-    early_visual = [clip for clip in visual_clips if clip.start_seconds <= duration_seconds * 0.25]
-    takeoff_anchor = (
-        min(
-            early_visual,
-            key=lambda clip: abs(clip.start_seconds - duration_seconds * 0.12),
-        ).start_seconds
-        if early_visual
-        else duration_seconds * 0.04
-    )
-    takeoff_start = max(
-        0.0,
-        min(
-            duration_seconds - clip_length,
-            takeoff_anchor - clip_length,
-        ),
-    )
-    phases = [("takeoff", takeoff_start + clip_length / 2)]
+    phases: list[tuple[str, float]] = []
     elevations = [elevation for _timestamp, elevation in samples]
     climb_candidates: list[tuple[float, float]] = []
     for index in range(1, len(elevations)):
@@ -467,25 +484,11 @@ def select_flight_event_clips(
         _, best_index = max(climb_candidates)
         phases.append(("thermal", (timestamps[best_index] - timestamps[0]) / 1000))
 
-    phases.append(("landing", duration_seconds * 0.96))
-
-    selected: list[HighlightClip] = []
     for category, position in phases:
-        center = (
-            position
-            if category == "takeoff"
-            else (video_time(position) if category == "thermal" else position)
-        )
+        center = video_time(position)
         start = max(0.0, min(duration_seconds - clip_length, center - clip_length / 2))
         selected.append(HighlightClip(start, clip_length, 0.0, category))
-    for clip in visual_clips:
-        if len(selected) >= 6:
-            break
-        if all(
-            abs(clip.start_seconds - chosen.start_seconds) >= clip_length for chosen in selected
-        ):
-            selected.append(clip)
-    return sorted(selected, key=lambda clip: clip.start_seconds)
+    return fill_with_visual_clips()
 
 
 def _render_clip(

--- a/apps/backend/models.py
+++ b/apps/backend/models.py
@@ -352,7 +352,6 @@ class HighlightVideoJob(Base):
     overlay_video_path = Column(String)
     output_path = Column(String)
     selection_json = Column(Text)
-    prompt = Column(Text)
     output_format = Column(String, nullable=False, default="original")
     overlay_offset_seconds = Column(Float, nullable=False, default=0.0)
     started_at = Column(DateTime)

--- a/apps/backend/routes.py
+++ b/apps/backend/routes.py
@@ -132,7 +132,6 @@ from schemas import (
     GoproOverlayLayoutsResponse,
     GoproOverlayProbeResponse,
     HighlightVideoClipResponse,
-    HighlightVideoCreateRequest,
     HighlightVideoDeleteResponse,
     HighlightVideoJobResponse,
     IntervalsPreviewResponse,
@@ -4759,18 +4758,10 @@ def _highlight_job_payload(job: HighlightVideoJob) -> HighlightVideoJobResponse:
         output_format=job.output_format,
         overlay_offset_seconds=float(job.overlay_offset_seconds or 0.0),
         selection=selection,
-        prompt=job.prompt,
         created_at=job.created_at,
         updated_at=job.updated_at,
         completed_at=job.completed_at,
     )
-
-
-def _normalize_highlight_prompt(prompt: str | None) -> str | None:
-    """Store absent prompts consistently instead of preserving whitespace-only input."""
-    if prompt is None:
-        return None
-    return prompt.strip() or None
 
 
 @router.get(
@@ -4906,7 +4897,6 @@ def get_flight_highlight_video_thumbnail(
 def create_flight_highlight_video(
     flight_id: str,
     background_tasks: BackgroundTasks,
-    payload: HighlightVideoCreateRequest | None = None,
     db: Session = Depends(get_db),
 ) -> HighlightVideoJobResponse:
     flight = db.query(Flight).filter(Flight.id == flight_id).first()
@@ -4939,7 +4929,6 @@ def create_flight_highlight_video(
         source_video_path=str(pano_path),
         overlay_video_path=overlay_path,
         output_format="original",
-        prompt=_normalize_highlight_prompt(payload.prompt if payload else None),
         overlay_offset_seconds=float(flight.gopro_overlay_gpx_offset or 0.0),
     )
     db.add(job)

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -196,10 +196,6 @@ class HighlightVideoClipResponse(BaseModel):
     category: str
 
 
-class HighlightVideoCreateRequest(BaseModel):
-    prompt: str | None = Field(default=None, max_length=4000)
-
-
 class HighlightVideoJobResponse(BaseModel):
     job_id: str
     flight_id: str
@@ -210,7 +206,6 @@ class HighlightVideoJobResponse(BaseModel):
     output_format: str
     overlay_offset_seconds: float
     selection: list[HighlightVideoClipResponse] = Field(default_factory=list)
-    prompt: str | None = None
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None = None

--- a/apps/backend/tests/unit/test_highlight_video.py
+++ b/apps/backend/tests/unit/test_highlight_video.py
@@ -45,10 +45,27 @@ def test_event_selection_guarantees_takeoff_landing_and_thermal():
     clips = select_flight_event_clips(
         600,
         points,
-        [HighlightClip(300, 8, 0, "dynamic")],
+        [
+            HighlightClip(30, 8, 0, "dynamic"),
+            HighlightClip(300, 8, 0, "dynamic"),
+            HighlightClip(540, 8, 0, "dynamic"),
+        ],
     )
 
     assert {clip.category for clip in clips} >= {"takeoff", "landing", "thermal"}
+
+
+def test_event_selection_uses_visual_activity_for_phases_without_fixed_offsets():
+    clips = select_flight_event_clips(
+        600,
+        None,
+        [HighlightClip(42, 8, 0, "dynamic"), HighlightClip(520, 8, 0, "dynamic")],
+    )
+
+    assert [(clip.category, clip.start_seconds) for clip in clips[:2]] == [
+        ("takeoff", 42),
+        ("landing", 520),
+    ]
 
 
 def test_thermal_selection_uses_sustained_climb_not_single_altitude_spike():

--- a/apps/backend/tests/unit/test_highlight_video_prompt_migration.py
+++ b/apps/backend/tests/unit/test_highlight_video_prompt_migration.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-MIGRATION = Path(__file__).parents[2] / "sql_migrations" / "027_add_highlight_video_prompt.sql"
-
-
-def test_highlight_video_prompt_migration_adds_prompt_column() -> None:
-    assert "ALTER TABLE highlight_video_jobs ADD COLUMN prompt TEXT" in MIGRATION.read_text()

--- a/apps/backend/tests/unit/test_highlight_video_schemas.py
+++ b/apps/backend/tests/unit/test_highlight_video_schemas.py
@@ -1,24 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from schemas import HighlightVideoCreateRequest, HighlightVideoDeleteResponse
-from routes import _normalize_highlight_prompt
-
-
-def test_highlight_video_create_request_accepts_and_limits_prompt() -> None:
-    assert (
-        HighlightVideoCreateRequest(prompt="Prioritize the thermal").prompt
-        == "Prioritize the thermal"
-    )
-
-    with pytest.raises(ValidationError):
-        HighlightVideoCreateRequest(prompt="x" * 4001)
-
-
-def test_highlight_prompt_normalization_discards_whitespace_only_input() -> None:
-    assert _normalize_highlight_prompt("  thermal moments  ") == "thermal moments"
-    assert _normalize_highlight_prompt(" \n\t ") is None
-    assert _normalize_highlight_prompt(None) is None
+from schemas import HighlightVideoDeleteResponse
 
 
 def test_highlight_video_delete_response_accepts_zero_and_positive_counts() -> None:

--- a/apps/frontend/src/components/flights/details/FlightDetails.tsx
+++ b/apps/frontend/src/components/flights/details/FlightDetails.tsx
@@ -937,8 +937,8 @@ export function FlightDetails({
             isGenerationPending={createHighlightVideo.isPending}
             isCancellationPending={cancelHighlightVideo.isPending}
             isDeletionPending={deleteHighlightVideo.isPending}
-            onGenerate={(prompt) => {
-              createHighlightVideo.mutate(prompt, {
+            onGenerate={() => {
+              createHighlightVideo.mutate(undefined, {
                 onSuccess: () =>
                   toast.success(t('flights.highlightVideoStarted')),
                 onError: async (error) =>

--- a/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/HighlightVideoJobCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@dashboard-parapente/design-system';
 import {
@@ -21,7 +20,7 @@ interface HighlightVideoJobCardProps {
   isGenerationPending: boolean;
   isCancellationPending: boolean;
   isDeletionPending: boolean;
-  onGenerate: (prompt: string) => void;
+  onGenerate: () => void;
   onCancel: () => void;
   onDownload: () => void;
   onDelete: () => void;
@@ -41,8 +40,6 @@ export function HighlightVideoJobCard({
   onDelete,
 }: HighlightVideoJobCardProps) {
   const { t } = useTranslation();
-  const [editedPrompt, setEditedPrompt] = useState<string | null>(null);
-  const prompt = editedPrompt ?? job?.prompt ?? '';
   const status = job?.status ?? null;
   const isProcessing = status === 'queued' || status === 'running';
   const isGenerationLocked = !hasPanoVideo;
@@ -112,29 +109,6 @@ export function HighlightVideoJobCard({
             />
           </div>
         )}
-        {!isProcessing && (
-          <div className="mt-3">
-            <label
-              htmlFor="highlight-video-prompt"
-              className="mb-1 block text-xs font-semibold text-slate-800 dark:text-slate-200"
-            >
-              {t('flights.highlightVideoPromptLabel')}
-            </label>
-            <textarea
-              id="highlight-video-prompt"
-              value={prompt}
-              onChange={(event) => setEditedPrompt(event.target.value)}
-              placeholder={t('flights.highlightVideoPromptPlaceholder')}
-              maxLength={4000}
-              rows={4}
-              className="w-full resize-y rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:border-violet-500 focus:ring-2 focus:ring-violet-500/30 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
-              disabled={isGenerationLocked}
-            />
-            <p className="mt-1 text-right text-[11px] text-slate-500 dark:text-slate-400">
-              {prompt.length}/4000
-            </p>
-          </div>
-        )}
         {status === 'completed' && job && (
           <FlightMediaThumbnail
             path={`/flights/${flight.id}/highlight-videos/${job.job_id}/thumbnail`}
@@ -193,7 +167,7 @@ export function HighlightVideoJobCard({
           <Button
             variant="outline"
             className="mt-3 min-h-10 w-full rounded-lg border-violet-300 px-3 py-2 text-sm dark:border-violet-700"
-            onPress={() => onGenerate(prompt)}
+            onPress={onGenerate}
             isDisabled={isGenerationPending || isGenerationLocked}
           >
             <Sparkles className="h-4 w-4" aria-hidden="true" />

--- a/apps/frontend/src/hooks/flights/useHighlightVideos.ts
+++ b/apps/frontend/src/hooks/flights/useHighlightVideos.ts
@@ -26,9 +26,9 @@ export function useFlightHighlightVideos(flightId: string) {
 export function useCreateFlightHighlightVideo(flightId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (prompt: string) => {
+    mutationFn: async () => {
       const payload = await api
-        .post(`flights/${flightId}/highlight-videos`, { json: { prompt } })
+        .post(`flights/${flightId}/highlight-videos`)
         .json<unknown>();
       return HighlightVideoJobSchema.parse(payload);
     },

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1033,8 +1033,6 @@
     "highlightVideoLocked": "Locked",
     "highlightVideoRequiresPano": "Add the pano.mp4 file to generate best moments.",
     "highlightVideoGenerate": "Generate best moments",
-    "highlightVideoPromptLabel": "Selection instructions",
-    "highlightVideoPromptPlaceholder": "Describe which moments should be prioritized…",
     "highlightVideoDownload": "Download video",
     "highlightVideoDownloadError": "Unable to download the best-moments video.",
     "highlightVideoStarting": "Starting…",

--- a/apps/frontend/src/locales/fr/translation.json
+++ b/apps/frontend/src/locales/fr/translation.json
@@ -1037,8 +1037,6 @@
     "highlightVideoLocked": "Verrouillé",
     "highlightVideoRequiresPano": "Ajoutez le fichier pano.mp4 pour générer les meilleurs moments.",
     "highlightVideoGenerate": "Générer les meilleurs moments",
-    "highlightVideoPromptLabel": "Instructions de sélection",
-    "highlightVideoPromptPlaceholder": "Décris le type de moments à privilégier…",
     "highlightVideoDownload": "Télécharger la vidéo",
     "highlightVideoDownloadError": "Impossible de télécharger la vidéo des meilleurs moments.",
     "highlightVideoStarting": "Lancement…",

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -108,7 +108,6 @@ export const HighlightVideoJobSchema = z.object({
   output_format: z.string(),
   overlay_offset_seconds: z.number(),
   selection: z.array(HighlightVideoClipSchema).default([]),
-  prompt: z.string().nullish(),
   created_at: z.string(),
   updated_at: z.string().nullish(),
   completed_at: z.string().nullish(),


### PR DESCRIPTION
## Résumé
- retire le prompt de génération, puisqu’aucune IA ne l’utilise actuellement
- supprime les offsets fixes de 12 % et 96 % pour le décollage et l’atterrissage
- sélectionne ces phases uniquement parmi les candidats visuels détectés
- conserve le GPX pour l’identification des thermiques

## Validation
- tests unitaires backend ciblés : 12 passés
- tests API highlights : 7 passés
- type-check shared-types/frontend
- build frontend
- CodeRabbit : aucun finding