### PR TITLE
fix(frontend): keep video status badge authoritative

### DIFF
--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.test.tsx
@@ -290,7 +290,7 @@ describe('VideoExportJobsPanel', () => {
     expect(screen.getByRole('menuitem', { name: 'Logs' })).toBeInTheDocument();
   });
 
-  it('shows a stuck warning when an active job has not updated recently', () => {
+  it('keeps the real status when an active job has not updated recently', () => {
     jobs.push({
       job_id: 'job-stuck',
       flight_title: 'Vol bloqué',
@@ -304,7 +304,8 @@ describe('VideoExportJobsPanel', () => {
 
     render(<VideoExportJobsPanel limit={null} />);
 
-    expect(screen.getAllByText('Bloqué').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('En cours').length).toBeGreaterThan(1);
+    expect(screen.queryByText('Bloqué')).not.toBeInTheDocument();
     expect(
       screen.getAllByText(/Aucune progression depuis .* Le traitement semble bloqué/u)
         .length

--- a/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
+++ b/apps/frontend/src/components/flights/video-export/VideoExportJobsPanel.tsx
@@ -292,11 +292,8 @@ function canDeleteJobRow(job: VideoExportJob) {
 function JobStatusBadge({ job }: { job: VideoExportJob }) {
   const { t } = useTranslation();
   const phase = getJobPhase(job);
-  const stalled = getStalledJobMinutes(job) !== null;
   const statusLabel = getStatusLabelParts(job);
   const statusClassName =
-    (stalled &&
-      'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300') ||
     statusClassNames[job.status] ||
     statusClassNames[phase] ||
     statusClassNames.processing;
@@ -305,9 +302,7 @@ function JobStatusBadge({ job }: { job: VideoExportJob }) {
     <span
       className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ${statusClassName}`}
     >
-      {stalled
-        ? t('videoJobs.status.stalled', 'Bloqué')
-        : t(statusLabel.key, statusLabel.fallback)}
+      {t(statusLabel.key, statusLabel.fallback)}
     </span>
   );
 }


### PR DESCRIPTION
## Résumé

- conserve le statut réel `processing/capturing` dans le badge vidéo ;
- garde l’avertissement de progression lente séparé, sans afficher à tort « Bloqué » ;
- met à jour le test de non-régression.

## Validation

- test ciblé VideoExportJobsPanel : 13/13 ;
- type-check frontend : OK ;
- build frontend : OK ;
- CodeRabbit : aucun finding.
- lint frontend : erreurs préexistantes hors de cette correction.