### PR TITLE
fix(gopro): restore overlay listing and resolution tags

### DIFF
--- a/apps/backend/gopro_overlay_export.py
+++ b/apps/backend/gopro_overlay_export.py
@@ -482,6 +482,9 @@ def _job_to_payload(
         ),
         "video_width": job.video_width,
         "video_height": job.video_height,
+        "output_resolution": (
+            command.get("output_resolution") if isinstance(command, dict) else None
+        ),
         "gpx_offset": _gpx_offset_from_command_metadata(command),
         "render_method": _render_method_from_command(command),
         "created_at": _to_iso(job.created_at),
@@ -2131,6 +2134,7 @@ def _create_gopro_overlay_job_from_paths(
         "log_path": str(log_path),
         "video_width": None,
         "video_height": None,
+        "output_resolution": output_resolution,
         "gpx_offset": gpx_offset,
         "created_at": _utc_now(),
         "updated_at": _utc_now(),
@@ -2321,12 +2325,20 @@ def _run_job(job_id: str) -> None:
         if return_code != 0 and gpu_render_enabled:
             _unlink_if_exists(temp_output_path)
             _append_job_log(log_path, "GPU overlay failed; retrying with CPU rendering")
+            fallback_metadata = current_job.get("command") if current_job else None
+            if not isinstance(fallback_metadata, dict):
+                fallback_metadata = {}
+            fallback_metadata = {
+                **fallback_metadata,
+                "command": cpu_command,
+                "render_method": "cpu",
+            }
             _update_job(
                 job_id,
                 message="GPU unavailable; retrying overlay on CPU",
                 render_method="cpu",
                 command=cpu_command,
-                command_json=json.dumps({"command": cpu_command, "render_method": "cpu"}),
+                command_json=json.dumps(fallback_metadata),
             )
             logger.warning("GPU overlay failed for job %s; retrying on CPU", job_id)
             try:

--- a/apps/backend/schemas.py
+++ b/apps/backend/schemas.py
@@ -117,6 +117,7 @@ class GoproOverlayJob(BaseModel):
     output_filename: str
     video_width: int | None = None
     video_height: int | None = None
+    output_resolution: Literal["1080p", "4k", "source"] | None = None
     gpx_offset: float = 0.0
     created_at: datetime
     updated_at: datetime

--- a/apps/backend/tests/api/test_gopro_overlay_endpoints.py
+++ b/apps/backend/tests/api/test_gopro_overlay_endpoints.py
@@ -3426,6 +3426,7 @@ def test_cancel_queued_gopro_overlay_job_removes_rq_job(monkeypatch):
         "pip_path": None,
         "video_width": None,
         "video_height": None,
+        "command": {"output_resolution": "4k"},
         "updated_at": "2026-01-01T00:00:00+00:00",
     }
     monkeypatch.setattr(gopro_overlay_export.config, "JOB_QUEUE_BACKEND", "rq")
@@ -3842,6 +3843,9 @@ def test_run_job_passes_configured_overlay_gpu_args(monkeypatch, tmp_path):
         assert fallback_command[fallback_command.index("--config-dir") + 1] == "/config"
         assert "--profile" not in fallback_command
         assert "--double-buffer" not in fallback_command
+        fallback_job = gopro_overlay_export.get_gopro_overlay_job(job_id, include_command=True)
+        assert fallback_job is not None
+        assert fallback_job["command"]["output_resolution"] == "4k"
     finally:
         gopro_overlay_export._JOBS.pop(job_id, None)
         gopro_overlay_export._PROCESSES.pop(job_id, None)

--- a/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
+++ b/apps/frontend/src/components/flights/details/GoproOverlayJobCard.tsx
@@ -7,6 +7,15 @@ import type { Flight } from '../../../types';
 import { FlightMediaThumbnail } from './FlightMediaThumbnail';
 import { FlightYoutubeUploadControls } from './FlightYoutubeUploadControls';
 
