### PR TITLE
fix: synchronize job status and fps display

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, reopened, closed]
   workflow_run:
     workflows: ['CI - Nx Monorepo']
-    types: [completed]
+    types: [completed, in_progress]
 
 env:
   PROJECT_ID: 'PVT_kwHOCaf4ns4BTClc'
@@ -208,3 +208,78 @@ jobs:
             -f optionId="$STATUS_BLOCKED"
 
           echo "Moved PR to blocked"
+
+  # Job 4: When a blocked Renovate PR is retried, mark it as in progress again
+  mark-in-progress:
+    name: Mark running PR as in progress
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.action == 'in_progress' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Check if Renovate PR and update status
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          # Find the PR for this workflow run
+          PR_DATA=$(gh pr view "$HEAD_BRANCH" --repo "${{ github.repository }}" --json author,nodeId 2>/dev/null || echo "")
+
+          if [ -z "$PR_DATA" ]; then
+            echo "No PR found for branch $HEAD_BRANCH, skipping"
+            exit 0
+          fi
+
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+          PR_NODE_ID=$(echo "$PR_DATA" | jq -r '.nodeId')
+
+          if [ "$PR_AUTHOR" != "renovate" ]; then
+            echo "PR is not from Renovate (author: $PR_AUTHOR), skipping"
+            exit 0
+          fi
+
+          # Find the item ID for this PR in the project
+          ITEM_ID=$(gh api graphql -f query='
+            query($projectId: ID!, $cursor: String) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100, after: $cursor) {
+                    nodes {
+                      id
+                      content {
+                        ... on PullRequest { id }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" --jq ".data.node.items.nodes[] | select(.content.id == \"$PR_NODE_ID\") | .id")
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "PR not found in project, skipping"
+            exit 0
+          fi
+
+          # Update status to "In progress"
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(
+                input: {
+                  projectId: $projectId
+                  itemId: $itemId
+                  fieldId: $fieldId
+                  value: { singleSelectOptionId: $optionId }
+                }
+              ) {
+                projectV2Item { id }
+              }
+            }
+          ' \
+            -f projectId="$PROJECT_ID" \
+            -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" \
+            -f optionId="$STATUS_IN_PROGRESS"
+
+          echo "Moved running PR to In progress"

--- a/apps/backend/tests/unit/test_video_export_manual.py
+++ b/apps/backend/tests/unit/test_video_export_manual.py
@@ -255,6 +255,10 @@ def test_capture_progress_percent_spans_capture_phase_range():
     assert video_export_manual._capture_progress_percent(100, 100) == 80
 
 
+def test_capture_fps_excludes_frames_restored_during_resume():
+    assert video_export_manual._capture_fps(150, 100, 5) == 10
+
+
 def test_parse_ffmpeg_out_time_seconds_parses_progress_lines():
     assert video_export_manual._parse_ffmpeg_out_time_seconds("out_time_ms=3000000") == 3.0
     assert video_export_manual._parse_ffmpeg_out_time_seconds("out_time_us=1500000") == 1.5

--- a/apps/backend/video_export_manual.py
+++ b/apps/backend/video_export_manual.py
@@ -1175,6 +1175,12 @@ def _capture_progress_percent(frame_count: int, total_frames: int) -> int:
     return min(80, max(5, int(5 + ratio * 75)))
 
 
+def _capture_fps(frame_count: int, resume_from_frame: int, elapsed: float) -> float:
+    """Return capture throughput excluding frames restored from disk."""
+    captured_since_start = max(0, frame_count - resume_from_frame)
+    return captured_since_start / elapsed if elapsed > 0 else 0
+
+
 def _parse_ffmpeg_out_time_seconds(line: str) -> float | None:
     if "=" not in line:
         return None
@@ -1950,7 +1956,6 @@ async def _export_video_manual_render(job_id: str):
             frame_count = 0
             ms_per_frame = (duration_seconds * 1000) / max(total_frames, 1)
             _log_job(job_id, f"Capturing 1 frame every {ms_per_frame:.1f}ms")
-            start_time = time.time()
             resume_from_frame = _first_missing_frame_index(frames_dir, total_frames)
             if resume_from_frame > 0:
                 frame_count = resume_from_frame
@@ -1969,6 +1974,7 @@ async def _export_video_manual_render(job_id: str):
                 )
                 _log_job(job_id, f"Resuming capture from frame {resume_from_frame}/{total_frames}")
 
+            start_time = time.time()
             encoding_output_file = temp_dir / "encoding.mp4"
             concurrent_encoding = is_fast_mode and accelerator == "cpu"
             ffmpeg_cmd = _ffmpeg_command(
@@ -2094,7 +2100,7 @@ async def _export_video_manual_render(job_id: str):
                 if frame_count % 10 == 0:
                     progress = _capture_progress_percent(frame_count, total_frames)
                     elapsed = time.time() - start_time
-                    fps_actual = frame_count / elapsed if elapsed > 0 else 0
+                    fps_actual = _capture_fps(frame_count, resume_from_frame, elapsed)
                     eta_seconds = (total_frames - frame_count) / fps_actual if fps_actual > 0 else 0
                     eta_seconds_int = max(0, int(eta_seconds)) if eta_seconds > 0 else None
 

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -33,6 +33,7 @@ const {
       progress: 42,
       message: 'Capturing frames',
       mode: 'manual_fast',
+      fps: 30,
       log_tail: ['Opening viewer', 'Captured 10/100 frames'],
       can_cancel: true,
       can_delete: true,

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -394,7 +394,7 @@ function FpsCell({ job }: { job: VideoExportJob }) {
       </span>
     );
   }
-  const fps = job.fps_actual ?? job.fps;
+  const fps = job.fps_actual;
   return typeof fps === 'number' && Number.isFinite(fps) ? (
     <span className="whitespace-nowrap font-mono text-xs text-gray-700 dark:text-gray-200">
       {fps.toFixed(1)} fps


### PR DESCRIPTION
## Résumé
- repasse les PR Renovate à `In progress` lorsqu’un run CI redémarre après un blocage
- affiche uniquement le FPS réellement mesuré pendant le traitement
- corrige le calcul du FPS lors de la reprise d’un export en excluant les frames déjà présentes

## Validation
- Ruff : OK
- git diff --check : OK
- CodeRabbit : 0 finding
- Tests frontend ciblés : non exécutables dans le worktree, dépendance workspace `@dashboard-parapente/design-system` absente