+function getResolutionLabel(job: GoproOverlayJob): string | null {
+  if (job.output_resolution === '4k') return '4K (3840 × 2160)';
+  if (job.output_resolution === '1080p') return '1080p (1920 × 1080)';
+  if (job.video_width && job.video_height) {
+    return `${job.video_width} × ${job.video_height}`;
+  }
+  return null;
+}
+
 interface GoproOverlayJobCardProps {
   job: GoproOverlayJob;
   youtubeUploadFlight?: Flight;
@@ -37,10 +46,7 @@ export function GoproOverlayJobCard({
     ['cpu', 'gpu'].includes(job.render_method)
       ? t(`flights.generationLogs.method.${job.render_method}`)
       : null;
-  const resolutionLabel =
-    job.video_width && job.video_height
-      ? `${job.video_width} × ${job.video_height}`
-      : null;
+  const resolutionLabel = getResolutionLabel(job);
   const isProcessing = isGoproOverlayInProgress(job.status);
   const progress = Math.max(0, Math.min(100, Math.round(job.progress ?? 0)));
 

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.test.tsx
@@ -71,8 +71,8 @@ function createWrapper() {
   };
 }
 
-function TestHarness() {
-  const { data } = useVideoExportJobs();
+function TestHarness({ typeFilter = 'all' }: { typeFilter?: string }) {
+  const { data } = useVideoExportJobs({ typeFilter });
 
   return <div>{data?.jobs.map((job) => job.job_id).join(',')}</div>;
 }
@@ -112,6 +112,23 @@ describe('useVideoExportJobs', () => {
 
     await waitFor(() => {
       expect(screen.getByText('job-from-stream')).toBeInTheDocument();
+    });
+  });
+
+  it('requests and caches the selected job type', async () => {
+    render(<TestHarness typeFilter="gopro" />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith(
+        'video-export-jobs',
+        expect.objectContaining({
+          searchParams: expect.objectContaining({ type_filter: 'gopro' }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(eventSourceMock.instances[0]?.url).toContain('type_filter=gopro');
     });
   });
 });

--- a/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
+++ b/apps/frontend/src/hooks/flights/useVideoExportJobs.ts
@@ -73,6 +73,15 @@ export type VideoExportTempCleanupResult = {
 
 const videoExportJobsQueryKey = ['video-export-jobs'];
 
+function videoExportJobsQueryKeyFor(
+  page: number,
+  pageSize: number,
+  statusFilter: string,
+  typeFilter: string
+) {
+  return [...videoExportJobsQueryKey, page, pageSize, statusFilter, typeFilter];
+}
+
 function toVideoExportJobsResponse(value: unknown): VideoExportJobsPage | null {
   if (!value || typeof value !== 'object' || !('jobs' in value)) {
     return null;
@@ -92,7 +101,8 @@ function toVideoExportJobsResponse(value: unknown): VideoExportJobsPage | null {
     page,
     pageSize,
     total,
-    totalPages: response.total_pages ?? Math.max(1, Math.ceil(total / pageSize)),
+    totalPages:
+      response.total_pages ?? Math.max(1, Math.ceil(total / pageSize)),
   };
 }
 
@@ -103,7 +113,12 @@ export const videoExportJobsQueryOptions = ({
   typeFilter = 'all',
 }: { page?: number; pageSize?: number } & VideoExportJobsFilters = {}) =>
   queryOptions<VideoExportJobsPage>({
-    queryKey: [...videoExportJobsQueryKey, page, pageSize],
+    queryKey: videoExportJobsQueryKeyFor(
+      page,
+      pageSize,
+      statusFilter,
+      typeFilter
+    ),
     queryFn: async () => {
       const data = await api
         .get('video-export-jobs', {
@@ -126,7 +141,9 @@ export function useVideoExportJobs({
   typeFilter = 'all',
 }: { page?: number; pageSize?: number } & VideoExportJobsFilters = {}) {
   const queryClient = useQueryClient();
-  const query = useQuery(videoExportJobsQueryOptions({ page, pageSize }));
+  const query = useQuery(
+    videoExportJobsQueryOptions({ page, pageSize, statusFilter, typeFilter })
+  );
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -160,7 +177,7 @@ export function useVideoExportJobs({
       }
 
       queryClient.setQueryData(
-        [...videoExportJobsQueryKey, page, pageSize],
+        videoExportJobsQueryKeyFor(page, pageSize, statusFilter, typeFilter),
         data
       );
     };

--- a/libs/shared-types/src/index.ts
+++ b/libs/shared-types/src/index.ts
@@ -82,6 +82,7 @@ export const GoproOverlayJobSchema = z.object({
   output_filename: z.string(),
   video_width: z.number().nullish(),
   video_height: z.number().nullish(),
+  output_resolution: z.enum(['1080p', '4k', 'source']).nullish(),
   gpx_offset: z.number().optional().default(0),
   created_at: z.string(),
   updated_at: z.string(),


### PR DESCRIPTION
## Résumé
- corrige le cache et les requêtes filtrées de la liste des jobs vidéo pour conserver les overlays GoPro
- affiche la résolution réellement demandée (4K ou 1080p) au lieu du layout source
- préserve la résolution lors du fallback GPU vers CPU
- ajoute les tests de non-régression

## Validation
- test frontend ciblé : 2/2 OK
- build et type-check frontend : OK
- CodeRabbit : 0 finding
- syntaxe Python : OK
- pytest backend non exécutable localement : pytest absent et pyproject.toml incompatible avec uv

Commit: df98b278